### PR TITLE
feat(docs): generate website API reference from Gleam docs metadata

### DIFF
--- a/.changes/unreleased/Added-20260622-101100.yaml
+++ b/.changes/unreleased/Added-20260622-101100.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: |-
+    Generate native API reference pages on the documentation website from Gleam's docs metadata.
+    A new `pnpm generate:reference` script (wired into `just site-build` and `just site-check`) turns `package-interface.json` into Starlight reference pages for every public module, surfaced in the same navigation, styling, and search as the rest of the docs site.
+time: 2026-06-22T10:11:00.000000-07:00

--- a/justfile
+++ b/justfile
@@ -83,16 +83,24 @@ changelog:
 site-dev:
     pnpm -C website dev
 
-# Build website
-site-build:
-    pnpm -C website build:site
-
 # Install website dependencies
 site-deps:
     pnpm -C website install
 
+# Generate website reference docs from Gleam docs metadata
+site-reference: docs
+    pnpm -C website generate:reference
+
+# Test the website reference docs generator
+site-reference-test:
+    pnpm -C website test:reference
+
+# Build website
+site-build: site-reference
+    pnpm -C website build:site
+
 # Check website (Astro check)
-site-check:
+site-check: site-reference
     pnpm -C website check:astro
 
 # Clean website build artifacts

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -113,6 +113,16 @@ export default defineConfig({
 							label: "API Overview",
 							slug: "reference",
 						},
+						{
+							label: "Generated API",
+							items: [
+								{
+									autogenerate: {
+										directory: "reference/api",
+									},
+								},
+							],
+						},
 					],
 				},
 				{

--- a/website/package.json
+++ b/website/package.json
@@ -21,8 +21,10 @@
 		"check:astro": "astro check",
 		"clean": "rimraf dist *.tsbuildinfo *.done.build.log .astro",
 		"dev": "astro dev",
+		"generate:reference": "node scripts/generate-reference.mjs",
 		"preview": "astro preview",
-		"start": "astro dev"
+		"start": "astro dev",
+		"test:reference": "node --test scripts/generate-reference.test.mjs"
 	},
 	"dependencies": {
 		"@astrojs/check": "^0.9.6",

--- a/website/scripts/generate-reference.mjs
+++ b/website/scripts/generate-reference.mjs
@@ -1,0 +1,408 @@
+// Generates Markdown reference pages from Gleam's package-interface.json.
+//
+// Reads build/dev/docs/<package-name>/package-interface.json (produced by
+// `gleam docs build`) and writes one Markdown page per public module into
+// website/src/content/docs/reference/api. The hand-written reference index at
+// website/src/content/docs/reference/index.md is intentionally left untouched.
+
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const websiteRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(websiteRoot, "..");
+const defaultOutputDir = path.join(
+	websiteRoot,
+	"src",
+	"content",
+	"docs",
+	"reference",
+	"api",
+);
+// URL base path the generated pages are served from. Must match defaultOutputDir
+// relative to website/src/content/docs.
+const referenceBasePath = "/reference/api";
+
+export async function generateReference({
+	docsJsonPath,
+	outputDir = defaultOutputDir,
+} = {}) {
+	const packageName = await readPackageName();
+	const jsonPath =
+		docsJsonPath ??
+		path.join(
+			repoRoot,
+			"build",
+			"dev",
+			"docs",
+			packageName,
+			"package-interface.json",
+		);
+	const packageInterface = await readPackageInterface(jsonPath, packageName);
+	const modules = Object.entries(packageInterface.modules).sort(
+		([left], [right]) => left.localeCompare(right),
+	);
+
+	await rm(outputDir, { force: true, recursive: true });
+	await mkdir(outputDir, { recursive: true });
+	await writeFile(
+		path.join(outputDir, "index.md"),
+		renderIndex(packageInterface, modules),
+	);
+
+	for (const [moduleName, moduleInterface] of modules) {
+		await writeFile(
+			path.join(outputDir, `${moduleSlug(moduleName)}.md`),
+			renderModulePage(moduleName, moduleInterface),
+		);
+	}
+
+	return { pageCount: modules.length + 1, moduleCount: modules.length };
+}
+
+async function readPackageName() {
+	const gleamTomlPath = path.join(repoRoot, "gleam.toml");
+	const gleamToml = await readFile(gleamTomlPath, "utf8");
+	const match = gleamToml.match(/^name\s*=\s*"([^"]+)"/m);
+	if (!match) {
+		throw new Error(
+			`Missing package name in ${path.relative(repoRoot, gleamTomlPath)}`,
+		);
+	}
+	return match[1];
+}
+
+async function readPackageInterface(docsJsonPath, packageName) {
+	let raw;
+	try {
+		raw = await readFile(docsJsonPath, "utf8");
+	} catch (error) {
+		if (error && error.code === "ENOENT") {
+			throw new Error(
+				`Missing ${path.relative(repoRoot, docsJsonPath)}. Run \`gleam docs build\` from the repository root first.`,
+			);
+		}
+		throw error;
+	}
+
+	const parsed = JSON.parse(raw);
+	if (!parsed || parsed.name !== packageName || typeof parsed.modules !== "object") {
+		throw new Error(
+			`Invalid Gleam package interface JSON at ${path.relative(repoRoot, docsJsonPath)}`,
+		);
+	}
+
+	return parsed;
+}
+
+function moduleSlug(moduleName) {
+	return moduleName.replaceAll("/", "-");
+}
+
+function descriptionFromDocs(documentation, fallback) {
+	const text = normalizeDoc(documentation);
+	const firstLine = text.split("\n").find((line) => line.trim().length > 0);
+	return firstLine ? firstLine.replaceAll('"', '\\"') : fallback;
+}
+
+function normalizeDoc(documentation) {
+	if (Array.isArray(documentation)) {
+		return documentation.map((line) => line.trimEnd()).join("\n").trim();
+	}
+	if (typeof documentation === "string") {
+		return documentation.trim();
+	}
+	return "";
+}
+
+function code(value) {
+	return `\`${String(value).replaceAll("`", "\\`")}\``;
+}
+
+function variableSymbol(id) {
+	return String.fromCharCode("a".charCodeAt(0) + (Number.isInteger(id) ? id : 0));
+}
+
+function renderTypeParameters(count) {
+	if (!Number.isInteger(count) || count <= 0) {
+		return "";
+	}
+	return `(${Array.from({ length: count }, (_, i) => variableSymbol(i)).join(", ")})`;
+}
+
+function renderType(type, currentModule) {
+	if (!type || typeof type !== "object") {
+		return "Unknown";
+	}
+
+	switch (type.kind) {
+		case "named": {
+			let qualifier = "";
+			if (type.module && type.module !== "gleam" && type.module !== currentModule) {
+				const segments = type.module.split("/");
+				qualifier = `${segments[segments.length - 1]}.`;
+			}
+			const parameters =
+				Array.isArray(type.parameters) && type.parameters.length > 0
+					? `(${type.parameters.map((t) => renderType(t, currentModule)).join(", ")})`
+					: "";
+			return `${qualifier}${type.name}${parameters}`;
+		}
+		case "fn": {
+			const parameters = Array.isArray(type.parameters)
+				? type.parameters.map((t) => renderType(t, currentModule)).join(", ")
+				: "";
+			return `fn(${parameters}) -> ${renderType(type.return, currentModule)}`;
+		}
+		case "tuple":
+			return `#(${(type.elements || []).map((t) => renderType(t, currentModule)).join(", ")})`;
+		case "variable":
+			return variableSymbol(type.id ?? 0);
+		default:
+			return type.name || type.kind || "Unknown";
+	}
+}
+
+function renderParameter(parameter, currentModule) {
+	const label = parameter.label ? `${parameter.label}: ` : "";
+	return `${label}${renderType(parameter.type, currentModule)}`;
+}
+
+function renderConstructor(constructor, currentModule) {
+	const parameters = constructor.parameters || constructor.arguments || [];
+	if (parameters.length === 0) {
+		return constructor.name;
+	}
+	if (parameters.length === 1) {
+		return `${constructor.name}(${renderParameter(parameters[0], currentModule)})`;
+	}
+	const rendered = parameters.map((p) => renderParameter(p, currentModule)).join(",\n  ");
+	return `${constructor.name}(\n  ${rendered}\n)`;
+}
+
+function renderFunctionSignature(name, parameters, returnType, currentModule) {
+	let rendered;
+	if (!Array.isArray(parameters) || parameters.length === 0) {
+		rendered = "()";
+	} else if (parameters.length === 1) {
+		rendered = `(${renderParameter(parameters[0], currentModule)})`;
+	} else {
+		const params = parameters.map((p) => renderParameter(p, currentModule)).join(",\n  ");
+		rendered = `(\n  ${params}\n)`;
+	}
+	return `pub fn ${name}${rendered} -> ${returnType ? renderType(returnType, currentModule) : "Nil"}`;
+}
+
+function renderTypeDefinition(name, typeDef, currentModule) {
+	const params = renderTypeParameters(typeDef.parameters || 0);
+	const constructors = normalizeConstructors(typeDef.constructors);
+	if (constructors.length === 0) {
+		return `pub type ${name}${params}`;
+	}
+	const body = constructors
+		.map((c) => `  ${renderConstructor(c, currentModule).replaceAll("\n", "\n  ")}`)
+		.join("\n");
+	return `pub type ${name}${params} {\n${body}\n}`;
+}
+
+function renderAliasDefinition(name, alias, currentModule) {
+	const params = renderTypeParameters(alias.parameters || 0);
+	return `pub type ${name}${params} = ${renderType(alias.alias ?? alias.type, currentModule)}`;
+}
+
+function renderConstantDefinition(name, constant, currentModule) {
+	return `pub const ${name}: ${renderType(constant.type, currentModule)}`;
+}
+
+function deprecationBlock(deprecation) {
+	if (!deprecation || typeof deprecation !== "object") {
+		return "";
+	}
+	const message = (deprecation.message || "").trim();
+	const body = message.length > 0 ? message : "This item has been deprecated.";
+	return `\n\n:::caution[Deprecated]\n${body}\n:::`;
+}
+
+function renderIndex(packageInterface, modules) {
+	const moduleRows = modules
+		.map(([moduleName, moduleInterface]) => {
+			const description = descriptionFromDocs(
+				moduleInterface.documentation,
+				`Reference for ${moduleName}.`,
+			);
+			return `| [${code(moduleName)}](${referenceBasePath}/${moduleSlug(moduleName)}/) | ${description} |`;
+		})
+		.join("\n");
+
+	return `---
+title: API Reference
+description: Generated API reference from Gleam docs metadata.
+---
+
+This reference is generated from Gleam's docs metadata for ${code(packageInterface.name)} ${code(packageInterface.version)}.
+
+:::note[Generated content]
+Pages under \`${referenceBasePath}/\` are generated from Gleam's docs metadata and reflect every public type, function, and constant. The canonical, hosted API docs live on [HexDocs](https://hexdocs.pm/${packageInterface.name}/).
+:::
+
+## Modules
+
+| Module | Description |
+|---|---|
+${moduleRows}
+`;
+}
+
+function renderModulePage(moduleName, moduleInterface) {
+	const description = descriptionFromDocs(
+		moduleInterface.documentation,
+		`Reference for ${moduleName}.`,
+	);
+	const sections = [
+		renderTypes(moduleInterface.types, moduleName),
+		renderTypeAliases(moduleInterface["type-aliases"], moduleName),
+		renderConstants(moduleInterface.constants, moduleName),
+		renderFunctions(moduleInterface.functions, moduleName),
+	].filter(Boolean);
+
+	return `---
+title: ${moduleName}
+description: ${description}
+---
+
+${normalizeDoc(moduleInterface.documentation) || description}
+
+${sections.join("\n\n")}
+`;
+}
+
+function renderConstructorsSection(typeInterface, moduleName) {
+	const constructors = normalizeConstructors(typeInterface.constructors).filter(
+		(c) => normalizeDoc(c.documentation).length > 0,
+	);
+	if (constructors.length === 0) {
+		return "";
+	}
+
+	const items = constructors
+		.map((c) => `##### ${code(renderConstructor(c, moduleName))}\n\n${normalizeDoc(c.documentation)}`)
+		.join("\n\n");
+	return `#### Constructors\n\n${items}`;
+}
+
+function renderTypes(types, moduleName) {
+	const entries = Object.entries(types || {}).sort(([left], [right]) =>
+		left.localeCompare(right),
+	);
+	if (entries.length === 0) {
+		return "";
+	}
+
+	return [
+		"## Types",
+		...entries.map(([name, typeInterface]) => {
+			const docs = normalizeDoc(typeInterface.documentation);
+			const deprecation = deprecationBlock(typeInterface.deprecation);
+			const definition = renderTypeDefinition(name, typeInterface, moduleName);
+			const constructors = renderConstructorsSection(typeInterface, moduleName);
+			const sections = [
+				docs ? `${docs}${deprecation}` : deprecation.replace(/^\n\n/, ""),
+				`\`\`\`gleam\n${definition}\n\`\`\``,
+				constructors,
+			].filter((section) => section && section.length > 0);
+			return `### ${code(name)}\n\n${sections.join("\n\n")}`;
+		}),
+	].join("\n\n");
+}
+
+function normalizeConstructors(constructors) {
+	if (Array.isArray(constructors)) {
+		return constructors;
+	}
+	return Object.entries(constructors || {})
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([name, constructor]) => ({ name, ...constructor }));
+}
+
+function renderTypeAliases(typeAliases, moduleName) {
+	const entries = Object.entries(typeAliases || {}).sort(([left], [right]) =>
+		left.localeCompare(right),
+	);
+	if (entries.length === 0) {
+		return "";
+	}
+
+	return [
+		"## Type aliases",
+		...entries.map(([name, alias]) => `### ${code(name)}
+
+${normalizeDoc(alias.documentation)}${deprecationBlock(alias.deprecation)}
+
+\`\`\`gleam
+${renderAliasDefinition(name, alias, moduleName)}
+\`\`\``),
+	].join("\n\n");
+}
+
+function renderConstants(constants, moduleName) {
+	const entries = Object.entries(constants || {}).sort(([left], [right]) =>
+		left.localeCompare(right),
+	);
+	if (entries.length === 0) {
+		return "";
+	}
+
+	return [
+		"## Constants",
+		...entries.map(([name, constant]) => `### ${code(name)}
+
+${normalizeDoc(constant.documentation)}${deprecationBlock(constant.deprecation)}
+
+\`\`\`gleam
+${renderConstantDefinition(name, constant, moduleName)}
+\`\`\``),
+	].join("\n\n");
+}
+
+function renderFunctions(functions, moduleName) {
+	const entries = Object.entries(functions || {}).sort(([left], [right]) =>
+		left.localeCompare(right),
+	);
+	if (entries.length === 0) {
+		return "";
+	}
+
+	return [
+		"## Functions",
+		...entries.map(([name, functionInterface]) => {
+			const signature = renderFunctionSignature(
+				name,
+				functionInterface.parameters,
+				functionInterface.return,
+				moduleName,
+			);
+			return `### ${code(name)}
+
+${normalizeDoc(functionInterface.documentation)}${deprecationBlock(functionInterface.deprecation)}
+
+\`\`\`gleam
+${signature}
+\`\`\``;
+		}),
+	].join("\n\n");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	generateReference()
+		.then(({ pageCount }) => {
+			console.log(
+				`Generated ${pageCount} reference pages in ${path.relative(repoRoot, defaultOutputDir)}`,
+			);
+		})
+		.catch((error) => {
+			console.error(error.message);
+			process.exit(1);
+		});
+}

