### PR TITLE
refactor(time): use gleam_time monotonic API

### DIFF
--- a/.changes/unreleased/Changed-20260514-091811.yaml
+++ b/.changes/unreleased/Changed-20260514-091811.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Beryl uses `gleam_time` monotonic clocks for internal heartbeat and rate-limit timing instead of its own monotonic Erlang FFI helpers.
+time: 2026-05-14T09:18:11.016000000-07:00

--- a/examples/chatrooms/manifest.toml
+++ b/examples/chatrooms/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "beryl", version = "0.1.0", build_tools = ["gleam"], requirements = ["birch", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../.." },
+  { name = "beryl", version = "0.1.0", build_tools = ["gleam"], requirements = ["birch", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "mist"], source = "local", path = "../.." },
   { name = "birch", version = "0.2.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "simplifile"], otp_app = "birch", source = "hex", outer_checksum = "20CCDACA9E2A17E1D7F2C35322E619E7DDF98774FDC598D01AD5F414928E6261" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
@@ -12,7 +12,7 @@ packages = [
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
   { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
-  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], source = "local", path = "../../../time" },
   { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
   { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
   { name = "gramps", version = "6.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D55636072DEE173F6586A5679D3C02EC7A0DE3F8646B78C351B72908FF223DF7" },

--- a/examples/collab_docs/manifest.toml
+++ b/examples/collab_docs/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "beryl", version = "0.1.0", build_tools = ["gleam"], requirements = ["birch", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../.." },
+  { name = "beryl", version = "0.1.0", build_tools = ["gleam"], requirements = ["birch", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "mist"], source = "local", path = "../.." },
   { name = "birch", version = "0.2.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "simplifile"], otp_app = "birch", source = "hex", outer_checksum = "20CCDACA9E2A17E1D7F2C35322E619E7DDF98774FDC598D01AD5F414928E6261" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
@@ -12,7 +12,7 @@ packages = [
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
   { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
-  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], source = "local", path = "../../../time" },
   { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
   { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
   { name = "gramps", version = "6.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D55636072DEE173F6586A5679D3C02EC7A0DE3F8646B78C351B72908FF223DF7" },

--- a/examples/cursors/manifest.toml
+++ b/examples/cursors/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "beryl", version = "0.1.0", build_tools = ["gleam"], requirements = ["birch", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../.." },
+  { name = "beryl", version = "0.1.0", build_tools = ["gleam"], requirements = ["birch", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "mist"], source = "local", path = "../.." },
   { name = "birch", version = "0.2.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "simplifile"], otp_app = "birch", source = "hex", outer_checksum = "20CCDACA9E2A17E1D7F2C35322E619E7DDF98774FDC598D01AD5F414928E6261" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
@@ -12,7 +12,7 @@ packages = [
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
   { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
-  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], source = "local", path = "../../../time" },
   { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
   { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
   { name = "gramps", version = "6.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D55636072DEE173F6586A5679D3C02EC7A0DE3F8646B78C351B72908FF223DF7" },

--- a/gleam.toml
+++ b/gleam.toml
@@ -14,6 +14,7 @@ gleam_json = ">= 3.0.0 and < 4.0.0"
 gleam_crypto = ">= 1.5.1 and < 2.0.0"
 gleam_http = ">= 4.3.0 and < 5.0.0"
 mist = ">= 6.0.0 and < 7.0.0"
+gleam_time = { path = "../time" }
 
 birch = ">= 0.2.1 and < 1.0.0"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -12,7 +12,7 @@ packages = [
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
-  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], source = "local", path = "../time" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
   { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
   { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
@@ -34,6 +34,7 @@ gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
 gleam_json = { version = ">= 3.0.0 and < 4.0.0" }
 gleam_otp = { version = ">= 0.12.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
+gleam_time = { path = "../time" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 mist = { version = ">= 6.0.0 and < 7.0.0" }
 phoenix_channel_fixtures = { git = "https://github.com/tylerbutler/phoenix_channel_fixtures.git", ref = "7daccb856d17db6278980277237c201b2acdcdf1" }

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -26,6 +26,8 @@ import gleam/otp/actor
 import gleam/result
 import gleam/set.{type Set}
 import gleam/string
+import gleam/time/duration
+import gleam/time/monotonic
 
 /// Type-erased channel handler for storage
 /// The actual typed Channel is converted to this for the registry
@@ -149,8 +151,8 @@ pub type SocketInfo {
     subscribed_topics: Set(String),
     /// Per-topic assigns (topic -> Dynamic assigns)
     channel_assigns: Dict(String, Dynamic),
-    /// Monotonic timestamp (ms) of the last heartbeat received
-    last_heartbeat: Int,
+    /// Monotonic instant of the last heartbeat received
+    last_heartbeat: monotonic.Instant,
   )
 }
 
@@ -203,10 +205,6 @@ pub type Message {
   // Heartbeat timeout enforcement
   CheckHeartbeats
 }
-
-/// Erlang monotonic time in milliseconds
-@external(erlang, "beryl_ffi", "monotonic_time_ms")
-fn monotonic_time_ms() -> Int
 
 /// Coerce an external PubSub record message into the typed PubSub message.
 @external(erlang, "beryl_ffi", "identity")
@@ -420,7 +418,7 @@ fn handle_socket_connected(
       handler_pid: handler_pid,
       subscribed_topics: set.new(),
       channel_assigns: dict.new(),
-      last_heartbeat: monotonic_time_ms(),
+      last_heartbeat: monotonic.now(),
     )
 
   let logger = internal.logger("beryl.coordinator")
@@ -911,7 +909,7 @@ fn handle_heartbeat(
     Error(_) -> actor.continue(state)
     Ok(socket_info) -> {
       let updated_socket =
-        SocketInfo(..socket_info, last_heartbeat: monotonic_time_ms())
+        SocketInfo(..socket_info, last_heartbeat: monotonic.now())
       let new_sockets = dict.insert(state.sockets, socket_id, updated_socket)
 
       let reply = state.config.codec.encode_heartbeat_reply(ref)
@@ -923,12 +921,15 @@ fn handle_heartbeat(
 
 /// Check all sockets for heartbeat timeout and evict stale ones
 fn handle_check_heartbeats(state: State) -> actor.Next(State, Message) {
-  let now = monotonic_time_ms()
+  let now = monotonic.now()
   let timeout_ms = state.config.heartbeat_timeout_ms
 
   let stale_socket_ids =
     dict.fold(state.sockets, [], fn(acc, socket_id, socket_info) {
-      let elapsed = now - socket_info.last_heartbeat
+      let elapsed =
+        monotonic.difference(socket_info.last_heartbeat, now)
+        |> duration.to_milliseconds
+
       case elapsed > timeout_ms {
         True -> [socket_id, ..acc]
         False -> acc

--- a/src/beryl/rate_limit.gleam
+++ b/src/beryl/rate_limit.gleam
@@ -10,10 +10,8 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/otp/actor
 import gleam/result
-
-/// Erlang monotonic time in nanoseconds
-@external(erlang, "beryl_ffi", "monotonic_time_ns")
-fn monotonic_time_ns() -> Int
+import gleam/time/duration
+import gleam/time/monotonic
 
 // ── Configuration ───────────────────────────────────────────────────────────
 
@@ -43,7 +41,7 @@ type BucketState {
     tokens_ns: Int,
     max_tokens_ns: Int,
     ns_per_token: Int,
-    last_refill_ns: Int,
+    last_refill: monotonic.Instant,
   )
 }
 
@@ -54,24 +52,32 @@ type BucketMsg {
 
 const one_second_ns = 1_000_000_000
 
+fn duration_to_nanoseconds(elapsed: duration.Duration) -> Int {
+  let #(seconds, nanoseconds) = duration.to_seconds_and_nanoseconds(elapsed)
+  seconds * one_second_ns + nanoseconds
+}
+
 fn new_bucket_state(cfg: RateLimitConfig) -> BucketState {
   let ns_per_token = one_second_ns / int.max(cfg.per_second, 1)
   BucketState(
     tokens_ns: cfg.burst * ns_per_token,
     max_tokens_ns: cfg.burst * ns_per_token,
     ns_per_token: ns_per_token,
-    last_refill_ns: monotonic_time_ns(),
+    last_refill: monotonic.now(),
   )
 }
 
 fn refill(state: BucketState) -> BucketState {
-  let now = monotonic_time_ns()
-  let elapsed = now - state.last_refill_ns
+  let now = monotonic.now()
+  let elapsed =
+    monotonic.difference(state.last_refill, now)
+    |> duration_to_nanoseconds
+
   case elapsed > 0 {
     False -> state
     True -> {
       let new_tokens = int.min(state.tokens_ns + elapsed, state.max_tokens_ns)
-      BucketState(..state, tokens_ns: new_tokens, last_refill_ns: now)
+      BucketState(..state, tokens_ns: new_tokens, last_refill: now)
     }
   }
 }

--- a/src/beryl_ffi.erl
+++ b/src/beryl_ffi.erl
@@ -1,16 +1,9 @@
 -module(beryl_ffi).
--export([identity/1, monotonic_time_ms/0, monotonic_time_ns/0,
-         string_starts_with/2, stop_supervisor/1,
+-export([identity/1, string_starts_with/2, stop_supervisor/1,
          get_cached_logger/1, set_cached_logger/2]).
 
 %% Identity function for type erasure
 identity(X) -> X.
-
-%% Return Erlang monotonic time in milliseconds
-monotonic_time_ms() -> erlang:monotonic_time(millisecond).
-
-%% Return Erlang monotonic time in nanoseconds
-monotonic_time_ns() -> erlang:monotonic_time(nanosecond).
 
 %% Check if a string starts with a prefix
 string_starts_with(String, Prefix) ->


### PR DESCRIPTION
> [!NOTE]
> This won't pass CI as it is becuase it depends on a local version of gleam_time. Once https://github.com/gleam-lang/time/pull/47 or something like it is merged and released, this can be re-worked into a mergeable PR.

## Summary

- Add `gleam_time` as a direct local dependency from `../time`.
- Replace Beryl's monotonic heartbeat and rate-limit timing FFI with `gleam/time/monotonic` and `gleam/time/duration`.
- Remove the now-unused monotonic time helpers from `beryl_ffi.erl`.
- Add a changie fragment for the internal timing dependency change.

## Validation

- `just ci`