### PR TITLE
feat(channel): add handle_info callback

### DIFF
--- a/.changes/unreleased/Added-20260504-112043.yaml
+++ b/.changes/unreleased/Added-20260504-112043.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add channel handle_info support for OTP messages.\nChannels can now receive server-originated messages through with_handle_info and beryl.send_info, including push-style delivery for Reply and Push results.
+time: 2026-05-04T11:20:43.636204777-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -320,6 +320,27 @@ pub fn broadcast_from(
   }
 }
 
+/// Send a server-originated OTP message to a joined channel context.
+///
+/// The message is delivered to the channel's `handle_info` callback for the
+/// specific socket/topic pair. If the socket is not connected, the topic is not
+/// joined, or no handler matches the topic, the message is ignored.
+pub fn send_info(
+  channels: Channels,
+  socket_id: String,
+  topic_name: String,
+  message: a,
+) -> Nil {
+  process.send(
+    channels.coordinator,
+    coordinator.HandleInfo(
+      socket_id,
+      topic_name,
+      unsafe_coerce_to_dynamic(message),
+    ),
+  )
+}
+
 /// Push a message to a specific socket via its context
 ///
 /// Note: In the lean MVP, this uses the send function from SocketContext.
@@ -424,6 +445,12 @@ fn erase_channel_types(
       let typed_socket = create_socket_with_assigns(ctx)
 
       typed_channel.handle_binary(data, unsafe_coerce_socket(typed_socket))
+      |> erase_handle_result
+    },
+    handle_info: fn(message: Dynamic, ctx: coordinator.SocketContext) {
+      let typed_socket = create_socket_with_assigns(ctx)
+
+      typed_channel.handle_info(message, unsafe_coerce_socket(typed_socket))
       |> erase_handle_result
     },
     terminate: fn(reason: channel.StopReason, ctx: coordinator.SocketContext) {

--- a/src/beryl/channel.gleam
+++ b/src/beryl/channel.gleam
@@ -23,6 +23,7 @@
 //// ```
 
 import beryl/socket.{type Socket}
+import gleam/dynamic.{type Dynamic}
 import gleam/json.{type Json}
 import gleam/option.{type Option}
 
@@ -77,6 +78,8 @@ pub type Channel(assigns) {
     ///
     /// Binary frames bypass the Phoenix wire protocol and are passed as raw BitArray.
     handle_binary: fn(BitArray, Socket(assigns)) -> HandleResult(assigns),
+    /// Called when an OTP process sends a server-originated message to this channel
+    handle_info: fn(Dynamic, Socket(assigns)) -> HandleResult(assigns),
     /// Called when the client leaves or disconnects
     ///
     /// Use for cleanup (presence, database updates, etc.)
@@ -94,6 +97,7 @@ pub fn new(
     join: join,
     handle_in: fn(_, _, socket) { NoReply(socket) },
     handle_binary: fn(_, socket) { NoReply(socket) },
+    handle_info: fn(_, socket) { NoReply(socket) },
     terminate: fn(_, _) { Nil },
   )
 }
@@ -112,6 +116,17 @@ pub fn with_handle_binary(
   handler: fn(BitArray, Socket(assigns)) -> HandleResult(assigns),
 ) -> Channel(assigns) {
   Channel(..channel, handle_binary: handler)
+}
+
+/// Add a server-originated OTP message handler.
+///
+/// `Reply` results are sent as pushes because server-originated messages do not
+/// have a client message ref to reply to.
+pub fn with_handle_info(
+  channel: Channel(assigns),
+  handler: fn(Dynamic, Socket(assigns)) -> HandleResult(assigns),
+) -> Channel(assigns) {
+  Channel(..channel, handle_info: handler)
 }
 
 /// Add a terminate handler for cleanup

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -32,6 +32,7 @@ pub type ChannelHandler {
     join: fn(String, Dynamic, SocketContext) -> JoinResultErased,
     handle_in: fn(String, Dynamic, SocketContext) -> HandleResultErased,
     handle_binary: fn(BitArray, SocketContext) -> HandleResultErased,
+    handle_info: fn(Dynamic, SocketContext) -> HandleResultErased,
     terminate: fn(StopReason, SocketContext) -> Nil,
   )
 }
