### PR TITLE
fix(channel): preserve broadcast_from exclusions over pubsub

### DIFF
--- a/.changes/unreleased/Fixed-20260504-113110.yaml
+++ b/.changes/unreleased/Fixed-20260504-113110.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: |-
+    Preserve broadcast_from socket exclusions across PubSub coordinators.
+
+    PubSub-enabled channel coordinators now subscribe to local topics and carry excluded socket metadata so clustered broadcasts do not echo back to the sender socket.
+time: 2026-05-04T11:31:10.753016394-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -207,7 +207,12 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
           channel_limiter: channel_limiter,
         )
 
-      case coordinator.start_with_config(coord_config) {
+      let coordinator_result = case config.pubsub {
+        Some(ps) -> coordinator.start_with_config_and_pubsub(coord_config, ps)
+        None -> coordinator.start_with_config(coord_config)
+      }
+
+      case coordinator_result {
         Error(_) -> Error(CoordinatorStartFailed)
         Ok(coord) ->
           Ok(Channels(coordinator: coord, config: config, pubsub: config.pubsub))
@@ -278,7 +283,11 @@ pub fn broadcast(
   )
   // Distributed broadcast via PubSub (if configured)
   case channels.pubsub {
-    Some(ps) -> pubsub.broadcast(ps, topic_name, event, payload)
+    Some(ps) -> {
+      let assert Ok(coordinator_pid) =
+        process.subject_owner(channels.coordinator)
+      pubsub.broadcast_from(ps, coordinator_pid, topic_name, event, payload)
+    }
     None -> Nil
   }
 }
@@ -286,6 +295,9 @@ pub fn broadcast(
 /// Broadcast a message to all subscribers except one socket
 ///
 /// Useful for broadcasting a message to everyone except the sender.
+/// When PubSub is configured, the excluded socket ID is preserved across
+/// coordinators so clustered deployments do not echo the event back to that
+/// socket on another node.
 ///
 /// ## Example
 ///
@@ -312,10 +324,19 @@ pub fn broadcast_from(
     coordinator.Broadcast(topic_name, event, payload, Some(except_socket_id)),
   )
   // Distributed broadcast via PubSub (if configured)
-  // Note: PubSub broadcast_from excludes by pid, not socket_id.
-  // For cross-node, we broadcast to all since the sender is on a different node.
   case channels.pubsub {
-    Some(ps) -> pubsub.broadcast(ps, topic_name, event, payload)
+    Some(ps) -> {
+      let assert Ok(coordinator_pid) =
+        process.subject_owner(channels.coordinator)
+      pubsub.broadcast_from_socket(
+        ps,
+        coordinator_pid,
+        except_socket_id,
+        topic_name,
+        event,
+        payload,
+      )
+    }
     None -> Nil
   }
 }

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -9,12 +9,14 @@
 
 import beryl/channel.{type StopReason}
 import beryl/internal
+import beryl/pubsub.{type PubSub}
 import beryl/rate_limit.{type RateLimiter}
 import beryl/topic.{type TopicPattern}
 import beryl/wire
 import birch/logger as log
 import gleam/dict.{type Dict}
 import gleam/dynamic.{type Dynamic}
+import gleam/erlang/atom
 import gleam/erlang/process.{type Subject}
 import gleam/int
 import gleam/json
@@ -119,6 +121,8 @@ pub type State {
     topics: Dict(String, Set(String)),
     /// Heartbeat timeout configuration
     config: CoordinatorConfig,
+    /// Optional PubSub for distributed broadcasts
+    pubsub: Option(PubSub),
     /// The coordinator's own subject, used for scheduling timers
     self_subject: Option(Subject(Message)),
   )
@@ -184,6 +188,7 @@ pub type Message {
     payload: json.Json,
     except: Option(String),
   )
+  RemoteBroadcast(pubsub.Message)
   // Heartbeat timeout enforcement
   CheckHeartbeats
 }
