### PR TITLE
fix(just): clean example builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,40 @@ For a complete end-to-end walkthrough including Phoenix JS client code, see the
 - **Website & guides**: <https://beryl.tylerbutler.com>
 - **Generated API docs**: <https://hexdocs.pm/beryl/>
 
+## Ecosystem
+
+Beryl is the server-side channel runtime. It owns socket registration, channel
+handlers, broadcasts, presence, groups, pubsub, and transport integration.
+Beryl has its own pluggable wire codec, and its Phoenix codec is kept compatible
+with Roost and Aquamarine by shared conformance fixtures.
+
+```mermaid
+flowchart TD
+    fixtures["phoenix_channel_fixtures\ncanonical wire test data"]
+    roost["roost\nPhoenix channel wire protocol"]
+    beryl["beryl\nserver runtime"]
+    aquamarine["aquamarine\nclient runtime"]
+    gluegun["gluegun\nclient WebSocket transport"]
+    mist["mist\nserver WebSocket transport"]
+
+    fixtures -. "test fixtures" .-> roost
+    fixtures -. "test fixtures" .-> beryl
+    fixtures -. "test fixtures" .-> aquamarine
+
+    roost --> aquamarine
+    mist --> beryl
+    gluegun --> aquamarine
+
+    aquamarine <-- "Phoenix channel wire" --> beryl
+```
+
+| Package | Responsibility |
+|---------|----------------|
+| `phoenix_channel_fixtures` | Shared test fixtures for Phoenix channel wire compatibility. |
+| `roost` | Pure Phoenix channel frame constants, encode/decode helpers, and reply helpers. |
+| `beryl` | Server-side runtime with its own pluggable codec; its Phoenix codec is fixture-tested. |
+| `aquamarine` | Client-side channel runtime that uses Roost for Phoenix compatibility. |
+
 ## Features
 
 - **Channels** — Topic-based pub/sub with typed callbacks and pattern matching (e.g. `room:*`, `document:*:*`)

--- a/justfile
+++ b/justfile
@@ -101,10 +101,17 @@ examples-list:
     @ls examples/
 
 # Build all examples
-examples-build: examples-client-build
+examples-build: examples-clean examples-client-build
     cd examples/cursors && gleam build
     cd examples/chatrooms && gleam build
     cd examples/collab_docs && gleam build
+
+# Clean example build artifacts
+examples-clean:
+    rm -rf examples/cursors/_build
+    rm -rf examples/chatrooms/_build
+    rm -rf examples/collab_docs/_build
+    rm -rf examples/collab_docs/client/_build
 
 # Build JavaScript clients used by examples
 examples-client-build:
@@ -123,7 +130,8 @@ examples-test: examples-build
 # === MAINTENANCE ===
 
 # Remove build artifacts
-clean:
+clean: examples-clean
+    rm -rf _build
     rm -rf build
 
 # === CI ===


### PR DESCRIPTION
## Summary

- Add an `examples-clean` just recipe that removes example Gleam build artifacts before example builds.
- Wire `examples-build` and top-level `clean` through `examples-clean` so CI/example runs start from a clean example build state.
- Document the Beryl ecosystem packages and their wire-compatibility relationship in the README.

## Validation

- `just ci` (failed once in `examples/chatrooms`: Playwright test "system message when user leaves" timed out waiting for a second user)
- `pnpm -C examples/chatrooms test --grep "system message when user leaves"` (passed on focused rerun)