@@ -176,6 +177,7 @@ pub type Message {
     ref: Option(String),
   )
   HandleBinary(socket_id: String, data: BitArray)
+  HandleInfo(socket_id: String, topic: String, message: Dynamic)
   Heartbeat(socket_id: String, ref: String)
   // Broadcasting
   Broadcast(
@@ -304,6 +306,9 @@ fn handle_message(
       handle_in(state, socket_id, topic_name, event, payload, ref)
 
     HandleBinary(socket_id, data) -> handle_binary_in(state, socket_id, data)
+
+    HandleInfo(socket_id, topic_name, message) ->
+      handle_info(state, socket_id, topic_name, message)
 
     Heartbeat(socket_id, ref) -> handle_heartbeat(state, socket_id, ref)
 
@@ -639,6 +644,81 @@ fn handle_in_inner(
                     }
                     None -> Nil
                   }
+                  let state =
+                    update_assigns(state, socket_id, topic_name, new_assigns)
+                  actor.continue(state)
+                }
+
+                PushErased(push_event, push_payload, new_assigns) -> {
+                  let msg = wire.push(topic_name, push_event, push_payload)
+                  let _ = socket_info.send(msg)
+                  let state =
+                    update_assigns(state, socket_id, topic_name, new_assigns)
+                  actor.continue(state)
+                }
+
+                StopErased(reason) -> {
+                  let state =
+                    terminate_channel(state, socket_id, topic_name, reason)
+                  actor.continue(state)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+fn handle_info(
+  state: State,
+  socket_id: String,
+  topic_name: String,
+  message: Dynamic,
+) -> actor.Next(State, Message) {
+  handle_info_inner(state, socket_id, topic_name, message)
+}
+
+fn handle_info_inner(
+  state: State,
+  socket_id: String,
+  topic_name: String,
+  message: Dynamic,
+) -> actor.Next(State, Message) {
+  case dict.get(state.sockets, socket_id) {
+    Error(_) -> actor.continue(state)
+    Ok(socket_info) -> {
+      case set.contains(socket_info.subscribed_topics, topic_name) {
+        False -> actor.continue(state)
+        True -> {
+          case find_handler(state.handlers, topic_name) {
+            None -> actor.continue(state)
+            Some(handler) -> {
+              let assigns =
+                dict.get(socket_info.channel_assigns, topic_name)
+                |> result.unwrap(dynamic.nil())
+
+              let ctx =
+                SocketContext(
+                  socket_id: socket_id,
+                  topic: topic_name,
+                  assigns: assigns,
+                  send: socket_info.send,
+                  send_binary: socket_info.send_binary,
+                  handler_pid: socket_info.handler_pid,
+                )
+
+              case handler.handle_info(message, ctx) {
+                NoReplyErased(new_assigns) -> {
+                  let state =
+                    update_assigns(state, socket_id, topic_name, new_assigns)
+                  actor.continue(state)
+                }
+
+                ReplyErased(reply_event, reply_payload, new_assigns) -> {
+                  let msg = wire.push(topic_name, reply_event, reply_payload)
+                  let _ = socket_info.send(msg)
                   let state =
                     update_assigns(state, socket_id, topic_name, new_assigns)
                   actor.continue(state)

--- a/test/beryl_test.gleam
+++ b/test/beryl_test.gleam
@@ -1,7 +1,12 @@
 import beryl
+import beryl/channel
+import beryl/coordinator
 import beryl/socket
 import beryl/topic
 import beryl/wire
+import gleam/dynamic
+import gleam/dynamic/decode
+import gleam/erlang/process
 import gleam/json
 import gleam/option
 import gleam/string
@@ -106,6 +111,116 @@ pub fn default_config_test() {
 
   config.heartbeat_timeout_ms
   |> should.equal(60_000)
+}
+
+pub fn send_info_routes_message_to_joined_channel_test() {
+  let assert Ok(channels) = beryl.start(beryl.default_config())
+  let sent_messages = process.new_subject()
+
+  process.send(
+    channels.coordinator,
+    coordinator.SocketConnected(
+      "socket-info",
+      fn(text) {
+        process.send(sent_messages, text)
+        Ok(Nil)
+      },
+      fn(_) { Ok(Nil) },
+      dynamic.nil(),
+    ),
+  )
+
+  let handler =
+    channel.new(fn(_topic, _payload, socket) {
+      channel.JoinOk(reply: option.None, socket: socket)
+    })
+    |> channel.with_handle_info(fn(message, socket) {
+      case decode.run(message, decode.string) {
+        Ok("notify") ->
+          channel.Push(
+            "server_notify",
+            json.object([#("ok", json.bool(True))]),
+            socket,
+          )
+        _ -> channel.NoReply(socket)
+      }
+    })
+
+  beryl.register(channels, "room:*", handler)
+  |> should.equal(Ok(Nil))
+
+  process.send(
+    channels.coordinator,
+    coordinator.Join(
+      "socket-info",
+      "room:lobby",
+      dynamic.nil(),
+      option.None,
+      "join-ref",
+    ),
+  )
+
+  let assert Ok(join_reply) = process.receive(sent_messages, 500)
+  join_reply |> string.contains("phx_reply") |> should.be_true
+
+  beryl.send_info(channels, "socket-info", "room:lobby", "notify")
+
+  let assert Ok(push) = process.receive(sent_messages, 500)
+  push |> string.contains("server_notify") |> should.be_true
+  push |> string.contains("\"ok\":true") |> should.be_true
+}
+
+pub fn send_info_reply_result_pushes_message_to_client_test() {
+  let assert Ok(channels) = beryl.start(beryl.default_config())
+  let sent_messages = process.new_subject()
+
+  process.send(
+    channels.coordinator,
+    coordinator.SocketConnected(
+      "socket-info-reply",
+      fn(text) {
+        process.send(sent_messages, text)
+        Ok(Nil)
+      },
+      fn(_) { Ok(Nil) },
+      dynamic.nil(),
+    ),
+  )
+
+  let handler =
+    channel.new(fn(_topic, _payload, socket) {
+      channel.JoinOk(reply: option.None, socket: socket)
+    })
+    |> channel.with_handle_info(fn(_message, socket) {
+      channel.Reply(
+        "server_reply",
+        json.object([#("ok", json.bool(True))]),
+        socket,
+      )
+    })
+
+  beryl.register(channels, "room:*", handler)
+  |> should.equal(Ok(Nil))
+
+  process.send(
+    channels.coordinator,
+    coordinator.Join(
+      "socket-info-reply",
+      "room:lobby",
+      dynamic.nil(),
+      option.None,
+      "join-ref",
+    ),
+  )
+
+  let assert Ok(join_reply) = process.receive(sent_messages, 500)
+  join_reply |> string.contains("phx_reply") |> should.be_true
+
+  beryl.send_info(channels, "socket-info-reply", "room:lobby", "reply")
+
+  let assert Ok(push) = process.receive(sent_messages, 500)
+  push |> string.contains("server_reply") |> should.be_true
+  push |> string.contains("\"ok\":true") |> should.be_true
 }
 
 // Wire protocol tests

--- a/test/heartbeat_test.gleam
+++ b/test/heartbeat_test.gleam
@@ -302,6 +302,9 @@ fn register_handler_with_terminate(
       handle_binary: fn(_data, ctx) {
         coordinator.NoReplyErased(assigns: ctx.assigns)
       },
+      handle_info: fn(_message, ctx) {
+        coordinator.NoReplyErased(assigns: ctx.assigns)
+      },
       terminate: fn(reason, _ctx) { process.send(terminate_subject, reason) },
     )
 


### PR DESCRIPTION
## Summary

- Add `channel.with_handle_info/2` and a `handle_info` callback for server-originated OTP messages.
- Add `beryl.send_info/4` to deliver typed messages to a joined socket/topic channel context.
- Wire coordinator `HandleInfo` routing through the existing channel result handling semantics.
- Add changie entry and tests for `Push` and `Reply` results from `handle_info`.

Fixes #43

## Validation

- `gleam test --target erlang test/beryl_test.gleam`
- `just format-check && just check && just test && just build`

Note: `just ci` reached the examples E2E step and failed because Playwright browsers are not installed in the local environment.