--- a/website/scripts/generate-reference.test.mjs
+++ b/website/scripts/generate-reference.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { generateReference } from "./generate-reference.mjs";
+
+const fixture = {
+	name: "beryl",
+	version: "9.9.9",
+	modules: {
+		"beryl/channel": {
+			documentation: ["Channel behaviour and callbacks.", "", "Second line."],
+			types: {
+				HandleResult: {
+					documentation: "Result of handling an inbound message.",
+					parameters: 1,
+					constructors: [
+						{
+							name: "Reply",
+							documentation: "Reply to the sender.",
+							parameters: [{ label: "payload", type: { kind: "variable", id: 0 } }],
+						},
+						{ name: "NoReply", parameters: [] },
+					],
+				},
+				LegacyThing: {
+					documentation: "An old type.",
+					parameters: 0,
+					constructors: [],
+					deprecation: { message: "Use HandleResult instead." },
+				},
+			},
+			"type-aliases": {
+				Assigns: {
+					documentation: "Convenience alias for socket assigns.",
+					parameters: 0,
+					alias: {
+						kind: "named",
+						name: "Dict",
+						module: "gleam/dict",
+						parameters: [
+							{ kind: "named", name: "String", module: "gleam" },
+							{ kind: "variable", id: 0 },
+						],
+					},
+				},
+			},
+			constants: {
+				default_timeout: {
+					documentation: "Default reply timeout.",
+					type: { kind: "named", name: "Int", module: "gleam" },
+				},
+			},
+			functions: {
+				handle: {
+					documentation: "Handle an inbound message.",
+					parameters: [
+						{ label: "message", type: { kind: "named", name: "String", module: "gleam" } },
+						{
+							label: "coords",
+							type: {
+								kind: "tuple",
+								elements: [
+									{ kind: "named", name: "Int", module: "gleam" },
+									{ kind: "named", name: "Int", module: "gleam" },
+								],
+							},
+						},
+						{
+							label: "callback",
+							type: {
+								kind: "fn",
+								parameters: [{ kind: "named", name: "String", module: "gleam" }],
+								return: { kind: "named", name: "Nil", module: "gleam" },
+							},
+						},
+					],
+					return: {
+						kind: "named",
+						name: "HandleResult",
+						module: "beryl/channel",
+						parameters: [{ kind: "variable", id: 0 }],
+					},
+				},
+			},
+		},
+		beryl: {
+			documentation: "Top-level API.",
+			types: {},
+			"type-aliases": {},
+			constants: {},
+			functions: {},
+		},
+	},
+};
+
+async function withFixture(run) {
+	const dir = await mkdtemp(path.join(tmpdir(), "beryl-ref-"));
+	try {
+		const jsonPath = path.join(dir, "package-interface.json");
+		const outputDir = path.join(dir, "out");
+		await writeFile(jsonPath, JSON.stringify(fixture));
+		await run({ jsonPath, outputDir });
+	} finally {
+		await rm(dir, { force: true, recursive: true });
+	}
+}
+
+test("generates an index and one page per module", async () => {
+	await withFixture(async ({ jsonPath, outputDir }) => {
+		const result = await generateReference({ docsJsonPath: jsonPath, outputDir });
+		assert.equal(result.moduleCount, 2);
+		assert.equal(result.pageCount, 3);
+
+		const index = await readFile(path.join(outputDir, "index.md"), "utf8");
+		assert.match(index, /title: API Reference/);
+		assert.match(index, /`beryl` `9\.9\.9`/);
+		// Modules are sorted alphabetically: beryl before beryl/channel.
+		assert.ok(index.indexOf("/reference/api/beryl/") < index.indexOf("/reference/api/beryl-channel/"));
+	});
+});
+
+test("renders types, aliases, constants, and functions", async () => {
+	await withFixture(async ({ jsonPath, outputDir }) => {
+		await generateReference({ docsJsonPath: jsonPath, outputDir });
+		const page = await readFile(path.join(outputDir, "beryl-channel.md"), "utf8");
+
+		// Module doc array is normalized to multi-line text.
+		assert.match(page, /Channel behaviour and callbacks\./);
+
+		// Type with parameters and documented constructors.
+		assert.match(page, /pub type HandleResult\(a\)/);
+		assert.match(page, /Reply\(payload: a\)/);
+		assert.match(page, /NoReply/);
+
+		// Type alias with a foreign type uses last module segment, drops prelude qualifier.
+		assert.match(page, /pub type Assigns = dict\.Dict\(String, a\)/);
+
+		// Constant.
+		assert.match(page, /pub const default_timeout: Int/);
+
+		// Function signature: tuple, fn type, current-module return without qualifier.
+		assert.match(page, /pub fn handle\(/);
+		assert.match(page, /coords: #\(Int, Int\)/);
+		assert.match(page, /callback: fn\(String\) -> Nil/);
+		assert.match(page, /-> HandleResult\(a\)/);
+	});
+});
+
+test("surfaces deprecations as a caution block", async () => {
+	await withFixture(async ({ jsonPath, outputDir }) => {
+		await generateReference({ docsJsonPath: jsonPath, outputDir });
+		const page = await readFile(path.join(outputDir, "beryl-channel.md"), "utf8");
+		assert.match(page, /:::caution\[Deprecated\]\nUse HandleResult instead\.\n:::/);
+	});
+});
+
+test("reports a helpful error when the docs JSON is missing", async () => {
+	await withFixture(async ({ outputDir }) => {
+		await assert.rejects(
+			generateReference({
+				docsJsonPath: path.join(outputDir, "does-not-exist.json"),
+				outputDir,
+			}),
+			/gleam docs build/,
+		);
+	});
+});

--- a/website/src/content/docs/reference/api/beryl-bridge.md
+++ b/website/src/content/docs/reference/api/beryl-bridge.md
@@ -1,0 +1,131 @@
+---
+title: beryl/bridge
+description: Bridge - Forward an external OTP actor's message stream to a socket channel.
+---
+
+Bridge - Forward an external OTP actor's message stream to a socket channel.
+
+ A common pattern is a long-lived domain actor (e.g. a per-document session)
+ that emits updates which need to be pushed to each joined socket. Wiring
+ this up by hand requires per-socket boilerplate: spawn a forwarder process
+ holding a `Subject`, subscribe it to the domain actor, translate each
+ message and call `beryl.send_info`, then tear the process down on
+ `terminate`.
+
+ `bridge` packages that plumbing into a single helper. Start a bridge inside
+ a channel `join`, store the handle in the socket assigns, subscribe the
+ returned `Subject` to your domain actor, and stop the bridge in `terminate`.
+ The forwarder also monitors the owning channel process, so it is cleaned up
+ automatically if that process dies — no leaked processes.
+
+ ## Example
+
+ ```gleam
+ import beryl
+ import beryl/bridge.{type Bridge}
+ import beryl/channel
+ import beryl/socket
+
+ // Messages emitted by your domain actor.
+ pub type DocEvent {
+   Updated(version: Int)
+ }
+
+ pub type Assigns {
+   Assigns(bridge: Bridge(DocEvent))
+ }
+
+ fn join(channels, doc_actor, topic, _payload, socket) {
+   // Forward each DocEvent to this socket's `handle_info` callback.
+   let b =
+     bridge.start(
+       channels: channels,
+       socket_id: socket.id(socket),
+       topic: topic,
+       with: fn(event) { event },
+     )
+   // Subscribe the domain actor to the bridge's subject.
+   doc.subscribe(doc_actor, bridge.subject(b))
+   channel.JoinOk(reply: None, socket: socket.set_assigns(socket, Assigns(b)))
+ }
+
+ fn terminate(_reason, socket) {
+   bridge.stop(socket.get_assigns(socket).bridge)
+ }
+ ```
+
+## Types
+
+### `Bridge`
+
+A handle to a running bridge forwarder process.
+
+ `message` is the type emitted by the external actor and received on the
+ bridge's `Subject`. Obtain that subject with `subject` to wire it up to a
+ domain actor, and call `stop` to tear the forwarder down.
+
+```gleam
+pub type Bridge(a)
+```
+
+## Functions
+
+### `pid`
+
+The forwarder process id.
+
+ Exposed for diagnostics and supervision; you normally only need `subject`
+ and `stop`.
+
+```gleam
+pub fn pid(Bridge(a)) -> process.Pid
+```
+
+### `start`
+
+Start a bridge that forwards values from an external `Subject` to a socket's
+ channel as `handle_info` messages.
+
+ The returned `Bridge` owns a freshly spawned forwarder process. Pass
+ `subject(bridge)` to the external/domain actor so it delivers its stream to
+ the forwarder; each received value is mapped with `transform` and delivered
+ via `beryl.send_info(channels, socket_id, topic, transform(value))`.
+
+ Use `transform` to translate the domain message into whatever your channel's
+ `handle_info` expects. If no translation is needed, pass the identity
+ function `fn(value) { value }`.
+
+ The forwarder monitors the calling (channel) process and exits if it dies,
+ so a missed `stop` will not leak a process. Always call `stop` from your
+ channel's `terminate` for prompt, deterministic cleanup.
+
+```gleam
+pub fn start(
+  channels: beryl.Channels,
+  socket_id: String,
+  topic: String,
+  with: fn(a) -> b
+) -> Bridge(a)
+```
+
+### `stop`
+
+Stop the bridge's forwarder process.
+
+ Call this from your channel's `terminate` callback. It is safe to call more
+ than once and after the forwarder has already exited.
+
+```gleam
+pub fn stop(Bridge(a)) -> Nil
+```
+
+### `subject`
+
+The `Subject` the external actor should send its stream to.
+
+ Hand this to your domain actor (e.g. as its subscriber) so each emitted
+ value is forwarded to the bridged socket/topic.
+
+```gleam
+pub fn subject(Bridge(a)) -> process.Subject(a)
+```

--- a/website/src/content/docs/reference/api/beryl-channel.md
+++ b/website/src/content/docs/reference/api/beryl-channel.md
@@ -1,0 +1,252 @@
+---
+title: beryl/channel
+description: Channel - Topic-based message handlers
+---
+
+Channel - Topic-based message handlers
+
+ Channels handle real-time communication for topic patterns. Each channel
+ defines how to handle joins, incoming messages, and cleanup.
+
+ ## Example
+
+ ```gleam
+ pub type RoomAssigns {
+   RoomAssigns(user_id: String, room_id: String)
+ }
+
+ pub fn new() -> Channel(RoomAssigns, info) {
+   channel.new(join)
+   |> channel.with_handle_in(handle_in)
+   |> channel.with_terminate(terminate)
+ }
+
+ fn join(topic, payload, socket) {
+   let assigns = RoomAssigns(user_id: "...", room_id: "...")
+   channel.JoinOk(reply: None, socket: socket.set_assigns(socket, assigns))
+ }
+ ```
+
+## Types
+
+### `Channel`
+
+Channel behavior definition
+
+ Type parameters:
+ - `assigns`: Socket state type for this channel
+ - `info`: Server-originated/internal message type delivered to `handle_info`
+   (see `beryl.send_info`). Channels that do not use `handle_info` leave this
+   parameter generic.
+
+```gleam
+pub type Channel(a, b) {
+  Channel(
+    join: fn(String, dynamic.Dynamic, socket.Socket(a)) -> JoinResult(a),
+    handle_in: fn(String, dynamic.Dynamic, socket.Socket(a)) -> HandleResult(a),
+    handle_binary: fn(BitArray, socket.Socket(a)) -> HandleResult(a),
+    handle_info: fn(b, socket.Socket(a)) -> HandleResult(a),
+    terminate: fn(StopReason, socket.Socket(a)) -> Nil
+  )
+}
+```
+
+### `HandleResult`
+
+Result of handling an incoming message
+
+```gleam
+pub type HandleResult(a) {
+  NoReply(socket: socket.Socket(a))
+  Reply(
+    event: String,
+    payload: json.Json,
+    socket: socket.Socket(a)
+  )
+  Push(
+    event: String,
+    payload: json.Json,
+    socket: socket.Socket(a)
+  )
+  Stop(reason: StopReason)
+}
+```
+
+#### Constructors
+
+##### `NoReply(socket: socket.Socket(a))`
+
+Continue without sending a reply
+
+##### `Reply(
+  event: String,
+  payload: json.Json,
+  socket: socket.Socket(a)
+)`
+
+Send a reply to the client in response to their message.
+
+ When returned from `handle_in`, this is encoded as a Phoenix `phx_reply`
+ tied to the original client ref — the `event` field is ignored by the
+ coordinator. When returned from `handle_info` (where no client ref
+ exists), it is sent as a push using `event` as the event name.
+
+##### `Push(
+  event: String,
+  payload: json.Json,
+  socket: socket.Socket(a)
+)`
+
+Push a message to the client (server-initiated)
+
+##### `Stop(reason: StopReason)`
+
+Stop the channel with a reason
+
+### `JoinResult`
+
+Result of joining a channel
+
+```gleam
+pub type JoinResult(a) {
+  JoinOk(
+    reply: option.Option(json.Json),
+    socket: socket.Socket(a)
+  )
+  JoinError(reason: json.Json)
+}
+```
+
+#### Constructors
+
+##### `JoinOk(
+  reply: option.Option(json.Json),
+  socket: socket.Socket(a)
+)`
+
+Join succeeded, optionally send a reply payload
+
+##### `JoinError(reason: json.Json)`
+
+Join failed with error payload
+
+### `StopReason`
+
+Why a channel is stopping
+
+```gleam
+pub type StopReason {
+  Normal
+  Shutdown
+  HeartbeatTimeout
+  Error(String)
+}
+```
+
+#### Constructors
+
+##### `Normal`
+
+Normal shutdown (client left or disconnected cleanly)
+
+##### `Shutdown`
+
+Server-initiated shutdown
+
+##### `HeartbeatTimeout`
+
+Client failed to send heartbeat within the configured timeout
+
+##### `Error(String)`
+
+Error occurred
+
+## Functions
+
+### `decode_payload`
+
+Decode an inbound channel payload into an application type.
+
+```gleam
+pub fn decode_payload(
+  dynamic.Dynamic,
+  decode.Decoder(a)
+) -> Result(a, List(decode.DecodeError))
+```
+
+### `error`
+
+Create a simple error response
+
+```gleam
+pub fn error(String) -> json.Json
+```
+
+### `error_with_code`
+
+Create an error response with code
+
+```gleam
+pub fn error_with_code(
+  Int,
+  String
+) -> json.Json
+```
+
+### `new`
+
+Create a new channel with just a join handler.
+
+ Other handlers can be added using the `with_*` functions.
+
+```gleam
+pub fn new(fn(String, dynamic.Dynamic, socket.Socket(a)) -> JoinResult(a)) -> Channel(a, b)
+```
+
+### `with_handle_binary`
+
+Add a binary message handler
+
+```gleam
+pub fn with_handle_binary(
+  Channel(a, b),
+  fn(BitArray, socket.Socket(a)) -> HandleResult(a)
+) -> Channel(a, b)
+```
+
+### `with_handle_in`
+
+Add an incoming message handler
+
+```gleam
+pub fn with_handle_in(
+  Channel(a, b),
+  fn(String, dynamic.Dynamic, socket.Socket(a)) -> HandleResult(a)
+) -> Channel(a, b)
+```
+
+### `with_handle_info`
+
+Add a server-originated OTP message handler.
+
+ The handler receives the typed `info` value sent via `beryl.send_info`.
+ `Reply` results are sent as pushes because server-originated messages do not
+ have a client message ref to reply to.
+
+```gleam
+pub fn with_handle_info(
+  Channel(a, b),
+  fn(b, socket.Socket(a)) -> HandleResult(a)
+) -> Channel(a, b)
+```
+
+### `with_terminate`
+
+Add a terminate handler for cleanup
+
+```gleam
+pub fn with_terminate(
+  Channel(a, b),
+  fn(StopReason, socket.Socket(a)) -> Nil
+) -> Channel(a, b)
+```

--- a/website/src/content/docs/reference/api/beryl-group.md
+++ b/website/src/content/docs/reference/api/beryl-group.md
@@ -1,0 +1,166 @@
+---
+title: beryl/group
+description: Channel Groups - Named collections of topics for multi-topic broadcasting
+---
+
+Channel Groups - Named collections of topics for multi-topic broadcasting
+
+ Groups let you organize topics and broadcast to all of them at once.
+ Useful for scenarios like broadcasting to all channels in a "team" or
+ sending a system-wide notification.
+
+ ## Example
+
+ ```gleam
+ let assert Ok(groups) = group.start()
+ let assert Ok(Nil) = group.create(groups, "team:engineering")
+ let assert Ok(Nil) = group.add(groups, "team:engineering", "room:frontend")
+ let assert Ok(Nil) = group.add(groups, "team:engineering", "room:backend")
+ group.broadcast(groups, channels, "team:engineering", "announce", payload)
+ ```
+
+## Types
+
+### `GroupError`
+
+Errors from group operations
+
+```gleam
+pub type GroupError {
+  AlreadyExists
+  NotFound
+  StartFailed
+}
+```
+
+#### Constructors
+
+##### `AlreadyExists`
+
+The group already exists
+
+##### `NotFound`
+
+The group was not found
+
+##### `StartFailed`
+
+The actor failed to start
+
+### `Groups`
+
+A running Groups instance
+
+```gleam
+pub type Groups {
+  Groups(subject: process.Subject(Message))
+}
+```
+
+### `Message`
+
+Messages the groups actor handles
+
+```gleam
+pub type Message
+```
+
+## Functions
+
+### `add`
+
+Add a topic to a group
+
+```gleam
+pub fn add(
+  Groups,
+  String,
+  String
+) -> Result(Nil, GroupError)
+```
+
+### `broadcast`
+
+Broadcast a message to all topics in a group
+
+ Sends the message to every topic in the named group via beryl.broadcast().
+ If the group doesn't exist, this is a silent no-op (fire and forget).
+
+```gleam
+pub fn broadcast(
+  Groups,
+  beryl.Channels,
+  String,
+  String,
+  json.Json
+) -> Nil
+```
+
+### `create`
+
+Create a new named group
+
+```gleam
+pub fn create(
+  Groups,
+  String
+) -> Result(Nil, GroupError)
+```
+
+### `delete`
+
+Delete a group
+
+```gleam
+pub fn delete(
+  Groups,
+  String
+) -> Result(Nil, GroupError)
+```
+
+### `list_groups`
+
+List all group names
+
+```gleam
+pub fn list_groups(Groups) -> List(String)
+```
+
+### `remove`
+
+Remove a topic from a group
+
+```gleam
+pub fn remove(
+  Groups,
+  String,
+  String
+) -> Result(Nil, GroupError)
+```
+
+### `start`
+
+Start the groups actor
+
+```gleam
+pub fn start() -> Result(Groups, GroupError)
+```
+
+### `start_named`
+
+Start the groups actor with a registered name (for supervision)
+
+```gleam
+pub fn start_named(process.Name(Message)) -> Result(actor.Started(process.Subject(Message)), actor.StartError)
+```
+
+### `topics`
+
+Get all topics in a group
+
+```gleam
+pub fn topics(
+  Groups,
+  String
+) -> Result(set.Set(String), GroupError)
+```

--- a/website/src/content/docs/reference/api/beryl-presence-wire.md
+++ b/website/src/content/docs/reference/api/beryl-presence-wire.md
@@ -1,0 +1,29 @@
+---
+title: beryl/presence/wire
+description: Phoenix-compatible wire encoding for presence diffs.
+---
+
+Phoenix-compatible wire encoding for presence diffs.
+
+## Functions
+
+### `encode_diff`
+
+Encode a presence diff for one topic as a Phoenix-compatible payload.
+
+ The resulting JSON has `joins` and `leaves` maps keyed by presence key,
+ where each value contains the tracked metadata under `metas`.
+
+ ```json
+ {
+   "joins": { "user:1": { "metas": [{ "status": "online" }] } },
+   "leaves": { "user:2": { "metas": [{ "status": "offline" }] } }
+ }
+ ```
+
+```gleam
+pub fn encode_diff(
+  presence.Diff,
+  String
+) -> json.Json
+```

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -1,0 +1,239 @@
+---
+title: beryl/presence
+description: Presence - Distributed presence tracking backed by a CRDT
+---
+
+Presence - Distributed presence tracking backed by a CRDT
+
+ Wraps the pure `lattice_presence/presence_state` CRDT in an OTP actor that:
+ - Handles track/untrack calls
+ - Periodically broadcasts state via PubSub for cross-node replication
+ - Receives remote state from PubSub and merges it internally
+ - Invokes `on_diff` callback when merges produce non-empty diffs
+
+ ## Example
+
+ ```gleam
+ let assert Ok(ps) = pubsub.start(pubsub.default_config())
+ let config = presence.Config(
+   pubsub: Some(ps),
+   replica: "node1",
+   broadcast_interval_ms: 1500,
+   on_diff: None,
+ )
+ let assert Ok(p) = presence.start(config)
+ let ref = presence.track(p, "room:lobby", "user:1", "socket-1", meta)
+ let entries = presence.list(p, "room:lobby")
+ ```
+
+## Types
+
+### `Config`
+
+Configuration for starting presence
+
+```gleam
+pub type Config {
+  Config(
+    pubsub: option.Option(pubsub.PubSub),
+    replica: String,
+    broadcast_interval_ms: Int,
+    on_diff: option.Option(fn(Diff) -> Nil)
+  )
+}
+```
+
+### `Diff`
+
+An opaque diff representing presence joins and leaves grouped by topic.
+
+ This is passed to `Config.on_diff` and accepted by
+ `beryl.broadcast_presence_diff`.
+
+```gleam
+pub type Diff
+```
+
+### `Message`
+
+Messages the presence actor handles
+
+```gleam
+pub type Message
+```
+
+### `Presence`
+
+A running Presence instance
+
+```gleam
+pub type Presence {
+  Presence(subject: process.Subject(Message))
+}
+```
+
+### `PresenceEntry`
+
+A presence entry returned from queries and diff accessors.
+
+```gleam
+pub type PresenceEntry {
+  PresenceEntry(
+    pid: String,
+    key: String,
+    meta: json.Json
+  )
+}
+```
+
+### `PresenceError`
+
+Errors from presence operations
+
+```gleam
+pub type PresenceError {
+  StartFailed(actor.StartError)
+}
+```
+
+#### Constructors
+
+##### `StartFailed(actor.StartError)`
+
+The actor failed to start, wrapping the underlying OTP start error
+
+## Functions
+
+### `default_config`
+
+Default configuration (no PubSub, no replication)
+
+```gleam
+pub fn default_config(String) -> Config
+```
+
+### `diff`
+
+Build a presence diff from topic-grouped joins and leaves.
+
+ Most applications receive diffs from `Config.on_diff`; this helper is for
+ callers that need to construct a diff to pass to `beryl.broadcast_presence_diff`.
+
+```gleam
+pub fn diff(
+  joins: List(#(String, List(PresenceEntry))),
+  leaves: List(#(String, List(PresenceEntry)))
+) -> Diff
+```
+
+### `diff_joins`
+
+Get presence joins for a topic in this diff.
+
+```gleam
+pub fn diff_joins(
+  Diff,
+  String
+) -> List(PresenceEntry)
+```
+
+### `diff_leaves`
+
+Get presence leaves for a topic in this diff.
+
+```gleam
+pub fn diff_leaves(
+  Diff,
+  String
+) -> List(PresenceEntry)
+```
+
+### `diff_topics`
+
+List topics touched by this diff.
+
+```gleam
+pub fn diff_topics(Diff) -> List(String)
+```
+
+### `get_by_key`
+
+Get presences for a specific key within a topic
+
+```gleam
+pub fn get_by_key(
+  Presence,
+  String,
+  String
+) -> List(#(String, json.Json))
+```
+
+### `list`
+
+List all presences for a topic
+
+```gleam
+pub fn list(
+  Presence,
+  String
+) -> List(PresenceEntry)
+```
+
+### `start`
+
+Start the presence actor
+
+```gleam
+pub fn start(Config) -> Result(Presence, PresenceError)
+```
+
+### `start_named`
+
+Start the presence actor with a registered name (for supervision)
+
+```gleam
+pub fn start_named(
+  Config,
+  process.Name(Message)
+) -> Result(actor.Started(process.Subject(Message)), actor.StartError)
+```
+
+### `track`
+
+Track a presence in a topic
+
+ Returns a reference string (the pid) that can be used to untrack later.
+
+```gleam
+pub fn track(
+  Presence,
+  String,
+  String,
+  String,
+  json.Json
+) -> String
+```
+
+### `untrack`
+
+Untrack a specific presence by topic, key, and pid
+
+```gleam
+pub fn untrack(
+  Presence,
+  String,
+  String,
+  String
+) -> Nil
+```
+
+### `untrack_all`
+
+Untrack all presences for a pid (e.g., when a socket disconnects)
+
+```gleam
+pub fn untrack_all(
+  Presence,
+  String
+) -> Nil
+```

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -1,0 +1,229 @@
+---
+title: beryl/pubsub
+description: PubSub - Distributed publish/subscribe using Erlang pg
+---
+
+PubSub - Distributed publish/subscribe using Erlang pg
+
+ Provides topic-based pub/sub messaging backed by Erlang's built-in `pg`
+ module. Subscribers are tracked by process group, so messages are delivered
+ to all nodes in the cluster automatically.
+
+ ## Quick Start
+
+ ```gleam
+ let assert Ok(ps) = pubsub.start(pubsub.default_config())
+ pubsub.subscribe(ps, "room:lobby")
+ pubsub.broadcast(ps, "room:lobby", "new_msg", json.string("hello"))
+ ```
+
+## Types
+
+### `Message`
+
+A PubSub message delivered to subscribers
+
+```gleam
+pub type Message {
+  Message(
+    topic: String,
+    event: String,
+    payload: json.Json,
+    from: PubSubFrom
+  )
+}
+```
+
+### `PubSub`
+
+A running PubSub instance
+
+```gleam
+pub type PubSub {
+  PubSub(scope: dynamic.Dynamic)
+}
+```
+
+### `PubSubConfig`
+
+PubSub configuration
+
+```gleam
+pub type PubSubConfig {
+  PubSubConfig(scope: dynamic.Dynamic)
+}
+```
+
+### `PubSubFrom`
+
+Identifies the sender of a broadcast
+
+```gleam
+pub type PubSubFrom {
+  System
+  FromPid(process.Pid)
+  FromSocket(
+    process.Pid,
+    String
+  )
+}
+```
+
+#### Constructors
+
+##### `System`
+
+Broadcast originated from the system (no sender pid)
+
+##### `FromPid(process.Pid)`
+
+Broadcast originated from a specific process
+
+##### `FromSocket(
+  process.Pid,
+  String
+)`
+
+Broadcast originated from a process and should exclude a socket ID
+
+### `StartError`
+
+Errors when starting PubSub
+
+```gleam
+pub type StartError {
+  PgStartFailed
+}
+```
+
+## Functions
+
+### `broadcast`
+
+Broadcast a message to all subscribers of a topic (all nodes)
+
+```gleam
+pub fn broadcast(
+  PubSub,
+  String,
+  String,
+  json.Json
+) -> Nil
+```
+
+### `broadcast_from`
+
+Broadcast a message to all subscribers except those from a specific pid
+
+```gleam
+pub fn broadcast_from(
+  PubSub,
+  process.Pid,
+  String,
+  String,
+  json.Json
+) -> Nil
+```
+
+### `broadcast_from_socket`
+
+Broadcast a message to all subscribers except a process, preserving a socket
+ ID that receiving channel coordinators should exclude locally.
+
+```gleam
+pub fn broadcast_from_socket(
+  PubSub,
+  process.Pid,
+  String,
+  String,
+  String,
+  json.Json
+) -> Nil
+```
+
+### `config_with_scope`
+
+Create a PubSub configuration with a custom scope name
+
+```gleam
+pub fn config_with_scope(String) -> PubSubConfig
+```
+
+### `default_config`
+
+Create a default PubSub configuration with scope `beryl_pubsub`
+
+```gleam
+pub fn default_config() -> PubSubConfig
+```
+
+### `local_broadcast`
+
+Broadcast a message to local subscribers only (current node)
+
+```gleam
+pub fn local_broadcast(
+  PubSub,
+  String,
+  String,
+  json.Json
+) -> Nil
+```
+
+### `start`
+
+Start a PubSub instance
+
+ This starts a pg scope. If the scope is already started (e.g., by another
+ node or previous call), this is a no-op.
+
+```gleam
+pub fn start(PubSubConfig) -> Result(PubSub, StartError)
+```
+
+### `subscribe`
+
+Subscribe the current process to a topic
+
+ The calling process will receive `Message` values when broadcasts
+ are sent to this topic.
+
+```gleam
+pub fn subscribe(
+  PubSub,
+  String
+) -> Nil
+```
+
+### `subscriber_count`
+
+Get the number of subscribers for a topic (all nodes)
+
+```gleam
+pub fn subscriber_count(
+  PubSub,
+  String
+) -> Int
+```
+
+### `subscribers`
+
+Get all subscribers for a topic (all nodes)
+
+```gleam
+pub fn subscribers(
+  PubSub,
+  String
+) -> List(process.Pid)
+```
+
+### `unsubscribe`
+
+Unsubscribe the current process from a topic
+
+```gleam
+pub fn unsubscribe(
+  PubSub,
+  String
+) -> Nil
+```

--- a/website/src/content/docs/reference/api/beryl-socket.md
+++ b/website/src/content/docs/reference/api/beryl-socket.md
@@ -1,0 +1,134 @@
+---
+title: beryl/socket
+description: Socket - Connected client with typed state
+---
+
+Socket - Connected client with typed state
+
+ A Socket represents a connected WebSocket client. The `assigns` type
+ parameter allows compile-time checking of socket state, ensuring type
+ safety when accessing channel-specific data.
+
+ ## Example
+
+ ```gleam
+ // Define your channel's assigns type
+ pub type RoomAssigns {
+   RoomAssigns(user_id: String, room_id: String, joined_at: Int)
+ }
+
+ // Socket has compile-time type safety
+ fn handle_message(socket: Socket(RoomAssigns)) {
+   let assigns = socket.get_assigns(socket)
+   io.println("User " <> assigns.user_id <> " in room " <> assigns.room_id)
+ }
+ ```
+
+## Types
+
+### `Socket`
+
+A connected client socket with typed assigns
+
+ The `assigns` type parameter provides compile-time type safety for
+ channel-specific state. Each channel can define its own assigns type,
+ and the compiler ensures you only access fields that exist.
+
+```gleam
+pub type Socket(a)
+```
+
+### `Transport`
+
+Transport abstraction for sending messages
+
+```gleam
+pub type Transport {
+  Transport(
+    send_text: fn(String) -> Result(Nil, TransportError),
+    send_binary: fn(BitArray) -> Result(Nil, TransportError),
+    close: fn() -> Result(Nil, TransportError)
+  )
+}
+```
+
+### `TransportError`
+
+```gleam
+pub type TransportError {
+  ConnectionClosed
+  SendFailed(String)
+}
+```
+
+## Functions
+
+### `get_assigns`
+
+Get the current assigns
+
+```gleam
+pub fn get_assigns(Socket(a)) -> a
+```
+
+### `id`
+
+Get the socket ID
+
+```gleam
+pub fn id(Socket(a)) -> String
+```
+
+### `map_assigns`
+
+Map assigns to a new type
+
+ Useful when transitioning between channel types or transforming state:
+
+ ```gleam
+ let socket = socket.map_assigns(socket, fn(old) {
+   NewAssigns(user_id: old.user_id, extra: "data")
+ })
+ ```
+
+```gleam
+pub fn map_assigns(
+  Socket(a),
+  fn(a) -> b
+) -> Socket(b)
+```
+
+### `new`
+
+Create a new socket with initial assigns
+
+ Typically called by the WebSocket transport when a connection is established.
+
+```gleam
+pub fn new(
+  String,
+  a,
+  Transport
+) -> Socket(a)
+```
+
+### `set_assigns`
+
+Update the assigns (returns new socket)
+
+ Use this in channel handlers to update socket state:
+
+ ```gleam
+ fn handle_in(event, payload, socket) {
+   let new_assigns = RoomAssigns(..socket.get_assigns(socket), last_seen: now())
+   let socket = socket.set_assigns(socket, new_assigns)
+   channel.NoReply(socket)
+ }
+ ```
+
+```gleam
+pub fn set_assigns(
+  Socket(a),
+  a
+) -> Socket(a)
+```

--- a/website/src/content/docs/reference/api/beryl-supervisor.md
+++ b/website/src/content/docs/reference/api/beryl-supervisor.md
@@ -1,0 +1,142 @@
+---
+title: beryl/supervisor
+description: Supervisor - OTP supervision tree for beryl subsystems
+---
+
+Supervisor - OTP supervision tree for beryl subsystems
+
+ Starts all configured beryl subsystems (coordinator, presence, groups)
+ under an OTP supervisor with a rest-for-one strategy. If the coordinator
+ crashes, downstream subsystems (presence, groups) are also restarted to
+ maintain state consistency — a fresh coordinator has no knowledge of
+ existing subscriptions, so presence/groups tracking stale topic data
+ would be inconsistent. PubSub is not supervised here; it is backed by
+ Erlang's `pg` module which has its own lifecycle.
+
+ ## Example
+
+ ```gleam
+ import beryl
+ import beryl/supervisor
+ import beryl/presence
+ import beryl/wire
+ import gleam/option.{None, Some}
+
+ let config = supervisor.SupervisedConfig(
+   channels: beryl.config(wire.phoenix_codec()),
+   presence: Some(presence.default_config("node1")),
+   groups: True,
+ )
+ let assert Ok(supervised) = supervisor.start(config)
+ // supervised.channels, supervised.presence, supervised.groups
+ ```
+
+## Types
+
+### `StartError`
+
+Errors when starting the supervised system
+
+```gleam
+pub type StartError {
+  SupervisorStartFailed(actor.StartError)
+  InvalidHeartbeatTimeout
+}
+```
+
+#### Constructors
+
+##### `SupervisorStartFailed(actor.StartError)`
+
+The supervisor failed to start
+
+##### `InvalidHeartbeatTimeout`
+
+heartbeat_timeout_ms must be > 0
+
+### `SupervisedChannels`
+
+Handle to all supervised beryl subsystems
+
+```gleam
+pub type SupervisedChannels {
+  SupervisedChannels(
+    channels: beryl.Channels,
+    presence: option.Option(presence.Presence),
+    groups: option.Option(group.Groups),
+    supervisor_pid: process.Pid
+  )
+}
+```
+
+### `SupervisedConfig`
+
+Configuration for starting all beryl subsystems under a supervisor
+
+```gleam
+pub type SupervisedConfig {
+  SupervisedConfig(
+    channels: beryl.Config,
+    presence: option.Option(presence.Config),
+    groups: Bool
+  )
+}
+```
+
+## Functions
+
+### `child_spec`
+
+Create a child specification for composing beryl into a larger supervision tree
+
+ Returns a supervisor-type child spec that starts the beryl supervision tree.
+ This enables embedding beryl as a subtree in an application's top-level
+ supervisor.
+
+ ## Example
+
+ ```gleam
+ import beryl/supervisor
+ import gleam/otp/static_supervisor
+
+ let beryl_config = supervisor.SupervisedConfig(
+   channels: beryl.config(wire.phoenix_codec()),
+   presence: None,
+   groups: True,
+ )
+
+ static_supervisor.new(static_supervisor.OneForOne)
+ |> static_supervisor.add(supervisor.child_spec(beryl_config))
+ |> static_supervisor.start()
+ ```
+
+```gleam
+pub fn child_spec(SupervisedConfig) -> supervision.ChildSpecification(SupervisedChannels)
+```
+
+### `start`
+
+Start all configured beryl subsystems under an OTP supervisor
+
+ Uses a rest-for-one strategy: if the coordinator crashes, presence and
+ groups are also restarted to maintain state consistency (a fresh coordinator
+ has no knowledge of existing subscriptions or sockets).
+ Child start order: coordinator -> presence (optional) -> groups (optional).
+
+ The existing `beryl.start()` function is preserved for unsupervised use.
+
+```gleam
+pub fn start(SupervisedConfig) -> Result(SupervisedChannels, StartError)
+```
+
+### `stop`
+
+Stop the supervisor and all its children
+
+ Cleanly shuts down the supervisor process, which terminates all child
+ processes (coordinator, presence, groups) in reverse start order. After
+ this call the `SupervisedChannels` handle should no longer be used.
+
+```gleam
+pub fn stop(SupervisedChannels) -> Nil
+```

--- a/website/src/content/docs/reference/api/beryl-topic.md
+++ b/website/src/content/docs/reference/api/beryl-topic.md
@@ -1,0 +1,190 @@
+---
+title: beryl/topic
+description: Topic - Pattern matching for channel routing
+---
+
+Topic - Pattern matching for channel routing
+
+ Topics are string identifiers that clients join (e.g., "room:lobby").
+ Patterns define how topics are routed to channel handlers. Patterns can be
+ exact, legacy trailing prefix wildcards, or segment-aware wildcards where
+ "*" occupies a complete colon-delimited segment.
+
+## Types
+
+### `TopicError`
+
+```gleam
+pub type TopicError {
+  EmptyTopic
+  InvalidFormat(String)
+}
+```
+
+### `TopicPattern`
+
+Topic pattern for routing
+
+```gleam
+pub type TopicPattern {
+  Exact(String)
+  Wildcard(prefix: String)
+  SegmentWildcard(segments: List(String))
+}
+```
+
+#### Constructors
+
+##### `Exact(String)`
+
+Exact match: "room:lobby" only matches "room:lobby"
+
+##### `Wildcard(prefix: String)`
+
+Wildcard suffix: "room:*" matches "room:lobby", "room:123", etc.
+
+##### `SegmentWildcard(segments: List(String))`
+
+Segment wildcard: "document:*:ops" matches the same number of ":"
+ segments where "*" occupies one complete segment.
+
+## Functions
+
+### `extract_id`
+
+Extract the wildcard portion from a topic
+
+ ## Examples
+
+ ```gleam
+ extract_id(Wildcard("room:"), "room:lobby") // -> Ok("lobby")
+ extract_id(Wildcard("doc:"), "doc:abc:123") // -> Ok("abc:123")
+ extract_id(SegmentWildcard(["doc", "*", "ops"]), "doc:abc:ops") // -> Ok("abc")
+ extract_id(Exact("room:lobby"), "room:lobby") // -> Error(Nil)
+ ```
+
+```gleam
+pub fn extract_id(
+  TopicPattern,
+  String
+) -> Result(String, Nil)
+```
+
+### `extract_wildcards`
+
+Extract values captured by wildcard segments.
+
+ For legacy prefix wildcards, returns the suffix as a single value.
+ For segment wildcards, returns each topic segment matched by "*".
+
+ ## Examples
+
+ ```gleam
+ extract_wildcards(parse_pattern("document:*:*"), "document:tenant-a:doc-42")
+ // -> Ok(["tenant-a", "doc-42"])
+ ```
+
+```gleam
+pub fn extract_wildcards(
+  TopicPattern,
+  String
+) -> Result(List(String), Nil)
+```
+
+### `from_segments`
+
+Build a topic from segments
+
+ ## Examples
+
+ ```gleam
+ from_segments(["room", "lobby"]) // -> "room:lobby"
+ from_segments(["doc", "tenant", "123"]) // -> "doc:tenant:123"
+ ```
+
+```gleam
+pub fn from_segments(List(String)) -> String
+```
+
+### `matches`
+
+Check if a topic matches a pattern
+
+ ## Examples
+
+ ```gleam
+ matches(Wildcard("room:"), "room:lobby") // -> True
+ matches(Wildcard("room:"), "user:123") // -> False
+ matches(Exact("room:lobby"), "room:lobby") // -> True
+ matches(Exact("room:lobby"), "room:other") // -> False
+ matches(parse_pattern("document:*:ops"), "document:tenant-a:ops") // -> True
+ matches(parse_pattern("document:*:ops"), "document:tenant-a:view") // -> False
+ ```
+
+```gleam
+pub fn matches(
+  TopicPattern,
+  String
+) -> Bool
+```
+
+### `namespace`
+
+Get the first segment (namespace) of a topic
+
+ ## Examples
+
+ ```gleam
+ namespace("room:lobby") // -> Ok("room")
+ namespace("") // -> Error(Nil)
+ ```
+
+```gleam
+pub fn namespace(String) -> Result(String, Nil)
+```
+
+### `parse_pattern`
+
+Parse a pattern string into TopicPattern
+
+ ## Examples
+
+ ```gleam
+ parse_pattern("room:*") // -> Wildcard("room:")
+ parse_pattern("room:lobby") // -> Exact("room:lobby")
+ parse_pattern("document:*:ops") // -> SegmentWildcard(["document", "*", "ops"])
+ parse_pattern("document:*:*") // -> SegmentWildcard(["document", "*", "*"])
+ parse_pattern("document:tenant-a:*") // -> Wildcard("document:tenant-a:")
+ ```
+
+```gleam
+pub fn parse_pattern(String) -> TopicPattern
+```
+
+### `segments`
+
+Parse a topic into segments by splitting on ":"
+
+ ## Examples
+
+ ```gleam
+ segments("room:lobby") // -> ["room", "lobby"]
+ segments("doc:tenant:123:ops") // -> ["doc", "tenant", "123", "ops"]
+ ```
+
+```gleam
+pub fn segments(String) -> List(String)
+```
+
+### `validate`
+
+Validate a topic string
+
+ Topics must:
+ - Not be empty
+ - Not contain control characters
+ - Not start or end with ":"
+
+```gleam
+pub fn validate(String) -> Result(String, TopicError)
+```

--- a/website/src/content/docs/reference/api/beryl-transport-mist.md
+++ b/website/src/content/docs/reference/api/beryl-transport-mist.md
@@ -1,0 +1,111 @@
+---
+title: beryl/transport/mist
+description: Mist WebSocket Transport - Direct Mist integration for beryl
+---
+
+Mist WebSocket Transport - Direct Mist integration for beryl
+
+ This module provides the bridge between Mist's native WebSocket handling
+ and the beryl coordinator using Mist request and response types directly.
+
+## Types
+
+### `TransportConfig`
+
+Configuration for the Mist WebSocket transport
+
+ The `assigns` type parameter is the socket-level state produced by the
+ `on_connect` hook. It defaults to `Nil` when no hook is configured.
+
+```gleam
+pub type TransportConfig(a) {
+  TransportConfig(
+    path: String,
+    on_connect: option.Option(fn(request.Request(http.Connection)) -> Result(a, Nil))
+  )
+}
+```
+
+## Functions
+
+### `default_config`
+
+Create a default transport config with no connect hook.
+
+ The resulting config seeds `Nil` assigns. Add `with_on_connect` to
+ authenticate connections and/or seed initial assigns.
+
+```gleam
+pub fn default_config(String) -> TransportConfig(Nil)
+```
+
+### `handler`
+
+Build a combined request handler that serves both WebSocket channels and
+ regular HTTP from a single Mist listener.
+
+ The returned function inspects each request and routes it:
+ - WebSocket upgrade requests matching the configured socket path are handed
+   to [`upgrade`](#upgrade) (which also runs any `on_connect` callback).
+ - Everything else — non-upgrade requests, or upgrades to a different path —
+   falls through to `http_fallback`.
+
+ This removes the boilerplate upgrade guard integrators would otherwise write
+ by hand:
+
+ ```gleam
+ mist_transport.handler(channels, mist_transport.default_config("/socket"), http_handler)
+ |> mist.new
+ |> mist.port(8000)
+ |> mist.start
+ ```
+
+```gleam
+pub fn handler(
+  beryl.Channels,
+  TransportConfig(a),
+  fn(request.Request(http.Connection)) -> response.Response(mist.ResponseData)
+) -> fn(request.Request(http.Connection)) -> response.Response(mist.ResponseData)
+```
+
+### `upgrade`
+
+Upgrade a request to WebSocket if it matches the configured path
+
+ Usage in your Mist handler:
+ ```gleam
+ fn handle_request(req: Request(Connection), channels: Channels) -> Response(ResponseData) {
+   use <- mist_transport.upgrade(req, channels, mist_transport.default_config("/socket"))
+   // Fall through to regular HTTP routing
+   case request.path_segments(req) {
+     [] -> index_page()
+     _ -> response.new(404) |> response.set_body(mist.Bytes(bytes_tree.new()))
+   }
+ }
+ ```
+
+```gleam
+pub fn upgrade(
+  request.Request(http.Connection),
+  beryl.Channels,
+  TransportConfig(a),
+  fn() -> response.Response(mist.ResponseData)
+) -> response.Response(mist.ResponseData)
+```
+
+### `with_on_connect`
+
+Set a socket-level connect/authentication callback on the transport config.
+
+ The callback receives the HTTP request before the WebSocket upgrade and
+ runs once per socket. Return `Ok(assigns)` to allow the connection and seed
+ initial socket assigns that channels can read at join time, or `Error(Nil)`
+ to reject the connection with a 403 Forbidden response before any channel
+ join occurs.
+
+```gleam
+pub fn with_on_connect(
+  TransportConfig(a),
+  fn(request.Request(http.Connection)) -> Result(b, Nil)
+) -> TransportConfig(b)
+```

--- a/website/src/content/docs/reference/api/beryl-wire-codec.md
+++ b/website/src/content/docs/reference/api/beryl-wire-codec.md
@@ -1,0 +1,120 @@
+---
+title: beryl/wire/codec
+description: Pluggable wire codec for beryl.
+---
+
+Pluggable wire codec for beryl.
+
+ A `Codec` plugs the coordinator into any over-the-wire framing. The
+ canonical implementation is `beryl/wire.phoenix_codec()`, which ships
+ the Phoenix array format (`[join_ref, ref, topic, event, payload]`).
+
+ To run beryl over your own framing, build a `Codec` value and pass it
+ to `beryl.config(codec)`. The coordinator decodes inbound text via
+ `codec.decode_text`, optionally decodes inbound binary via
+ `codec.decode_binary`, dispatches based on the structural `InboundKind`,
+ and produces outbound text or binary frames via `codec.encode_*` helpers.
+
+ All codecs must normalise inbound traffic to the `Inbound` shape so
+ the coordinator can stay framing-agnostic.
+
+## Types
+
+### `Codec`
+
+A wire codec.
+
+```gleam
+pub type Codec {
+  Codec(
+    decode_text: fn(String) -> Result(Inbound, DecodeError),
+    decode_binary: option.Option(fn(BitArray) -> Result(Inbound, DecodeError)),
+    encode_reply: fn(option.Option(String), option.Option(String), String, ReplyStatus, json.Json) -> Frame,
+    encode_push: fn(String, String, json.Json) -> Frame,
+    encode_heartbeat_reply: fn(option.Option(String)) -> Frame
+  )
+}
+```
+
+### `DecodeError`
+
+Errors a codec may emit when decoding inbound bytes.
+
+```gleam
+pub type DecodeError {
+  InvalidJson(reason: String)
+  InvalidFormat(reason: String)
+  MissingField(name: String)
+}
+```
+
+### `Frame`
+
+Encoded WebSocket frame returned by a codec.
+
+```gleam
+pub type Frame {
+  TextFrame(String)
+  BinaryFrame(BitArray)
+}
+```
+
+### `Inbound`
+
+Normalised inbound message shape.
+
+ - `join_ref`: optional client-side reference assigned at join time
+   (used by some Phoenix replies; codecs without this concept should
+   pass `None`)
+ - `ref`: optional per-message reference for reply correlation
+ - `topic`: subscription topic (e.g. `"room:lobby"`, `"doc:abc"`)
+ - `kind`: structural protocol event or user event
+ - `payload`: message body as a `Dynamic` for the channel handler to
+   decode
+
+```gleam
+pub type Inbound {
+  Inbound(
+    join_ref: option.Option(String),
+    ref: option.Option(String),
+    topic: String,
+    kind: InboundKind,
+    payload: dynamic.Dynamic
+  )
+}
+```
+
+### `InboundKind`
+
+Structural inbound message kind used for protocol dispatch.
+
+```gleam
+pub type InboundKind {
+  Join
+  Leave
+  Heartbeat
+  Event(String)
+}
+```
+
+### `ReplyStatus`
+
+Status of a reply produced by a channel handler.
+
+```gleam
+pub type ReplyStatus {
+  StatusOk
+  StatusError
+}
+```
+
+## Functions
+
+### `format_decode_error`
+
+Format a `DecodeError` as a human-readable string. Used by the
+ coordinator's log messages and by `wire.format_decode_error`.
+
+```gleam
+pub fn format_decode_error(DecodeError) -> String
+```

--- a/website/src/content/docs/reference/api/beryl-wire.md
+++ b/website/src/content/docs/reference/api/beryl-wire.md
@@ -1,0 +1,96 @@
+---
+title: beryl/wire
+description: Phoenix Wire Protocol — encoding/decoding helpers and the canonical
+---
+
+Phoenix Wire Protocol — encoding/decoding helpers and the canonical
+ `phoenix_codec()` for `beryl/wire/codec`.
+
+ Phoenix uses a JSON array format: `[join_ref, ref, topic, event, payload]`.
+ This module parses and emits that format, and exposes a `Codec` value
+ that plugs the Phoenix framing into the coordinator.
+
+ To use Phoenix framing (the historical default) construct beryl with:
+
+ ```gleam
+ beryl.config(wire.phoenix_codec())
+ ```
+
+## Functions
+
+### `decode_message`
+
+Parse a JSON string into an `Inbound`.
+
+ Expected format: `[join_ref, ref, topic, event, payload]` where
+ `join_ref` and `ref` may be `null`.
+
+```gleam
+pub fn decode_message(String) -> Result(codec.Inbound, codec.DecodeError)
+```
+
+### `dynamic_to_json`
+
+Convert a `Dynamic` (decoded from JSON) back into `json.Json`.
+
+```gleam
+pub fn dynamic_to_json(dynamic.Dynamic) -> json.Json
+```
+
+### `encode`
+
+Encode an `Inbound` back to a Phoenix wire JSON string.
+
+```gleam
+pub fn encode(codec.Inbound) -> String
+```
+
+### `format_decode_error`
+
+Format a `DecodeError` as a human-readable string.
+
+```gleam
+pub fn format_decode_error(codec.DecodeError) -> String
+```
+
+### `heartbeat_reply`
+
+Create a Phoenix heartbeat reply.
+
+```gleam
+pub fn heartbeat_reply(option.Option(String)) -> codec.Frame
+```
+
+### `phoenix_codec`
+
+The canonical Phoenix wire codec. Pass to `beryl.config/1`.
+
+```gleam
+pub fn phoenix_codec() -> codec.Codec
+```
+
+### `push`
+
+Create a server-initiated push message.
+
+```gleam
+pub fn push(
+  String,
+  String,
+  json.Json
+) -> codec.Frame
+```
+
+### `reply_json`
+
+Create a Phoenix `phx_reply` JSON string.
+
+```gleam
+pub fn reply_json(
+  option.Option(String),
+  option.Option(String),
+  String,
+  codec.ReplyStatus,
+  json.Json
+) -> codec.Frame
+```

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -1,0 +1,452 @@
+---
+title: beryl
+description: Beryl - Type-safe real-time communication
+---
+
+Beryl - Type-safe real-time communication
+
+ A standalone Gleam library for building real-time applications on the BEAM.
+ Provides WebSocket channels, distributed presence tracking, pub/sub
+ messaging, and channel groups.
+
+ ## Features
+
+ - **Channels** — Topic-based WebSocket messaging with pattern matching
+   (`beryl`, `beryl/channel`)
+ - **PubSub** — Distributed publish/subscribe via Erlang `pg`
+   (`beryl/pubsub`)
+ - **Presence** — Distributed presence tracking backed by a causal-context
+   CRDT (add-wins observed-remove set) (`beryl/presence`)
+ - **Groups** — Named collections of topics for multi-topic broadcasting
+   (`beryl/group`)
+
+ ## Quick Start
+
+ ```gleam
+ import beryl
+ import beryl/channel
+ import beryl/pubsub
+ import beryl/presence
+ import beryl/group
+ import beryl/wire
+
+ pub fn main() {
+   // Optional: start PubSub for distributed messaging
+   let assert Ok(ps) = pubsub.start(pubsub.default_config())
+
+   // Start channels system (with or without PubSub)
+   let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
+   let assert Ok(channels) = beryl.start(config)
+
+   // Register a channel handler
+   let _ = beryl.register(channels, "room:*", room_channel.new())
+
+   // Start presence tracking
+   let assert Ok(p) = presence.start(presence.default_config("node1"))
+
+   // Start channel groups
+   let assert Ok(groups) = group.start()
+   let assert Ok(Nil) = group.create(groups, "team:eng")
+   let assert Ok(Nil) = group.add(groups, "team:eng", "room:frontend")
+
+   // Broadcast to all topics in a group
+   group.broadcast(groups, channels, "team:eng", "announce", payload)
+ }
+ ```
+
+## Types
+
+### `Channels`
+
+Channels system handle
+
+ This is the main entry point for interacting with the channels system.
+ Pass this to channel handlers and the WebSocket transport.
+
+```gleam
+pub type Channels {
+  Channels(
+    coordinator: process.Subject(coordinator.Message),
+    config: Config,
+    pubsub: option.Option(pubsub.PubSub)
+  )
+}
+```
+
+### `Config`
+
+Configuration for the channels system
+
+```gleam
+pub type Config {
+  Config(
+    codec: codec.Codec,
+    heartbeat_interval_ms: Int,
+    heartbeat_timeout_ms: Int,
+    max_connections_per_ip: Int,
+    pubsub: option.Option(pubsub.PubSub),
+    message_rate: Int,
+    message_burst: Int,
+    join_rate: Int,
+    join_burst: Int,
+    channel_rate: Int,
+    channel_burst: Int,
+    logging: LoggingConfig
+  )
+}
+```
+
+### `LoggingConfig`
+
+Logging configuration for Beryl diagnostics.
+
+```gleam
+pub type LoggingConfig {
+  LoggingConfig(
+    level: LogLevel,
+    include_payloads: Bool,
+    payload_preview_bytes: Int
+  )
+}
+```
+
+### `LogLevel`
+
+Logging verbosity for Beryl's internal Birch loggers.
+
+```gleam
+pub type LogLevel {
+  Trace
+  Debug
+  Info
+  Warn
+  Err
+}
+```
+
+### `RegisterError`
+
+Errors when registering a channel handler.
+
+```gleam
+pub type RegisterError {
+  PatternAlreadyRegistered(String)
+  InvalidPattern(String)
+}
+```
+
+#### Constructors
+
+##### `PatternAlreadyRegistered(String)`
+
+A handler is already registered for this exact topic pattern.
+
+##### `InvalidPattern(String)`
+
+The topic pattern is invalid.
+
+### `StartError`
+
+Errors when starting channels
+
+```gleam
+pub type StartError {
+  CoordinatorStartFailed
+  InvalidHeartbeatTimeout
+}
+```
+
+#### Constructors
+
+##### `InvalidHeartbeatTimeout`
+
+heartbeat_timeout_ms must be > 0 (it is used to derive the check interval)
+
+## Functions
+
+### `broadcast`
+
+Broadcast a message to all subscribers of a topic
+
+ This sends the message to all sockets subscribed to the topic.
+
+ ## Example
+
+ ```gleam
+ beryl.broadcast(
+   channels,
+   "room:lobby",
+   "new_message",
+   json.object([#("text", json.string("Hello!"))]),
+ )
+ ```
+
+```gleam
+pub fn broadcast(
+  Channels,
+  String,
+  String,
+  json.Json
+) -> Nil
+```
+
+### `broadcast_from`
+
+Broadcast a message to all subscribers except one socket
+
+ Useful for broadcasting a message to everyone except the sender.
+ When PubSub is configured, the excluded socket ID is preserved across
+ coordinators so clustered deployments do not echo the event back to that
+ socket on another node.
+
+ ## Example
+
+ ```gleam
+ // In a channel handler, broadcast to others
+ beryl.broadcast_from(
+   channels,
+   socket_id,
+   "room:lobby",
+   "user_typing",
+   json.object([#("user", json.string("alice"))]),
+ )
+ ```
+
+```gleam
+pub fn broadcast_from(
+  Channels,
+  String,
+  String,
+  String,
+  json.Json
+) -> Nil
+```
+
+### `broadcast_presence_diff`
+
+Broadcast a Phoenix-compatible `presence_diff` event for a topic.
+
+ This encodes the topic's joins and leaves as:
+
+ ```json
+ {
+   "joins": { "user:1": { "metas": [{ "status": "online" }] } },
+   "leaves": { "user:2": { "metas": [{ "status": "offline" }] } }
+ }
+ ```
+
+ When the channels system was started with PubSub, the broadcast is
+ distributed using the same semantics as `broadcast`.
+
+```gleam
+pub fn broadcast_presence_diff(
+  Channels,
+  String,
+  presence.Diff
+) -> Nil
+```
+
+### `config`
+
+Build a configuration with sensible defaults.
+
+ A `codec` is required — beryl no longer ships an implicit Phoenix
+ default. Pass `wire.phoenix_codec()` to keep Phoenix wire compatibility,
+ or your own `Codec` for a custom framing.
+
+```gleam
+pub fn config(codec.Codec) -> Config
+```
+
+### `extract_topic_id`
+
+Get the topic ID from a topic using wildcard extraction
+
+ For pattern "room:*" and topic "room:lobby", returns Ok("lobby").
+ For segment wildcard patterns with one wildcard segment, returns that
+ segment. Use `topic.extract_wildcards` when extracting multiple segments.
+
+ ## Example
+
+ ```gleam
+ let assert Ok("lobby") = topic.extract_id(topic.Wildcard("room:"), "room:lobby")
+ ```
+
+```gleam
+pub fn extract_topic_id(
+  topic.TopicPattern,
+  String
+) -> Result(String, Nil)
+```
+
+### `logging_config`
+
+Build a logging configuration.
+
+ Payloads are excluded by default to avoid accidental sensitive-data
+ exposure. Use `with_payload_preview_bytes` to adjust the bounded preview
+ size when payload previews are enabled.
+
+```gleam
+pub fn logging_config(
+  level: LogLevel,
+  include_payloads: Bool
+) -> LoggingConfig
+```
+
+### `register`
+
+Register a channel handler for a topic pattern
+
+ Patterns can be exact matches like "room:lobby", legacy prefix wildcards
+ like "room:*" which match any topic starting with "room:", or segment
+ wildcards like "document:*:ops" where "*" matches one complete segment.
+
+ ## Example
+
+ ```gleam
+ // Create a typed channel
+ let chat_channel = channel.new(fn(topic, payload, socket) {
+   // Handle join
+   channel.JoinOk(reply: None, socket: socket)
+ })
+ |> channel.with_handle_in(fn(event, payload, socket) {
+   // Handle incoming messages
+   channel.NoReply(socket)
+ })
+
+ // Register it with a legacy prefix wildcard
+ beryl.register(channels, "chat:*", chat_channel)
+
+ // Exact topic
+ beryl.register(channels, "room:lobby", lobby_channel)
+
+ // Segment-aware wildcard
+ beryl.register(channels, "document:*:ops", ops_channel)
+ ```
+
+```gleam
+pub fn register(
+  Channels,
+  String,
+  channel.Channel(a, b)
+) -> Result(Nil, RegisterError)
+```
+
+### `send_info`
+
+Send a server-originated OTP message to a joined channel context.
+
+ The message is delivered to the channel's `handle_info` callback for the
+ specific socket/topic pair as the typed `info` value — the receiving handler
+ matches on it directly without any `Dynamic` decode or unsafe cast. If the
+ socket is not connected, the topic is not joined, or no handler matches the
+ topic, the message is ignored.
+
+ Note: a single `Channels` system may host channels with different `info`
+ types, so this function accepts a generic message and the matching channel's
+ `handle_info` recovers the concrete type. Send a value whose type matches the
+ target channel's `info` parameter.
+
+```gleam
+pub fn send_info(
+  Channels,
+  String,
+  String,
+  a
+) -> Nil
+```
+
+### `start`
+
+Start the channels system
+
+ Call once at application startup. Returns a handle that can be passed
+ to the WebSocket transport and used for broadcasting.
+
+ Heartbeat timeout enforcement is configured via `heartbeat_interval_ms`
+ and `heartbeat_timeout_ms` in the Config. The coordinator checks for
+ stale sockets at `heartbeat_interval_ms` and evicts any socket that
+ hasn't sent a heartbeat within `heartbeat_timeout_ms`.
+
+ ## Example
+
+ ```gleam
+ pub fn main() {
+   let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+   // Use channels...
+ }
+ ```
+
+```gleam
+pub fn start(Config) -> Result(Channels, StartError)
+```
+
+### `with_channel_rate`
+
+Configure per-channel message rate limiting
+
+```gleam
+pub fn with_channel_rate(
+  Config,
+  per_second: Int,
+  burst: Int
+) -> Config
+```
+
+### `with_join_rate`
+
+Configure per-socket join rate limiting
+
+```gleam
+pub fn with_join_rate(
+  Config,
+  per_second: Int,
+  burst: Int
+) -> Config
+```
+
+### `with_logging`
+
+Configure Beryl's internal logging.
+
+```gleam
+pub fn with_logging(
+  Config,
+  LoggingConfig
+) -> Config
+```
+
+### `with_message_rate`
+
+Configure per-socket message rate limiting
+
+```gleam
+pub fn with_message_rate(
+  Config,
+  per_second: Int,
+  burst: Int
+) -> Config
+```
+
+### `with_payload_preview_bytes`
+
+Configure the maximum payload/frame preview length for logs.
+
+```gleam
+pub fn with_payload_preview_bytes(
+  LoggingConfig,
+  bytes: Int
+) -> LoggingConfig
+```
+
+### `with_pubsub`
+
+Add PubSub to a configuration for distributed broadcasts
+
+```gleam
+pub fn with_pubsub(
+  Config,
+  pubsub.PubSub
+) -> Config
+```

--- a/website/src/content/docs/reference/api/index.md
+++ b/website/src/content/docs/reference/api/index.md
@@ -1,0 +1,28 @@
+---
+title: API Reference
+description: Generated API reference from Gleam docs metadata.
+---
+
+This reference is generated from Gleam's docs metadata for `beryl` `0.1.0`.
+
+:::note[Generated content]
+Pages under `/reference/api/` are generated from Gleam's docs metadata and reflect every public type, function, and constant. The canonical, hosted API docs live on [HexDocs](https://hexdocs.pm/beryl/).
+:::
+
+## Modules
+
+| Module | Description |
+|---|---|
+| [`beryl`](/reference/api/beryl/) | Beryl - Type-safe real-time communication |
+| [`beryl/bridge`](/reference/api/beryl-bridge/) | Bridge - Forward an external OTP actor's message stream to a socket channel. |
+| [`beryl/channel`](/reference/api/beryl-channel/) | Channel - Topic-based message handlers |
+| [`beryl/group`](/reference/api/beryl-group/) | Channel Groups - Named collections of topics for multi-topic broadcasting |
+| [`beryl/presence`](/reference/api/beryl-presence/) | Presence - Distributed presence tracking backed by a CRDT |
+| [`beryl/presence/wire`](/reference/api/beryl-presence-wire/) | Phoenix-compatible wire encoding for presence diffs. |
+| [`beryl/pubsub`](/reference/api/beryl-pubsub/) | PubSub - Distributed publish/subscribe using Erlang pg |
+| [`beryl/socket`](/reference/api/beryl-socket/) | Socket - Connected client with typed state |
+| [`beryl/supervisor`](/reference/api/beryl-supervisor/) | Supervisor - OTP supervision tree for beryl subsystems |
+| [`beryl/topic`](/reference/api/beryl-topic/) | Topic - Pattern matching for channel routing |
+| [`beryl/transport/mist`](/reference/api/beryl-transport-mist/) | Mist WebSocket Transport - Direct Mist integration for beryl |
+| [`beryl/wire`](/reference/api/beryl-wire/) | Phoenix Wire Protocol — encoding/decoding helpers and the canonical |
+| [`beryl/wire/codec`](/reference/api/beryl-wire-codec/) | Pluggable wire codec for beryl. |


### PR DESCRIPTION
## Summary

Generates the documentation website's API reference from Gleam's docs metadata (`package-interface.json`), so every public module, type, alias, constant, and function appears in the Starlight site with the same navigation, styling, and search as the rest of the docs.

This replaces the earlier approach on this branch with a self-contained generator, tests, and `just`/`pnpm` wiring.

## What's included

- **Generator** — `website/scripts/generate-reference.mjs`
  - Reads `build/dev/docs/<package>/package-interface.json` (package name derived from `gleam.toml`).
  - Writes one Markdown page per public module plus an index into `website/src/content/docs/reference/api/`.
  - Renders Types, Type aliases, Constants, and Functions (with constructors, tuple/fn/variable types); omits prelude/current-module qualifiers; surfaces deprecations as `:::caution` blocks; sorts modules and members for stable diffs.
  - The hand-written `reference/index.md` (module map, wire protocol, HexDocs link) is intentionally preserved — generated pages live under `reference/api/`.
- **Tests** — `website/scripts/generate-reference.test.mjs` (Node test runner, uses temp dirs): index + per-module pages, all member kinds, deprecation rendering, and a helpful error when the docs JSON is missing.
- **Scripts** — `website/package.json`: `generate:reference`, `test:reference`.
- **Just recipes** — `site-reference` (depends on `docs`), `site-reference-test`; `site-build` and `site-check` now depend on `site-reference`.
- **Sidebar** — `astro.config.mjs`: a "Generated API" autogenerated group under Reference (Starlight 0.39 nested-items form).

## Validation

- `pnpm test:reference` → 4/4 pass.
- `pnpm check:astro` → 0 errors / 0 warnings.
- `pnpm build:site` → 31 pages built, all 14 `/reference/api/*` pages render with valid links.

## Notes

- Generated reference pages are committed so Netlify (`pnpm build:site`) serves them without running the generator.
- A changie `Added` fragment is included.
