### PR TITLE
feat(presence): add presence_diff broadcast api

### DIFF
--- a/.changes/unreleased/Added-20260504-114657.yaml
+++ b/.changes/unreleased/Added-20260504-114657.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: |-
+    Add Phoenix-compatible presence_diff broadcasting.
+
+    Adds a presence diff encoder and channel broadcast helper so applications can send Phoenix-shaped joins/leaves payloads to subscribed sockets locally or through PubSub. Local presence track and untrack operations now also invoke on_diff with concrete diffs.
+time: 2026-05-04T11:46:57.387265609-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -51,6 +51,8 @@
 
 import beryl/channel.{type Channel}
 import beryl/coordinator
+import beryl/presence/state.{type Diff}
+import beryl/presence/wire as presence_wire
 import beryl/pubsub.{type PubSub}
 import beryl/rate_limit
 import beryl/socket.{type Socket}
@@ -290,6 +292,32 @@ pub fn broadcast(
     }
     None -> Nil
   }
+}
+
+/// Broadcast a Phoenix-compatible `presence_diff` event for a topic.
+///
+/// This encodes the topic's joins and leaves as:
+///
+/// ```json
+/// {
+///   "joins": { "user:1": { "metas": [{ "status": "online" }] } },
+///   "leaves": { "user:2": { "metas": [{ "status": "offline" }] } }
+/// }
+/// ```
+///
+/// When the channels system was started with PubSub, the broadcast is
+/// distributed using the same semantics as `broadcast`.
+pub fn broadcast_presence_diff(
+  channels: Channels,
+  topic_name: String,
+  diff: Diff,
+) -> Nil {
+  broadcast(
+    channels,
+    topic_name,
+    "presence_diff",
+    presence_wire.encode_diff(diff, topic_name),
+  )
 }
 
 /// Broadcast a message to all subscribers except one socket

--- a/src/beryl/presence.gleam
+++ b/src/beryl/presence.gleam
@@ -22,7 +22,7 @@
 //// ```
 
 import beryl/internal
-import beryl/presence/state.{type Diff, type State}
+import beryl/presence/state.{type Diff, type State, Diff}
 import beryl/presence/state_json
 import beryl/pubsub.{type PubSub}
 import birch/logger as log
