### PR TITLE
build: update toolchain

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,8 +1,5 @@
 [tools]
 changie = "latest"
-erlang = "27"
-gleam = "latest"
-just = "latest"
 rebar = "latest"
 
 [env]

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 erlang 27.2.1
-gleam 1.14.0
-just 1.38.0
+gleam 1.16.0
+just 1.50.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,8 @@ gleam test
 
 Managed via `.tool-versions` (source of truth for CI):
 - Erlang 27.2.1
-- Gleam 1.14.0
-- just 1.38.0
+- Gleam 1.16.0
+- just 1.50.0
 
 Local development can use `.mise.toml` for flexible versions.
 

--- a/DEV.md
+++ b/DEV.md
@@ -9,8 +9,8 @@ Ensure you have the following installed:
 | Tool | Version | Purpose |
 |------|---------|---------|
 | Erlang/OTP | 27.2.1+ | BEAM runtime |
-| Gleam | 1.14.0+ | Compiler and tooling |
-| just | 1.38.0+ | Task runner |
+| Gleam | 1.16.0+ | Compiler and tooling |
+| just | 1.50.0+ | Task runner |
 
 **Recommended:** Use [mise](https://mise.jdx.dev/) or [asdf](https://asdf-vm.com/) with the provided `.tool-versions` file.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ### Prerequisites
 
 - [Erlang](https://www.erlang.org/) 27+
-- [Gleam](https://gleam.run/) 1.1+
+- [Gleam](https://gleam.run/) 1.3+
 - [just](https://github.com/casey/just) (task runner)
 
 Install tools via [mise](https://mise.jdx.dev/) or [asdf](https://asdf-vm.com/):

--- a/gleam.toml
+++ b/gleam.toml
@@ -3,7 +3,7 @@ version = "0.1.0"
 description = "Type-safe real-time channels and presence for Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "tylerbutler", repo = "beryl" }
-gleam = ">= 1.1.0"
+gleam = ">= 1.3.0"
 target = "erlang"
 
 [dependencies]

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -452,7 +452,9 @@ fn create_socket_from_context(ctx: coordinator.SocketContext) -> Socket(Nil) {
   socket.new(ctx.socket_id, Nil, transport_from_context(ctx))
 }
 
-fn create_socket_with_assigns(ctx: coordinator.SocketContext) -> Socket(Dynamic) {
+fn create_socket_with_assigns(
+  ctx: coordinator.SocketContext,
+) -> Socket(Dynamic) {
   socket.new(ctx.socket_id, ctx.assigns, transport_from_context(ctx))
 }
 

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -280,7 +280,10 @@ fn schedule_heartbeat_check(
 }
 
 /// Handle incoming messages
-fn handle_message(state: State, message: Message) -> actor.Next(State, Message) {
+fn handle_message(
+  state: State,
+  message: Message,
+) -> actor.Next(State, Message) {
   case message {
     RegisterChannel(pattern, handler, reply) ->
       handle_register_channel(state, pattern, handler, reply)

--- a/src/beryl/group.gleam
+++ b/src/beryl/group.gleam
@@ -151,7 +151,10 @@ pub fn broadcast(
 
 // ── Actor loop ──────────────────────────────────────────────────────────────
 
-fn handle_message(state: State, message: Message) -> actor.Next(State, Message) {
+fn handle_message(
+  state: State,
+  message: Message,
+) -> actor.Next(State, Message) {
   case message {
     Create(name, reply) -> {
       case dict.has_key(state.groups, name) {

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -81,7 +81,9 @@ pub type StartError {
 /// Child start order: coordinator -> presence (optional) -> groups (optional).
 ///
 /// The existing `beryl.start()` function is preserved for unsupervised use.
-pub fn start(config: SupervisedConfig) -> Result(SupervisedChannels, StartError) {
+pub fn start(
+  config: SupervisedConfig,
+) -> Result(SupervisedChannels, StartError) {
   // Validate heartbeat_timeout_ms before deriving check_interval
   case config.channels.heartbeat_timeout_ms <= 0 {
     True -> Error(InvalidHeartbeatTimeout)

--- a/test/heartbeat_test.gleam
+++ b/test/heartbeat_test.gleam
@@ -380,6 +380,9 @@ pub fn topic_cleanup_after_heartbeat_eviction_test() {
   socket_is_connected(coord, "socket-stale", sent_stale)
   |> should.be_false
 
+  let assert Ok(reason) = process.receive(terminate_reasons, 200)
+  reason |> should.equal(channel.HeartbeatTimeout)
+
   // Active socket still connected
   socket_is_connected(coord, "socket-active", sent_active)
   |> should.be_true

--- a/test/pubsub_test.gleam
+++ b/test/pubsub_test.gleam
@@ -7,7 +7,16 @@ import gleeunit
 import gleeunit/should
 
 @external(erlang, "beryl_ffi", "identity")
-fn coerce_to_pubsub_message(value: dynamic.Dynamic) -> pubsub.Message
+fn unsafe_coerce_to_pubsub_message(value: dynamic.Dynamic) -> pubsub.Message
+
+fn pubsub_message_selector() {
+  process.new_selector()
+  |> process.select_record(
+    atom.create("message"),
+    4,
+    unsafe_coerce_to_pubsub_message,
+  )
+}
 
 pub fn main() {
   gleeunit.main()
@@ -66,13 +75,7 @@ pub fn pubsub_broadcast_delivers_message_test() {
 
   pubsub.broadcast(ps, "room:lobby", "new_msg", json.string("hello"))
 
-  let selector =
-    process.new_selector()
-    |> process.select_record(
-      atom.create("message"),
-      4,
-      coerce_to_pubsub_message,
-    )
+  let selector = pubsub_message_selector()
 
   let assert Ok(message) = process.selector_receive(from: selector, within: 100)
   message.topic |> should.equal("room:lobby")
@@ -93,13 +96,7 @@ pub fn pubsub_broadcast_from_excludes_sender_test() {
   // Broadcast from self - should NOT receive it
   pubsub.broadcast_from(ps, process.self(), "room:lobby", "typing", json.null())
 
-  let selector =
-    process.new_selector()
-    |> process.select_record(
-      atom.create("message"),
-      4,
-      coerce_to_pubsub_message,
-    )
+  let selector = pubsub_message_selector()
 
   // Should time out since we excluded ourselves
   let result = process.selector_receive(from: selector, within: 50)

--- a/test/pubsub_test.gleam
+++ b/test/pubsub_test.gleam
@@ -1,9 +1,13 @@
 import beryl/pubsub
 import gleam/dynamic
+import gleam/erlang/atom
 import gleam/erlang/process
 import gleam/json
 import gleeunit
 import gleeunit/should
+
+@external(erlang, "beryl_ffi", "identity")
+fn coerce_to_pubsub_message(value: dynamic.Dynamic) -> pubsub.Message
 
 pub fn main() {
   gleeunit.main()
@@ -62,13 +66,19 @@ pub fn pubsub_broadcast_delivers_message_test() {
 
   pubsub.broadcast(ps, "room:lobby", "new_msg", json.string("hello"))
 
-  // Receive the message from our own mailbox using select_other for untyped messages
   let selector =
     process.new_selector()
-    |> process.select_other(fn(msg: dynamic.Dynamic) { msg })
+    |> process.select_record(
+      atom.create("message"),
+      4,
+      coerce_to_pubsub_message,
+    )
 
-  let result = process.selector_receive(from: selector, within: 100)
-  should.be_ok(result)
+  let assert Ok(message) = process.selector_receive(from: selector, within: 100)
+  message.topic |> should.equal("room:lobby")
+  message.event |> should.equal("new_msg")
+  message.payload |> should.equal(json.string("hello"))
+  message.from |> should.equal(pubsub.System)
 
   // Cleanup
   pubsub.unsubscribe(ps, "room:lobby")
@@ -83,11 +93,15 @@ pub fn pubsub_broadcast_from_excludes_sender_test() {
   // Broadcast from self - should NOT receive it
   pubsub.broadcast_from(ps, process.self(), "room:lobby", "typing", json.null())
 
-  // Should time out since we excluded ourselves
   let selector =
     process.new_selector()
-    |> process.select_other(fn(msg: dynamic.Dynamic) { msg })
+    |> process.select_record(
+      atom.create("message"),
+      4,
+      coerce_to_pubsub_message,
+    )
 
+  // Should time out since we excluded ourselves
   let result = process.selector_receive(from: selector, within: 50)
   should.be_error(result)
 

--- a/test/test_helpers.gleam
+++ b/test/test_helpers.gleam
@@ -18,7 +18,11 @@ import gleeunit/should
 /// // Wait until presence list has 2 entries (up to 2 seconds)
 /// wait_until(fn() { list.length(presence.list(p1, "room:lobby")) == 2 }, 2000, 20)
 /// ```
-pub fn wait_until(check: fn() -> Bool, timeout_ms: Int, interval_ms: Int) -> Nil {
+pub fn wait_until(
+  check: fn() -> Bool,
+  timeout_ms: Int,
+  interval_ms: Int,
+) -> Nil {
   case check() {
     True -> Nil
     False -> {

--- a/website/src/content/docs/installation.md
+++ b/website/src/content/docs/installation.md
@@ -16,7 +16,7 @@ This adds beryl to your `gleam.toml` dependencies. beryl targets the **Erlang (B
 
 ## Requirements
 
-- **Gleam** >= 1.1.0
+- **Gleam** >= 1.3.0
 - **Erlang/OTP** >= 26 (recommended: 27+)
 - **Target**: Erlang only
 


### PR DESCRIPTION
## Summary

- Bump the pinned Gleam and just toolchain versions
- Update the package minimum Gleam requirement
- Refresh stale developer and installation docs to match the new versions
- Refactor PubSub tests to share the BEAM record selector helper

## Validation

- `gleam test --target erlang`
- `just format-check`
- `just check`
