### PR TITLE
feat(codec)!: complete pluggable codec abstraction

### DIFF
--- a/.changes/unreleased/Changed-20260514-123556.yaml
+++ b/.changes/unreleased/Changed-20260514-123556.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: |-
+    Pluggable codecs can route text and binary frames.
+
+    Channel join and message callbacks now receive inbound payloads as `Dynamic` values so handlers can decode them directly, and the codec contract now supports structural join/leave/heartbeat dispatch plus binary outbound frames. Custom transports should route inbound WebSocket frames through `coordinator.route_message` or `coordinator.route_binary` instead of constructing internal channel messages directly.
+time: 2026-05-14T12:35:56.000000000-07:00

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ import beryl
 import beryl/channel.{type Channel, type HandleResult, type JoinResult}
 import beryl/socket.{type Socket}
 import beryl/transport/mist as mist_transport
+import beryl/wire
+import gleam/dynamic/decode
 import gleam/erlang/process
 import gleam/json
 import gleam/option.{None}
@@ -32,7 +34,14 @@ pub type RoomAssigns { RoomAssigns(username: String) }
 
 fn new_channel() -> Channel(RoomAssigns) {
   channel.new(fn(_topic, payload, socket) {
-    let username = // ... extract from payload
+    let username_decoder = {
+      use username <- decode.field("username", decode.string)
+      decode.success(username)
+    }
+    let username = case channel.decode_payload(payload, username_decoder) {
+      Ok(username) -> username
+      Error(_) -> "anonymous"
+    }
     channel.JoinOk(reply: None, socket: socket.set_assigns(socket, RoomAssigns(username:)))
   })
   |> channel.with_handle_in(fn(_event, _payload, socket) {
@@ -41,7 +50,7 @@ fn new_channel() -> Channel(RoomAssigns) {
 }
 
 pub fn main() {
-  let assert Ok(channels) = beryl.start(beryl.default_config())
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
   let assert Ok(_) = beryl.register(channels, "room:*", new_channel())
 
   let assert Ok(_) =

--- a/docs/superpowers/plans/2026-05-08-collab-docs-crdt-example.md
+++ b/docs/superpowers/plans/2026-05-08-collab-docs-crdt-example.md
@@ -773,6 +773,7 @@ Create `examples/collab_docs/src/collab_docs.gleam`:
 ```gleam
 import beryl
 import beryl/transport/mist as mist_transport
+import beryl/wire
 import collab_docs/channel
 import collab_docs/doc_store
 import collab_docs/router
@@ -782,7 +783,7 @@ import mist
 
 pub fn main() {
   let assert Ok(store) = doc_store.start()
-  let assert Ok(channels) = beryl.start(beryl.default_config())
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
   let handler = channel.new_handler(channels, store)
   let assert Ok(_) = beryl.register(channels, "document:*:*", handler)
 

--- a/examples/chatrooms/manifest.toml
+++ b/examples/chatrooms/manifest.toml
@@ -4,6 +4,7 @@
 packages = [
   { name = "beryl", version = "0.1.0", build_tools = ["gleam"], requirements = ["birch", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../.." },
   { name = "birch", version = "0.2.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "simplifile"], otp_app = "birch", source = "hex", outer_checksum = "20CCDACA9E2A17E1D7F2C35322E619E7DDF98774FDC598D01AD5F414928E6261" },
+  { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_crypto", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "2DE9E4EF53CF6FEE049D4F765731F7178F7A11AEFAE00EEE63BF7536B354AD3F" },
@@ -24,6 +25,7 @@ packages = [
 
 [requirements]
 beryl = { path = "../.." }
+example_helpers = { path = "../example_helpers" }
 gleam_erlang = { version = ">= 0.29.0 and < 2.0.0" }
 gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
 gleam_json = { version = ">= 3.0.0 and < 4.0.0" }

--- a/examples/chatrooms/src/chatrooms.gleam
+++ b/examples/chatrooms/src/chatrooms.gleam
@@ -1,8 +1,8 @@
 import beryl
-import beryl/wire
 import beryl/group
 import beryl/presence
 import beryl/transport/mist as mist_transport
+import beryl/wire
 import chatrooms/chat_channel
 import chatrooms/router
 import gleam/erlang/process

--- a/examples/chatrooms/src/chatrooms/chat_channel.gleam
+++ b/examples/chatrooms/src/chatrooms/chat_channel.gleam
@@ -3,8 +3,9 @@ import beryl/channel.{type Channel, type HandleResult, type JoinResult}
 import beryl/group
 import beryl/presence.{type Presence}
 import beryl/socket.{type Socket}
+import example_helpers/color
+import example_helpers/payload
 import gleam/dynamic.{type Dynamic}
-import gleam/dynamic/decode
 import gleam/int
 import gleam/json
 import gleam/list
@@ -74,8 +75,8 @@ fn join(
             "Room is full (max " <> int.to_string(max_room_users) <> ")",
           ))
         False -> {
-          let username = extract_string(payload, "username", "Anonymous")
-          let color = random_pastel_color(socket.id(socket))
+          let username = payload.string_or(payload, "username", "Anonymous")
+          let color = color.pastel_for(socket.id(socket))
           let assigns =
             ChatAssigns(
               username:,
@@ -139,7 +140,7 @@ fn handle_in(
 
   case event {
     "new_msg" -> {
-      let text = extract_string(payload, "text", "")
+      let text = payload.string_or(payload, "text", "")
       case string.trim(text) {
         "" ->
           // Reject empty messages with error code
@@ -273,37 +274,5 @@ fn terminate(_reason: channel.StopReason, socket: Socket(ChatAssigns)) -> Nil {
 
 // --- Helpers ---
 
-fn random_pastel_color(seed: String) -> String {
-  let hash =
-    seed
-    |> to_charcode_sum
-  let hue = hash % 360
-  "hsl(" <> int.to_string(hue) <> ", 70%, 65%)"
-}
-
-fn to_charcode_sum(s: String) -> Int {
-  s
-  |> string_to_codepoints
-  |> list.fold(0, fn(acc, cp) { acc + cp })
-}
-
-@external(erlang, "chatrooms_ffi", "string_to_codepoints")
-fn string_to_codepoints(s: String) -> List(Int)
-
 @external(erlang, "chatrooms_ffi", "timestamp_ms")
 fn timestamp_ms() -> Int
-
-fn extract_string(
-  payload: Dynamic,
-  field_name: String,
-  default: String,
-) -> String {
-  let decoder = {
-    use value <- decode.field(field_name, decode.string)
-    decode.success(value)
-  }
-  case channel.decode_payload(payload, decoder) {
-    Ok(value) -> value
-    Error(_) -> default
-  }
-}

--- a/examples/chatrooms/src/chatrooms/chat_channel.gleam
+++ b/examples/chatrooms/src/chatrooms/chat_channel.gleam
@@ -3,6 +3,7 @@ import beryl/channel.{type Channel, type HandleResult, type JoinResult}
 import beryl/group
 import beryl/presence.{type Presence}
 import beryl/socket.{type Socket}
+import gleam/dynamic.{type Dynamic}
 import gleam/dynamic/decode
 import gleam/int
 import gleam/json
@@ -45,7 +46,7 @@ fn join(
   presence: Presence,
   groups: group.Groups,
   topic: String,
-  payload: json.Json,
+  payload: Dynamic,
   socket: Socket(ChatAssigns),
 ) -> JoinResult(ChatAssigns) {
   // Extract room name from topic (e.g., "general" from "room:general")
@@ -131,7 +132,7 @@ fn join(
 
 fn handle_in(
   event: String,
-  payload: json.Json,
+  payload: Dynamic,
   socket: Socket(ChatAssigns),
 ) -> HandleResult(ChatAssigns) {
   let assigns = socket.get_assigns(socket)
@@ -293,16 +294,15 @@ fn string_to_codepoints(s: String) -> List(Int)
 fn timestamp_ms() -> Int
 
 fn extract_string(
-  payload: json.Json,
+  payload: Dynamic,
   field_name: String,
   default: String,
 ) -> String {
-  let json_str = json.to_string(payload)
   let decoder = {
     use value <- decode.field(field_name, decode.string)
     decode.success(value)
   }
-  case json.parse(json_str, decoder) {
+  case channel.decode_payload(payload, decoder) {
     Ok(value) -> value
     Error(_) -> default
   }

--- a/examples/chatrooms/src/chatrooms/router.gleam
+++ b/examples/chatrooms/src/chatrooms/router.gleam
@@ -1,18 +1,13 @@
 import beryl
 import beryl/group
 import beryl/presence
-import gleam/bytes_tree
-import gleam/erlang/application
-import gleam/http
+import example_helpers/static
 import gleam/http/request.{type Request}
 import gleam/http/response.{type Response}
 import gleam/json
 import gleam/list
-import gleam/option
-import gleam/result
 import gleam/set
 import gleam/string
-import gleam/uri
 import mist.{type Connection, type ResponseData}
 
 pub type Context {
@@ -27,12 +22,16 @@ pub fn handle_request(
   req: Request(Connection),
   ctx: Context,
 ) -> Response(ResponseData) {
-  use <- serve_static(req, under: "/static", from: priv_directory())
+  use <- static.serve_static(
+    req,
+    under: "/static",
+    from: static.priv_static("chatrooms"),
+  )
 
   case request.path_segments(req) {
     [] -> index_page(ctx)
     ["api", "rooms"] -> rooms_api(ctx)
-    _ -> not_found()
+    _ -> static.not_found()
   }
 }
 
@@ -57,7 +56,7 @@ fn rooms_api(ctx: Context) -> Response(ResponseData) {
   }
 
   let body = json.to_string(json.array(rooms, fn(r) { r }))
-  json_response(body)
+  static.json_response(body)
 }
 
 fn index_page(ctx: Context) -> Response(ResponseData) {
@@ -124,88 +123,5 @@ fn index_page(ctx: Context) -> Response(ResponseData) {
 </body>
 </html>"
 
-  html_response(html)
-}
-
-fn serve_static(
-  req: Request(Connection),
-  under prefix: String,
-  from directory: String,
-  next handler: fn() -> Response(ResponseData),
-) -> Response(ResponseData) {
-  let path = drop_leading_slashes(req.path)
-  let prefix = drop_leading_slashes(prefix)
-
-  case req.method, string.starts_with(path, prefix) {
-    http.Get, True -> {
-      let static_path = path |> string.drop_start(string.length(prefix))
-      let relative =
-        static_path
-        |> uri.percent_decode
-        |> result.unwrap(static_path)
-        |> string.split("/")
-        |> list.filter(fn(segment) {
-          segment != "" && segment != "." && segment != ".."
-        })
-        |> string.join("/")
-
-      case relative {
-        "" -> not_found()
-        _ -> {
-          let file_path = directory <> "/" <> relative
-          case mist.send_file(file_path, offset: 0, limit: option.None) {
-            Ok(body) ->
-              response.new(200)
-              |> response.set_header("content-type", mime_type_for(file_path))
-              |> response.set_body(body)
-            Error(mist.UnknownFileError) ->
-              response.new(500)
-              |> response.set_body(mist.Bytes(bytes_tree.new()))
-            Error(_) -> not_found()
-          }
-        }
-      }
-    }
-    _, _ -> handler()
-  }
-}
-
-fn html_response(html: String) -> Response(ResponseData) {
-  response.new(200)
-  |> response.set_header("content-type", "text/html; charset=utf-8")
-  |> response.set_body(mist.Bytes(bytes_tree.from_string(html)))
-}
-
-fn json_response(json: String) -> Response(ResponseData) {
-  response.new(200)
-  |> response.set_header("content-type", "application/json; charset=utf-8")
-  |> response.set_body(mist.Bytes(bytes_tree.from_string(json)))
-}
-
-fn not_found() -> Response(ResponseData) {
-  response.new(404)
-  |> response.set_body(mist.Bytes(bytes_tree.from_string("Not found")))
-}
-
-fn drop_leading_slashes(path: String) -> String {
-  case path {
-    "/" <> rest -> drop_leading_slashes(rest)
-    _ -> path
-  }
-}
-
-fn mime_type_for(path: String) -> String {
-  case string.split(path, ".") |> list.last {
-    Ok("css") -> "text/css; charset=utf-8"
-    Ok("js") -> "application/javascript; charset=utf-8"
-    Ok("mjs") -> "application/javascript; charset=utf-8"
-    Ok("html") -> "text/html; charset=utf-8"
-    Ok("json") -> "application/json; charset=utf-8"
-    _ -> "application/octet-stream"
-  }
-}
-
-fn priv_directory() -> String {
-  let assert Ok(priv) = application.priv_directory("chatrooms")
-  priv <> "/static"
+  static.html_response(html)
 }

--- a/examples/chatrooms/src/chatrooms_ffi.erl
+++ b/examples/chatrooms/src/chatrooms_ffi.erl
@@ -1,10 +1,6 @@
 -module(chatrooms_ffi).
--export([timestamp_ms/0, string_to_codepoints/1]).
+-export([timestamp_ms/0]).
 
 %% Returns the current Unix timestamp in milliseconds
 timestamp_ms() ->
     erlang:system_time(millisecond).
-
-%% Convert a string to a list of codepoint integers
-string_to_codepoints(Str) ->
-    unicode:characters_to_list(Str).

--- a/examples/collab_docs/gleam.toml
+++ b/examples/collab_docs/gleam.toml
@@ -6,6 +6,7 @@ target = "erlang"
 
 [dependencies]
 beryl = { path = "../.." }
+example_helpers = { path = "../example_helpers" }
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 gleam_crypto = ">= 1.6.0 and < 2.0.0"
 gleam_erlang = ">= 0.29.0 and < 2.0.0"

--- a/examples/collab_docs/src/collab_docs.gleam
+++ b/examples/collab_docs/src/collab_docs.gleam
@@ -1,6 +1,6 @@
 import beryl
-import beryl/wire
 import beryl/transport/mist as mist_transport
+import beryl/wire
 import collab_docs/auth
 import collab_docs/channel
 import collab_docs/doc_store

--- a/examples/collab_docs/src/collab_docs/channel.gleam
+++ b/examples/collab_docs/src/collab_docs/channel.gleam
@@ -80,8 +80,7 @@ fn join(
         Error(_) -> channel.JoinError(reason: error_payload("missing_token"))
         Ok(token) ->
           case auth.verify_tenant(token, tenant, secret) {
-            Error(_) ->
-              channel.JoinError(reason: error_payload("unauthorized"))
+            Error(_) -> channel.JoinError(reason: error_payload("unauthorized"))
             Ok(Nil) -> {
               let document_key = build_document_key(tenant, document)
               let assigns =

--- a/examples/collab_docs/src/collab_docs/channel.gleam
+++ b/examples/collab_docs/src/collab_docs/channel.gleam
@@ -4,6 +4,7 @@ import beryl/socket.{type Socket}
 import beryl/topic
 import collab_docs/auth
 import collab_docs/doc_store.{type Store}
+import gleam/dynamic.{type Dynamic}
 import gleam/dynamic/decode
 import gleam/io
 import gleam/json
@@ -50,13 +51,13 @@ pub fn build_document_key(tenant: String, document: String) -> String {
   |> json.to_string
 }
 
-fn extract_token(payload: json.Json) -> Result(String, Nil) {
+fn extract_token(payload: Dynamic) -> Result(String, Nil) {
   let decoder = {
     use token <- decode.field("token", decode.string)
     decode.success(token)
   }
 
-  json.parse(json.to_string(payload), decoder)
+  channel.decode_payload(payload, decoder)
   |> result.replace_error(Nil)
 }
 
@@ -65,7 +66,7 @@ fn join(
   store: Store,
   secret: BitArray,
   topic_name: String,
-  payload: json.Json,
+  payload: Dynamic,
   socket: Socket(Assigns),
 ) -> JoinResult(Assigns) {
   let pattern = topic.parse_pattern(document_topic_pattern_string)
@@ -120,7 +121,7 @@ fn join(
 
 fn handle_in(
   event: String,
-  payload: json.Json,
+  payload: Dynamic,
   socket: Socket(Assigns),
 ) -> HandleResult(Assigns) {
   case event {
@@ -130,7 +131,7 @@ fn handle_in(
 }
 
 fn sync_state(
-  payload: json.Json,
+  payload: Dynamic,
   socket: Socket(Assigns),
 ) -> HandleResult(Assigns) {
   case extract_state(payload) {
@@ -159,13 +160,13 @@ fn reply_error(code: String, socket: Socket(Assigns)) -> HandleResult(Assigns) {
   channel.Reply(event: "state_error", payload: error_payload(code), socket:)
 }
 
-fn extract_state(payload: json.Json) -> Result(String, Nil) {
+fn extract_state(payload: Dynamic) -> Result(String, Nil) {
   let decoder = {
     use state <- decode.field("state", decode.string)
     decode.success(state)
   }
 
-  json.parse(json.to_string(payload), decoder)
+  channel.decode_payload(payload, decoder)
   |> result.replace_error(Nil)
 }
 

--- a/examples/collab_docs/src/collab_docs/channel.gleam
+++ b/examples/collab_docs/src/collab_docs/channel.gleam
@@ -17,7 +17,6 @@ import gleam/string
 const max_state_bytes = 65_536
 
 /// Topic pattern for document channels: `document:<tenant>:<document>`.
-/// Hoisted so we don't reparse on every join.
 const document_topic_pattern_string = "document:*:*"
 
 /// State stored in each socket's assigns.
@@ -39,8 +38,9 @@ pub fn new_handler(
   store: Store,
   secret: BitArray,
 ) -> Channel(Assigns) {
+  let pattern = topic.parse_pattern(document_topic_pattern_string)
   channel.new(fn(topic_name, payload, socket) {
-    join(channels, store, secret, topic_name, payload, socket)
+    join(channels, store, secret, pattern, topic_name, payload, socket)
   })
   |> channel.with_handle_in(handle_in)
 }
@@ -65,12 +65,11 @@ fn join(
   channels: beryl.Channels,
   store: Store,
   secret: BitArray,
+  pattern: topic.TopicPattern,
   topic_name: String,
   payload: Dynamic,
   socket: Socket(Assigns),
 ) -> JoinResult(Assigns) {
-  let pattern = topic.parse_pattern(document_topic_pattern_string)
-
   case topic.extract_wildcards(pattern, topic_name) {
     Ok([tenant, document]) -> {
       // Channel-level auth: the join payload must carry a `token` HMAC-signed

--- a/examples/collab_docs/src/collab_docs/doc_store.gleam
+++ b/examples/collab_docs/src/collab_docs/doc_store.gleam
@@ -2,6 +2,7 @@ import gleam/dict.{type Dict}
 import gleam/erlang/process.{type Subject}
 import gleam/io
 import gleam/json
+import gleam/option.{type Option, None, Some}
 import gleam/otp/actor
 import gleam/result
 import lattice_maps/or_map.{type ORMap}
@@ -18,7 +19,15 @@ type Message {
 }
 
 type State {
-  State(docs: Dict(String, ORMap))
+  State(docs: Dict(String, Doc))
+}
+
+/// One stored document. The encoded JSON is cached so concurrent joins for
+/// the same document don't each pay a full `or_map.to_json |> json.to_string`
+/// inside the doc_store actor (which would serialise unrelated docs too).
+/// The cache is invalidated on every merge.
+type Doc {
+  Doc(ormap: ORMap, encoded: Option(String))
 }
 
 /// Failure modes for `get_state`.
@@ -74,11 +83,22 @@ fn handle_message(
 ) -> actor.Next(State, Message) {
   case message {
     GetState(key, reply) -> {
-      let response =
-        dict.get(state.docs, key)
-        |> result.map(fn(doc) { doc |> or_map.to_json |> json.to_string })
-      process.send(reply, response)
-      actor.continue(state)
+      case dict.get(state.docs, key) {
+        Error(_) -> {
+          process.send(reply, Error(Nil))
+          actor.continue(state)
+        }
+        Ok(Doc(_, Some(cached))) -> {
+          process.send(reply, Ok(cached))
+          actor.continue(state)
+        }
+        Ok(Doc(ormap, None)) -> {
+          let encoded = ormap |> or_map.to_json |> json.to_string
+          process.send(reply, Ok(encoded))
+          let new_docs = dict.insert(state.docs, key, Doc(ormap, Some(encoded)))
+          actor.continue(State(docs: new_docs))
+        }
+      }
     }
 
     MergeState(key, encoded) -> {
@@ -101,15 +121,15 @@ fn handle_message(
 }
 
 fn merge_doc(
-  docs: Dict(String, ORMap),
+  docs: Dict(String, Doc),
   key: String,
   remote: ORMap,
-) -> Dict(String, ORMap) {
+) -> Dict(String, Doc) {
   case dict.get(docs, key) {
-    Error(_) -> dict.insert(docs, key, remote)
-    Ok(local) ->
+    Error(_) -> dict.insert(docs, key, Doc(remote, None))
+    Ok(Doc(local, _)) ->
       case or_map.merge(local, remote) {
-        Ok(merged) -> dict.insert(docs, key, merged)
+        Ok(merged) -> dict.insert(docs, key, Doc(merged, None))
         Error(_) -> {
           // ORMap merges should be commutative — failure indicates a real
           // bug worth seeing rather than silently dropping remote edits.

--- a/examples/collab_docs/src/collab_docs/router.gleam
+++ b/examples/collab_docs/src/collab_docs/router.gleam
@@ -1,16 +1,9 @@
 import beryl
 import collab_docs/auth
 import collab_docs/doc_store.{type Store}
-import gleam/bytes_tree
-import gleam/erlang/application
-import gleam/http
+import example_helpers/static
 import gleam/http/request.{type Request}
 import gleam/http/response.{type Response}
-import gleam/list
-import gleam/option
-import gleam/result
-import gleam/string
-import gleam/uri
 import mist.{type Connection, type ResponseData}
 
 /// Tenant the demo will issue tokens for. In a real app this comes from
@@ -25,28 +18,27 @@ pub fn handle_request(
   req: Request(Connection),
   ctx: Context,
 ) -> Response(ResponseData) {
-  use <- serve_static(req, under: "/static", from: priv_directory())
+  use <- static.serve_static(
+    req,
+    under: "/static",
+    from: static.priv_static("collab_docs"),
+  )
 
   case request.path_segments(req) {
     [] -> index_page(ctx)
-    _ -> not_found()
+    _ -> static.not_found()
   }
 }
 
 fn index_page(ctx: Context) -> Response(ResponseData) {
   let token = auth.sign_tenant(demo_tenant, ctx.secret)
-  let html =
-    "<!DOCTYPE html>
+  let html = "<!DOCTYPE html>
 <html lang=\"en\">
 <head>
   <meta charset=\"UTF-8\">
   <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
-  <meta name=\"beryl-tenant\" content=\""
-    <> demo_tenant
-    <> "\">
-  <meta name=\"beryl-tenant-token\" content=\""
-    <> token
-    <> "\">
+  <meta name=\"beryl-tenant\" content=\"" <> demo_tenant <> "\">
+  <meta name=\"beryl-tenant-token\" content=\"" <> token <> "\">
   <title>Collaborative CRDT Docs — beryl demo</title>
   <link rel=\"stylesheet\" href=\"/static/style.css\">
 </head>
@@ -68,82 +60,5 @@ fn index_page(ctx: Context) -> Response(ResponseData) {
 </body>
 </html>"
 
-  html_response(html)
-}
-
-fn serve_static(
-  req: Request(Connection),
-  under prefix: String,
-  from directory: String,
-  next handler: fn() -> Response(ResponseData),
-) -> Response(ResponseData) {
-  let path = drop_leading_slashes(req.path)
-  let prefix = drop_leading_slashes(prefix)
-
-  case req.method, string.starts_with(path, prefix) {
-    http.Get, True -> {
-      let static_path = path |> string.drop_start(string.length(prefix))
-      let relative =
-        static_path
-        |> uri.percent_decode
-        |> result.unwrap(static_path)
-        |> string.split("/")
-        |> list.filter(fn(segment) {
-          segment != "" && segment != "." && segment != ".."
-        })
-        |> string.join("/")
-
-      case relative {
-        "" -> not_found()
-        _ -> {
-          let file_path = directory <> "/" <> relative
-          case mist.send_file(file_path, offset: 0, limit: option.None) {
-            Ok(body) ->
-              response.new(200)
-              |> response.set_header("content-type", mime_type_for(file_path))
-              |> response.set_body(body)
-            Error(mist.UnknownFileError) ->
-              response.new(500)
-              |> response.set_body(mist.Bytes(bytes_tree.new()))
-            Error(_) -> not_found()
-          }
-        }
-      }
-    }
-    _, _ -> handler()
-  }
-}
-
-fn html_response(html: String) -> Response(ResponseData) {
-  response.new(200)
-  |> response.set_header("content-type", "text/html; charset=utf-8")
-  |> response.set_body(mist.Bytes(bytes_tree.from_string(html)))
-}
-
-fn not_found() -> Response(ResponseData) {
-  response.new(404)
-  |> response.set_body(mist.Bytes(bytes_tree.from_string("Not found")))
-}
-
-fn drop_leading_slashes(path: String) -> String {
-  case path {
-    "/" <> rest -> drop_leading_slashes(rest)
-    _ -> path
-  }
-}
-
-fn mime_type_for(path: String) -> String {
-  case string.split(path, ".") |> list.last {
-    Ok("css") -> "text/css; charset=utf-8"
-    Ok("js") -> "application/javascript; charset=utf-8"
-    Ok("mjs") -> "application/javascript; charset=utf-8"
-    Ok("html") -> "text/html; charset=utf-8"
-    Ok("json") -> "application/json; charset=utf-8"
-    _ -> "application/octet-stream"
-  }
-}
-
-fn priv_directory() -> String {
-  let assert Ok(priv) = application.priv_directory("collab_docs")
-  priv <> "/static"
+  static.html_response(html)
 }

--- a/examples/cursors/gleam.toml
+++ b/examples/cursors/gleam.toml
@@ -6,6 +6,7 @@ target = "erlang"
 
 [dependencies]
 beryl = { path = "../.." }
+example_helpers = { path = "../example_helpers" }
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 gleam_erlang = ">= 0.29.0 and < 2.0.0"
 gleam_otp = ">= 0.12.0 and < 2.0.0"

--- a/examples/cursors/manifest.toml
+++ b/examples/cursors/manifest.toml
@@ -4,6 +4,7 @@
 packages = [
   { name = "beryl", version = "0.1.0", build_tools = ["gleam"], requirements = ["birch", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../.." },
   { name = "birch", version = "0.2.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "simplifile"], otp_app = "birch", source = "hex", outer_checksum = "20CCDACA9E2A17E1D7F2C35322E619E7DDF98774FDC598D01AD5F414928E6261" },
+  { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_crypto", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "2DE9E4EF53CF6FEE049D4F765731F7178F7A11AEFAE00EEE63BF7536B354AD3F" },
@@ -24,6 +25,7 @@ packages = [
 
 [requirements]
 beryl = { path = "../.." }
+example_helpers = { path = "../example_helpers" }
 gleam_erlang = { version = ">= 0.29.0 and < 2.0.0" }
 gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
 gleam_json = { version = ">= 3.0.0 and < 4.0.0" }

--- a/examples/cursors/src/cursors.gleam
+++ b/examples/cursors/src/cursors.gleam
@@ -1,7 +1,7 @@
 import beryl
-import beryl/wire
 import beryl/presence
 import beryl/transport/mist as mist_transport
+import beryl/wire
 import cursors/cursor_channel
 import cursors/router
 import gleam/erlang/process

--- a/examples/cursors/src/cursors/cursor_channel.gleam
+++ b/examples/cursors/src/cursors/cursor_channel.gleam
@@ -2,9 +2,10 @@ import beryl
 import beryl/channel.{type Channel, type HandleResult, type JoinResult}
 import beryl/presence.{type Presence}
 import beryl/socket.{type Socket}
+import example_helpers/color
+import example_helpers/payload
 import gleam/dynamic.{type Dynamic}
 import gleam/dynamic/decode
-import gleam/int
 import gleam/json
 import gleam/list
 import gleam/option.{Some}
@@ -40,8 +41,8 @@ fn join(
   socket: Socket(CursorAssigns),
 ) -> JoinResult(CursorAssigns) {
   // Extract username from join payload, default to "Anonymous"
-  let username = extract_string(payload, "username", "Anonymous")
-  let color = random_pastel_color(socket.id(socket))
+  let username = payload.string_or(payload, "username", "Anonymous")
+  let color = color.pastel_for(socket.id(socket))
 
   // Set up assigns
   let assigns = CursorAssigns(username:, color:, channels:, presence:, topic:)
@@ -125,40 +126,6 @@ fn terminate(
 }
 
 // --- Helpers ---
-
-/// Generate a deterministic pastel color from a socket ID
-fn random_pastel_color(seed: String) -> String {
-  let hash =
-    seed
-    |> to_charcode_sum
-  let hue = hash % 360
-  "hsl(" <> int.to_string(hue) <> ", 70%, 65%)"
-}
-
-fn to_charcode_sum(s: String) -> Int {
-  s
-  |> string_to_codepoints
-  |> list.fold(0, fn(acc, cp) { acc + cp })
-}
-
-@external(erlang, "cursors_ffi", "string_to_codepoints")
-fn string_to_codepoints(s: String) -> List(Int)
-
-/// Extract a string field from a JSON value, with a default
-fn extract_string(
-  payload: Dynamic,
-  field_name: String,
-  default: String,
-) -> String {
-  let decoder = {
-    use value <- decode.field(field_name, decode.string)
-    decode.success(value)
-  }
-  case channel.decode_payload(payload, decoder) {
-    Ok(value) -> value
-    Error(_) -> default
-  }
-}
 
 /// Extract a number from JSON payload and return it as Json
 fn extract_json_number(payload: Dynamic, field_name: String) -> json.Json {

--- a/examples/cursors/src/cursors/cursor_channel.gleam
+++ b/examples/cursors/src/cursors/cursor_channel.gleam
@@ -2,6 +2,7 @@ import beryl
 import beryl/channel.{type Channel, type HandleResult, type JoinResult}
 import beryl/presence.{type Presence}
 import beryl/socket.{type Socket}
+import gleam/dynamic.{type Dynamic}
 import gleam/dynamic/decode
 import gleam/int
 import gleam/json
@@ -35,7 +36,7 @@ fn join(
   channels: beryl.Channels,
   presence: Presence,
   topic: String,
-  payload: json.Json,
+  payload: Dynamic,
   socket: Socket(CursorAssigns),
 ) -> JoinResult(CursorAssigns) {
   // Extract username from join payload, default to "Anonymous"
@@ -77,7 +78,7 @@ fn join(
 
 fn handle_in(
   event: String,
-  payload: json.Json,
+  payload: Dynamic,
   socket: Socket(CursorAssigns),
 ) -> HandleResult(CursorAssigns) {
   let assigns = socket.get_assigns(socket)
@@ -145,36 +146,34 @@ fn string_to_codepoints(s: String) -> List(Int)
 
 /// Extract a string field from a JSON value, with a default
 fn extract_string(
-  payload: json.Json,
+  payload: Dynamic,
   field_name: String,
   default: String,
 ) -> String {
-  let json_str = json.to_string(payload)
   let decoder = {
     use value <- decode.field(field_name, decode.string)
     decode.success(value)
   }
-  case json.parse(json_str, decoder) {
+  case channel.decode_payload(payload, decoder) {
     Ok(value) -> value
     Error(_) -> default
   }
 }
 
 /// Extract a number from JSON payload and return it as Json
-fn extract_json_number(payload: json.Json, field_name: String) -> json.Json {
-  let json_str = json.to_string(payload)
+fn extract_json_number(payload: Dynamic, field_name: String) -> json.Json {
   let float_decoder = {
     use value <- decode.field(field_name, decode.float)
     decode.success(value)
   }
-  case json.parse(json_str, float_decoder) {
+  case channel.decode_payload(payload, float_decoder) {
     Ok(value) -> json.float(value)
     Error(_) -> {
       let int_decoder = {
         use value <- decode.field(field_name, decode.int)
         decode.success(value)
       }
-      case json.parse(json_str, int_decoder) {
+      case channel.decode_payload(payload, int_decoder) {
         Ok(value) -> json.int(value)
         Error(_) -> json.float(0.0)
       }

--- a/examples/cursors/src/cursors/router.gleam
+++ b/examples/cursors/src/cursors/router.gleam
@@ -1,15 +1,8 @@
 import beryl
 import beryl/presence
-import gleam/bytes_tree
-import gleam/erlang/application
-import gleam/http
+import example_helpers/static
 import gleam/http/request.{type Request}
 import gleam/http/response.{type Response}
-import gleam/list
-import gleam/option
-import gleam/result
-import gleam/string
-import gleam/uri
 import mist.{type Connection, type ResponseData}
 
 pub type Context {
@@ -20,11 +13,15 @@ pub fn handle_request(
   req: Request(Connection),
   _ctx: Context,
 ) -> Response(ResponseData) {
-  use <- serve_static(req, under: "/static", from: priv_directory())
+  use <- static.serve_static(
+    req,
+    under: "/static",
+    from: static.priv_static("cursors"),
+  )
 
   case request.path_segments(req) {
     [] -> index_page()
-    _ -> not_found()
+    _ -> static.not_found()
   }
 }
 
@@ -58,82 +55,5 @@ fn index_page() -> Response(ResponseData) {
 </body>
 </html>"
 
-  html_response(html)
-}
-
-fn serve_static(
-  req: Request(Connection),
-  under prefix: String,
-  from directory: String,
-  next handler: fn() -> Response(ResponseData),
-) -> Response(ResponseData) {
-  let path = drop_leading_slashes(req.path)
-  let prefix = drop_leading_slashes(prefix)
-
-  case req.method, string.starts_with(path, prefix) {
-    http.Get, True -> {
-      let static_path = path |> string.drop_start(string.length(prefix))
-      let relative =
-        static_path
-        |> uri.percent_decode
-        |> result.unwrap(static_path)
-        |> string.split("/")
-        |> list.filter(fn(segment) {
-          segment != "" && segment != "." && segment != ".."
-        })
-        |> string.join("/")
-
-      case relative {
-        "" -> not_found()
-        _ -> {
-          let file_path = directory <> "/" <> relative
-          case mist.send_file(file_path, offset: 0, limit: option.None) {
-            Ok(body) ->
-              response.new(200)
-              |> response.set_header("content-type", mime_type_for(file_path))
-              |> response.set_body(body)
-            Error(mist.UnknownFileError) ->
-              response.new(500)
-              |> response.set_body(mist.Bytes(bytes_tree.new()))
-            Error(_) -> not_found()
-          }
-        }
-      }
-    }
-    _, _ -> handler()
-  }
-}
-
-fn html_response(html: String) -> Response(ResponseData) {
-  response.new(200)
-  |> response.set_header("content-type", "text/html; charset=utf-8")
-  |> response.set_body(mist.Bytes(bytes_tree.from_string(html)))
-}
-
-fn not_found() -> Response(ResponseData) {
-  response.new(404)
-  |> response.set_body(mist.Bytes(bytes_tree.from_string("Not found")))
-}
-
-fn drop_leading_slashes(path: String) -> String {
-  case path {
-    "/" <> rest -> drop_leading_slashes(rest)
-    _ -> path
-  }
-}
-
-fn mime_type_for(path: String) -> String {
-  case string.split(path, ".") |> list.last {
-    Ok("css") -> "text/css; charset=utf-8"
-    Ok("js") -> "application/javascript; charset=utf-8"
-    Ok("mjs") -> "application/javascript; charset=utf-8"
-    Ok("html") -> "text/html; charset=utf-8"
-    Ok("json") -> "application/json; charset=utf-8"
-    _ -> "application/octet-stream"
-  }
-}
-
-fn priv_directory() -> String {
-  let assert Ok(priv) = application.priv_directory("cursors")
-  priv <> "/static"
+  static.html_response(html)
 }

--- a/examples/cursors/src/cursors_ffi.erl
+++ b/examples/cursors/src/cursors_ffi.erl
@@ -1,5 +1,0 @@
--module(cursors_ffi).
--export([string_to_codepoints/1]).
-
-string_to_codepoints(String) ->
-    lists:map(fun(CP) -> CP end, unicode:characters_to_list(String)).

--- a/examples/example_helpers/gleam.toml
+++ b/examples/example_helpers/gleam.toml
@@ -1,18 +1,12 @@
-name = "chatrooms"
+name = "example_helpers"
 version = "0.1.0"
-description = "Multi-room chat demo for beryl"
+description = "Shared helpers used across the beryl example apps"
 gleam = ">= 1.4.0"
 target = "erlang"
 
 [dependencies]
 beryl = { path = "../.." }
-example_helpers = { path = "../example_helpers" }
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 gleam_erlang = ">= 0.29.0 and < 2.0.0"
-gleam_otp = ">= 0.12.0 and < 2.0.0"
-gleam_json = ">= 3.0.0 and < 4.0.0"
 gleam_http = ">= 4.3.0 and < 5.0.0"
 mist = ">= 6.0.0 and < 7.0.0"
-
-[dev-dependencies]
-gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/examples/example_helpers/manifest.toml
+++ b/examples/example_helpers/manifest.toml
@@ -4,7 +4,6 @@
 packages = [
   { name = "beryl", version = "0.1.0", build_tools = ["gleam"], requirements = ["birch", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../.." },
   { name = "birch", version = "0.2.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "simplifile"], otp_app = "birch", source = "hex", outer_checksum = "20CCDACA9E2A17E1D7F2C35322E619E7DDF98774FDC598D01AD5F414928E6261" },
-  { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_crypto", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "2DE9E4EF53CF6FEE049D4F765731F7178F7A11AEFAE00EEE63BF7536B354AD3F" },
@@ -12,17 +11,11 @@ packages = [
   { name = "gleam_http", version = "4.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "82EA6A717C842456188C190AFB372665EA56CE13D8559BF3B1DD9E40F619EE0C" },
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
-  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_stdlib", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0C5506589DF4C63DF5D6FFBB834562D6865C6C2AEE0019D7B37886BD6D128141" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
-  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
   { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
   { name = "gramps", version = "6.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D55636072DEE173F6586A5679D3C02EC7A0DE3F8646B78C351B72908FF223DF7" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
-  { name = "lattice_core", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "lattice_core", source = "hex", outer_checksum = "E0A7CC27CB58795D10DF4B7186891FDBF90F10A5FBF34C5862E5E936814A2CD5" },
-  { name = "lattice_counters", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], otp_app = "lattice_counters", source = "hex", outer_checksum = "28F3662014B5667F30CE8167BB75DB1FCD0A91D447F074EE45B521481287CB4F" },
-  { name = "lattice_maps", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core", "lattice_counters", "lattice_registers", "lattice_sets"], otp_app = "lattice_maps", source = "hex", outer_checksum = "7C0E20C6FF61E732B433AE34AE843B10E4B849571AE1EDE5EB9E4BC1F684ADDF" },
-  { name = "lattice_registers", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], otp_app = "lattice_registers", source = "hex", outer_checksum = "6B62A7687D5D138BC36B00090BF1A4BA03E40183550040018B69652204B158A4" },
-  { name = "lattice_sets", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], otp_app = "lattice_sets", source = "hex", outer_checksum = "C73BDB01ED288E326AADE8BD37B88C63750915692E736CF0E968B37C9E69F28E" },
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
@@ -30,15 +23,7 @@ packages = [
 
 [requirements]
 beryl = { path = "../.." }
-example_helpers = { path = "../example_helpers" }
-gleam_crypto = { version = ">= 1.6.0 and < 2.0.0" }
 gleam_erlang = { version = ">= 0.29.0 and < 2.0.0" }
 gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
-gleam_json = { version = ">= 3.0.0 and < 4.0.0" }
-gleam_otp = { version = ">= 0.12.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
-gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
-lattice_core = { version = ">= 1.0.0 and < 2.0.0" }
-lattice_maps = { version = ">= 1.0.0 and < 2.0.0" }
-lattice_registers = { version = ">= 1.0.0 and < 2.0.0" }
 mist = { version = ">= 6.0.0 and < 7.0.0" }

--- a/examples/example_helpers/src/example_helpers.gleam
+++ b/examples/example_helpers/src/example_helpers.gleam
@@ -1,0 +1,4 @@
+/// Empty entrypoint; consumers import from the `example_helpers/*` submodules.
+pub fn main() {
+  Nil
+}

--- a/examples/example_helpers/src/example_helpers/color.gleam
+++ b/examples/example_helpers/src/example_helpers/color.gleam
@@ -1,0 +1,24 @@
+//// Tiny color helpers used by the example apps for distinguishing users
+//// at a glance — not intended for general-purpose use.
+
+import gleam/int
+import gleam/list
+
+/// Generate a deterministic pastel HSL color string from a seed.
+///
+/// Different seeds produce visually distinct hues; the same seed always
+/// produces the same color, so a presence list rendered twice in the same
+/// session keeps user colors stable.
+pub fn pastel_for(seed: String) -> String {
+  let hue = charcode_sum(seed) % 360
+  "hsl(" <> int.to_string(hue) <> ", 70%, 65%)"
+}
+
+fn charcode_sum(s: String) -> Int {
+  s
+  |> string_to_codepoints
+  |> list.fold(0, fn(acc, cp) { acc + cp })
+}
+
+@external(erlang, "example_helpers_ffi", "string_to_codepoints")
+fn string_to_codepoints(s: String) -> List(Int)

--- a/examples/example_helpers/src/example_helpers/payload.gleam
+++ b/examples/example_helpers/src/example_helpers/payload.gleam
@@ -1,0 +1,26 @@
+//// Tiny JSON-payload accessors used by the example channels. These are
+//// deliberately permissive (returning defaults on missing/wrong-type fields)
+//// because example UIs would rather render "Anonymous" than crash; real
+//// applications should validate and reject malformed payloads instead.
+
+import beryl/channel
+import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode
+
+/// Read a string-valued field from a channel payload, falling back to
+/// `default` if the field is missing, not a string, or the payload isn't
+/// a dict.
+pub fn string_or(
+  payload: Dynamic,
+  field_name: String,
+  default: String,
+) -> String {
+  let decoder = {
+    use value <- decode.field(field_name, decode.string)
+    decode.success(value)
+  }
+  case channel.decode_payload(payload, decoder) {
+    Ok(value) -> value
+    Error(_) -> default
+  }
+}

--- a/examples/example_helpers/src/example_helpers/static.gleam
+++ b/examples/example_helpers/src/example_helpers/static.gleam
@@ -1,0 +1,112 @@
+//// Static-file and HTTP-response helpers shared by the beryl example apps.
+////
+//// Example apps each serve a few HTML pages, a JSON API or two, and a small
+//// directory of CSS/JS assets from their `priv/static` folder. The router
+//// boilerplate was identical across `chatrooms`, `cursors`, and `collab_docs`;
+//// this module extracts it so each example's router shrinks to its
+//// app-specific routes.
+
+import gleam/bytes_tree
+import gleam/erlang/application
+import gleam/http
+import gleam/http/request.{type Request}
+import gleam/http/response.{type Response}
+import gleam/list
+import gleam/option
+import gleam/result
+import gleam/string
+import gleam/uri
+import mist.{type Connection, type ResponseData}
+
+/// Serve files from `directory` under the URL prefix `prefix`. Falls through
+/// to `handler` for non-GET requests and for paths that don't match.
+pub fn serve_static(
+  req: Request(Connection),
+  under prefix: String,
+  from directory: String,
+  next handler: fn() -> Response(ResponseData),
+) -> Response(ResponseData) {
+  let path = drop_leading_slashes(req.path)
+  let prefix = drop_leading_slashes(prefix)
+
+  case req.method, string.starts_with(path, prefix) {
+    http.Get, True -> {
+      let static_path = path |> string.drop_start(string.length(prefix))
+      let relative =
+        static_path
+        |> uri.percent_decode
+        |> result.unwrap(static_path)
+        |> string.split("/")
+        |> list.filter(fn(segment) {
+          segment != "" && segment != "." && segment != ".."
+        })
+        |> string.join("/")
+
+      case relative {
+        "" -> not_found()
+        _ -> {
+          let file_path = directory <> "/" <> relative
+          case mist.send_file(file_path, offset: 0, limit: option.None) {
+            Ok(body) ->
+              response.new(200)
+              |> response.set_header("content-type", mime_type_for(file_path))
+              |> response.set_body(body)
+            Error(mist.UnknownFileError) ->
+              response.new(500)
+              |> response.set_body(mist.Bytes(bytes_tree.new()))
+            Error(_) -> not_found()
+          }
+        }
+      }
+    }
+    _, _ -> handler()
+  }
+}
+
+/// Build a 200 HTML response from a string body.
+pub fn html_response(html: String) -> Response(ResponseData) {
+  response.new(200)
+  |> response.set_header("content-type", "text/html; charset=utf-8")
+  |> response.set_body(mist.Bytes(bytes_tree.from_string(html)))
+}
+
+/// Build a 200 JSON response from an already-serialized JSON string body.
+pub fn json_response(json: String) -> Response(ResponseData) {
+  response.new(200)
+  |> response.set_header("content-type", "application/json; charset=utf-8")
+  |> response.set_body(mist.Bytes(bytes_tree.from_string(json)))
+}
+
+/// Build a plain `404 Not found` response.
+pub fn not_found() -> Response(ResponseData) {
+  response.new(404)
+  |> response.set_body(mist.Bytes(bytes_tree.from_string("Not found")))
+}
+
+/// Strip consecutive leading slashes from a path.
+pub fn drop_leading_slashes(path: String) -> String {
+  case path {
+    "/" <> rest -> drop_leading_slashes(rest)
+    _ -> path
+  }
+}
+
+/// Guess a content-type for a path by its extension. Defaults to
+/// `application/octet-stream` for unknown extensions.
+pub fn mime_type_for(path: String) -> String {
+  case string.split(path, ".") |> list.last {
+    Ok("css") -> "text/css; charset=utf-8"
+    Ok("js") -> "application/javascript; charset=utf-8"
+    Ok("mjs") -> "application/javascript; charset=utf-8"
+    Ok("html") -> "text/html; charset=utf-8"
+    Ok("json") -> "application/json; charset=utf-8"
+    _ -> "application/octet-stream"
+  }
+}
+
+/// Resolve `<priv>/static` for an OTP application. Crashes if the application
+/// isn't loaded — examples always have their own priv tree at runtime.
+pub fn priv_static(app_name: String) -> String {
+  let assert Ok(priv) = application.priv_directory(app_name)
+  priv <> "/static"
+}

--- a/examples/example_helpers/src/example_helpers_ffi.erl
+++ b/examples/example_helpers/src/example_helpers_ffi.erl
@@ -1,0 +1,5 @@
+-module(example_helpers_ffi).
+-export([string_to_codepoints/1]).
+
+string_to_codepoints(Str) ->
+    unicode:characters_to_list(Str).

--- a/justfile
+++ b/justfile
@@ -16,6 +16,7 @@ default:
 # Download project dependencies (including examples)
 deps:
     gleam deps download
+    cd examples/example_helpers && gleam deps download
     cd examples/cursors && gleam deps download
     cd examples/chatrooms && gleam deps download
     cd examples/collab_docs && gleam deps download

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -24,6 +24,7 @@
 //// import beryl/pubsub
 //// import beryl/presence
 //// import beryl/group
+//// import beryl/wire
 ////
 //// pub fn main() {
 ////   // Optional: start PubSub for distributed messaging

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -57,7 +57,6 @@ import beryl/pubsub.{type PubSub}
 import beryl/rate_limit
 import beryl/socket.{type Socket}
 import beryl/topic
-import beryl/wire
 import beryl/wire/codec
 import gleam/dynamic.{type Dynamic}
 import gleam/erlang/process.{type Subject}
@@ -448,14 +447,11 @@ fn erase_channel_types(
       // Create a typed socket with Nil assigns (will be set by join)
       let typed_socket = create_socket_from_context(ctx)
 
-      // Decode Dynamic payload to Json for the handler
-      let json_payload = wire.dynamic_to_json(payload)
-
       // Call the typed join handler (unsafe coerce socket to expected type)
       case
         typed_channel.join(
           topic_name,
-          json_payload,
+          payload,
           unsafe_coerce_socket(typed_socket),
         )
       {
@@ -476,11 +472,10 @@ fn erase_channel_types(
       ctx: coordinator.SocketContext,
     ) {
       let typed_socket = create_socket_with_assigns(ctx)
-      let json_payload = wire.dynamic_to_json(payload)
 
       typed_channel.handle_in(
         event,
-        json_payload,
+        payload,
         unsafe_coerce_socket(typed_socket),
       )
       |> erase_handle_result

--- a/src/beryl/channel.gleam
+++ b/src/beryl/channel.gleam
@@ -24,6 +24,7 @@
 
 import beryl/socket.{type Socket}
 import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode
 import gleam/json.{type Json}
 import gleam/option.{type Option}
 
@@ -74,11 +75,11 @@ pub type Channel(assigns) {
     ///
     /// Return JoinOk to accept the connection (with optional reply payload),
     /// or JoinError to reject it.
-    join: fn(String, Json, Socket(assigns)) -> JoinResult(assigns),
+    join: fn(String, Dynamic, Socket(assigns)) -> JoinResult(assigns),
     /// Called when a client sends a text message to this channel
     ///
     /// The event string identifies the message type (e.g., "new_message", "typing").
-    handle_in: fn(String, Json, Socket(assigns)) -> HandleResult(assigns),
+    handle_in: fn(String, Dynamic, Socket(assigns)) -> HandleResult(assigns),
     /// Called when a client sends a binary frame to this channel
     ///
     /// Binary frames bypass the Phoenix wire protocol and are passed as raw BitArray.
@@ -96,7 +97,7 @@ pub type Channel(assigns) {
 ///
 /// Other handlers can be added using the `with_*` functions.
 pub fn new(
-  join: fn(String, Json, Socket(assigns)) -> JoinResult(assigns),
+  join: fn(String, Dynamic, Socket(assigns)) -> JoinResult(assigns),
 ) -> Channel(assigns) {
   Channel(
     join: join,
@@ -110,9 +111,17 @@ pub fn new(
 /// Add an incoming message handler
 pub fn with_handle_in(
   channel: Channel(assigns),
-  handler: fn(String, Json, Socket(assigns)) -> HandleResult(assigns),
+  handler: fn(String, Dynamic, Socket(assigns)) -> HandleResult(assigns),
 ) -> Channel(assigns) {
   Channel(..channel, handle_in: handler)
+}
+
+/// Decode an inbound channel payload into an application type.
+pub fn decode_payload(
+  payload: Dynamic,
+  decoder: decode.Decoder(a),
+) -> Result(a, List(decode.DecodeError)) {
+  decode.run(payload, decoder)
 }
 
 /// Add a binary message handler

--- a/src/beryl/channel.gleam
+++ b/src/beryl/channel.gleam
@@ -82,7 +82,8 @@ pub type Channel(assigns) {
     handle_in: fn(String, Dynamic, Socket(assigns)) -> HandleResult(assigns),
     /// Called when a client sends a binary frame to this channel
     ///
-    /// Binary frames bypass the Phoenix wire protocol and are passed as raw BitArray.
+    /// Binary frames are passed as raw BitArray when the configured codec has
+    /// no binary decoder.
     handle_binary: fn(BitArray, Socket(assigns)) -> HandleResult(assigns),
     /// Called when an OTP process sends a server-originated message to this channel
     handle_info: fn(Dynamic, Socket(assigns)) -> HandleResult(assigns),

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -154,6 +154,19 @@ pub type SocketInfo {
   )
 }
 
+fn send_frame(socket_info: SocketInfo, frame: codec.Frame) -> Nil {
+  case frame {
+    codec.TextFrame(text) -> {
+      let _ = socket_info.send(text)
+      Nil
+    }
+    codec.BinaryFrame(data) -> {
+      let _ = socket_info.send_binary(data)
+      Nil
+    }
+  }
+}
+
 /// Messages the coordinator handles
 pub type Message {
   // Channel registration
@@ -171,24 +184,8 @@ pub type Message {
   )
   SocketDisconnected(socket_id: String)
   // Channel operations
-  Join(
-    socket_id: String,
-    topic: String,
-    payload: Dynamic,
-    join_ref: Option(String),
-    ref: String,
-  )
-  Leave(socket_id: String, topic: String, ref: Option(String))
-  HandleIn(
-    socket_id: String,
-    topic: String,
-    event: String,
-    payload: Dynamic,
-    ref: Option(String),
-  )
   HandleBinary(socket_id: String, data: BitArray)
   HandleInfo(socket_id: String, topic: String, message: Dynamic)
-  Heartbeat(socket_id: String, ref: String)
   /// Raw inbound text from the transport — decoded inside the actor using
   /// the configured codec.
   RouteText(socket_id: String, raw_text: String)
@@ -354,21 +351,10 @@ fn handle_message(
     SocketDisconnected(socket_id) ->
       handle_socket_disconnected(state, socket_id)
 
-    Join(socket_id, topic_name, payload, join_ref, ref) ->
-      handle_join(state, socket_id, topic_name, payload, join_ref, ref)
-
-    Leave(socket_id, topic_name, ref) ->
-      handle_leave(state, socket_id, topic_name, ref)
-
-    HandleIn(socket_id, topic_name, event, payload, ref) ->
-      handle_in(state, socket_id, topic_name, event, payload, ref)
-
     HandleBinary(socket_id, data) -> handle_binary_in(state, socket_id, data)
 
     HandleInfo(socket_id, topic_name, message) ->
       handle_info(state, socket_id, topic_name, message)
-
-    Heartbeat(socket_id, ref) -> handle_heartbeat(state, socket_id, ref)
 
     RouteText(socket_id, raw_text) ->
       handle_route_text(state, socket_id, raw_text)
@@ -456,7 +442,7 @@ fn handle_join(
   topic_name: String,
   payload: Dynamic,
   join_ref: Option(String),
-  ref: String,
+  ref: Option(String),
 ) -> actor.Next(State, Message) {
   // Check join rate limit
   case
@@ -480,7 +466,7 @@ fn handle_join(
               codec.StatusError,
               json.object([#("reason", json.string("rate_limited"))]),
             )
-          let _ = socket_info.send(reply)
+          send_frame(socket_info, reply)
           Nil
         }
         Error(_) -> Nil
@@ -498,7 +484,7 @@ fn handle_join_inner(
   topic_name: String,
   payload: Dynamic,
   join_ref: Option(String),
-  ref: String,
+  ref: Option(String),
 ) -> actor.Next(State, Message) {
   case dict.get(state.sockets, socket_id) {
     Error(_) -> actor.continue(state)
@@ -513,7 +499,7 @@ fn handle_join_inner(
               codec.StatusError,
               json.object([#("reason", json.string("no_channel_handler"))]),
             )
-          let _ = socket_info.send(reply)
+          send_frame(socket_info, reply)
           actor.continue(state)
         }
         Some(handler) -> {
@@ -537,7 +523,7 @@ fn handle_join_inner(
                   codec.StatusError,
                   reason,
                 )
-              let _ = socket_info.send(reply)
+              send_frame(socket_info, reply)
               actor.continue(state)
             }
             JoinOkErased(reply_payload, assigns) -> {
@@ -581,7 +567,7 @@ fn handle_join_inner(
                   codec.StatusOk,
                   response,
                 )
-              let _ = socket_info.send(reply)
+              send_frame(socket_info, reply)
 
               actor.continue(
                 State(..state, sockets: new_sockets, topics: new_topics),
@@ -607,12 +593,12 @@ fn handle_leave(
       let reply =
         state.config.codec.encode_reply(
           None,
-          r,
+          Some(r),
           topic_name,
           codec.StatusOk,
           json.object([]),
         )
-      let _ = socket_info.send(reply)
+      send_frame(socket_info, reply)
       Nil
     }
     _, _ -> Nil
@@ -710,12 +696,12 @@ fn handle_in_inner(
                       let reply =
                         state.config.codec.encode_reply(
                           None,
-                          r,
+                          Some(r),
                           topic_name,
                           codec.StatusOk,
                           reply_payload,
                         )
-                      let _ = socket_info.send(reply)
+                      send_frame(socket_info, reply)
                       Nil
                     }
                     None -> Nil
@@ -732,7 +718,7 @@ fn handle_in_inner(
                       push_event,
                       push_payload,
                     )
-                  let _ = socket_info.send(msg)
+                  send_frame(socket_info, msg)
                   let state =
                     update_assigns(state, socket_id, topic_name, new_assigns)
                   actor.continue(state)
@@ -798,7 +784,7 @@ fn handle_info(
                       reply_event,
                       reply_payload,
                     )
-                  let _ = socket_info.send(msg)
+                  send_frame(socket_info, msg)
                   let state =
                     update_assigns(state, socket_id, topic_name, new_assigns)
                   actor.continue(state)
@@ -837,11 +823,37 @@ fn handle_binary_in(
       ])
       actor.continue(state)
     }
-    Ok(_) -> handle_binary_in_inner(state, socket_id, data)
+    Ok(_) -> {
+      case state.config.codec.decode_binary {
+        Some(decode_binary) ->
+          handle_route_binary_frame(state, socket_id, data, decode_binary)
+        None -> handle_raw_binary_in_inner(state, socket_id, data)
+      }
+    }
   }
 }
 
-fn handle_binary_in_inner(
+fn handle_route_binary_frame(
+  state: State,
+  socket_id: String,
+  data: BitArray,
+  decode_binary: fn(BitArray) -> Result(codec.Inbound, codec.DecodeError),
+) -> actor.Next(State, Message) {
+  case decode_binary(data) {
+    Error(err) -> {
+      let logger = internal.logger("beryl.coordinator")
+      logger
+      |> log.warn("Failed to decode binary wire protocol message", [
+        #("socket_id", socket_id),
+        #("error", wire_format_decode_error(err)),
+      ])
+      actor.continue(state)
+    }
+    Ok(msg) -> dispatch_inbound(state, socket_id, msg)
+  }
+}
+
+fn handle_raw_binary_in_inner(
   state: State,
   socket_id: String,
   data: BitArray,
@@ -878,7 +890,7 @@ fn handle_binary_in_inner(
                       "binary_reply",
                       reply_payload,
                     )
-                  let _ = socket_info.send(msg)
+                  send_frame(socket_info, msg)
                   update_assigns(st, socket_id, topic_name, new_assigns)
                 }
                 PushErased(push_event, push_payload, new_assigns) -> {
@@ -888,7 +900,7 @@ fn handle_binary_in_inner(
                       push_event,
                       push_payload,
                     )
-                  let _ = socket_info.send(msg)
+                  send_frame(socket_info, msg)
                   update_assigns(st, socket_id, topic_name, new_assigns)
                 }
                 StopErased(reason) ->
@@ -905,7 +917,7 @@ fn handle_binary_in_inner(
 fn handle_heartbeat(
   state: State,
   socket_id: String,
-  ref: String,
+  ref: Option(String),
 ) -> actor.Next(State, Message) {
   case dict.get(state.sockets, socket_id) {
     Error(_) -> actor.continue(state)
@@ -915,7 +927,7 @@ fn handle_heartbeat(
       let new_sockets = dict.insert(state.sockets, socket_id, updated_socket)
 
       let reply = state.config.codec.encode_heartbeat_reply(ref)
-      let _ = socket_info.send(reply)
+      send_frame(socket_info, reply)
       actor.continue(State(..state, sockets: new_sockets))
     }
   }
@@ -1005,7 +1017,7 @@ fn handle_broadcast(
   list.each(recipients, fn(socket_id) {
     case dict.get(state.sockets, socket_id) {
       Ok(socket_info) -> {
-        let _ = socket_info.send(msg)
+        send_frame(socket_info, msg)
         Nil
       }
       Error(_) -> Nil
@@ -1149,7 +1161,7 @@ fn handle_route_text(
   raw_text: String,
 ) -> actor.Next(State, Message) {
   let codec = state.config.codec
-  case codec.decode(raw_text) {
+  case codec.decode_text(raw_text) {
     Error(err) -> {
       let logger = internal.logger("beryl.coordinator")
       logger
@@ -1160,29 +1172,29 @@ fn handle_route_text(
       ])
       actor.continue(state)
     }
-    Ok(msg) -> {
-      case msg.event {
-        e if e == codec.join_event -> {
-          let ref = option.unwrap(msg.ref, "")
-          handle_join(
-            state,
-            socket_id,
-            msg.topic,
-            msg.payload,
-            msg.join_ref,
-            ref,
-          )
-        }
-        e if e == codec.leave_event ->
-          handle_leave(state, socket_id, msg.topic, msg.ref)
-        e if e == codec.heartbeat_event -> {
-          let ref = option.unwrap(msg.ref, "")
-          handle_heartbeat(state, socket_id, ref)
-        }
-        event ->
-          handle_in(state, socket_id, msg.topic, event, msg.payload, msg.ref)
-      }
-    }
+    Ok(msg) -> dispatch_inbound(state, socket_id, msg)
+  }
+}
+
+fn dispatch_inbound(
+  state: State,
+  socket_id: String,
+  msg: codec.Inbound,
+) -> actor.Next(State, Message) {
+  case msg.kind {
+    codec.Join ->
+      handle_join(
+        state,
+        socket_id,
+        msg.topic,
+        msg.payload,
+        msg.join_ref,
+        msg.ref,
+      )
+    codec.Leave -> handle_leave(state, socket_id, msg.topic, msg.ref)
+    codec.Heartbeat -> handle_heartbeat(state, socket_id, msg.ref)
+    codec.Event(event) ->
+      handle_in(state, socket_id, msg.topic, event, msg.payload, msg.ref)
   }
 }
 

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -51,8 +51,6 @@ pub type SocketContext {
     send: fn(String) -> Result(Nil, Nil),
     /// Function to send binary data to this socket
     send_binary: fn(BitArray) -> Result(Nil, Nil),
-    /// PID of the WebSocket handler process (for direct messaging)
-    handler_pid: Dynamic,
   )
 }
 
@@ -143,8 +141,6 @@ pub type SocketInfo {
     send: fn(String) -> Result(Nil, Nil),
     /// Function to send binary to this socket's WebSocket
     send_binary: fn(BitArray) -> Result(Nil, Nil),
-    /// PID of the WebSocket handler process (for direct messaging)
-    handler_pid: Dynamic,
     /// Topics this socket is subscribed to
     subscribed_topics: Set(String),
     /// Per-topic assigns (topic -> Dynamic assigns)
@@ -180,15 +176,21 @@ pub type Message {
     socket_id: String,
     send: fn(String) -> Result(Nil, Nil),
     send_binary: fn(BitArray) -> Result(Nil, Nil),
-    handler_pid: Dynamic,
   )
   SocketDisconnected(socket_id: String)
   // Channel operations
   HandleBinary(socket_id: String, data: BitArray)
   HandleInfo(socket_id: String, topic: String, message: Dynamic)
   /// Raw inbound text from the transport — decoded inside the actor using
-  /// the configured codec.
+  /// the configured codec. Prefer `RouteInbound` (decoded in the transport)
+  /// when the codec is already available there.
   RouteText(socket_id: String, raw_text: String)
+  /// Pre-decoded inbound message from the transport — bypasses actor-side
+  /// decoding so JSON parsing doesn't serialize on the coordinator's mailbox.
+  RouteInbound(socket_id: String, msg: codec.Inbound)
+  /// Synchronously fetch the configured codec. Transports call this once
+  /// at upgrade time to cache the codec for in-transport decoding.
+  GetCodec(reply: Subject(Codec))
   // Broadcasting
   Broadcast(
     topic: String,
@@ -345,8 +347,8 @@ fn handle_message(
     RegisterChannel(pattern, handler, reply) ->
       handle_register_channel(state, pattern, handler, reply)
 
-    SocketConnected(socket_id, send, send_binary, handler_pid) ->
-      handle_socket_connected(state, socket_id, send, send_binary, handler_pid)
+    SocketConnected(socket_id, send, send_binary) ->
+      handle_socket_connected(state, socket_id, send, send_binary)
 
     SocketDisconnected(socket_id) ->
       handle_socket_disconnected(state, socket_id)
@@ -358,6 +360,13 @@ fn handle_message(
 
     RouteText(socket_id, raw_text) ->
       handle_route_text(state, socket_id, raw_text)
+
+    RouteInbound(socket_id, msg) -> dispatch_inbound(state, socket_id, msg)
+
+    GetCodec(reply) -> {
+      process.send(reply, state.config.codec)
+      actor.continue(state)
+    }
 
     Broadcast(topic_name, event, payload, except) ->
       handle_broadcast(state, topic_name, event, payload, except)
@@ -396,14 +405,12 @@ fn handle_socket_connected(
   socket_id: String,
   send: fn(String) -> Result(Nil, Nil),
   send_binary: fn(BitArray) -> Result(Nil, Nil),
-  handler_pid: Dynamic,
 ) -> actor.Next(State, Message) {
   let socket_info =
     SocketInfo(
       id: socket_id,
       send: send,
       send_binary: send_binary,
-      handler_pid: handler_pid,
       subscribed_topics: set.new(),
       channel_assigns: dict.new(),
       last_heartbeat: monotonic_time_ms(),
@@ -510,7 +517,6 @@ fn handle_join_inner(
               assigns: dynamic.nil(),
               send: socket_info.send,
               send_binary: socket_info.send_binary,
-              handler_pid: socket_info.handler_pid,
             )
 
           case handler.join(topic_name, payload, ctx) {
@@ -680,7 +686,6 @@ fn handle_in_inner(
                   assigns: assigns,
                   send: socket_info.send,
                   send_binary: socket_info.send_binary,
-                  handler_pid: socket_info.handler_pid,
                 )
 
               case handler.handle_in(event, payload, ctx) {
@@ -764,7 +769,6 @@ fn handle_info(
                   assigns: assigns,
                   send: socket_info.send,
                   send_binary: socket_info.send_binary,
-                  handler_pid: socket_info.handler_pid,
                 )
 
               case handler.handle_info(message, ctx) {
@@ -877,7 +881,6 @@ fn handle_raw_binary_in_inner(
                   assigns: assigns,
                   send: socket_info.send,
                   send_binary: socket_info.send_binary,
-                  handler_pid: socket_info.handler_pid,
                 )
 
               case handler.handle_binary(data, ctx) {
@@ -1080,7 +1083,6 @@ fn terminate_channel(
                   assigns: assigns,
                   send: socket_info.send,
                   send_binary: socket_info.send_binary,
-                  handler_pid: socket_info.handler_pid,
                 )
               handler.terminate(reason, ctx)
             }
@@ -1144,8 +1146,9 @@ fn update_assigns(
 
 /// Route raw inbound text from a transport to the coordinator.
 ///
-/// The coordinator decodes the text using its configured `Codec` inside
-/// the actor (so the codec lives in one place, not in every transport).
+/// Decoding runs inside the coordinator actor. Prefer `route_inbound` when
+/// the transport can decode locally — that keeps JSON parsing off the
+/// coordinator's mailbox so it doesn't serialize across all sockets.
 /// Frames that fail to decode are logged and dropped.
 pub fn route_message(
   coord: Subject(Message),
@@ -1153,6 +1156,25 @@ pub fn route_message(
   raw_text: String,
 ) -> Nil {
   process.send(coord, RouteText(socket_id, raw_text))
+}
+
+/// Route a pre-decoded inbound message from a transport. Use this when
+/// the transport already has the configured codec (via `get_codec`) and
+/// decodes inline, so the JSON parsing cost lands on the per-connection
+/// process instead of the shared coordinator actor.
+pub fn route_inbound(
+  coord: Subject(Message),
+  socket_id: String,
+  msg: codec.Inbound,
+) -> Nil {
+  process.send(coord, RouteInbound(socket_id, msg))
+}
+
+/// Synchronously fetch the configured codec from the coordinator. Intended
+/// to be called once per WebSocket connection at upgrade time so the
+/// transport can cache and use it for inline decoding.
+pub fn get_codec(coord: Subject(Message)) -> Codec {
+  process.call(coord, 5000, GetCodec)
 }
 
 fn handle_route_text(

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -1222,8 +1222,9 @@ fn dispatch_inbound(
 
 /// Route a binary WebSocket frame to the coordinator.
 ///
-/// Binary frames bypass the Phoenix wire protocol and are dispatched
-/// to all subscribed topics for the socket.
+/// Binary frames are decoded by the configured codec when it has a binary
+/// decoder; otherwise they are dispatched raw to all subscribed topics for
+/// the socket.
 pub fn route_binary(
   coord: Subject(Message),
   socket_id: String,

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -845,7 +845,7 @@ fn handle_route_binary_frame(
       logger
       |> log.warn("Failed to decode binary wire protocol message", [
         #("socket_id", socket_id),
-        #("error", wire_format_decode_error(err)),
+        #("error", codec.format_decode_error(err)),
       ])
       actor.continue(state)
     }
@@ -1167,7 +1167,7 @@ fn handle_route_text(
       logger
       |> log.warn("Failed to decode wire protocol message", [
         #("socket_id", socket_id),
-        #("error", wire_format_decode_error(err)),
+        #("error", codec.format_decode_error(err)),
         #("frame_preview", string.slice(raw_text, 0, 200)),
       ])
       actor.continue(state)
@@ -1195,14 +1195,6 @@ fn dispatch_inbound(
     codec.Heartbeat -> handle_heartbeat(state, socket_id, msg.ref)
     codec.Event(event) ->
       handle_in(state, socket_id, msg.topic, event, msg.payload, msg.ref)
-  }
-}
-
-fn wire_format_decode_error(error: codec.DecodeError) -> String {
-  case error {
-    codec.InvalidJson(reason) -> "InvalidJson: " <> reason
-    codec.InvalidFormat(reason) -> "InvalidFormat: " <> reason
-    codec.MissingField(name) -> "MissingField: " <> name
   }
 }
 

--- a/src/beryl/presence.gleam
+++ b/src/beryl/presence.gleam
@@ -106,6 +106,9 @@ type ActorState {
     config: Config,
     /// The actor's own subject, needed for scheduling BroadcastTick
     self_subject: Option(Subject(Message)),
+    /// Set whenever the local CRDT mutates; cleared after a broadcast tick.
+    /// Skips the encode+broadcast when there is nothing new to gossip.
+    dirty: Bool,
   )
 }
 
@@ -144,7 +147,12 @@ fn build_presence(
 
   actor.new_with_initialiser(5000, fn(subject) {
     let initial =
-      ActorState(crdt: crdt, config: config, self_subject: Some(subject))
+      ActorState(
+        crdt: crdt,
+        config: config,
+        self_subject: Some(subject),
+        dirty: False,
+      )
 
     case config.pubsub {
       Some(ps) -> {
@@ -180,7 +188,12 @@ fn build_presence(
       }
       None -> {
         let no_pubsub_initial =
-          ActorState(crdt: crdt, config: config, self_subject: None)
+          ActorState(
+            crdt: crdt,
+            config: config,
+            self_subject: None,
+            dirty: False,
+          )
         actor.initialised(no_pubsub_initial)
         |> actor.returning(subject)
         |> Ok
@@ -281,7 +294,7 @@ fn handle_message(
         #("pid", pid),
       ])
       process.send(reply, pid)
-      actor.continue(ActorState(..actor_state, crdt: new_crdt))
+      actor.continue(ActorState(..actor_state, crdt: new_crdt, dirty: True))
     }
 
     Untrack(topic, key, pid, reply) -> {
@@ -295,7 +308,7 @@ fn handle_message(
         #("pid", pid),
       ])
       process.send(reply, Nil)
-      actor.continue(ActorState(..actor_state, crdt: new_crdt))
+      actor.continue(ActorState(..actor_state, crdt: new_crdt, dirty: True))
     }
 
     UntrackAll(pid, reply) -> {
@@ -303,7 +316,7 @@ fn handle_message(
       let new_crdt = state.leave_by_pid(actor_state.crdt, pid)
       maybe_invoke_on_diff(actor_state.config, diff)
       process.send(reply, Nil)
-      actor.continue(ActorState(..actor_state, crdt: new_crdt))
+      actor.continue(ActorState(..actor_state, crdt: new_crdt, dirty: True))
     }
 
     List(topic, reply) -> {
@@ -322,37 +335,48 @@ fn handle_message(
 
     MergeRemote(remote) -> {
       let #(new_crdt, diff) = state.merge(actor_state.crdt, remote)
+      let changed = !{ dict.is_empty(diff.joins) && dict.is_empty(diff.leaves) }
       maybe_invoke_on_diff(actor_state.config, diff)
-      actor.continue(ActorState(..actor_state, crdt: new_crdt))
+      actor.continue(
+        ActorState(
+          ..actor_state,
+          crdt: new_crdt,
+          dirty: actor_state.dirty || changed,
+        ),
+      )
     }
 
     BroadcastTick -> {
       case actor_state.config.pubsub, actor_state.self_subject {
         Some(ps), Some(subject) -> {
-          // Build envelope with state as nested JSON object (not double-encoded string)
-          let payload =
-            json.object([
-              #("v", json.int(1)),
-              #("sender", json.string(actor_state.config.replica)),
-              #("state", state_json.encode(actor_state.crdt)),
-            ])
+          let new_state = case actor_state.dirty {
+            False -> actor_state
+            True -> {
+              let payload =
+                json.object([
+                  #("v", json.int(1)),
+                  #("sender", json.string(actor_state.config.replica)),
+                  #("state", state_json.encode(actor_state.crdt)),
+                ])
 
-          // Broadcast via PubSub, skipping self-delivery
-          pubsub.broadcast_from(
-            ps,
-            process.self(),
-            sync_topic,
-            sync_event,
-            payload,
-          )
+              pubsub.broadcast_from(
+                ps,
+                process.self(),
+                sync_topic,
+                sync_event,
+                payload,
+              )
 
-          // Reschedule next tick
+              ActorState(..actor_state, dirty: False)
+            }
+          }
+
           schedule_broadcast_tick(
             subject,
             actor_state.config.broadcast_interval_ms,
           )
 
-          actor.continue(actor_state)
+          actor.continue(new_state)
         }
         _, _ -> actor.continue(actor_state)
       }
@@ -448,8 +472,15 @@ fn handle_sync_payload(
     }
     Ok(#(_sender, remote_state)) -> {
       let #(new_crdt, diff) = state.merge(actor_state.crdt, remote_state)
+      let changed = !{ dict.is_empty(diff.joins) && dict.is_empty(diff.leaves) }
       maybe_invoke_on_diff(actor_state.config, diff)
-      actor.continue(ActorState(..actor_state, crdt: new_crdt))
+      actor.continue(
+        ActorState(
+          ..actor_state,
+          crdt: new_crdt,
+          dirty: actor_state.dirty || changed,
+        ),
+      )
     }
   }
 }

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -14,6 +14,7 @@
 //// import beryl
 //// import beryl/supervisor
 //// import beryl/presence
+//// import beryl/wire
 //// import gleam/option.{None, Some}
 ////
 //// let config = supervisor.SupervisedConfig(

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -4,10 +4,10 @@
 //// and the beryl coordinator using Mist request and response types directly.
 
 import beryl/coordinator.{type Message as CoordinatorMessage}
+import beryl/wire/codec.{type Codec}
 import gleam/bit_array
 import gleam/bytes_tree
 import gleam/crypto
-import gleam/dynamic.{type Dynamic}
 import gleam/erlang/process.{type Subject}
 import gleam/http/request.{type Request}
 import gleam/http/response.{type Response}
@@ -15,14 +15,6 @@ import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/string
 import mist.{type Connection, type ResponseData, type WebsocketConnection}
-
-/// Get current process PID as Dynamic (for handler_pid in SocketConnected)
-@external(erlang, "beryl_ffi", "identity")
-fn unsafe_coerce(value: a) -> Dynamic
-
-fn get_self() -> Dynamic {
-  unsafe_coerce(process.self())
-}
 
 /// Configuration for the Mist WebSocket transport
 pub type TransportConfig {
@@ -55,7 +47,13 @@ pub fn with_on_connect(
 
 /// State maintained per WebSocket connection
 type ConnectionState {
-  ConnectionState(socket_id: String, coordinator: Subject(CoordinatorMessage))
+  ConnectionState(
+    socket_id: String,
+    coordinator: Subject(CoordinatorMessage),
+    /// Codec cached at upgrade time so inbound frames are decoded inline
+    /// on the per-connection process instead of on the coordinator actor.
+    codec: Codec,
+  )
 }
 
 type SendRequest {
@@ -154,13 +152,20 @@ fn on_init(
   }
 
   // Register with coordinator
-  let handler_pid = get_self()
   process.send(
     coordinator,
-    coordinator.SocketConnected(socket_id, send_fn, send_binary_fn, handler_pid),
+    coordinator.SocketConnected(socket_id, send_fn, send_binary_fn),
   )
 
-  let state = ConnectionState(socket_id: socket_id, coordinator: coordinator)
+  // Fetch the codec once so inbound frames can be decoded inline
+  let codec = coordinator.get_codec(coordinator)
+
+  let state =
+    ConnectionState(
+      socket_id: socket_id,
+      coordinator: coordinator,
+      codec: codec,
+    )
 
   #(state, Some(selector))
 }
@@ -177,11 +182,34 @@ fn on_message(
 ) -> mist.Next(ConnectionState, SendRequest) {
   case message {
     mist.Text(text) -> {
-      coordinator.route_message(state.coordinator, state.socket_id, text)
+      // Decode inline so the coordinator actor's mailbox doesn't serialize
+      // JSON parsing across every connection. Fall back to the actor-side
+      // decoder on error so the coordinator's logging path stays the single
+      // source of truth for malformed-frame diagnostics.
+      case state.codec.decode_text(text) {
+        Ok(inbound) ->
+          coordinator.route_inbound(state.coordinator, state.socket_id, inbound)
+        Error(_) ->
+          coordinator.route_message(state.coordinator, state.socket_id, text)
+      }
       mist.continue(state)
     }
     mist.Binary(data) -> {
-      coordinator.route_binary(state.coordinator, state.socket_id, data)
+      case state.codec.decode_binary {
+        Some(decode) ->
+          case decode(data) {
+            Ok(inbound) ->
+              coordinator.route_inbound(
+                state.coordinator,
+                state.socket_id,
+                inbound,
+              )
+            Error(_) ->
+              coordinator.route_binary(state.coordinator, state.socket_id, data)
+          }
+        None ->
+          coordinator.route_binary(state.coordinator, state.socket_id, data)
+      }
       mist.continue(state)
     }
     mist.Closed | mist.Shutdown -> mist.stop()

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -165,7 +165,11 @@ fn on_init(
   #(state, Some(selector))
 }
 
-/// Handle incoming WebSocket messages
+/// Handle incoming WebSocket messages.
+///
+/// Text frames are decoded by the coordinator's codec. Binary frames are also
+/// offered to the codec when it has a binary decoder; otherwise they are routed
+/// to raw channel binary handlers.
 fn on_message(
   state: ConnectionState,
   message: mist.WebsocketMessage(SendRequest),

--- a/src/beryl/wire.gleam
+++ b/src/beryl/wire.gleam
@@ -14,7 +14,7 @@
 import beryl/wire/codec.{
   type Codec, type DecodeError, type Frame, type Inbound, type InboundKind,
   type ReplyStatus, Codec, Event, Heartbeat, Inbound, InvalidFormat, InvalidJson,
-  Join, Leave, MissingField, StatusError, StatusOk, TextFrame,
+  Join, Leave, StatusError, StatusOk, TextFrame,
 }
 import gleam/dict
 import gleam/dynamic.{type Dynamic}
@@ -22,6 +22,8 @@ import gleam/dynamic/decode
 import gleam/json
 import gleam/list
 import gleam/option.{type Option, None, Some}
+
+const expected_array_message = "Expected array of 5 elements [join_ref, ref, topic, event, payload]"
 
 /// The canonical Phoenix wire codec. Pass to `beryl.config/1`.
 pub fn phoenix_codec() -> Codec {
@@ -48,27 +50,18 @@ pub fn decode_message(json_string: String) -> Result(Inbound, DecodeError) {
     Error(json.UnexpectedSequence(seq)) ->
       Error(InvalidJson("Unexpected sequence: " <> seq))
     Error(json.UnableToDecode(_)) ->
-      Error(InvalidFormat(
-        "Expected array of 5 elements [join_ref, ref, topic, event, payload]",
-      ))
+      Error(InvalidFormat(expected_array_message))
   }
 }
 
 fn decode_inbound_value(value: Dynamic) -> Result(Inbound, DecodeError) {
   case decode.run(value, decode.list(decode.dynamic)) {
-    Ok(items) -> {
+    Ok(items) ->
       case list.length(items) {
         5 -> decode_inbound_fields(value)
-        _ ->
-          Error(InvalidFormat(
-            "Expected array of 5 elements [join_ref, ref, topic, event, payload]",
-          ))
+        _ -> Error(InvalidFormat(expected_array_message))
       }
-    }
-    Error(_) ->
-      Error(InvalidFormat(
-        "Expected array of 5 elements [join_ref, ref, topic, event, payload]",
-      ))
+    Error(_) -> Error(InvalidFormat(expected_array_message))
   }
 }
 
@@ -90,10 +83,7 @@ fn decode_inbound_fields(value: Dynamic) -> Result(Inbound, DecodeError) {
 
   case decode.run(value, wire_decoder) {
     Ok(msg) -> Ok(msg)
-    Error(_) ->
-      Error(InvalidFormat(
-        "Expected array of 5 elements [join_ref, ref, topic, event, payload]",
-      ))
+    Error(_) -> Error(InvalidFormat(expected_array_message))
   }
 }
 
@@ -287,9 +277,5 @@ pub fn is_system_event(event: String) -> Bool {
 
 /// Format a `DecodeError` as a human-readable string.
 pub fn format_decode_error(error: DecodeError) -> String {
-  case error {
-    InvalidJson(reason) -> "Invalid JSON: " <> reason
-    InvalidFormat(reason) -> "Invalid format: " <> reason
-    MissingField(name) -> "Missing required field: " <> name
-  }
+  codec.format_decode_error(error)
 }

--- a/src/beryl/wire.gleam
+++ b/src/beryl/wire.gleam
@@ -12,8 +12,9 @@
 //// ```
 
 import beryl/wire/codec.{
-  type Codec, type DecodeError, type Inbound, type ReplyStatus, Codec, Inbound,
-  InvalidFormat, InvalidJson, MissingField, StatusError, StatusOk,
+  type Codec, type DecodeError, type Frame, type Inbound, type InboundKind,
+  type ReplyStatus, Codec, Event, Heartbeat, Inbound, InvalidFormat, InvalidJson,
+  Join, Leave, MissingField, StatusError, StatusOk, TextFrame,
 }
 import gleam/dict
 import gleam/dynamic.{type Dynamic}
@@ -25,13 +26,11 @@ import gleam/option.{type Option, None, Some}
 /// The canonical Phoenix wire codec. Pass to `beryl.config/1`.
 pub fn phoenix_codec() -> Codec {
   Codec(
-    decode: decode_message,
+    decode_text: decode_message,
+    decode_binary: None,
     encode_reply: reply_json,
     encode_push: push,
     encode_heartbeat_reply: heartbeat_reply,
-    join_event: "phx_join",
-    leave_event: "phx_leave",
-    heartbeat_event: "heartbeat",
   )
 }
 
@@ -84,7 +83,7 @@ fn decode_inbound_fields(value: Dynamic) -> Result(Inbound, DecodeError) {
       join_ref: join_ref,
       ref: ref,
       topic: topic,
-      event: event,
+      kind: classify_phoenix_event(event),
       payload: payload,
     ))
   }
@@ -103,16 +102,35 @@ pub fn encode(msg: Inbound) -> String {
   let join_ref_json = option_to_json(msg.join_ref)
   let ref_json = option_to_json(msg.ref)
   let payload_json = dynamic_to_json(msg.payload)
+  let event = phoenix_event_name(msg.kind)
 
   json.to_string(
     json.preprocessed_array([
       join_ref_json,
       ref_json,
       json.string(msg.topic),
-      json.string(msg.event),
+      json.string(event),
       payload_json,
     ]),
   )
+}
+
+fn classify_phoenix_event(event: String) -> InboundKind {
+  case event {
+    "phx_join" -> Join
+    "phx_leave" -> Leave
+    "heartbeat" -> Heartbeat
+    other -> Event(other)
+  }
+}
+
+fn phoenix_event_name(kind: InboundKind) -> String {
+  case kind {
+    Join -> "phx_join"
+    Leave -> "phx_leave"
+    Heartbeat -> "heartbeat"
+    Event(event) -> event
+  }
 }
 
 /// Convert a `Dynamic` (decoded from JSON) back into `json.Json`.
@@ -175,11 +193,11 @@ fn try_decode_complex(value: Dynamic) -> json.Json {
 /// Create a Phoenix `phx_reply` JSON string.
 pub fn reply_json(
   join_ref: Option(String),
-  ref: String,
+  ref: Option(String),
   topic: String,
   status: ReplyStatus,
   response: json.Json,
-) -> String {
+) -> Frame {
   let status_string = case status {
     StatusOk -> "ok"
     StatusError -> "error"
@@ -191,43 +209,49 @@ pub fn reply_json(
       #("response", response),
     ])
 
-  json.to_string(
-    json.preprocessed_array([
-      option_to_json(join_ref),
-      json.string(ref),
-      json.string(topic),
-      json.string("phx_reply"),
-      payload,
-    ]),
+  TextFrame(
+    json.to_string(
+      json.preprocessed_array([
+        option_to_json(join_ref),
+        option_to_json(ref),
+        json.string(topic),
+        json.string("phx_reply"),
+        payload,
+      ]),
+    ),
   )
 }
 
 /// Create a server-initiated push message.
-pub fn push(topic: String, event: String, payload: json.Json) -> String {
-  json.to_string(
-    json.preprocessed_array([
-      json.null(),
-      json.null(),
-      json.string(topic),
-      json.string(event),
-      payload,
-    ]),
+pub fn push(topic: String, event: String, payload: json.Json) -> Frame {
+  TextFrame(
+    json.to_string(
+      json.preprocessed_array([
+        json.null(),
+        json.null(),
+        json.string(topic),
+        json.string(event),
+        payload,
+      ]),
+    ),
   )
 }
 
 /// Create a Phoenix heartbeat reply.
-pub fn heartbeat_reply(ref: String) -> String {
-  json.to_string(
-    json.preprocessed_array([
-      json.null(),
-      json.string(ref),
-      json.string("phoenix"),
-      json.string("phx_reply"),
-      json.object([
-        #("status", json.string("ok")),
-        #("response", json.object([])),
+pub fn heartbeat_reply(ref: Option(String)) -> Frame {
+  TextFrame(
+    json.to_string(
+      json.preprocessed_array([
+        json.null(),
+        option_to_json(ref),
+        json.string("phoenix"),
+        json.string("phx_reply"),
+        json.object([
+          #("status", json.string("ok")),
+          #("response", json.object([])),
+        ]),
       ]),
-    ]),
+    ),
   )
 }
 
@@ -240,10 +264,8 @@ fn option_to_json(opt: Option(String)) -> json.Json {
 
 /// Check if this is a Phoenix system event.
 ///
-/// Note: This is Phoenix-specific. Codecs using their own protocol
-/// constants (e.g. `ws_join`/`ws_leave`) should compare against their
-/// codec's `join_event`/`leave_event`/`heartbeat_event` fields directly
-/// rather than using this helper.
+/// Note: This is Phoenix-specific. The coordinator dispatches decoded messages
+/// structurally using `codec.InboundKind` rather than consulting this helper.
 pub fn is_phoenix_system_event(event: String) -> Bool {
   case event {
     "phx_join"

--- a/src/beryl/wire/codec.gleam
+++ b/src/beryl/wire/codec.gleam
@@ -64,6 +64,16 @@ pub type ReplyStatus {
   StatusError
 }
 
+/// Format a `DecodeError` as a human-readable string. Used by the
+/// coordinator's log messages and by `wire.format_decode_error`.
+pub fn format_decode_error(error: DecodeError) -> String {
+  case error {
+    InvalidJson(reason) -> "Invalid JSON: " <> reason
+    InvalidFormat(reason) -> "Invalid format: " <> reason
+    MissingField(name) -> "Missing required field: " <> name
+  }
+}
+
 /// A wire codec.
 pub type Codec {
   Codec(

--- a/src/beryl/wire/codec.gleam
+++ b/src/beryl/wire/codec.gleam
@@ -5,10 +5,10 @@
 //// the Phoenix array format (`[join_ref, ref, topic, event, payload]`).
 ////
 //// To run beryl over your own framing, build a `Codec` value and pass it
-//// to `beryl.config(codec)`. The coordinator decodes inbound bytes via
-//// `codec.decode`, dispatches based on the `event` string against the
-//// codec's `join_event`, `leave_event`, and `heartbeat_event` constants,
-//// and produces outbound bytes via `codec.encode_*` helpers.
+//// to `beryl.config(codec)`. The coordinator decodes inbound text via
+//// `codec.decode_text`, optionally decodes inbound binary via
+//// `codec.decode_binary`, dispatches based on the structural `InboundKind`,
+//// and produces outbound text or binary frames via `codec.encode_*` helpers.
 ////
 //// All codecs must normalise inbound traffic to the `Inbound` shape so
 //// the coordinator can stay framing-agnostic.
@@ -17,6 +17,20 @@ import gleam/dynamic.{type Dynamic}
 import gleam/json
 import gleam/option.{type Option}
 
+/// Encoded WebSocket frame returned by a codec.
+pub type Frame {
+  TextFrame(String)
+  BinaryFrame(BitArray)
+}
+
+/// Structural inbound message kind used for protocol dispatch.
+pub type InboundKind {
+  Join
+  Leave
+  Heartbeat
+  Event(String)
+}
+
 /// Normalised inbound message shape.
 ///
 /// - `join_ref`: optional client-side reference assigned at join time
@@ -24,8 +38,7 @@ import gleam/option.{type Option}
 ///   pass `None`)
 /// - `ref`: optional per-message reference for reply correlation
 /// - `topic`: subscription topic (e.g. `"room:lobby"`, `"doc:abc"`)
-/// - `event`: event/kind discriminator (e.g. `"new_message"`, `"delta"`,
-///   or system events like the codec's `join_event`)
+/// - `kind`: structural protocol event or user event
 /// - `payload`: message body as a `Dynamic` for the channel handler to
 ///   decode
 pub type Inbound {
@@ -33,7 +46,7 @@ pub type Inbound {
     join_ref: Option(String),
     ref: Option(String),
     topic: String,
-    event: String,
+    kind: InboundKind,
     payload: Dynamic,
   )
 }
@@ -55,19 +68,23 @@ pub type ReplyStatus {
 pub type Codec {
   Codec(
     /// Decode raw inbound text into a normalised `Inbound`.
-    decode: fn(String) -> Result(Inbound, DecodeError),
+    decode_text: fn(String) -> Result(Inbound, DecodeError),
+    /// Decode raw inbound binary into a normalised `Inbound`.
+    ///
+    /// When `None`, binary WebSocket frames are routed to `channel.handle_binary`
+    /// as raw data for backwards compatibility.
+    decode_binary: Option(fn(BitArray) -> Result(Inbound, DecodeError)),
     /// Encode a reply to a client message: `(join_ref, ref, topic, status, response_payload)`.
-    encode_reply: fn(Option(String), String, String, ReplyStatus, json.Json) ->
+    encode_reply: fn(
+      Option(String),
+      Option(String),
       String,
+      ReplyStatus,
+      json.Json,
+    ) -> Frame,
     /// Encode a server-initiated push: `(topic, event, payload)`.
-    encode_push: fn(String, String, json.Json) -> String,
+    encode_push: fn(String, String, json.Json) -> Frame,
     /// Encode a heartbeat reply for a given client `ref`.
-    encode_heartbeat_reply: fn(String) -> String,
-    /// Event name signalling a client wants to join a topic.
-    join_event: String,
-    /// Event name signalling a client wants to leave a topic.
-    leave_event: String,
-    /// Event name signalling a heartbeat ping.
-    heartbeat_event: String,
+    encode_heartbeat_reply: fn(Option(String)) -> Frame,
   )
 }

--- a/test/beryl_test.gleam
+++ b/test/beryl_test.gleam
@@ -5,7 +5,6 @@ import beryl/socket
 import beryl/topic
 import beryl/wire
 import beryl/wire/codec
-import gleam/dynamic
 import gleam/dynamic/decode
 import gleam/erlang/process
 import gleam/json
@@ -187,7 +186,6 @@ pub fn segment_wildcard_registered_channel_routes_matching_topic_test() {
         Ok(Nil)
       },
       fn(_) { Ok(Nil) },
-      dynamic.nil(),
     ),
   )
 
@@ -229,7 +227,6 @@ pub fn segment_wildcard_registered_channel_rejects_wrong_segment_test() {
         Ok(Nil)
       },
       fn(_) { Ok(Nil) },
-      dynamic.nil(),
     ),
   )
 
@@ -276,7 +273,6 @@ pub fn send_info_routes_message_to_joined_channel_test() {
         Ok(Nil)
       },
       fn(_) { Ok(Nil) },
-      dynamic.nil(),
     ),
   )
 
@@ -328,7 +324,6 @@ pub fn send_info_reply_result_pushes_message_to_client_test() {
         Ok(Nil)
       },
       fn(_) { Ok(Nil) },
-      dynamic.nil(),
     ),
   )
 

--- a/test/beryl_test.gleam
+++ b/test/beryl_test.gleam
@@ -23,6 +23,11 @@ fn mock_transport() -> socket.Transport {
   )
 }
 
+fn text_frame(frame: codec.Frame) -> String {
+  let assert codec.TextFrame(text) = frame
+  text
+}
+
 pub fn main() {
   gleeunit.main()
 }
@@ -200,15 +205,10 @@ pub fn segment_wildcard_registered_channel_routes_matching_topic_test() {
   beryl.register(channels, "document:*:ops", handler)
   |> should.equal(Ok(Nil))
 
-  process.send(
+  coordinator.route_message(
     channels.coordinator,
-    coordinator.Join(
-      "segment-socket",
-      "document:tenant-a:ops",
-      dynamic.nil(),
-      option.None,
-      "join-ref",
-    ),
+    "segment-socket",
+    "[null,\"join-ref\",\"document:tenant-a:ops\",\"phx_join\",{}]",
   )
 
   let assert Ok(join_reply) = process.receive(sent_messages, 500)
@@ -241,15 +241,10 @@ pub fn segment_wildcard_registered_channel_rejects_wrong_segment_test() {
   beryl.register(channels, "document:*:ops", handler)
   |> should.equal(Ok(Nil))
 
-  process.send(
+  coordinator.route_message(
     channels.coordinator,
-    coordinator.Join(
-      "segment-reject-socket",
-      "document:tenant-a:view",
-      dynamic.nil(),
-      option.None,
-      "join-ref",
-    ),
+    "segment-reject-socket",
+    "[null,\"join-ref\",\"document:tenant-a:view\",\"phx_join\",{}]",
   )
 
   let assert Ok(join_reply) = process.receive(sent_messages, 500)
@@ -304,15 +299,10 @@ pub fn send_info_routes_message_to_joined_channel_test() {
   beryl.register(channels, "room:*", handler)
   |> should.equal(Ok(Nil))
 
-  process.send(
+  coordinator.route_message(
     channels.coordinator,
-    coordinator.Join(
-      "socket-info",
-      "room:lobby",
-      dynamic.nil(),
-      option.None,
-      "join-ref",
-    ),
+    "socket-info",
+    "[null,\"join-ref\",\"room:lobby\",\"phx_join\",{}]",
   )
 
   let assert Ok(join_reply) = process.receive(sent_messages, 500)
@@ -357,15 +347,10 @@ pub fn send_info_reply_result_pushes_message_to_client_test() {
   beryl.register(channels, "room:*", handler)
   |> should.equal(Ok(Nil))
 
-  process.send(
+  coordinator.route_message(
     channels.coordinator,
-    coordinator.Join(
-      "socket-info-reply",
-      "room:lobby",
-      dynamic.nil(),
-      option.None,
-      "join-ref",
-    ),
+    "socket-info-reply",
+    "[null,\"join-ref\",\"room:lobby\",\"phx_join\",{}]",
   )
 
   let assert Ok(join_reply) = process.receive(sent_messages, 500)
@@ -390,7 +375,7 @@ pub fn decode_valid_message_test() {
   msg.join_ref |> should.equal(option.Some("j1"))
   msg.ref |> should.equal(option.Some("r1"))
   msg.topic |> should.equal("room:lobby")
-  msg.event |> should.equal("phx_join")
+  msg.kind |> should.equal(codec.Join)
 }
 
 pub fn decode_message_with_null_refs_test() {
@@ -400,7 +385,7 @@ pub fn decode_message_with_null_refs_test() {
   msg.join_ref |> should.equal(option.None)
   msg.ref |> should.equal(option.Some("ref"))
   msg.topic |> should.equal("topic")
-  msg.event |> should.equal("event")
+  msg.kind |> should.equal(codec.Event("event"))
 }
 
 pub fn decode_message_both_refs_null_test() {
@@ -412,7 +397,7 @@ pub fn decode_message_both_refs_null_test() {
   msg.join_ref |> should.equal(option.None)
   msg.ref |> should.equal(option.None)
   msg.topic |> should.equal("room:lobby")
-  msg.event |> should.equal("new_msg")
+  msg.kind |> should.equal(codec.Event("new_msg"))
 }
 
 pub fn decode_invalid_json_test() {
@@ -461,47 +446,47 @@ pub fn reply_json_ok_test() {
   let reply =
     wire.reply_json(
       option.Some("j1"),
-      "ref1",
+      option.Some("ref1"),
       "room:lobby",
       codec.StatusOk,
       json.object([]),
     )
 
-  reply |> string.contains("phx_reply") |> should.be_true
-  reply |> string.contains("\"status\":\"ok\"") |> should.be_true
-  reply |> string.contains("room:lobby") |> should.be_true
+  text_frame(reply) |> string.contains("phx_reply") |> should.be_true
+  text_frame(reply) |> string.contains("\"status\":\"ok\"") |> should.be_true
+  text_frame(reply) |> string.contains("room:lobby") |> should.be_true
 }
 
 pub fn reply_json_error_test() {
   let reply =
     wire.reply_json(
       option.None,
-      "ref1",
+      option.Some("ref1"),
       "room:lobby",
       codec.StatusError,
       json.object([#("reason", json.string("unauthorized"))]),
     )
 
-  reply |> string.contains("\"status\":\"error\"") |> should.be_true
-  reply |> string.contains("unauthorized") |> should.be_true
+  text_frame(reply) |> string.contains("\"status\":\"error\"") |> should.be_true
+  text_frame(reply) |> string.contains("unauthorized") |> should.be_true
 }
 
 pub fn push_message_test() {
   let msg = wire.push("room:lobby", "new_message", json.string("content"))
 
-  msg |> string.contains("room:lobby") |> should.be_true
-  msg |> string.contains("new_message") |> should.be_true
+  text_frame(msg) |> string.contains("room:lobby") |> should.be_true
+  text_frame(msg) |> string.contains("new_message") |> should.be_true
   // Push messages have null for join_ref and ref
-  msg |> string.starts_with("[null,null,") |> should.be_true
+  text_frame(msg) |> string.starts_with("[null,null,") |> should.be_true
 }
 
 pub fn heartbeat_reply_test() {
-  let reply = wire.heartbeat_reply("hb-123")
+  let reply = wire.heartbeat_reply(option.Some("hb-123"))
 
-  reply |> string.contains("phx_reply") |> should.be_true
-  reply |> string.contains("phoenix") |> should.be_true
-  reply |> string.contains("hb-123") |> should.be_true
-  reply |> string.contains("\"status\":\"ok\"") |> should.be_true
+  text_frame(reply) |> string.contains("phx_reply") |> should.be_true
+  text_frame(reply) |> string.contains("phoenix") |> should.be_true
+  text_frame(reply) |> string.contains("hb-123") |> should.be_true
+  text_frame(reply) |> string.contains("\"status\":\"ok\"") |> should.be_true
 }
 
 pub fn is_system_event_phx_join_test() {

--- a/test/binary_codec_test.gleam
+++ b/test/binary_codec_test.gleam
@@ -1,0 +1,318 @@
+import beryl
+import beryl/channel
+import beryl/coordinator
+import beryl/wire
+import beryl/wire/codec
+import gleam/bit_array
+import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode
+import gleam/erlang/process
+import gleam/json
+import gleam/option.{type Option, None, Some}
+import gleam/string
+import gleeunit/should
+
+pub fn main() {
+  Nil
+}
+
+fn binary_test_codec() -> codec.Codec {
+  codec.Codec(
+    decode_text: fn(_) { Error(codec.InvalidFormat("text unsupported")) },
+    decode_binary: Some(decode_binary_frame),
+    encode_reply: encode_reply,
+    encode_push: encode_push,
+    encode_heartbeat_reply: encode_heartbeat_reply,
+  )
+}
+
+fn decode_binary_frame(
+  data: BitArray,
+) -> Result(codec.Inbound, codec.DecodeError) {
+  case bit_array.to_string(data) {
+    Ok(raw) -> decode_binary_text(raw)
+    Error(_) -> Error(codec.InvalidFormat("Expected UTF-8 binary test frame"))
+  }
+}
+
+fn decode_binary_text(raw: String) -> Result(codec.Inbound, codec.DecodeError) {
+  case string.split(raw, "|") {
+    ["J", join_ref, ref, topic, payload_json] -> {
+      use payload <- result_try(decode_payload(payload_json))
+      Ok(codec.Inbound(
+        join_ref: Some(join_ref),
+        ref: Some(ref),
+        topic: topic,
+        kind: codec.Join,
+        payload: payload,
+      ))
+    }
+    ["L", ref, topic] ->
+      Ok(codec.Inbound(
+        join_ref: None,
+        ref: Some(ref),
+        topic: topic,
+        kind: codec.Leave,
+        payload: dynamic_nil(),
+      ))
+    ["H", ref] ->
+      Ok(codec.Inbound(
+        join_ref: None,
+        ref: Some(ref),
+        topic: "phoenix",
+        kind: codec.Heartbeat,
+        payload: dynamic_nil(),
+      ))
+    ["E", ref, topic, event, payload_json] -> {
+      use payload <- result_try(decode_payload(payload_json))
+      Ok(codec.Inbound(
+        join_ref: None,
+        ref: Some(ref),
+        topic: topic,
+        kind: codec.Event(event),
+        payload: payload,
+      ))
+    }
+    _ -> Error(codec.InvalidFormat("Unknown binary test frame"))
+  }
+}
+
+fn decode_payload(payload_json: String) -> Result(Dynamic, codec.DecodeError) {
+  case json.parse(from: payload_json, using: decode.dynamic) {
+    Ok(payload) -> Ok(payload)
+    Error(_) -> Error(codec.InvalidJson("Invalid payload JSON"))
+  }
+}
+
+fn result_try(
+  result: Result(a, codec.DecodeError),
+  next: fn(a) -> Result(b, codec.DecodeError),
+) -> Result(b, codec.DecodeError) {
+  case result {
+    Ok(value) -> next(value)
+    Error(error) -> Error(error)
+  }
+}
+
+fn dynamic_nil() -> Dynamic {
+  json.parse(from: "{}", using: decode.dynamic)
+  |> result_to_dynamic
+}
+
+fn result_to_dynamic(result: Result(Dynamic, a)) -> Dynamic {
+  let assert Ok(value) = result
+  value
+}
+
+fn encode_reply(
+  _join_ref: Option(String),
+  ref: Option(String),
+  topic: String,
+  status: codec.ReplyStatus,
+  response: json.Json,
+) -> codec.Frame {
+  let status_string = case status {
+    codec.StatusOk -> "ok"
+    codec.StatusError -> "error"
+  }
+
+  {
+    "R|"
+    <> ref_to_string(ref)
+    <> "|"
+    <> topic
+    <> "|"
+    <> status_string
+    <> "|"
+    <> json.to_string(response)
+  }
+  |> bit_array.from_string
+  |> codec.BinaryFrame
+}
+
+fn encode_push(
+  topic: String,
+  event: String,
+  payload: json.Json,
+) -> codec.Frame {
+  { "P|" <> topic <> "|" <> event <> "|" <> json.to_string(payload) }
+  |> bit_array.from_string
+  |> codec.BinaryFrame
+}
+
+fn encode_heartbeat_reply(ref: Option(String)) -> codec.Frame {
+  encode_reply(None, ref, "phoenix", codec.StatusOk, json.object([]))
+}
+
+fn ref_to_string(ref: Option(String)) -> String {
+  case ref {
+    Some(value) -> value
+    None -> "null"
+  }
+}
+
+pub fn binary_codec_routes_join_message_and_reply_over_binary_test() {
+  let sent_text = process.new_subject()
+  let sent_binary = process.new_subject()
+  let assert Ok(channels) = beryl.start(beryl.config(binary_test_codec()))
+
+  process.send(
+    channels.coordinator,
+    coordinator.SocketConnected(
+      "socket-1",
+      fn(text) {
+        process.send(sent_text, text)
+        Ok(Nil)
+      },
+      fn(data) {
+        process.send(sent_binary, data)
+        Ok(Nil)
+      },
+      dynamic_nil(),
+    ),
+  )
+
+  let seen_payload = process.new_subject()
+  let handler =
+    channel.new(fn(_topic, payload, socket) {
+      let user_decoder = {
+        use user <- decode.field("user", decode.string)
+        decode.success(user)
+      }
+      let assert Ok(user) = channel.decode_payload(payload, user_decoder)
+      process.send(seen_payload, user)
+      channel.JoinOk(
+        reply: Some(json.object([#("joined", json.bool(True))])),
+        socket: socket,
+      )
+    })
+    |> channel.with_handle_in(fn(event, payload, socket) {
+      let body_decoder = {
+        use body <- decode.field("body", decode.string)
+        decode.success(body)
+      }
+      let assert Ok(body) = channel.decode_payload(payload, body_decoder)
+      process.send(seen_payload, event <> ":" <> body)
+      channel.Reply(event, json.object([#("ok", json.bool(True))]), socket)
+    })
+
+  beryl.register(channels, "room:*", handler) |> should.equal(Ok(Nil))
+
+  coordinator.route_binary(
+    channels.coordinator,
+    "socket-1",
+    bit_array.from_string("J|join-ref|join-1|room:lobby|{\"user\":\"alice\"}"),
+  )
+
+  process.receive(seen_payload, 500) |> should.equal(Ok("alice"))
+  let assert Ok(join_reply_bits) = process.receive(sent_binary, 500)
+  bit_array.to_string(join_reply_bits)
+  |> should.equal(Ok("R|join-1|room:lobby|ok|{\"joined\":true}"))
+
+  coordinator.route_binary(
+    channels.coordinator,
+    "socket-1",
+    bit_array.from_string("E|event-1|room:lobby|ping|{\"body\":\"hi\"}"),
+  )
+
+  process.receive(seen_payload, 500) |> should.equal(Ok("ping:hi"))
+  let assert Ok(event_reply_bits) = process.receive(sent_binary, 500)
+  bit_array.to_string(event_reply_bits)
+  |> should.equal(Ok("R|event-1|room:lobby|ok|{\"ok\":true}"))
+
+  process.receive(sent_text, 50) |> should.be_error
+}
+
+pub fn binary_codec_broadcast_uses_binary_send_test() {
+  let sent_text = process.new_subject()
+  let sent_binary = process.new_subject()
+  let assert Ok(channels) = beryl.start(beryl.config(binary_test_codec()))
+
+  process.send(
+    channels.coordinator,
+    coordinator.SocketConnected(
+      "socket-1",
+      fn(text) {
+        process.send(sent_text, text)
+        Ok(Nil)
+      },
+      fn(data) {
+        process.send(sent_binary, data)
+        Ok(Nil)
+      },
+      dynamic_nil(),
+    ),
+  )
+
+  let handler =
+    channel.new(fn(_topic, _payload, socket) {
+      channel.JoinOk(reply: None, socket: socket)
+    })
+
+  beryl.register(channels, "room:*", handler) |> should.equal(Ok(Nil))
+
+  coordinator.route_binary(
+    channels.coordinator,
+    "socket-1",
+    bit_array.from_string("J|join-ref|join-1|room:lobby|{}"),
+  )
+  let assert Ok(_join_reply) = process.receive(sent_binary, 500)
+
+  beryl.broadcast(
+    channels,
+    "room:lobby",
+    "announcement",
+    json.object([#("body", json.string("hello"))]),
+  )
+
+  let assert Ok(broadcast_bits) = process.receive(sent_binary, 500)
+  bit_array.to_string(broadcast_bits)
+  |> should.equal(Ok("P|room:lobby|announcement|{\"body\":\"hello\"}"))
+  process.receive(sent_text, 50) |> should.be_error
+}
+
+pub fn phoenix_codec_without_binary_decoder_preserves_raw_binary_handler_test() {
+  let sent_text = process.new_subject()
+  let seen_binary = process.new_subject()
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+
+  process.send(
+    channels.coordinator,
+    coordinator.SocketConnected(
+      "socket-1",
+      fn(text) {
+        process.send(sent_text, text)
+        Ok(Nil)
+      },
+      fn(_) { Ok(Nil) },
+      dynamic_nil(),
+    ),
+  )
+
+  let handler =
+    channel.new(fn(_topic, _payload, socket) {
+      channel.JoinOk(reply: None, socket: socket)
+    })
+    |> channel.with_handle_binary(fn(data, socket) {
+      process.send(seen_binary, data)
+      channel.NoReply(socket)
+    })
+
+  beryl.register(channels, "room:*", handler) |> should.equal(Ok(Nil))
+
+  coordinator.route_message(
+    channels.coordinator,
+    "socket-1",
+    "[null,\"join-ref\",\"room:lobby\",\"phx_join\",{}]",
+  )
+  let assert Ok(_join_reply) = process.receive(sent_text, 500)
+
+  coordinator.route_binary(
+    channels.coordinator,
+    "socket-1",
+    bit_array.from_string("raw"),
+  )
+
+  let assert Ok(raw_bits) = process.receive(seen_binary, 500)
+  bit_array.to_string(raw_bits) |> should.equal(Ok("raw"))
+}

--- a/test/binary_codec_test.gleam
+++ b/test/binary_codec_test.gleam
@@ -168,7 +168,6 @@ pub fn binary_codec_routes_join_message_and_reply_over_binary_test() {
         process.send(sent_binary, data)
         Ok(Nil)
       },
-      dynamic_nil(),
     ),
   )
 
@@ -240,7 +239,6 @@ pub fn binary_codec_broadcast_uses_binary_send_test() {
         process.send(sent_binary, data)
         Ok(Nil)
       },
-      dynamic_nil(),
     ),
   )
 
@@ -285,7 +283,6 @@ pub fn phoenix_codec_without_binary_decoder_preserves_raw_binary_handler_test() 
         Ok(Nil)
       },
       fn(_) { Ok(Nil) },
-      dynamic_nil(),
     ),
   )
 

--- a/test/broadcast_test.gleam
+++ b/test/broadcast_test.gleam
@@ -58,12 +58,7 @@ fn connect_socket(
 
   process.send(
     channels.coordinator,
-    coordinator.SocketConnected(
-      socket_id,
-      send,
-      fn(_) { Ok(Nil) },
-      dynamic.nil(),
-    ),
+    coordinator.SocketConnected(socket_id, send, fn(_) { Ok(Nil) }),
   )
   process.sleep(10)
   sent

--- a/test/broadcast_test.gleam
+++ b/test/broadcast_test.gleam
@@ -75,9 +75,10 @@ fn join_topic(
   topic_name: String,
   sent: process.Subject(String),
 ) -> Nil {
-  process.send(
+  coordinator.route_message(
     channels.coordinator,
-    coordinator.Join(socket_id, topic_name, dynamic.nil(), None, "join-ref"),
+    socket_id,
+    "[null,\"join-ref\",\"" <> topic_name <> "\",\"phx_join\",{}]",
   )
 
   let assert Ok(reply) = process.receive(sent, 500)

--- a/test/heartbeat_test.gleam
+++ b/test/heartbeat_test.gleam
@@ -60,7 +60,7 @@ fn socket_is_connected(
 ) -> Bool {
   // Drain any pending messages first
   drain(sent_messages)
-  process.send(coord, coordinator.Heartbeat(socket_id, "probe"))
+  send_heartbeat(coord, socket_id, "probe")
   case process.receive(sent_messages, 50) {
     Ok(_) -> True
     Error(_) -> False
@@ -73,6 +73,18 @@ fn drain(subject: process.Subject(String)) -> Nil {
     Ok(_) -> drain(subject)
     Error(_) -> Nil
   }
+}
+
+fn send_heartbeat(
+  coord: process.Subject(coordinator.Message),
+  socket_id: String,
+  ref: String,
+) -> Nil {
+  coordinator.route_message(
+    coord,
+    socket_id,
+    "[null,\"" <> ref <> "\",\"phoenix\",\"heartbeat\",{}]",
+  )
 }
 
 pub fn heartbeat_timeout_evicts_stale_socket_test() {
@@ -96,13 +108,13 @@ pub fn heartbeat_resets_timeout_test() {
   let sent = connect_mock_socket(coord, "socket-1")
 
   // Send heartbeats to keep the socket alive
-  process.send(coord, coordinator.Heartbeat("socket-1", "hb-1"))
+  send_heartbeat(coord, "socket-1", "hb-1")
   process.sleep(50)
 
-  process.send(coord, coordinator.Heartbeat("socket-1", "hb-2"))
+  send_heartbeat(coord, "socket-1", "hb-2")
   process.sleep(50)
 
-  process.send(coord, coordinator.Heartbeat("socket-1", "hb-3"))
+  send_heartbeat(coord, "socket-1", "hb-3")
   process.sleep(50)
 
   // After 150ms total, the socket should still be alive because we kept
@@ -118,9 +130,9 @@ pub fn heartbeat_timeout_only_evicts_stale_sockets_test() {
 
   // Keep only "active-socket" alive with heartbeats
   process.sleep(40)
-  process.send(coord, coordinator.Heartbeat("active-socket", "hb-1"))
+  send_heartbeat(coord, "active-socket", "hb-1")
   process.sleep(40)
-  process.send(coord, coordinator.Heartbeat("active-socket", "hb-2"))
+  send_heartbeat(coord, "active-socket", "hb-2")
 
   // Wait for the stale socket to be evicted
   process.sleep(60)
@@ -209,7 +221,7 @@ pub fn heartbeat_reply_still_sent_test() {
   let coord = start_coordinator_with_heartbeat(0, 60_000)
   let sent = connect_mock_socket(coord, "socket-1")
 
-  process.send(coord, coordinator.Heartbeat("socket-1", "hb-ref-42"))
+  send_heartbeat(coord, "socket-1", "hb-ref-42")
 
   let assert Ok(reply) = process.receive(sent, 100)
   string.contains(reply, "phx_reply")
@@ -331,9 +343,10 @@ fn join_topic(
   topic_name: String,
   sent_messages: process.Subject(String),
 ) -> Nil {
-  process.send(
+  coordinator.route_message(
     coord,
-    coordinator.Join(socket_id, topic_name, dynamic.nil(), None, "join-ref"),
+    socket_id,
+    "[null,\"join-ref\",\"" <> topic_name <> "\",\"phx_join\",{}]",
   )
   // Wait for the join reply
   let assert Ok(reply) = process.receive(sent_messages, 200)
@@ -377,11 +390,11 @@ pub fn topic_cleanup_after_heartbeat_eviction_test() {
 
   // Keep active socket alive while stale one times out
   process.sleep(60)
-  process.send(coord, coordinator.Heartbeat("socket-active", "hb-1"))
+  send_heartbeat(coord, "socket-active", "hb-1")
   process.sleep(60)
-  process.send(coord, coordinator.Heartbeat("socket-active", "hb-2"))
+  send_heartbeat(coord, "socket-active", "hb-2")
   process.sleep(60)
-  process.send(coord, coordinator.Heartbeat("socket-active", "hb-3"))
+  send_heartbeat(coord, "socket-active", "hb-3")
 
   // Wait for stale socket eviction (stale hasn't sent heartbeats for 180ms+ > 150ms timeout)
   process.sleep(60)

--- a/test/heartbeat_test.gleam
+++ b/test/heartbeat_test.gleam
@@ -39,12 +39,7 @@ fn connect_mock_socket(
   }
   process.send(
     coord,
-    coordinator.SocketConnected(
-      socket_id,
-      send_fn,
-      fn(_) { Ok(Nil) },
-      dynamic.nil(),
-    ),
+    coordinator.SocketConnected(socket_id, send_fn, fn(_) { Ok(Nil) }),
   )
   // Small sleep to let the coordinator process the message
   process.sleep(10)

--- a/test/phoenix_contract_test.gleam
+++ b/test/phoenix_contract_test.gleam
@@ -228,7 +228,7 @@ fn contract_channel(
           socket.id(client_socket),
           "room:lobby",
           "broadcasted",
-          payload,
+          wire.dynamic_to_json(payload),
         )
         channel.NoReply(client_socket)
       }

--- a/test/wire_codec_test.gleam
+++ b/test/wire_codec_test.gleam
@@ -14,49 +14,44 @@ import phoenix_channel_fixtures/frame as fixtures
 
 pub fn phoenix_codec_round_trip_test() {
   let phoenix = wire.phoenix_codec()
-  let encoded = phoenix.encode_push("room:1", "msg", json.string("hi"))
-  let assert Ok(inbound) = phoenix.decode(encoded)
+  let encoded =
+    text_frame(phoenix.encode_push("room:1", "msg", json.string("hi")))
+  let assert Ok(inbound) = phoenix.decode_text(encoded)
   inbound.topic |> should.equal("room:1")
-  inbound.event |> should.equal("msg")
+  inbound.kind |> should.equal(codec.Event("msg"))
 }
 
-pub fn phoenix_codec_uses_phoenix_event_names_test() {
+pub fn phoenix_codec_decodes_system_events_to_kinds_test() {
   let phoenix = wire.phoenix_codec()
-  phoenix.join_event |> should.equal("phx_join")
-  phoenix.leave_event |> should.equal("phx_leave")
-  phoenix.heartbeat_event |> should.equal("heartbeat")
+
+  let assert Ok(join) =
+    phoenix.decode_text("[\"j\",\"r\",\"room:1\",\"phx_join\",{}]")
+  join.kind |> should.equal(codec.Join)
+
+  let assert Ok(leave) =
+    phoenix.decode_text("[null,\"r\",\"room:1\",\"phx_leave\",{}]")
+  leave.kind |> should.equal(codec.Leave)
+
+  let assert Ok(heartbeat) =
+    phoenix.decode_text("[null,\"r\",\"phoenix\",\"heartbeat\",{}]")
+  heartbeat.kind |> should.equal(codec.Heartbeat)
+
+  let assert Ok(event) =
+    phoenix.decode_text("[null,\"r\",\"room:1\",\"new_msg\",{}]")
+  event.kind |> should.equal(codec.Event("new_msg"))
 }
 
-// === Custom codec that swaps event names ===
-
-/// Build a tiny test codec that uses different system event names. We
-/// reuse the Phoenix wire format for encoding/decoding and only override
-/// the event names — that is enough to prove the coordinator dispatches
-/// based on the codec, not on hardcoded constants.
-fn fake_codec() -> codec.Codec {
+pub fn phoenix_codec_reply_accepts_missing_ref_test() {
   let phoenix = wire.phoenix_codec()
-  codec.Codec(
-    ..phoenix,
-    join_event: "JOIN",
-    leave_event: "LEAVE",
-    heartbeat_event: "PING",
+
+  let frame =
+    phoenix.encode_reply(None, None, "room:1", codec.StatusOk, json.object([]))
+
+  let assert codec.TextFrame(encoded) = frame
+  encoded
+  |> should.equal(
+    "[null,null,\"room:1\",\"phx_reply\",{\"status\":\"ok\",\"response\":{}}]",
   )
-}
-
-pub fn custom_codec_keeps_phoenix_decode_test() {
-  let custom = fake_codec()
-  // Build a Phoenix-format frame with our custom join_event name as the
-  // event field; the codec must still decode it (it shares the format).
-  let raw = "[null,\"r1\",\"room:1\",\"JOIN\",{}]"
-  let assert Ok(inbound) = custom.decode(raw)
-  inbound.event |> should.equal("JOIN")
-  inbound.event |> should.equal(custom.join_event)
-}
-
-pub fn custom_codec_distinct_from_phoenix_test() {
-  let custom = fake_codec()
-  let phoenix = wire.phoenix_codec()
-  custom.join_event |> should.not_equal(phoenix.join_event)
 }
 
 // === Inbound shape ===
@@ -68,7 +63,7 @@ pub fn inbound_record_holds_normalized_fields_test() {
       join_ref: Some("j"),
       ref: Some("r"),
       topic: "room:1",
-      event: "evt",
+      kind: codec.Event("evt"),
       payload: payload,
     )
   inbound.topic |> should.equal("room:1")
@@ -81,7 +76,7 @@ pub fn inbound_supports_optional_refs_test() {
       join_ref: None,
       ref: None,
       topic: "t",
-      event: "e",
+      kind: codec.Event("e"),
       payload: dynamic.nil(),
     )
   inbound.ref |> should.equal(None)
@@ -94,13 +89,13 @@ pub fn reply_status_round_trips_through_phoenix_codec_test() {
   let s =
     phoenix.encode_reply(
       Some("j"),
-      "r",
+      Some("r"),
       "topic:1",
       codec.StatusOk,
       json.object([#("k", json.string("v"))]),
     )
   // Sanity: it produced *something* recognisable as a Phoenix reply.
-  s
+  text_frame(s)
   |> wire.decode_message()
   |> should.be_ok()
 }
@@ -109,11 +104,11 @@ pub fn phoenix_codec_decodes_shared_inbound_fixtures_test() {
   let phoenix = wire.phoenix_codec()
   fixtures.inbound_common()
   |> list.each(fn(case_) {
-    let assert Ok(inbound) = phoenix.decode(case_.encoded)
+    let assert Ok(inbound) = phoenix.decode_text(case_.encoded)
     inbound.join_ref |> should.equal(case_.join_ref)
     inbound.ref |> should.equal(case_.ref)
     inbound.topic |> should.equal(case_.topic)
-    inbound.event |> should.equal(case_.event)
+    inbound.kind |> should.equal(phoenix_kind(case_.event))
     let assert Ok(expected_payload) =
       json.parse(from: json.to_string(case_.payload), using: decode.dynamic)
     inbound.payload |> should.equal(expected_payload)
@@ -131,6 +126,7 @@ pub fn phoenix_codec_encodes_shared_server_push_fixtures_test() {
         && event != fixtures.close_event
       ->
         phoenix.encode_push(case_.topic, event, case_.payload)
+        |> text_frame()
         |> should.equal(case_.encoded)
       _, _, _ -> Nil
     }
@@ -147,11 +143,12 @@ pub fn phoenix_codec_encodes_shared_reply_fixtures_test() {
     }
     phoenix.encode_reply(
       case_.join_ref,
-      case_.ref,
+      Some(case_.ref),
       case_.topic,
       status,
       case_.response,
     )
+    |> text_frame()
     |> should.equal(case_.encoded)
   })
 }
@@ -162,13 +159,29 @@ pub fn phoenix_codec_rejects_shared_invalid_fixtures_test() {
   |> list.each(fn(case_) {
     case case_.reason {
       fixtures.InvalidJson -> {
-        let assert Error(codec.InvalidJson(_)) = phoenix.decode(case_.encoded)
+        let assert Error(codec.InvalidJson(_)) =
+          phoenix.decode_text(case_.encoded)
         Nil
       }
       fixtures.InvalidFormat -> {
-        let assert Error(codec.InvalidFormat(_)) = phoenix.decode(case_.encoded)
+        let assert Error(codec.InvalidFormat(_)) =
+          phoenix.decode_text(case_.encoded)
         Nil
       }
     }
   })
+}
+
+fn text_frame(frame: codec.Frame) -> String {
+  let assert codec.TextFrame(text) = frame
+  text
+}
+
+fn phoenix_kind(event: String) -> codec.InboundKind {
+  case event {
+    "phx_join" -> codec.Join
+    "phx_leave" -> codec.Leave
+    "heartbeat" -> codec.Heartbeat
+    other -> codec.Event(other)
+  }
 }

--- a/website/src/content/docs/architecture/overview.md
+++ b/website/src/content/docs/architecture/overview.md
@@ -90,11 +90,13 @@ group.broadcast(groups, channels, "team:eng", "announce", payload)
 Optional OTP supervision tree for all beryl subsystems:
 
 ```gleam
+import beryl
 import beryl/supervisor
+import beryl/wire
 import gleam/option.{None, Some}
 
 let config = supervisor.SupervisedConfig(
-  channels: beryl.default_config(),
+  channels: beryl.config(wire.phoenix_codec()),
   presence: Some(presence.default_config("node1")),
   groups: True,
 )

--- a/website/src/content/docs/architecture/overview.md
+++ b/website/src/content/docs/architecture/overview.md
@@ -106,13 +106,13 @@ Uses **rest-for-one** strategy with the child order: coordinator â†’ presence â†
 
 ### Wire Protocol (`beryl/wire`)
 
-JSON encoding and decoding for the Phoenix-compatible wire protocol. Handles:
+Pluggable text/binary frame encoding and decoding. The built-in `wire.phoenix_codec()` handles:
 
 - Message parsing: `[join_ref, ref, topic, event, payload]` arrays
 - Reply encoding with status (`ok`/`error`) and response payload
 - Server push messages (no ref)
 - Heartbeat replies
-- Dynamic-to-JSON conversion for payloads
+- Structural dispatch for join, leave, heartbeat, and user events
 
 ### WebSocket Transport (`beryl/transport/mist`)
 
@@ -120,8 +120,8 @@ Integrates directly with Mist to handle WebSocket connections:
 
 1. Generates a unique socket ID per connection
 2. Registers the socket's send function with the coordinator
-3. Routes incoming text frames through the wire protocol decoder
-4. Routes binary frames directly to the coordinator
+3. Routes incoming text frames through the configured codec
+4. Routes binary frames through the codec when configured, or to raw binary channel handlers otherwise
 5. Notifies the coordinator on connection close
 
 ### Topic (`beryl/topic`)

--- a/website/src/content/docs/guides/channels.md
+++ b/website/src/content/docs/guides/channels.md
@@ -67,6 +67,8 @@ Channels are built using a builder pattern starting with `channel.new()`:
 ```gleam
 import beryl/channel.{type Channel, type HandleResult, type JoinResult}
 import beryl/socket.{type Socket}
+import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode
 import gleam/json.{type Json}
 import gleam/option.{type Option, None, Some}
 
@@ -90,7 +92,7 @@ Called when a client sends a `phx_join` message. Return `JoinOk` to accept or `J
 ```gleam
 fn join(
   topic: String,
-  payload: Json,
+  payload: Dynamic,
   socket: Socket(RoomAssigns),
 ) -> JoinResult(RoomAssigns) {
   // Extract room ID from topic pattern
@@ -113,13 +115,21 @@ Called for each incoming text message. The `event` string identifies the message
 ```gleam
 fn handle_in(
   event: String,
-  payload: Json,
+  payload: Dynamic,
   socket: Socket(RoomAssigns),
 ) -> HandleResult(RoomAssigns) {
   case event {
     "new_message" -> {
+      let text_decoder = {
+        use text <- decode.field("text", decode.string)
+        decode.success(text)
+      }
+      let reply_payload = case channel.decode_payload(payload, text_decoder) {
+        Ok(text) -> json.object([#("text", json.string(text))])
+        Error(_) -> channel.error("invalid payload")
+      }
       // Reply to the sender — event arg is ignored, phx_reply is always sent
-      channel.Reply("ok", payload, socket)
+      channel.Reply("ok", reply_payload, socket)
     }
     "typing" -> {
       // No reply needed
@@ -152,7 +162,7 @@ Channel handlers return one of these results:
 
 ### Binary handler
 
-Handle raw binary WebSocket frames (bypasses the wire protocol):
+Handle raw binary WebSocket frames when the configured codec does not decode binary frames:
 
 ```gleam
 fn handle_binary(

--- a/website/src/content/docs/guides/channels.md
+++ b/website/src/content/docs/guides/channels.md
@@ -306,8 +306,9 @@ Register channels with the beryl system using topic patterns:
 
 ```gleam
 import beryl
+import beryl/wire
 
-let assert Ok(channels) = beryl.start(beryl.default_config())
+let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
 
 // Register handlers for different topic patterns
 let assert Ok(Nil) = beryl.register(channels, "room:*", room_channel.new())

--- a/website/src/content/docs/guides/error-handling.md
+++ b/website/src/content/docs/guides/error-handling.md
@@ -113,7 +113,7 @@ When a client exceeds a configured rate limit, the offending message is **droppe
 
 ```gleam
 let config =
-  beryl.default_config()
+  beryl.config(wire.phoenix_codec())
   |> beryl.with_message_rate(per_second: 100, burst: 200)
   |> beryl.with_join_rate(per_second: 5, burst: 10)
   |> beryl.with_channel_rate(per_second: 50, burst: 100)

--- a/website/src/content/docs/guides/groups.md
+++ b/website/src/content/docs/guides/groups.md
@@ -135,11 +135,13 @@ let assert Ok(Nil) = group.delete(groups, "team:eng")
 When using `beryl/supervisor`, set `groups: True` in `SupervisedConfig` and access the groups handle from the returned `SupervisedChannels`:
 
 ```gleam
+import beryl
 import beryl/supervisor
+import beryl/wire
 import gleam/option.{None}
 
 let config = supervisor.SupervisedConfig(
-  channels: beryl.default_config(),
+  channels: beryl.config(wire.phoenix_codec()),
   presence: None,
   groups: True,
 )

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -106,9 +106,10 @@ The channel system uses PubSub internally for distributed broadcasts when config
 
 ```gleam
 import beryl
+import beryl/wire
 
 let assert Ok(ps) = pubsub.start(pubsub.default_config())
-let config = beryl.default_config() |> beryl.with_pubsub(ps)
+let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
 let assert Ok(channels) = beryl.start(config)
 
 // beryl.broadcast() now sends to all nodes automatically

--- a/website/src/content/docs/guides/supervision.md
+++ b/website/src/content/docs/guides/supervision.md
@@ -22,11 +22,12 @@ Use `beryl.start` for simple scripts, tests, or examples where crash recovery is
 import beryl
 import beryl/supervisor
 import beryl/presence
+import beryl/wire
 import gleam/option.{None, Some}
 
 pub fn main() {
   let config = supervisor.SupervisedConfig(
-    channels: beryl.default_config(),
+    channels: beryl.config(wire.phoenix_codec()),
     presence: Some(presence.default_config("node1")),
     groups: True,
   )
@@ -105,11 +106,13 @@ After `stop` returns, `supervised` should not be used. All child processes have 
 Use `supervisor.child_spec` to embed beryl as a subtree in your application's top-level supervisor:
 
 ```gleam
+import beryl
 import beryl/supervisor
+import beryl/wire
 import gleam/otp/static_supervisor
 
 let beryl_config = supervisor.SupervisedConfig(
-  channels: beryl.default_config(),
+  channels: beryl.config(wire.phoenix_codec()),
   presence: None,
   groups: True,
 )

--- a/website/src/content/docs/guides/websocket.md
+++ b/website/src/content/docs/guides/websocket.md
@@ -90,7 +90,7 @@ If clients cannot connect, see [Clients cannot connect at all](/troubleshooting#
 
 ## Wire protocol
 
-By default, beryl uses `wire.phoenix_codec()`, which speaks the Phoenix JSON array format:
+Pass `wire.phoenix_codec()` to `beryl.config` to use the Phoenix JSON array format:
 
 ```json
 [join_ref, ref, topic, event, payload]
@@ -150,7 +150,7 @@ Configure heartbeat timing in the beryl config:
 
 ```gleam
 let config = beryl.Config(
-  ..beryl.default_config(),
+  ..beryl.config(wire.phoenix_codec()),
   heartbeat_interval_ms: 30_000,  // Client sends every 30s
   heartbeat_timeout_ms: 60_000,   // Server evicts after 60s silence
 )
@@ -162,7 +162,7 @@ Protect against flood attacks with built-in rate limiting:
 
 ```gleam
 let config =
-  beryl.default_config()
+  beryl.config(wire.phoenix_codec())
   |> beryl.with_message_rate(per_second: 100, burst: 200)
   |> beryl.with_join_rate(per_second: 5, burst: 10)
   |> beryl.with_channel_rate(per_second: 50, burst: 100)

--- a/website/src/content/docs/guides/websocket.md
+++ b/website/src/content/docs/guides/websocket.md
@@ -90,11 +90,13 @@ If clients cannot connect, see [Clients cannot connect at all](/troubleshooting#
 
 ## Wire protocol
 
-beryl uses the Phoenix wire protocol — a JSON array format:
+By default, beryl uses `wire.phoenix_codec()`, which speaks the Phoenix JSON array format:
 
 ```json
 [join_ref, ref, topic, event, payload]
 ```
+
+Applications can pass a custom codec to `beryl.config(codec)` to use another text framing or a binary framing. Codec-produced outbound frames are sent as text or binary WebSocket frames according to the codec result.
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -114,6 +114,7 @@ Wire everything together in your application entry point:
 // src/my_app.gleam
 import beryl
 import beryl/transport/mist as mist_transport
+import beryl/wire
 import gleam/bytes_tree
 import gleam/erlang/process
 import gleam/http/request
@@ -123,7 +124,7 @@ import my_app/room_channel
 
 pub fn main() {
   // Start the beryl channel system.
-  let assert Ok(channels) = beryl.start(beryl.default_config())
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
 
   // Register the room channel for all "room:*" topics.
   let assert Ok(_) =

--- a/website/src/content/docs/reference/index.md
+++ b/website/src/content/docs/reference/index.md
@@ -28,7 +28,8 @@ This page provides a module map, broadcast cheatsheet, Phoenix wire protocol ref
 | `beryl/presence` | OTP actor wrapping the presence CRDT | Tracking who is online |
 | `beryl/presence/state` | Pure add-wins observed-remove CRDT | Testing, custom merge logic |
 | `beryl/group` | Named sets of topics for bulk broadcast | Rooms with multiple sub-topics |
-| `beryl/wire` | JSON encode/decode for the Phoenix wire format | Custom transports, protocol debugging |
+| `beryl/wire` | Phoenix-compatible codec and JSON helpers | Phoenix clients, custom transports, protocol debugging |
+| `beryl/wire/codec` | Pluggable codec contract for text and binary frames | Custom wire formats |
 | `beryl/transport/mist` | Mist WebSocket upgrade and dispatch | Wiring beryl to an HTTP server |
 
 ---
@@ -121,7 +122,7 @@ Follows the Phoenix presence diff format. Both `joins` and `leaves` are objects 
 
 ## Client compatibility
 
-Because beryl uses the standard Phoenix wire format, any Phoenix-compatible WebSocket client works out of the box:
+When started with `wire.phoenix_codec()`, beryl uses the standard Phoenix wire format, so any Phoenix-compatible WebSocket client works out of the box:
 
 | Client | Notes |
 |---|---|

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -79,7 +79,7 @@ This page lists common symptoms with targeted diagnosis steps. Start from your s
 3. **Single-node vs. multi-node.** Without PubSub, broadcasts are local to the node. If your deployment runs multiple BEAM nodes, configure PubSub:
    ```gleam
    let assert Ok(ps) = pubsub.start(pubsub.default_config())
-   let config = beryl.default_config() |> beryl.with_pubsub(ps)
+   let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
    ```
 
 4. **broadcast_from excluding the wrong socket.** `beryl.broadcast_from` excludes the socket whose ID you pass. Verify that the socket ID matches the sender.


### PR DESCRIPTION
## Summary

- Complete the pluggable codec abstraction with text/binary `Frame`s and optional binary decoding
- Switch coordinator dispatch to structural inbound kinds for join, leave, heartbeat, and user events
- Change channel join/message payloads to `Dynamic` and add `channel.decode_payload`
- Remove public codec-bypass coordinator messages and update tests, examples, docs, and changelog

## Breaking changes

- Channel `join` and `handle_in` callbacks now receive `Dynamic` inbound payloads instead of `json.Json`
- Custom codecs now implement `decode_text`, optional `decode_binary`, and return text/binary `Frame`s from encoders
- Transports/tests should route inbound frames through `coordinator.route_message` or `coordinator.route_binary` rather than constructing internal join/leave/heartbeat messages

## Validation

- `just ci`
