### PR TITLE
fix(codec)!: remove inbound bypass APIs

### DIFF
--- a/.changes/unreleased/Deprecated-20260509-082003.yaml
+++ b/.changes/unreleased/Deprecated-20260509-082003.yaml
@@ -1,3 +1,0 @@
-kind: Deprecated
-body: Renamed `wire.is_system_event/1` to `wire.is_phoenix_system_event/1` to make the Phoenix-specific event-name set explicit; the old name now forwards to the new one and emits a deprecation warning. Custom-codec users should compare against their codec's `join_event`/`leave_event`/`heartbeat_event` fields directly.
-time: 2026-05-09T08:20:03.000000-07:00

--- a/.changes/unreleased/Removed-20260515-152522.yaml
+++ b/.changes/unreleased/Removed-20260515-152522.yaml
@@ -1,0 +1,6 @@
+kind: Removed
+body: |-
+    Removed public coordinator APIs that bypassed codec dispatch.
+
+    `RouteInbound`, `route_inbound`, `GetCodec`, and `get_codec` have been removed so transports route raw frames through `coordinator.route_message` or `coordinator.route_binary` and the coordinator consistently decodes with the configured codec. The Phoenix-specific `wire.is_phoenix_system_event` and deprecated `wire.is_system_event` helpers have also been removed.
+time: 2026-05-15T15:25:22.961000-07:00

--- a/.changes/unreleased/Removed-20260515-152522.yaml
+++ b/.changes/unreleased/Removed-20260515-152522.yaml
@@ -2,5 +2,5 @@ kind: Removed
 body: |-
     Removed public coordinator APIs that bypassed codec dispatch.
 
-    `RouteInbound`, `route_inbound`, `GetCodec`, and `get_codec` have been removed so transports route raw frames through `coordinator.route_message` or `coordinator.route_binary` and the coordinator consistently decodes with the configured codec. The Phoenix-specific `wire.is_phoenix_system_event` and deprecated `wire.is_system_event` helpers have also been removed.
+    `RouteInbound`, `route_inbound`, `GetCodec`, and `get_codec` have been removed so custom transports can route raw frames through `coordinator.route_message` or `coordinator.route_binary` without fetching the codec from the coordinator. The Phoenix-specific `wire.is_phoenix_system_event` and deprecated `wire.is_system_event` helpers have also been removed. `beryl/transport/mist.upgrade` and `upgrade_connection` now take the `beryl.Channels` handle so Mist can decode inbound frames on each connection process without exposing codec lookup APIs.
 time: 2026-05-15T15:25:22.961000-07:00