@@ -191,6 +196,10 @@ pub type Message {
 /// Erlang monotonic time in milliseconds
 @external(erlang, "beryl_ffi", "monotonic_time_ms")
 fn monotonic_time_ms() -> Int
+
+/// Coerce an external PubSub record message into the typed PubSub message.
+@external(erlang, "beryl_ffi", "identity")
+fn coerce_to_pubsub_message(value: Dynamic) -> pubsub.Message
 
 /// Start the coordinator actor without heartbeat enforcement
 pub fn start() -> Result(Subject(Message), StartError) {
@@ -204,7 +213,22 @@ pub fn start_with_config(
   case validate_config(config) {
     Error(e) -> Error(e)
     Ok(Nil) ->
-      build_coordinator(config)
+      build_coordinator(config, None)
+      |> actor.start
+      |> result.map(fn(started) { started.data })
+      |> result.map_error(ActorStartFailed)
+  }
+}
+
+/// Start the coordinator actor with heartbeat timeout enforcement and PubSub.
+pub fn start_with_config_and_pubsub(
+  config: CoordinatorConfig,
+  ps: PubSub,
+) -> Result(Subject(Message), StartError) {
+  case validate_config(config) {
+    Error(e) -> Error(e)
+    Ok(Nil) ->
+      build_coordinator(config, Some(ps))
       |> actor.start
       |> result.map(fn(started) { started.data })
       |> result.map_error(ActorStartFailed)
@@ -219,7 +243,23 @@ pub fn start_named(
   case validate_config(config) {
     Error(e) -> Error(e)
     Ok(Nil) ->
-      build_coordinator(config)
+      build_coordinator(config, None)
+      |> actor.named(name)
+      |> actor.start
+      |> result.map_error(ActorStartFailed)
+  }
+}
+
+/// Start a named coordinator actor with PubSub.
+pub fn start_named_with_pubsub(
+  config: CoordinatorConfig,
+  ps: PubSub,
+  name: process.Name(Message),
+) -> Result(actor.Started(Subject(Message)), StartError) {
+  case validate_config(config) {
+    Error(e) -> Error(e)
+    Ok(Nil) ->
+      build_coordinator(config, Some(ps))
       |> actor.named(name)
       |> actor.start
       |> result.map_error(ActorStartFailed)
@@ -237,6 +277,7 @@ fn validate_config(config: CoordinatorConfig) -> Result(Nil, StartError) {
 
 fn build_coordinator(
   config: CoordinatorConfig,
+  ps: Option(PubSub),
 ) -> actor.Builder(State, Message, Subject(Message)) {
   let initial_state =
     State(
@@ -244,6 +285,7 @@ fn build_coordinator(
       sockets: dict.new(),
       topics: dict.new(),
       config: config,
+      pubsub: ps,
       self_subject: None,
     )
 
@@ -253,9 +295,27 @@ fn build_coordinator(
     // Schedule the first heartbeat check if configured
     schedule_heartbeat_check(subject, config)
 
-    actor.initialised(state)
-    |> actor.returning(subject)
-    |> Ok
+    let initialised = actor.initialised(state) |> actor.returning(subject)
+
+    case ps {
+      Some(_) -> {
+        let selector =
+          process.new_selector()
+          |> process.select(subject)
+          |> process.select_record(
+            atom.create("message"),
+            4,
+            fn(raw: Dynamic) -> Message {
+              RemoteBroadcast(coerce_to_pubsub_message(raw))
+            },
+          )
+
+        initialised
+        |> actor.selecting(selector)
+        |> Ok
+      }
+      None -> Ok(initialised)
+    }
   })
   |> actor.on_message(handle_message)
 }
@@ -309,6 +369,8 @@ fn handle_message(
 
     Broadcast(topic_name, event, payload, except) ->
       handle_broadcast(state, topic_name, event, payload, except)
+
+    RemoteBroadcast(pubsub_msg) -> handle_remote_broadcast(state, pubsub_msg)
 
     CheckHeartbeats -> handle_check_heartbeats(state)
   }
@@ -484,10 +546,17 @@ fn handle_join_inner(
                   channel_assigns: new_assigns,
                 )
 
-              let topic_subscribers =
+              let existing_topic_subscribers =
                 dict.get(state.topics, topic_name)
                 |> result.unwrap(set.new())
+              let topic_subscribers =
+                existing_topic_subscribers
                 |> set.insert(socket_id)
+
+              case state.pubsub, set.is_empty(existing_topic_subscribers) {
+                Some(ps), True -> pubsub.subscribe(ps, topic_name)
+                _, _ -> Nil
+              }
 
               let new_topics =
                 dict.insert(state.topics, topic_name, topic_subscribers)
@@ -853,6 +922,24 @@ fn handle_broadcast(
   actor.continue(state)
 }
 
+fn handle_remote_broadcast(
+  state: State,
+  pubsub_msg: pubsub.Message,
+) -> actor.Next(State, Message) {
+  let except = case pubsub_msg.from {
+    pubsub.FromSocket(_, socket_id) -> Some(socket_id)
+    pubsub.System | pubsub.FromPid(_) -> None
+  }
+
+  handle_broadcast(
+    state,
+    pubsub_msg.topic,
+    pubsub_msg.event,
+    pubsub_msg.payload,
+    except,
+  )
+}
+
 /// Find the first handler that matches the topic
 fn find_handler(
   handlers: List(ChannelHandler),
@@ -909,8 +996,16 @@ fn terminate_channel(
             dict.get(state.topics, topic_name)
             |> result.unwrap(set.new())
             |> set.delete(socket_id)
-          let new_topics =
-            dict.insert(state.topics, topic_name, topic_subscribers)
+          let new_topics = case set.is_empty(topic_subscribers) {
+            True -> {
+              case state.pubsub {
+                Some(ps) -> pubsub.unsubscribe(ps, topic_name)
+                None -> Nil
+              }
+              dict.delete(state.topics, topic_name)
+            }
+            False -> dict.insert(state.topics, topic_name, topic_subscribers)
+          }
 
           let new_sockets =
             dict.insert(state.sockets, socket_id, new_socket_info)

--- a/src/beryl/pubsub.gleam
+++ b/src/beryl/pubsub.gleam
@@ -28,6 +28,8 @@ pub type PubSubFrom {
   System
   /// Broadcast originated from a specific process
   FromPid(Pid)
+  /// Broadcast originated from a process and should exclude a socket ID
+  FromSocket(Pid, String)
 }
 
 /// PubSub configuration
@@ -133,6 +135,32 @@ pub fn broadcast_from(
 ) -> Nil {
   let msg =
     Message(topic: topic, event: event, payload: payload, from: FromPid(from))
+  let members = ffi_get_members(ps.scope, topic)
+  list.each(members, fn(pid) {
+    case pid == from {
+      True -> Nil
+      False -> ffi_send_to_pid(pid, msg)
+    }
+  })
+}
+
+/// Broadcast a message to all subscribers except a process, preserving a socket
+/// ID that receiving channel coordinators should exclude locally.
+pub fn broadcast_from_socket(
+  ps: PubSub,
+  from: Pid,
+  except_socket_id: String,
+  topic: String,
+  event: String,
+  payload: json.Json,
+) -> Nil {
+  let msg =
+    Message(
+      topic: topic,
+      event: event,
+      payload: payload,
+      from: FromSocket(from, except_socket_id),
+    )
   let members = ffi_get_members(ps.scope, topic)
   list.each(members, fn(pid) {
     case pid == from {

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -150,7 +150,17 @@ fn start_supervised(
     builder
     |> static_supervisor.add(
       supervision.worker(fn() {
-        coordinator.start_named(coord_config, coordinator_name)
+        let started = case config.channels.pubsub {
+          Some(ps) ->
+            coordinator.start_named_with_pubsub(
+              coord_config,
+              ps,
+              coordinator_name,
+            )
+          None -> coordinator.start_named(coord_config, coordinator_name)
+        }
+
+        started
         |> result.map_error(fn(err) {
           case err {
             coordinator.ActorStartFailed(e) -> e

--- a/test/broadcast_test.gleam
+++ b/test/broadcast_test.gleam
@@ -1,0 +1,148 @@
+import beryl
+import beryl/coordinator
+import beryl/pubsub
+import beryl/topic
+import gleam/dynamic
+import gleam/erlang/process
+import gleam/json
+import gleam/option.{None}
+import gleam/string
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+fn register_test_channel(channels: beryl.Channels) -> Nil {
+  let handler =
+    coordinator.ChannelHandler(
+      pattern: topic.parse_pattern("room:*"),
+      join: fn(_topic, _payload, _ctx) {
+        coordinator.JoinOkErased(reply: None, assigns: dynamic.nil())
+      },
+      handle_in: fn(_event, _payload, ctx) {
+        coordinator.NoReplyErased(assigns: ctx.assigns)
+      },
+      handle_binary: fn(_data, ctx) {
+        coordinator.NoReplyErased(assigns: ctx.assigns)
+      },
+      terminate: fn(_reason, _ctx) { Nil },
+    )
+
+  let reply = process.new_subject()
+  process.send(
+    channels.coordinator,
+    coordinator.RegisterChannel("room:*", handler, reply),
+  )
+  let assert Ok(Ok(Nil)) = process.receive(reply, 500)
+  Nil
+}
+
+fn connect_socket(
+  channels: beryl.Channels,
+  socket_id: String,
+) -> process.Subject(String) {
+  let sent = process.new_subject()
+  let send = fn(message: String) -> Result(Nil, Nil) {
+    process.send(sent, message)
+    Ok(Nil)
+  }
+
+  process.send(
+    channels.coordinator,
+    coordinator.SocketConnected(
+      socket_id,
+      send,
+      fn(_) { Ok(Nil) },
+      dynamic.nil(),
+    ),
+  )
+  process.sleep(10)
+  sent
+}
+
+fn join_topic(
+  channels: beryl.Channels,
+  socket_id: String,
+  topic_name: String,
+  sent: process.Subject(String),
+) -> Nil {
+  process.send(
+    channels.coordinator,
+    coordinator.Join(socket_id, topic_name, dynamic.nil(), None, "join-ref"),
+  )
+
+  let assert Ok(reply) = process.receive(sent, 500)
+  reply
+  |> string.contains("phx_reply")
+  |> should.be_true
+}
+
+fn drain(subject: process.Subject(String)) -> Nil {
+  case process.receive(subject, 0) {
+    Ok(_) -> drain(subject)
+    Error(_) -> Nil
+  }
+}
+
+pub fn broadcast_from_local_only_excludes_socket_test() {
+  let assert Ok(channels) = beryl.start(beryl.default_config())
+  register_test_channel(channels)
+
+  let sender = connect_socket(channels, "sender-socket")
+  let other = connect_socket(channels, "other-socket")
+  join_topic(channels, "sender-socket", "room:lobby", sender)
+  join_topic(channels, "other-socket", "room:lobby", other)
+  drain(sender)
+  drain(other)
+
+  beryl.broadcast_from(
+    channels,
+    "sender-socket",
+    "room:lobby",
+    "typing",
+    json.object([#("user", json.string("alice"))]),
+  )
+
+  let assert Ok(message) = process.receive(other, 500)
+  message
+  |> string.contains("typing")
+  |> should.be_true
+
+  process.receive(sender, 100)
+  |> should.be_error
+}
+
+pub fn broadcast_from_with_pubsub_excludes_socket_on_remote_coordinator_test() {
+  let assert Ok(ps) =
+    pubsub.start(pubsub.config_with_scope("test_broadcast_from_pubsub"))
+  let config = beryl.default_config() |> beryl.with_pubsub(ps)
+  let assert Ok(origin_channels) = beryl.start(config)
+  let assert Ok(remote_channels) = beryl.start(config)
+  register_test_channel(origin_channels)
+  register_test_channel(remote_channels)
+
+  let remote_sender = connect_socket(remote_channels, "sender-socket")
+  let remote_other = connect_socket(remote_channels, "other-socket")
+  join_topic(remote_channels, "sender-socket", "room:lobby", remote_sender)
+  join_topic(remote_channels, "other-socket", "room:lobby", remote_other)
+  drain(remote_sender)
+  drain(remote_other)
+
+  beryl.broadcast_from(
+    origin_channels,
+    "sender-socket",
+    "room:lobby",
+    "typing",
+    json.object([#("user", json.string("alice"))]),
+  )
+
+  let assert Ok(message) = process.receive(remote_other, 500)
+  message
+  |> string.contains("typing")
+  |> should.be_true
+
+  process.receive(remote_sender, 100)
+  |> should.be_error
+}

--- a/test/broadcast_test.gleam
+++ b/test/broadcast_test.gleam
@@ -27,6 +27,9 @@ fn register_test_channel(channels: beryl.Channels) -> Nil {
       handle_binary: fn(_data, ctx) {
         coordinator.NoReplyErased(assigns: ctx.assigns)
       },
+      handle_info: fn(_message, ctx) {
+        coordinator.NoReplyErased(assigns: ctx.assigns)
+      },
       terminate: fn(_reason, _ctx) { Nil },
     )
 


### PR DESCRIPTION
## Summary

- Preserve `broadcast_from/5` socket exclusions across PubSub-enabled coordinators
- Subscribe PubSub-enabled coordinators to channel topics when local sockets join
- Add regression coverage for local-only and PubSub-enabled `broadcast_from` behavior
- Add a changie entry for the fix

Fixes #45.

## Validation

- `gleam test test/broadcast_test.gleam`
- `gleam format src test`
- `just check`
- `just test`
- `just ci`