@@ -270,6 +270,10 @@ fn handle_message(
   case message {
     Track(topic, key, pid, meta, reply) -> {
       let new_crdt = state.join(actor_state.crdt, pid, topic, key, meta)
+      maybe_invoke_on_diff(
+        actor_state.config,
+        single_join_diff(topic, key, pid, meta),
+      )
       logger
       |> log.debug("Presence tracked", [
         #("topic", topic),
@@ -281,7 +285,9 @@ fn handle_message(
     }
 
     Untrack(topic, key, pid, reply) -> {
+      let diff = leave_diff(actor_state.crdt, topic, key, pid)
       let new_crdt = state.leave(actor_state.crdt, pid, topic, key)
+      maybe_invoke_on_diff(actor_state.config, diff)
       logger
       |> log.debug("Presence untracked", [
         #("topic", topic),
@@ -293,7 +299,9 @@ fn handle_message(
     }
 
     UntrackAll(pid, reply) -> {
+      let diff = leave_all_diff(actor_state.crdt, pid)
       let new_crdt = state.leave_by_pid(actor_state.crdt, pid)
+      maybe_invoke_on_diff(actor_state.config, diff)
       process.send(reply, Nil)
       actor.continue(ActorState(..actor_state, crdt: new_crdt))
     }
@@ -360,6 +368,52 @@ fn handle_message(
         }
       }
     }
+  }
+}
+
+fn single_join_diff(
+  topic: String,
+  key: String,
+  pid: String,
+  meta: json.Json,
+) -> Diff {
+  Diff(
+    joins: dict.from_list([#(topic, [#(key, pid, meta)])]),
+    leaves: dict.new(),
+  )
+}
+
+fn leave_diff(crdt: State, topic: String, key: String, pid: String) -> Diff {
+  let leaves =
+    state.get_by_key(crdt, topic, key)
+    |> list.filter(fn(entry) { entry.0 == pid })
+    |> list.map(fn(entry) { #(key, entry.0, entry.1) })
+
+  Diff(joins: dict.new(), leaves: topic_entries(topic, leaves))
+}
+
+fn leave_all_diff(crdt: State, pid: String) -> Diff {
+  let leaves =
+    state.online_list(crdt)
+    |> list.filter(fn(entry) { entry.0 == pid })
+    |> list.fold(dict.new(), fn(grouped, entry) {
+      let #(_, topic, key, meta) = entry
+      let existing =
+        dict.get(grouped, topic)
+        |> result.unwrap([])
+      dict.insert(grouped, topic, [#(key, pid, meta), ..existing])
+    })
+
+  Diff(joins: dict.new(), leaves: leaves)
+}
+
+fn topic_entries(
+  topic: String,
+  entries: List(#(String, String, json.Json)),
+) -> dict.Dict(String, List(#(String, String, json.Json))) {
+  case entries {
+    [] -> dict.new()
+    _ -> dict.from_list([#(topic, entries)])
   }
 }
 

--- a/src/beryl/presence/wire.gleam
+++ b/src/beryl/presence/wire.gleam
@@ -1,0 +1,61 @@
+//// Phoenix-compatible wire encoding for presence diffs.
+
+import beryl/presence/state.{type Diff}
+import gleam/dict.{type Dict}
+import gleam/json
+import gleam/list
+import gleam/result
+
+/// Encode a presence diff for one topic as a Phoenix-compatible payload.
+///
+/// The resulting JSON has `joins` and `leaves` maps keyed by presence key,
+/// where each value contains the tracked metadata under `metas`.
+///
+/// ```json
+/// {
+///   "joins": { "user:1": { "metas": [{ "status": "online" }] } },
+///   "leaves": { "user:2": { "metas": [{ "status": "offline" }] } }
+/// }
+/// ```
+pub fn encode_diff(diff: Diff, topic: String) -> json.Json {
+  json.object([
+    #("joins", encode_topic_entries(diff.joins, topic)),
+    #("leaves", encode_topic_entries(diff.leaves, topic)),
+  ])
+}
+
+fn encode_topic_entries(
+  entries_by_topic: Dict(String, List(#(String, String, json.Json))),
+  topic: String,
+) -> json.Json {
+  case dict.get(entries_by_topic, topic) {
+    Error(_) -> json.object([])
+    Ok(entries) -> {
+      entries
+      |> group_metas_by_key
+      |> dict.to_list
+      |> list.map(fn(entry) {
+        let #(key, metas) = entry
+        #(
+          key,
+          json.object([
+            #("metas", json.preprocessed_array(list.reverse(metas))),
+          ]),
+        )
+      })
+      |> json.object
+    }
+  }
+}
+
+fn group_metas_by_key(
+  entries: List(#(String, String, json.Json)),
+) -> Dict(String, List(json.Json)) {
+  list.fold(entries, dict.new(), fn(grouped, entry) {
+    let #(key, _pid, meta) = entry
+    let existing =
+      dict.get(grouped, key)
+      |> result.unwrap([])
+    dict.insert(grouped, key, [meta, ..existing])
+  })
+}

--- a/test/broadcast_test.gleam
+++ b/test/broadcast_test.gleam
@@ -1,11 +1,14 @@
 import beryl
 import beryl/coordinator
+import beryl/presence
+import beryl/presence/state
 import beryl/pubsub
 import beryl/topic
+import gleam/dict
 import gleam/dynamic
 import gleam/erlang/process
 import gleam/json
-import gleam/option.{None}
+import gleam/option.{None, Some}
 import gleam/string
 import gleeunit
 import gleeunit/should
@@ -89,6 +92,21 @@ fn drain(subject: process.Subject(String)) -> Nil {
   }
 }
 
+fn presence_diff() -> state.Diff {
+  state.Diff(
+    joins: dict.from_list([
+      #("room:lobby", [
+        #(
+          "user:1",
+          "socket-1",
+          json.object([#("status", json.string("online"))]),
+        ),
+      ]),
+    ]),
+    leaves: dict.new(),
+  )
+}
+
 pub fn broadcast_from_local_only_excludes_socket_test() {
   let assert Ok(channels) = beryl.start(beryl.default_config())
   register_test_channel(channels)
@@ -148,4 +166,93 @@ pub fn broadcast_from_with_pubsub_excludes_socket_on_remote_coordinator_test() {
 
   process.receive(remote_sender, 100)
   |> should.be_error
+}
+
+pub fn broadcast_presence_diff_local_delivers_phoenix_event_test() {
+  let assert Ok(channels) = beryl.start(beryl.default_config())
+  register_test_channel(channels)
+
+  let socket = connect_socket(channels, "socket-1")
+  join_topic(channels, "socket-1", "room:lobby", socket)
+  drain(socket)
+
+  beryl.broadcast_presence_diff(channels, "room:lobby", presence_diff())
+
+  let assert Ok(message) = process.receive(socket, 500)
+  message
+  |> string.contains("presence_diff")
+  |> should.be_true
+  message
+  |> string.contains("user:1")
+  |> should.be_true
+  message
+  |> string.contains("metas")
+  |> should.be_true
+}
+
+pub fn presence_track_can_broadcast_presence_diff_to_joined_socket_test() {
+  let assert Ok(channels) = beryl.start(beryl.default_config())
+  register_test_channel(channels)
+
+  let socket = connect_socket(channels, "socket-1")
+  join_topic(channels, "socket-1", "room:lobby", socket)
+  drain(socket)
+
+  let presence_config =
+    presence.Config(
+      pubsub: None,
+      replica: "node1",
+      broadcast_interval_ms: 0,
+      on_diff: Some(fn(diff) {
+        beryl.broadcast_presence_diff(channels, "room:lobby", diff)
+      }),
+    )
+  let assert Ok(p) = presence.start(presence_config)
+
+  let _ =
+    presence.track(
+      p,
+      "room:lobby",
+      "user:1",
+      "socket-1",
+      json.object([#("status", json.string("online"))]),
+    )
+
+  let assert Ok(message) = process.receive(socket, 500)
+  message
+  |> string.contains("presence_diff")
+  |> should.be_true
+  message
+  |> string.contains("user:1")
+  |> should.be_true
+  message
+  |> string.contains("metas")
+  |> should.be_true
+}
+
+pub fn broadcast_presence_diff_with_pubsub_delivers_to_remote_coordinator_test() {
+  let assert Ok(ps) =
+    pubsub.start(pubsub.config_with_scope("test_presence_diff_pubsub"))
+  let config = beryl.default_config() |> beryl.with_pubsub(ps)
+  let assert Ok(origin_channels) = beryl.start(config)
+  let assert Ok(remote_channels) = beryl.start(config)
+  register_test_channel(origin_channels)
+  register_test_channel(remote_channels)
+
+  let remote_socket = connect_socket(remote_channels, "socket-1")
+  join_topic(remote_channels, "socket-1", "room:lobby", remote_socket)
+  drain(remote_socket)
+
+  beryl.broadcast_presence_diff(origin_channels, "room:lobby", presence_diff())
+
+  let assert Ok(message) = process.receive(remote_socket, 500)
+  message
+  |> string.contains("presence_diff")
+  |> should.be_true
+  message
+  |> string.contains("user:1")
+  |> should.be_true
+  message
+  |> string.contains("metas")
+  |> should.be_true
 }

--- a/test/presence_test.gleam
+++ b/test/presence_test.gleam
@@ -175,6 +175,70 @@ pub fn on_diff_callback_receives_merge_diff_test() {
   dict.is_empty(diff.leaves) |> should.be_true
 }
 
+pub fn on_diff_callback_receives_local_track_diff_test() {
+  let diff_subject = process.new_subject()
+
+  let config =
+    presence.Config(
+      pubsub: None,
+      replica: "node1",
+      broadcast_interval_ms: 0,
+      on_diff: Some(fn(diff) { process.send(diff_subject, diff) }),
+    )
+
+  let assert Ok(p) = presence.start(config)
+
+  let _ =
+    presence.track(
+      p,
+      "room:lobby",
+      "user:1",
+      "socket-1",
+      json.object([#("status", json.string("online"))]),
+    )
+
+  let assert Ok(diff) = process.receive(diff_subject, 1000)
+  let assert Ok(joins) = dict.get(diff.joins, "room:lobby")
+  joins
+  |> should.equal([
+    #("user:1", "socket-1", json.object([#("status", json.string("online"))])),
+  ])
+  dict.is_empty(diff.leaves) |> should.be_true
+}
+
+pub fn on_diff_callback_receives_local_untrack_diff_test() {
+  let diff_subject = process.new_subject()
+
+  let config =
+    presence.Config(
+      pubsub: None,
+      replica: "node1",
+      broadcast_interval_ms: 0,
+      on_diff: Some(fn(diff) { process.send(diff_subject, diff) }),
+    )
+
+  let assert Ok(p) = presence.start(config)
+  let _ =
+    presence.track(
+      p,
+      "room:lobby",
+      "user:1",
+      "socket-1",
+      json.object([#("status", json.string("online"))]),
+    )
+  let assert Ok(_) = process.receive(diff_subject, 1000)
+
+  presence.untrack(p, "room:lobby", "user:1", "socket-1")
+
+  let assert Ok(diff) = process.receive(diff_subject, 1000)
+  dict.is_empty(diff.joins) |> should.be_true
+  let assert Ok(leaves) = dict.get(diff.leaves, "room:lobby")
+  leaves
+  |> should.equal([
+    #("user:1", "socket-1", json.object([#("status", json.string("online"))])),
+  ])
+}
+
 pub fn on_diff_callback_not_called_for_empty_diff_test() {
   let diff_subject = process.new_subject()
 

--- a/test/presence_wire_test.gleam
+++ b/test/presence_wire_test.gleam
@@ -1,0 +1,119 @@
+import beryl/presence/state
+import beryl/presence/wire as presence_wire
+import gleam/dict
+import gleam/dynamic/decode
+import gleam/json
+import gleam/list
+import gleam/string
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+fn sample_diff() -> state.Diff {
+  state.Diff(
+    joins: dict.from_list([
+      #("room:lobby", [
+        #(
+          "user:1",
+          "socket-1",
+          json.object([#("status", json.string("online"))]),
+        ),
+        #("user:1", "socket-2", json.object([#("status", json.string("away"))])),
+        #(
+          "user:2",
+          "socket-3",
+          json.object([#("device", json.string("mobile"))]),
+        ),
+      ]),
+    ]),
+    leaves: dict.from_list([
+      #("room:lobby", [
+        #(
+          "user:3",
+          "socket-4",
+          json.object([#("status", json.string("offline"))]),
+        ),
+      ]),
+      #("room:other", [
+        #(
+          "ignored",
+          "socket-5",
+          json.object([#("status", json.string("away"))]),
+        ),
+      ]),
+    ]),
+  )
+}
+
+pub fn encode_diff_groups_metas_by_presence_key_for_topic_test() {
+  let payload = presence_wire.encode_diff(sample_diff(), "room:lobby")
+  let encoded = json.to_string(payload)
+
+  let user1_metas_decoder = {
+    use user1_metas <- decode.field("joins", {
+      use user1_metas <- decode.field("user:1", {
+        use user1_metas <- decode.field(
+          "metas",
+          decode.list({
+            use status <- decode.field("status", decode.string)
+            decode.success(status)
+          }),
+        )
+        decode.success(user1_metas)
+      })
+      decode.success(user1_metas)
+    })
+    decode.success(user1_metas)
+  }
+  let assert Ok(user1_metas) = json.parse(encoded, user1_metas_decoder)
+  user1_metas |> list.length |> should.equal(2)
+
+  let user2_metas_decoder = {
+    use user2_metas <- decode.field("joins", {
+      use user2_metas <- decode.field("user:2", {
+        use user2_metas <- decode.field(
+          "metas",
+          decode.list({
+            use device <- decode.field("device", decode.string)
+            decode.success(device)
+          }),
+        )
+        decode.success(user2_metas)
+      })
+      decode.success(user2_metas)
+    })
+    decode.success(user2_metas)
+  }
+  let assert Ok(user2_metas) = json.parse(encoded, user2_metas_decoder)
+  user2_metas |> should.equal(["mobile"])
+
+  let user3_metas_decoder = {
+    use user3_metas <- decode.field("leaves", {
+      use user3_metas <- decode.field("user:3", {
+        use user3_metas <- decode.field(
+          "metas",
+          decode.list({
+            use status <- decode.field("status", decode.string)
+            decode.success(status)
+          }),
+        )
+        decode.success(user3_metas)
+      })
+      decode.success(user3_metas)
+    })
+    decode.success(user3_metas)
+  }
+  let assert Ok(user3_metas) = json.parse(encoded, user3_metas_decoder)
+  user3_metas |> should.equal(["offline"])
+}
+
+pub fn encode_diff_omits_other_topics_test() {
+  let payload = presence_wire.encode_diff(sample_diff(), "room:lobby")
+
+  json.to_string(payload)
+  |> string.contains("ignored")
+  |> should.be_false
+}

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -95,7 +95,35 @@ let config = presence.Config(
 )
 ```
 
-The `on_diff` callback fires whenever a merge produces non-empty changes, ensuring no diffs are lost during rapid state changes.
+The `on_diff` callback fires whenever local tracking changes or remote merges produce non-empty changes, ensuring no diffs are lost during rapid state changes.
+
+## Broadcasting Phoenix-compatible diffs
+
+Use `beryl.broadcast_presence_diff` to send a `presence_diff` event to sockets subscribed to the changed topic:
+
+```gleam
+import beryl
+
+let config = presence.Config(
+  pubsub: option.Some(ps),
+  replica: "node1",
+  broadcast_interval_ms: 1500,
+  on_diff: option.Some(fn(diff) {
+    beryl.broadcast_presence_diff(channels, "room:lobby", diff)
+  }),
+)
+```
+
+The payload matches Phoenix Presence's shape, with joins and leaves grouped by presence key:
+
+```json
+{
+  "joins": { "user:alice": { "metas": [{ "status": "online" }] } },
+  "leaves": { "user:bob": { "metas": [{ "status": "offline" }] } }
+}
+```
+
+For lower-level integrations, `beryl/presence/wire.encode_diff(diff, topic)` returns the encoded JSON payload without broadcasting it. If channels are configured with PubSub, `broadcast_presence_diff` uses the same distributed delivery behavior as `beryl.broadcast`.
 
 ## Cross-node replication
 


### PR DESCRIPTION
## Summary
- Add Phoenix-compatible presence diff encoding via `beryl/presence/wire.encode_diff`
- Add `beryl.broadcast_presence_diff` for local and PubSub-backed channel delivery
- Emit `on_diff` callbacks for local track/untrack operations so presence changes can be bridged directly to channel broadcasts
- Document the payload shape and add a changie entry

## Validation
- `just ci`

Closes #46