--- a/examples/chatrooms/src/chatrooms.gleam
+++ b/examples/chatrooms/src/chatrooms.gleam
@@ -54,7 +54,7 @@ pub fn main() {
 
   let assert Ok(_) =
     fn(req) {
-      mist_transport.upgrade(req, channels.coordinator, ws_config, fn() {
+      mist_transport.upgrade(req, channels, ws_config, fn() {
         router.handle_request(req, ctx)
       })
     }

--- a/examples/collab_docs/src/collab_docs.gleam
+++ b/examples/collab_docs/src/collab_docs.gleam
@@ -26,7 +26,7 @@ pub fn main() {
     fn(req) {
       mist_transport.upgrade(
         req,
-        channels.coordinator,
+        channels,
         mist_transport.default_config("/socket/websocket"),
         fn() { router.handle_request(req, ctx) },
       )

--- a/examples/cursors/src/cursors.gleam
+++ b/examples/cursors/src/cursors.gleam
@@ -35,7 +35,7 @@ pub fn main() {
     fn(req) {
       mist_transport.upgrade(
         req,
-        channels.coordinator,
+        channels,
         mist_transport.default_config("/socket/websocket"),
         fn() { router.handle_request(req, ctx) },
       )

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -184,6 +184,7 @@ pub type Message {
   /// Raw inbound text from the transport, decoded inside the actor using
   /// the configured codec.
   RouteText(socket_id: String, raw_text: String)
+  RouteDecoded(socket_id: String, msg: codec.Inbound)
   // Broadcasting
   Broadcast(
     topic: String,
@@ -353,6 +354,8 @@ fn handle_message(
 
     RouteText(socket_id, raw_text) ->
       handle_route_text(state, socket_id, raw_text)
+
+    RouteDecoded(socket_id, msg) -> dispatch_inbound(state, socket_id, msg)
 
     Broadcast(topic_name, event, payload, except) ->
       handle_broadcast(state, topic_name, event, payload, except)
@@ -801,7 +804,18 @@ fn handle_binary_in(
   socket_id: String,
   data: BitArray,
 ) -> actor.Next(State, Message) {
-  // Check per-socket message rate limit (binary shares with text)
+  case state.config.codec.decode_binary {
+    Some(decode_binary) ->
+      handle_route_binary_frame(state, socket_id, data, decode_binary)
+    None -> handle_raw_binary_with_rate_limit(state, socket_id, data)
+  }
+}
+
+fn handle_raw_binary_with_rate_limit(
+  state: State,
+  socket_id: String,
+  data: BitArray,
+) -> actor.Next(State, Message) {
   case
     rate_limit.check_optional(state.config.message_limiter, "msg:" <> socket_id)
   {
@@ -813,13 +827,7 @@ fn handle_binary_in(
       ])
       actor.continue(state)
     }
-    Ok(_) -> {
-      case state.config.codec.decode_binary {
-        Some(decode_binary) ->
-          handle_route_binary_frame(state, socket_id, data, decode_binary)
-        None -> handle_raw_binary_in_inner(state, socket_id, data)
-      }
-    }
+    Ok(_) -> handle_raw_binary_in_inner(state, socket_id, data)
   }
 }
 
@@ -1139,6 +1147,16 @@ pub fn route_message(
   raw_text: String,
 ) -> Nil {
   process.send(coord, RouteText(socket_id, raw_text))
+}
+
+/// Route a transport-decoded inbound message to the coordinator.
+@internal
+pub fn route_decoded(
+  coord: Subject(Message),
+  socket_id: String,
+  msg: codec.Inbound,
+) -> Nil {
+  process.send(coord, RouteDecoded(socket_id, msg))
 }
 
 fn handle_route_text(

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -181,16 +181,9 @@ pub type Message {
   // Channel operations
   HandleBinary(socket_id: String, data: BitArray)
   HandleInfo(socket_id: String, topic: String, message: Dynamic)
-  /// Raw inbound text from the transport — decoded inside the actor using
-  /// the configured codec. Prefer `RouteInbound` (decoded in the transport)
-  /// when the codec is already available there.
+  /// Raw inbound text from the transport, decoded inside the actor using
+  /// the configured codec.
   RouteText(socket_id: String, raw_text: String)
-  /// Pre-decoded inbound message from the transport — bypasses actor-side
-  /// decoding so JSON parsing doesn't serialize on the coordinator's mailbox.
-  RouteInbound(socket_id: String, msg: codec.Inbound)
-  /// Synchronously fetch the configured codec. Transports call this once
-  /// at upgrade time to cache the codec for in-transport decoding.
-  GetCodec(reply: Subject(Codec))
   // Broadcasting
   Broadcast(
     topic: String,
@@ -360,13 +353,6 @@ fn handle_message(
 
     RouteText(socket_id, raw_text) ->
       handle_route_text(state, socket_id, raw_text)
-
-    RouteInbound(socket_id, msg) -> dispatch_inbound(state, socket_id, msg)
-
-    GetCodec(reply) -> {
-      process.send(reply, state.config.codec)
-      actor.continue(state)
-    }
 
     Broadcast(topic_name, event, payload, except) ->
       handle_broadcast(state, topic_name, event, payload, except)
@@ -1146,9 +1132,6 @@ fn update_assigns(
 
 /// Route raw inbound text from a transport to the coordinator.
 ///
-/// Decoding runs inside the coordinator actor. Prefer `route_inbound` when
-/// the transport can decode locally — that keeps JSON parsing off the
-/// coordinator's mailbox so it doesn't serialize across all sockets.
 /// Frames that fail to decode are logged and dropped.
 pub fn route_message(
   coord: Subject(Message),
@@ -1156,25 +1139,6 @@ pub fn route_message(
   raw_text: String,
 ) -> Nil {
   process.send(coord, RouteText(socket_id, raw_text))
-}
-
-/// Route a pre-decoded inbound message from a transport. Use this when
-/// the transport already has the configured codec (via `get_codec`) and
-/// decodes inline, so the JSON parsing cost lands on the per-connection
-/// process instead of the shared coordinator actor.
-pub fn route_inbound(
-  coord: Subject(Message),
-  socket_id: String,
-  msg: codec.Inbound,
-) -> Nil {
-  process.send(coord, RouteInbound(socket_id, msg))
-}
-
-/// Synchronously fetch the configured codec from the coordinator. Intended
-/// to be called once per WebSocket connection at upgrade time so the
-/// transport can cache and use it for inline decoding.
-pub fn get_codec(coord: Subject(Message)) -> Codec {
-  process.call(coord, 5000, GetCodec)
 }
 
 fn handle_route_text(

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -3,7 +3,9 @@
 //// This module provides the bridge between Mist's native WebSocket handling
 //// and the beryl coordinator using Mist request and response types directly.
 
+import beryl.{type Channels}
 import beryl/coordinator.{type Message as CoordinatorMessage}
+import beryl/wire/codec.{type Codec}
 import gleam/bit_array
 import gleam/bytes_tree
 import gleam/crypto
@@ -46,7 +48,11 @@ pub fn with_on_connect(
 
 /// State maintained per WebSocket connection
 type ConnectionState {
-  ConnectionState(socket_id: String, coordinator: Subject(CoordinatorMessage))
+  ConnectionState(
+    socket_id: String,
+    coordinator: Subject(CoordinatorMessage),
+    codec: Codec,
+  )
 }
 
 type SendRequest {
@@ -59,7 +65,7 @@ type SendRequest {
 /// Usage in your Mist handler:
 /// ```gleam
 /// fn handle_request(req: Request(Connection), channels: Channels) -> Response(ResponseData) {
-///   use <- mist_transport.upgrade(req, channels.coordinator, mist_transport.default_config("/socket"))
+///   use <- mist_transport.upgrade(req, channels, mist_transport.default_config("/socket"))
 ///   // Fall through to regular HTTP routing
 ///   case request.path_segments(req) {
 ///     [] -> index_page()
@@ -69,7 +75,7 @@ type SendRequest {
 /// ```
 pub fn upgrade(
   request: Request(Connection),
-  coordinator: Subject(CoordinatorMessage),
+  channels: Channels,
   config: TransportConfig,
   next: fn() -> Response(ResponseData),
 ) -> Response(ResponseData) {
@@ -83,12 +89,12 @@ pub fn upgrade(
       case config.on_connect {
         Some(callback) ->
           case callback(request) {
-            Ok(Nil) -> do_upgrade(request, coordinator)
+            Ok(Nil) -> do_upgrade(request, channels)
             Error(Nil) ->
               response.new(403)
               |> response.set_body(mist.Bytes(bytes_tree.new()))
           }
-        None -> do_upgrade(request, coordinator)
+        None -> do_upgrade(request, channels)
       }
     }
   }
@@ -101,22 +107,24 @@ pub fn upgrade(
 /// with a full config or call your auth check before this function.
 pub fn upgrade_connection(
   request: Request(Connection),
-  coordinator: Subject(CoordinatorMessage),
+  channels: Channels,
 ) -> Response(ResponseData) {
-  do_upgrade(request, coordinator)
+  do_upgrade(request, channels)
 }
 
 /// Perform the actual WebSocket upgrade
 fn do_upgrade(
   request: Request(Connection),
-  coordinator: Subject(CoordinatorMessage),
+  channels: Channels,
 ) -> Response(ResponseData) {
   mist.websocket(
     request: request,
     handler: fn(state, message, connection) {
       on_message(state, message, connection)
     },
-    on_init: fn(connection) { on_init(connection, coordinator) },
+    on_init: fn(connection) {
+      on_init(connection, channels.coordinator, channels.config.codec)
+    },
     on_close: on_close,
   )
 }
@@ -125,6 +133,7 @@ fn do_upgrade(
 fn on_init(
   _connection: WebsocketConnection,
   coordinator: Subject(CoordinatorMessage),
+  codec: Codec,
 ) -> #(ConnectionState, Option(process.Selector(SendRequest))) {
   // Generate unique socket ID
   let socket_id = generate_socket_id()
@@ -150,15 +159,21 @@ fn on_init(
     coordinator.SocketConnected(socket_id, send_fn, send_binary_fn),
   )
 
-  let state = ConnectionState(socket_id: socket_id, coordinator: coordinator)
+  let state =
+    ConnectionState(
+      socket_id: socket_id,
+      coordinator: coordinator,
+      codec: codec,
+    )
 
   #(state, Some(selector))
 }
 
 /// Handle incoming WebSocket messages.
 ///
-/// Frames are routed to the coordinator, which decodes them with the configured
-/// codec and handles raw binary fallback when the codec has no binary decoder.
+/// Frames are decoded on the per-connection process, then routed to the
+/// coordinator for dispatch. Malformed frames fall back to the coordinator so
+/// diagnostics stay centralized.
 fn on_message(
   state: ConnectionState,
   message: mist.WebsocketMessage(SendRequest),
@@ -166,11 +181,30 @@ fn on_message(
 ) -> mist.Next(ConnectionState, SendRequest) {
   case message {
     mist.Text(text) -> {
-      coordinator.route_message(state.coordinator, state.socket_id, text)
+      case state.codec.decode_text(text) {
+        Ok(inbound) ->
+          coordinator.route_decoded(state.coordinator, state.socket_id, inbound)
+        Error(_) ->
+          coordinator.route_message(state.coordinator, state.socket_id, text)
+      }
       mist.continue(state)
     }
     mist.Binary(data) -> {
-      coordinator.route_binary(state.coordinator, state.socket_id, data)
+      case state.codec.decode_binary {
+        Some(decode) ->
+          case decode(data) {
+            Ok(inbound) ->
+              coordinator.route_decoded(
+                state.coordinator,
+                state.socket_id,
+                inbound,
+              )
+            Error(_) ->
+              coordinator.route_binary(state.coordinator, state.socket_id, data)
+          }
+        None ->
+          coordinator.route_binary(state.coordinator, state.socket_id, data)
+      }
       mist.continue(state)
     }
     mist.Closed | mist.Shutdown -> mist.stop()

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -4,7 +4,6 @@
 //// and the beryl coordinator using Mist request and response types directly.
 
 import beryl/coordinator.{type Message as CoordinatorMessage}
-import beryl/wire/codec.{type Codec}
 import gleam/bit_array
 import gleam/bytes_tree
 import gleam/crypto
@@ -47,13 +46,7 @@ pub fn with_on_connect(
 
 /// State maintained per WebSocket connection
 type ConnectionState {
-  ConnectionState(
-    socket_id: String,
-    coordinator: Subject(CoordinatorMessage),
-    /// Codec cached at upgrade time so inbound frames are decoded inline
-    /// on the per-connection process instead of on the coordinator actor.
-    codec: Codec,
-  )
+  ConnectionState(socket_id: String, coordinator: Subject(CoordinatorMessage))
 }
 
 type SendRequest {
@@ -157,24 +150,15 @@ fn on_init(
     coordinator.SocketConnected(socket_id, send_fn, send_binary_fn),
   )
 
-  // Fetch the codec once so inbound frames can be decoded inline
-  let codec = coordinator.get_codec(coordinator)
-
-  let state =
-    ConnectionState(
-      socket_id: socket_id,
-      coordinator: coordinator,
-      codec: codec,
-    )
+  let state = ConnectionState(socket_id: socket_id, coordinator: coordinator)
 
   #(state, Some(selector))
 }
 
 /// Handle incoming WebSocket messages.
 ///
-/// Text frames are decoded by the coordinator's codec. Binary frames are also
-/// offered to the codec when it has a binary decoder; otherwise they are routed
-/// to raw channel binary handlers.
+/// Frames are routed to the coordinator, which decodes them with the configured
+/// codec and handles raw binary fallback when the codec has no binary decoder.
 fn on_message(
   state: ConnectionState,
   message: mist.WebsocketMessage(SendRequest),
@@ -182,34 +166,11 @@ fn on_message(
 ) -> mist.Next(ConnectionState, SendRequest) {
   case message {
     mist.Text(text) -> {
-      // Decode inline so the coordinator actor's mailbox doesn't serialize
-      // JSON parsing across every connection. Fall back to the actor-side
-      // decoder on error so the coordinator's logging path stays the single
-      // source of truth for malformed-frame diagnostics.
-      case state.codec.decode_text(text) {
-        Ok(inbound) ->
-          coordinator.route_inbound(state.coordinator, state.socket_id, inbound)
-        Error(_) ->
-          coordinator.route_message(state.coordinator, state.socket_id, text)
-      }
+      coordinator.route_message(state.coordinator, state.socket_id, text)
       mist.continue(state)
     }
     mist.Binary(data) -> {
-      case state.codec.decode_binary {
-        Some(decode) ->
-          case decode(data) {
-            Ok(inbound) ->
-              coordinator.route_inbound(
-                state.coordinator,
-                state.socket_id,
-                inbound,
-              )
-            Error(_) ->
-              coordinator.route_binary(state.coordinator, state.socket_id, data)
-          }
-        None ->
-          coordinator.route_binary(state.coordinator, state.socket_id, data)
-      }
+      coordinator.route_binary(state.coordinator, state.socket_id, data)
       mist.continue(state)
     }
     mist.Closed | mist.Shutdown -> mist.stop()

--- a/src/beryl/wire.gleam
+++ b/src/beryl/wire.gleam
@@ -252,29 +252,6 @@ fn option_to_json(opt: Option(String)) -> json.Json {
   }
 }
 
-/// Check if this is a Phoenix system event.
-///
-/// Note: This is Phoenix-specific. The coordinator dispatches decoded messages
-/// structurally using `codec.InboundKind` rather than consulting this helper.
-pub fn is_phoenix_system_event(event: String) -> Bool {
-  case event {
-    "phx_join"
-    | "phx_leave"
-    | "phx_reply"
-    | "phx_error"
-    | "phx_close"
-    | "heartbeat" -> True
-    _ -> False
-  }
-}
-
-/// Deprecated: renamed to `is_phoenix_system_event` to clarify the
-/// Phoenix-specific event name set. Forwards to the new name.
-@deprecated("Use is_phoenix_system_event/1")
-pub fn is_system_event(event: String) -> Bool {
-  is_phoenix_system_event(event)
-}
-
 /// Format a `DecodeError` as a human-readable string.
 pub fn format_decode_error(error: DecodeError) -> String {
   codec.format_decode_error(error)

--- a/test/beryl_test.gleam
+++ b/test/beryl_test.gleam
@@ -484,36 +484,6 @@ pub fn heartbeat_reply_test() {
   text_frame(reply) |> string.contains("\"status\":\"ok\"") |> should.be_true
 }
 
-pub fn is_system_event_phx_join_test() {
-  wire.is_phoenix_system_event("phx_join") |> should.be_true
-}
-
-pub fn is_system_event_phx_leave_test() {
-  wire.is_phoenix_system_event("phx_leave") |> should.be_true
-}
-
-pub fn is_system_event_phx_reply_test() {
-  wire.is_phoenix_system_event("phx_reply") |> should.be_true
-}
-
-pub fn is_system_event_phx_error_test() {
-  wire.is_phoenix_system_event("phx_error") |> should.be_true
-}
-
-pub fn is_system_event_phx_close_test() {
-  wire.is_phoenix_system_event("phx_close") |> should.be_true
-}
-
-pub fn is_system_event_heartbeat_test() {
-  wire.is_phoenix_system_event("heartbeat") |> should.be_true
-}
-
-pub fn is_system_event_custom_test() {
-  wire.is_phoenix_system_event("new_message") |> should.be_false
-  wire.is_phoenix_system_event("typing") |> should.be_false
-  wire.is_phoenix_system_event("presence_diff") |> should.be_false
-}
-
 pub fn format_decode_error_invalid_json_test() {
   wire.format_decode_error(codec.InvalidJson("bad input"))
   |> string.contains("Invalid JSON")

--- a/test/binary_codec_test.gleam
+++ b/test/binary_codec_test.gleam
@@ -222,6 +222,57 @@ pub fn binary_codec_routes_join_message_and_reply_over_binary_test() {
   process.receive(sent_text, 50) |> should.be_error
 }
 
+pub fn binary_codec_event_consumes_one_message_rate_token_test() {
+  let sent_binary = process.new_subject()
+  let config =
+    beryl.config(binary_test_codec())
+    |> beryl.with_message_rate(per_second: 100, burst: 2)
+  let assert Ok(channels) = beryl.start(config)
+
+  process.send(
+    channels.coordinator,
+    coordinator.SocketConnected("socket-1", fn(_) { Ok(Nil) }, fn(data) {
+      process.send(sent_binary, data)
+      Ok(Nil)
+    }),
+  )
+
+  let handler =
+    channel.new(fn(_topic, _payload, socket) {
+      channel.JoinOk(reply: None, socket: socket)
+    })
+    |> channel.with_handle_in(fn(event, _payload, socket) {
+      channel.Reply(event, json.object([#("ok", json.bool(True))]), socket)
+    })
+
+  beryl.register(channels, "room:*", handler) |> should.equal(Ok(Nil))
+
+  coordinator.route_binary(
+    channels.coordinator,
+    "socket-1",
+    bit_array.from_string("J|join-ref|join-1|room:lobby|{}"),
+  )
+  let assert Ok(_join_reply_bits) = process.receive(sent_binary, 500)
+
+  coordinator.route_binary(
+    channels.coordinator,
+    "socket-1",
+    bit_array.from_string("E|event-1|room:lobby|ping|{}"),
+  )
+  let assert Ok(first_reply_bits) = process.receive(sent_binary, 500)
+  bit_array.to_string(first_reply_bits)
+  |> should.equal(Ok("R|event-1|room:lobby|ok|{\"ok\":true}"))
+
+  coordinator.route_binary(
+    channels.coordinator,
+    "socket-1",
+    bit_array.from_string("E|event-2|room:lobby|ping|{}"),
+  )
+  let assert Ok(second_reply_bits) = process.receive(sent_binary, 500)
+  bit_array.to_string(second_reply_bits)
+  |> should.equal(Ok("R|event-2|room:lobby|ok|{\"ok\":true}"))
+}
+
 pub fn binary_codec_broadcast_uses_binary_send_test() {
   let sent_text = process.new_subject()
   let sent_binary = process.new_subject()

--- a/test/phoenix_contract_test.gleam
+++ b/test/phoenix_contract_test.gleam
@@ -245,7 +245,7 @@ fn start_mist_server(channels: beryl.Channels) -> #(Int, process.Pid) {
   let handler = fn(request) {
     mist_transport.upgrade(
       request,
-      channels.coordinator,
+      channels,
       mist_transport.default_config("/socket/websocket"),
       fn() {
         response.new(404)


### PR DESCRIPTION
## Summary

- Remove public coordinator APIs that let callers bypass codec decoding (`RouteInbound`, `route_inbound`, `GetCodec`, `get_codec`)
- Route Mist text and binary frames through the coordinator raw-frame APIs
- Remove Phoenix-specific system-event helpers from `beryl/wire`
- Add a changie fragment for the breaking public API cleanup

## Breaking changes

Custom transports must send inbound frames through `coordinator.route_message` or `coordinator.route_binary`. The public pre-decoded inbound route and `wire.is_phoenix_system_event` / `wire.is_system_event` helpers are no longer available.

## Validation

- `gleam format --check src test`
- `just check`
- `just test`
- `just ci`

Closes #57
