### PR TITLE
feat(topic): add segment-aware wildcards

### DIFF
--- a/.changes/unreleased/Added-20260505-202007.yaml
+++ b/.changes/unreleased/Added-20260505-202007.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add segment-aware topic wildcard matching and wildcard segment extraction helpers.
+time: 2026-05-05T20:20:07.435635806-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -225,8 +225,9 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
 
 /// Register a channel handler for a topic pattern
 ///
-/// Patterns can be exact matches like "room:lobby" or wildcards like "room:*"
-/// which matches any topic starting with "room:".
+/// Patterns can be exact matches like "room:lobby", legacy prefix wildcards
+/// like "room:*" which match any topic starting with "room:", or segment
+/// wildcards like "document:*:ops" where "*" matches one complete segment.
 ///
 /// ## Example
 ///
@@ -241,8 +242,14 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
 ///   channel.NoReply(socket)
 /// })
 ///
-/// // Register it
+/// // Register it with a legacy prefix wildcard
 /// beryl.register(channels, "chat:*", chat_channel)
+///
+/// // Exact topic
+/// beryl.register(channels, "room:lobby", lobby_channel)
+///
+/// // Segment-aware wildcard
+/// beryl.register(channels, "document:*:ops", ops_channel)
 /// ```
 pub fn register(
   channels: Channels,
@@ -415,7 +422,9 @@ pub fn push_to_socket(
 
 /// Get the topic ID from a topic using wildcard extraction
 ///
-/// For pattern "room:*" and topic "room:lobby", returns Ok("lobby")
+/// For pattern "room:*" and topic "room:lobby", returns Ok("lobby").
+/// For segment wildcard patterns with one wildcard segment, returns that
+/// segment. Use `topic.extract_wildcards` when extracting multiple segments.
 ///
 /// ## Example
 ///

--- a/src/beryl/topic.gleam
+++ b/src/beryl/topic.gleam
@@ -1,7 +1,9 @@
 //// Topic - Pattern matching for channel routing
 ////
 //// Topics are string identifiers that clients join (e.g., "room:lobby").
-//// Patterns define how topics are routed to channel handlers.
+//// Patterns define how topics are routed to channel handlers. Patterns can be
+//// exact, legacy trailing prefix wildcards, or segment-aware wildcards where
+//// "*" occupies a complete colon-delimited segment.
 
 import gleam/list
 import gleam/string
@@ -12,6 +14,9 @@ pub type TopicPattern {
   Exact(String)
   /// Wildcard suffix: "room:*" matches "room:lobby", "room:123", etc.
   Wildcard(prefix: String)
+  /// Segment wildcard: "document:*:ops" matches the same number of ":"
+  /// segments where "*" occupies one complete segment.
+  SegmentWildcard(segments: List(String))
 }
 
 /// Parse a pattern string into TopicPattern
@@ -21,15 +26,21 @@ pub type TopicPattern {
 /// ```gleam
 /// parse_pattern("room:*") // -> Wildcard("room:")
 /// parse_pattern("room:lobby") // -> Exact("room:lobby")
-/// parse_pattern("doc:*:ops") // -> Exact("doc:*:ops") - only trailing * supported
+/// parse_pattern("document:*:ops") // -> SegmentWildcard(["document", "*", "ops"])
+/// parse_pattern("document:*:*") // -> SegmentWildcard(["document", "*", "*"])
+/// parse_pattern("document:tenant-a:*") // -> Wildcard("document:tenant-a:")
 /// ```
 pub fn parse_pattern(pattern: String) -> TopicPattern {
-  case string.ends_with(pattern, "*") {
-    True -> {
-      let prefix = string.drop_end(pattern, 1)
-      Wildcard(prefix)
-    }
-    False -> Exact(pattern)
+  case should_parse_segment_wildcard(pattern) {
+    True -> SegmentWildcard(segments(pattern))
+    False ->
+      case string.ends_with(pattern, "*") {
+        True -> {
+          let prefix = string.drop_end(pattern, 1)
+          Wildcard(prefix)
+        }
+        False -> Exact(pattern)
+      }
   }
 }
 
@@ -42,12 +53,49 @@ pub fn parse_pattern(pattern: String) -> TopicPattern {
 /// matches(Wildcard("room:"), "user:123") // -> False
 /// matches(Exact("room:lobby"), "room:lobby") // -> True
 /// matches(Exact("room:lobby"), "room:other") // -> False
+/// matches(parse_pattern("document:*:ops"), "document:tenant-a:ops") // -> True
+/// matches(parse_pattern("document:*:ops"), "document:tenant-a:view") // -> False
 /// ```
 pub fn matches(pattern: TopicPattern, topic: String) -> Bool {
   case pattern {
     Exact(p) -> p == topic
     Wildcard(prefix) -> string.starts_with(topic, prefix)
+    SegmentWildcard(pattern_parts) ->
+      segment_parts_match(pattern_parts, segments(topic))
   }
+}
+
+fn should_parse_segment_wildcard(pattern: String) -> Bool {
+  let parts = segments(pattern)
+
+  case has_full_wildcard_segment(parts) {
+    False -> False
+    True -> !string.ends_with(pattern, "*") || wildcard_segment_count(parts) > 1
+  }
+}
+
+fn has_full_wildcard_segment(parts: List(String)) -> Bool {
+  list.contains(parts, "*")
+}
+
+fn wildcard_segment_count(parts: List(String)) -> Int {
+  parts
+  |> list.filter(fn(part) { part == "*" })
+  |> list.length
+}
+
+fn segment_parts_match(
+  pattern_parts: List(String),
+  topic_parts: List(String),
+) -> Bool {
+  list.length(pattern_parts) == list.length(topic_parts)
+  && list.zip(pattern_parts, topic_parts)
+  |> list.all(fn(pair) {
+    case pair {
+      #("*", _) -> True
+      #(pattern_part, topic_part) -> pattern_part == topic_part
+    }
+  })
 }
 
 /// Extract the wildcard portion from a topic
@@ -57,6 +105,7 @@ pub fn matches(pattern: TopicPattern, topic: String) -> Bool {
 /// ```gleam
 /// extract_id(Wildcard("room:"), "room:lobby") // -> Ok("lobby")
 /// extract_id(Wildcard("doc:"), "doc:abc:123") // -> Ok("abc:123")
+/// extract_id(SegmentWildcard(["doc", "*", "ops"]), "doc:abc:ops") // -> Ok("abc")
 /// extract_id(Exact("room:lobby"), "room:lobby") // -> Error(Nil)
 /// ```
 pub fn extract_id(pattern: TopicPattern, topic: String) -> Result(String, Nil) {
@@ -66,6 +115,58 @@ pub fn extract_id(pattern: TopicPattern, topic: String) -> Result(String, Nil) {
       case string.starts_with(topic, prefix) {
         True -> Ok(string.drop_start(topic, string.length(prefix)))
         False -> Error(Nil)
+      }
+    }
+    SegmentWildcard(_) ->
+      case extract_wildcards(pattern, topic) {
+        Ok([id]) -> Ok(id)
+        _ -> Error(Nil)
+      }
+  }
+}
+
+/// Extract values captured by wildcard segments.
+///
+/// For legacy prefix wildcards, returns the suffix as a single value.
+/// For segment wildcards, returns each topic segment matched by "*".
+///
+/// ## Examples
+///
+/// ```gleam
+/// extract_wildcards(parse_pattern("document:*:*"), "document:tenant-a:doc-42")
+/// // -> Ok(["tenant-a", "doc-42"])
+/// ```
+pub fn extract_wildcards(
+  pattern: TopicPattern,
+  topic: String,
+) -> Result(List(String), Nil) {
+  case pattern {
+    Exact(p) ->
+      case p == topic {
+        True -> Ok([])
+        False -> Error(Nil)
+      }
+
+    Wildcard(prefix) ->
+      case string.starts_with(topic, prefix) {
+        True -> Ok([string.drop_start(topic, string.length(prefix))])
+        False -> Error(Nil)
+      }
+
+    SegmentWildcard(pattern_parts) -> {
+      let topic_parts = segments(topic)
+
+      case segment_parts_match(pattern_parts, topic_parts) {
+        False -> Error(Nil)
+        True ->
+          list.zip(pattern_parts, topic_parts)
+          |> list.filter_map(fn(pair) {
+            case pair {
+              #("*", value) -> Ok(value)
+              _ -> Error(Nil)
+            }
+          })
+          |> Ok
       }
     }
   }

--- a/test/beryl_test.gleam
+++ b/test/beryl_test.gleam
@@ -61,6 +61,73 @@ pub fn exact_matches_test() {
   |> should.be_false
 }
 
+pub fn parse_mid_segment_wildcard_pattern_test() {
+  topic.parse_pattern("document:*:ops")
+  |> should.equal(topic.SegmentWildcard(["document", "*", "ops"]))
+}
+
+pub fn parse_multi_segment_wildcard_pattern_test() {
+  topic.parse_pattern("document:*:*")
+  |> should.equal(topic.SegmentWildcard(["document", "*", "*"]))
+}
+
+pub fn single_trailing_wildcard_keeps_prefix_pattern_test() {
+  topic.parse_pattern("document:tenant-a:*")
+  |> should.equal(topic.Wildcard("document:tenant-a:"))
+}
+
+pub fn segment_wildcard_matches_same_shape_topics_test() {
+  let pattern = topic.parse_pattern("document:*:ops")
+
+  topic.matches(pattern, "document:tenant-a:ops")
+  |> should.be_true
+
+  topic.matches(pattern, "document:tenant-b:ops")
+  |> should.be_true
+
+  topic.matches(pattern, "document:tenant-a:view")
+  |> should.be_false
+
+  topic.matches(pattern, "document:tenant-a:doc-1:ops")
+  |> should.be_false
+}
+
+pub fn tenant_trailing_wildcard_matches_documents_test() {
+  let pattern = topic.parse_pattern("document:tenant-a:*")
+
+  topic.matches(pattern, "document:tenant-a:doc-1")
+  |> should.be_true
+
+  topic.matches(pattern, "document:tenant-a:doc-1:ops")
+  |> should.be_true
+
+  topic.matches(pattern, "document:tenant-b:doc-1")
+  |> should.be_false
+}
+
+pub fn extract_wildcards_from_segment_pattern_test() {
+  let pattern = topic.parse_pattern("document:*:*")
+
+  topic.extract_wildcards(pattern, "document:tenant-a:doc-42")
+  |> should.equal(Ok(["tenant-a", "doc-42"]))
+
+  topic.extract_wildcards(pattern, "document:tenant-a")
+  |> should.equal(Error(Nil))
+}
+
+pub fn extract_id_from_single_segment_wildcard_test() {
+  let pattern = topic.parse_pattern("document:*:ops")
+
+  topic.extract_id(pattern, "document:tenant-a:ops")
+  |> should.equal(Ok("tenant-a"))
+
+  topic.extract_id(
+    topic.parse_pattern("document:*:*"),
+    "document:tenant-a:doc-42",
+  )
+  |> should.equal(Error(Nil))
+}
+
 pub fn extract_id_test() {
   let pattern = topic.Wildcard("room:")
 
@@ -99,6 +166,93 @@ pub fn validate_topic_test() {
 
   topic.validate("invalid:")
   |> should.be_error
+}
+
+pub fn segment_wildcard_registered_channel_routes_matching_topic_test() {
+  let assert Ok(channels) = beryl.start(beryl.default_config())
+  let sent_messages = process.new_subject()
+
+  process.send(
+    channels.coordinator,
+    coordinator.SocketConnected(
+      "segment-socket",
+      fn(text) {
+        process.send(sent_messages, text)
+        Ok(Nil)
+      },
+      fn(_) { Ok(Nil) },
+      dynamic.nil(),
+    ),
+  )
+
+  let handler =
+    channel.new(fn(topic_name, _payload, socket) {
+      let assert Ok([tenant]) =
+        topic.extract_wildcards(
+          topic.parse_pattern("document:*:ops"),
+          topic_name,
+        )
+      let reply = json.object([#("tenant", json.string(tenant))])
+      channel.JoinOk(reply: option.Some(reply), socket: socket)
+    })
+
+  beryl.register(channels, "document:*:ops", handler)
+  |> should.equal(Ok(Nil))
+
+  process.send(
+    channels.coordinator,
+    coordinator.Join(
+      "segment-socket",
+      "document:tenant-a:ops",
+      dynamic.nil(),
+      option.None,
+      "join-ref",
+    ),
+  )
+
+  let assert Ok(join_reply) = process.receive(sent_messages, 500)
+  join_reply |> string.contains("phx_reply") |> should.be_true
+  join_reply |> string.contains("\"tenant\":\"tenant-a\"") |> should.be_true
+}
+
+pub fn segment_wildcard_registered_channel_rejects_wrong_segment_test() {
+  let assert Ok(channels) = beryl.start(beryl.default_config())
+  let sent_messages = process.new_subject()
+
+  process.send(
+    channels.coordinator,
+    coordinator.SocketConnected(
+      "segment-reject-socket",
+      fn(text) {
+        process.send(sent_messages, text)
+        Ok(Nil)
+      },
+      fn(_) { Ok(Nil) },
+      dynamic.nil(),
+    ),
+  )
+
+  let handler =
+    channel.new(fn(_topic_name, _payload, socket) {
+      channel.JoinOk(reply: option.None, socket: socket)
+    })
+
+  beryl.register(channels, "document:*:ops", handler)
+  |> should.equal(Ok(Nil))
+
+  process.send(
+    channels.coordinator,
+    coordinator.Join(
+      "segment-reject-socket",
+      "document:tenant-a:view",
+      dynamic.nil(),
+      option.None,
+      "join-ref",
+    ),
+  )
+
+  let assert Ok(join_reply) = process.receive(sent_messages, 500)
+  join_reply |> string.contains("no_channel_handler") |> should.be_true
 }
 
 // Config tests

--- a/website/src/content/docs/guides/channels.md
+++ b/website/src/content/docs/guides/channels.md
@@ -6,7 +6,7 @@ Channels are the core abstraction in beryl. A channel maps a topic pattern to a 
 
 ## Topics and patterns
 
-Topics are colon-delimited string identifiers. Patterns can be exact matches or use a trailing wildcard:
+Topics are colon-delimited string identifiers. Patterns can be exact matches, legacy trailing prefix wildcards, or segment-aware wildcards:
 
 ```gleam
 import beryl/topic
@@ -17,12 +17,47 @@ topic.parse_pattern("room:lobby")  // -> Exact("room:lobby")
 // Wildcard: matches "room:lobby", "room:123", etc.
 topic.parse_pattern("room:*")  // -> Wildcard("room:")
 
+// Segment wildcard: matches one complete segment per "*"
+topic.parse_pattern("document:*:ops")
+// -> SegmentWildcard(["document", "*", "ops"])
+
+// Multi-segment wildcard: extract tenant and document IDs
+topic.parse_pattern("document:*:*")
+// -> SegmentWildcard(["document", "*", "*"])
+
+// Single trailing "*" keeps prefix wildcard behavior
+topic.parse_pattern("document:tenant-a:*")
+// -> Wildcard("document:tenant-a:")
+
 // Extract the dynamic part
 topic.extract_id(Wildcard("room:"), "room:lobby")  // -> Ok("lobby")
+
+// Extract multiple dynamic segments
+topic.extract_wildcards(
+  topic.parse_pattern("document:*:*"),
+  "document:tenant-a:doc-42",
+)
+// -> Ok(["tenant-a", "doc-42"])
 
 // Parse topic segments
 topic.segments("room:lobby")  // -> ["room", "lobby"]
 topic.namespace("room:lobby")  // -> Ok("room")
+```
+
+Use `document:tenant-a:*` to route all documents for one tenant while keeping the existing trailing-wildcard prefix semantics. Use `document:*:*` when a handler needs to extract both tenant and document IDs from a topic with the exact shape `document:{tenant_id}:{document_id}`:
+
+```gleam
+let pattern = topic.parse_pattern("document:*:*")
+
+case topic.extract_wildcards(pattern, "document:tenant-a:doc-42") {
+  Ok([tenant_id, document_id]) -> {
+    // tenant_id == "tenant-a"
+    // document_id == "doc-42"
+  }
+  _ -> {
+    // Topic did not match the expected document shape.
+  }
+}
 ```
 
 ## Defining a channel


### PR DESCRIPTION
## Summary

- Add segment-aware topic wildcard patterns for routes such as `document:*:ops` and `document:*:*`
- Preserve legacy trailing wildcard prefix behavior for patterns such as `room:*` and `document:tenant-a:*`
- Add `topic.extract_wildcards` for extracting tenant/document segment captures
- Document segment-aware routing and add a changie fragment

Closes #48

## Tests

- `gleam test -- --filter "segment_wildcard"`
- `gleam test -- --filter "extract"`
- `gleam test -- --filter "segment_wildcard_registered_channel"`
- `just ci`
