### PR TITLE
feat(logging): add configurable diagnostics

### DIFF
--- a/.changes/unreleased/Added-20260515-161331.yaml
+++ b/.changes/unreleased/Added-20260515-161331.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: |-
+    App-configurable Beryl logging diagnostics.
+
+    Applications can now configure Beryl's internal `beryl.*` Birch loggers with `beryl.with_logging`, opt into debug-level channel lifecycle diagnostics, and keep payload/frame previews disabled by default unless bounded previews are explicitly enabled.
+time: 2026-05-15T16:13:31.000000000-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -61,6 +61,7 @@ import beryl/topic
 import beryl/wire/codec
 import gleam/dynamic.{type Dynamic}
 import gleam/erlang/process.{type Subject}
+import gleam/int
 import gleam/json
 import gleam/option.{type Option, None, Some}
 
@@ -176,11 +177,7 @@ pub fn with_payload_preview_bytes(
   logging: LoggingConfig,
   bytes bytes: Int,
 ) -> LoggingConfig {
-  let safe_bytes = case bytes < 0 {
-    True -> 0
-    False -> bytes
-  }
-  LoggingConfig(..logging, payload_preview_bytes: safe_bytes)
+  LoggingConfig(..logging, payload_preview_bytes: int.max(bytes, 0))
 }
 
 fn coordinator_log_level(level: LogLevel) -> coordinator.LogLevel {
@@ -199,13 +196,6 @@ fn coordinator_logging(logging: LoggingConfig) -> coordinator.LoggingConfig {
     include_payloads: logging.include_payloads,
     payload_preview_bytes: logging.payload_preview_bytes,
   )
-}
-
-@internal
-pub fn to_coordinator_logging(
-  logging: LoggingConfig,
-) -> coordinator.LoggingConfig {
-  coordinator_logging(logging)
 }
 
 /// Configure per-socket message rate limiting

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -71,6 +71,27 @@ pub type ChannelHandler =
 pub type RegisterError =
   coordinator.RegisterError
 
+/// Logging verbosity for Beryl's internal Birch loggers.
+pub type LogLevel {
+  Trace
+  Debug
+  Info
+  Warn
+  Err
+}
+
+/// Logging configuration for Beryl diagnostics.
+pub type LoggingConfig {
+  LoggingConfig(
+    /// Minimum level emitted by Beryl's namespaced loggers.
+    level: LogLevel,
+    /// Whether debug diagnostics may include bounded payload/frame previews.
+    include_payloads: Bool,
+    /// Maximum number of bytes/characters included in payload previews.
+    payload_preview_bytes: Int,
+  )
+}
+
 /// Configuration for the channels system
 pub type Config {
   Config(
@@ -97,6 +118,24 @@ pub type Config {
     channel_rate: Int,
     /// Per-channel message burst capacity (0 = defaults to channel_rate)
     channel_burst: Int,
+    /// Logging configuration for Beryl diagnostics
+    logging: LoggingConfig,
+  )
+}
+
+/// Build a logging configuration.
+///
+/// Payloads are excluded by default to avoid accidental sensitive-data
+/// exposure. Use `with_payload_preview_bytes` to adjust the bounded preview
+/// size when payload previews are enabled.
+pub fn logging_config(
+  level level: LogLevel,
+  include_payloads include_payloads: Bool,
+) -> LoggingConfig {
+  LoggingConfig(
+    level: level,
+    include_payloads: include_payloads,
+    payload_preview_bytes: 200,
   )
 }
 
@@ -118,12 +157,55 @@ pub fn config(codec: codec.Codec) -> Config {
     join_burst: 0,
     channel_rate: 0,
     channel_burst: 0,
+    logging: logging_config(level: Info, include_payloads: False),
   )
 }
 
 /// Add PubSub to a configuration for distributed broadcasts
 pub fn with_pubsub(config: Config, ps: PubSub) -> Config {
   Config(..config, pubsub: Some(ps))
+}
+
+/// Configure Beryl's internal logging.
+pub fn with_logging(config: Config, logging: LoggingConfig) -> Config {
+  Config(..config, logging: logging)
+}
+
+/// Configure the maximum payload/frame preview length for logs.
+pub fn with_payload_preview_bytes(
+  logging: LoggingConfig,
+  bytes bytes: Int,
+) -> LoggingConfig {
+  let safe_bytes = case bytes < 0 {
+    True -> 0
+    False -> bytes
+  }
+  LoggingConfig(..logging, payload_preview_bytes: safe_bytes)
+}
+
+fn coordinator_log_level(level: LogLevel) -> coordinator.LogLevel {
+  case level {
+    Trace -> coordinator.Trace
+    Debug -> coordinator.Debug
+    Info -> coordinator.Info
+    Warn -> coordinator.Warn
+    Err -> coordinator.Err
+  }
+}
+
+fn coordinator_logging(logging: LoggingConfig) -> coordinator.LoggingConfig {
+  coordinator.LoggingConfig(
+    level: coordinator_log_level(logging.level),
+    include_payloads: logging.include_payloads,
+    payload_preview_bytes: logging.payload_preview_bytes,
+  )
+}
+
+@internal
+pub fn to_coordinator_logging(
+  logging: LoggingConfig,
+) -> coordinator.LoggingConfig {
+  coordinator_logging(logging)
 }
 
 /// Configure per-socket message rate limiting
@@ -217,6 +299,7 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
           message_limiter: message_limiter,
           join_limiter: join_limiter,
           channel_limiter: channel_limiter,
+          logging: coordinator_logging(config.logging),
         )
 
       let coordinator_result = case config.pubsub {

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -155,17 +155,11 @@ fn internal_logging(config: LoggingConfig) -> internal.LoggingConfig {
 }
 
 fn coordinator_logger(state: State) -> Logger {
-  internal.logger_with_config(
-    "beryl.coordinator",
-    internal_logging(state.config.logging),
-  )
+  state.logger
 }
 
 fn optional_string(value: Option(String)) -> String {
-  case value {
-    Some(text) -> text
-    None -> ""
-  }
+  option.unwrap(value, "")
 }
 
 fn inbound_kind(kind: codec.InboundKind) -> String {
@@ -207,6 +201,8 @@ pub type State {
     config: CoordinatorConfig,
     /// Optional PubSub for distributed broadcasts
     pubsub: Option(PubSub),
+    /// Configured coordinator logger, cached for hot message paths.
+    logger: Logger,
     /// The coordinator's own subject, used for scheduling timers
     self_subject: Option(Subject(Message)),
   )
@@ -386,6 +382,10 @@ fn build_coordinator(
       topics: dict.new(),
       config: config,
       pubsub: ps,
+      logger: internal.logger_with_config(
+        "beryl.coordinator",
+        internal_logging(config.logging),
+      ),
       self_subject: None,
     )
 
@@ -1522,6 +1522,7 @@ fn handle_route_text(
   raw_text: String,
 ) -> actor.Next(State, Message) {
   let codec = state.config.codec
+  let logging = internal_logging(state.config.logging)
   case codec.decode_text(raw_text) {
     Error(err) -> {
       let logger = coordinator_logger(state)
@@ -1533,11 +1534,7 @@ fn handle_route_text(
             #("socket_id", socket_id),
             #("error", codec.format_decode_error(err)),
           ],
-          internal.preview_metadata(
-            "frame_preview",
-            raw_text,
-            internal_logging(state.config.logging),
-          ),
+          internal.preview_metadata("frame_preview", raw_text, logging),
         ),
       )
       actor.continue(state)
@@ -1555,11 +1552,7 @@ fn handle_route_text(
             #("ref", optional_string(msg.ref)),
             #("join_ref", optional_string(msg.join_ref)),
           ],
-          internal.preview_metadata(
-            "frame_preview",
-            raw_text,
-            internal_logging(state.config.logging),
-          ),
+          internal.preview_metadata("frame_preview", raw_text, logging),
         ),
       )
       dispatch_inbound(state, socket_id, msg)

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -13,7 +13,7 @@ import beryl/pubsub.{type PubSub}
 import beryl/rate_limit.{type RateLimiter}
 import beryl/topic.{type TopicPattern}
 import beryl/wire/codec.{type Codec}
-import birch/logger as log
+import birch/logger.{type Logger} as log
 import gleam/dict.{type Dict}
 import gleam/dynamic.{type Dynamic}
 import gleam/erlang/atom
@@ -82,6 +82,24 @@ pub type StartError {
   ActorStartFailed(actor.StartError)
 }
 
+/// Logging verbosity for the coordinator's internal Birch logger.
+pub type LogLevel {
+  Trace
+  Debug
+  Info
+  Warn
+  Err
+}
+
+/// Logging configuration for coordinator diagnostics.
+pub type LoggingConfig {
+  LoggingConfig(
+    level: LogLevel,
+    include_payloads: Bool,
+    payload_preview_bytes: Int,
+  )
+}
+
 /// Configuration for heartbeat enforcement
 pub type CoordinatorConfig {
   CoordinatorConfig(
@@ -98,6 +116,8 @@ pub type CoordinatorConfig {
     join_limiter: Option(RateLimiter),
     /// Per-channel message rate limiter (None = unlimited)
     channel_limiter: Option(RateLimiter),
+    /// Logging configuration for coordinator diagnostics.
+    logging: LoggingConfig,
   )
 }
 
@@ -112,7 +132,66 @@ pub fn config(codec: Codec) -> CoordinatorConfig {
     message_limiter: None,
     join_limiter: None,
     channel_limiter: None,
+    logging: LoggingConfig(
+      level: Info,
+      include_payloads: False,
+      payload_preview_bytes: 200,
+    ),
   )
+}
+
+fn internal_logging(config: LoggingConfig) -> internal.LoggingConfig {
+  internal.LoggingConfig(
+    level: case config.level {
+      Trace -> internal.Trace
+      Debug -> internal.Debug
+      Info -> internal.Info
+      Warn -> internal.Warn
+      Err -> internal.Err
+    },
+    include_payloads: config.include_payloads,
+    payload_preview_bytes: config.payload_preview_bytes,
+  )
+}
+
+fn coordinator_logger(state: State) -> Logger {
+  internal.logger_with_config(
+    "beryl.coordinator",
+    internal_logging(state.config.logging),
+  )
+}
+
+fn optional_string(value: Option(String)) -> String {
+  case value {
+    Some(text) -> text
+    None -> ""
+  }
+}
+
+fn inbound_kind(kind: codec.InboundKind) -> String {
+  case kind {
+    codec.Join -> "join"
+    codec.Leave -> "leave"
+    codec.Heartbeat -> "heartbeat"
+    codec.Event(event) -> event
+  }
+}
+
+fn stop_reason(reason: channel.StopReason) -> String {
+  case reason {
+    channel.Normal -> "normal"
+    channel.Shutdown -> "shutdown"
+    channel.HeartbeatTimeout -> "heartbeat_timeout"
+    channel.Error(message) -> message
+  }
+}
+
+fn joined_topics_metadata(socket_info: SocketInfo) -> List(#(String, String)) {
+  let topics = set.to_list(socket_info.subscribed_topics)
+  [
+    #("joined_topic_count", int.to_string(list.length(topics))),
+    #("joined_topics", string.join(topics, ",")),
+  ]
 }
 
 /// Internal state for coordinator actor
@@ -150,17 +229,45 @@ pub type SocketInfo {
   )
 }
 
-fn send_frame(socket_info: SocketInfo, frame: codec.Frame) -> Nil {
+fn send_frame(socket_info: SocketInfo, frame: codec.Frame) -> Result(Nil, Nil) {
   case frame {
-    codec.TextFrame(text) -> {
-      let _ = socket_info.send(text)
-      Nil
-    }
-    codec.BinaryFrame(data) -> {
-      let _ = socket_info.send_binary(data)
-      Nil
-    }
+    codec.TextFrame(text) -> socket_info.send(text)
+    codec.BinaryFrame(data) -> socket_info.send_binary(data)
   }
+}
+
+fn frame_kind(frame: codec.Frame) -> String {
+  case frame {
+    codec.TextFrame(_) -> "text"
+    codec.BinaryFrame(_) -> "binary"
+  }
+}
+
+fn send_frame_logged(
+  state: State,
+  socket_info: SocketInfo,
+  topic_name: String,
+  frame: codec.Frame,
+) -> Result(Nil, Nil) {
+  let result = send_frame(socket_info, frame)
+  let logger = coordinator_logger(state)
+  case result {
+    Ok(Nil) ->
+      logger
+      |> log.debug("Outbound frame sent", [
+        #("socket_id", socket_info.id),
+        #("topic", topic_name),
+        #("frame_kind", frame_kind(frame)),
+      ])
+    Error(Nil) ->
+      logger
+      |> log.warn("Outbound frame failed", [
+        #("socket_id", socket_info.id),
+        #("topic", topic_name),
+        #("frame_kind", frame_kind(frame)),
+      ])
+  }
+  result
 }
 
 /// Messages the coordinator handles
@@ -405,7 +512,7 @@ fn handle_socket_connected(
       last_heartbeat: monotonic_time_ms(),
     )
 
-  let logger = internal.logger("beryl.coordinator")
+  let logger = coordinator_logger(state)
   logger |> log.info("Socket connected", [#("socket_id", socket_id)])
   let new_sockets = dict.insert(state.sockets, socket_id, socket_info)
   actor.continue(State(..state, sockets: new_sockets))
@@ -415,8 +522,16 @@ fn handle_socket_disconnected(
   state: State,
   socket_id: String,
 ) -> actor.Next(State, Message) {
-  let logger = internal.logger("beryl.coordinator")
-  logger |> log.info("Socket disconnected", [#("socket_id", socket_id)])
+  let logger = coordinator_logger(state)
+  let metadata = case dict.get(state.sockets, socket_id) {
+    Ok(socket_info) ->
+      list.append(
+        [#("socket_id", socket_id)],
+        joined_topics_metadata(socket_info),
+      )
+    Error(_) -> [#("socket_id", socket_id)]
+  }
+  logger |> log.info("Socket disconnected", metadata)
   rate_limit.remove_by_prefix_optional(
     state.config.message_limiter,
     "msg:" <> socket_id,
@@ -445,7 +560,7 @@ fn handle_join(
     rate_limit.check_optional(state.config.join_limiter, "join:" <> socket_id)
   {
     Error(_) -> {
-      let logger = internal.logger("beryl.coordinator")
+      let logger = coordinator_logger(state)
       logger
       |> log.warn("Join rate limited", [
         #("socket_id", socket_id),
@@ -462,7 +577,7 @@ fn handle_join(
               codec.StatusError,
               json.object([#("reason", json.string("rate_limited"))]),
             )
-          send_frame(socket_info, reply)
+          let _ = send_frame_logged(state, socket_info, topic_name, reply)
           Nil
         }
         Error(_) -> Nil
@@ -483,10 +598,27 @@ fn handle_join_inner(
   ref: Option(String),
 ) -> actor.Next(State, Message) {
   case dict.get(state.sockets, socket_id) {
-    Error(_) -> actor.continue(state)
+    Error(_) -> {
+      let logger = coordinator_logger(state)
+      logger
+      |> log.debug("Join ignored", [
+        #("socket_id", socket_id),
+        #("topic", topic_name),
+        #("reason", "socket_not_found"),
+      ])
+      actor.continue(state)
+    }
     Ok(socket_info) -> {
       case find_handler(state.handlers, topic_name) {
         None -> {
+          let logger = coordinator_logger(state)
+          logger
+          |> log.debug("Join handler missing", [
+            #("socket_id", socket_id),
+            #("topic", topic_name),
+            #("ref", optional_string(ref)),
+            #("join_ref", optional_string(join_ref)),
+          ])
           let reply =
             state.config.codec.encode_reply(
               join_ref,
@@ -495,10 +627,18 @@ fn handle_join_inner(
               codec.StatusError,
               json.object([#("reason", json.string("no_channel_handler"))]),
             )
-          send_frame(socket_info, reply)
+          let _ = send_frame_logged(state, socket_info, topic_name, reply)
           actor.continue(state)
         }
         Some(handler) -> {
+          let logger = coordinator_logger(state)
+          logger
+          |> log.debug("Join handler matched", [
+            #("socket_id", socket_id),
+            #("topic", topic_name),
+            #("ref", optional_string(ref)),
+            #("join_ref", optional_string(join_ref)),
+          ])
           let ctx =
             SocketContext(
               socket_id: socket_id,
@@ -510,6 +650,13 @@ fn handle_join_inner(
 
           case handler.join(topic_name, payload, ctx) {
             JoinErrorErased(reason) -> {
+              logger
+              |> log.debug("Join rejected", [
+                #("socket_id", socket_id),
+                #("topic", topic_name),
+                #("ref", optional_string(ref)),
+                #("join_ref", optional_string(join_ref)),
+              ])
               let reply =
                 state.config.codec.encode_reply(
                   join_ref,
@@ -518,10 +665,17 @@ fn handle_join_inner(
                   codec.StatusError,
                   reason,
                 )
-              send_frame(socket_info, reply)
+              let _ = send_frame_logged(state, socket_info, topic_name, reply)
               actor.continue(state)
             }
             JoinOkErased(reply_payload, assigns) -> {
+              logger
+              |> log.debug("Join accepted", [
+                #("socket_id", socket_id),
+                #("topic", topic_name),
+                #("ref", optional_string(ref)),
+                #("join_ref", optional_string(join_ref)),
+              ])
               let new_subscribed =
                 set.insert(socket_info.subscribed_topics, topic_name)
               let new_assigns =
@@ -562,7 +716,7 @@ fn handle_join_inner(
                   codec.StatusOk,
                   response,
                 )
-              send_frame(socket_info, reply)
+              let _ = send_frame_logged(state, socket_info, topic_name, reply)
 
               actor.continue(
                 State(..state, sockets: new_sockets, topics: new_topics),
@@ -593,7 +747,7 @@ fn handle_leave(
           codec.StatusOk,
           json.object([]),
         )
-      send_frame(socket_info, reply)
+      let _ = send_frame_logged(state, socket_info, topic_name, reply)
       Nil
     }
     _, _ -> Nil
@@ -615,7 +769,7 @@ fn handle_in(
     rate_limit.check_optional(state.config.message_limiter, "msg:" <> socket_id)
   {
     Error(_) -> {
-      let logger = internal.logger("beryl.coordinator")
+      let logger = coordinator_logger(state)
       logger
       |> log.warn("Message rate limited", [
         #("socket_id", socket_id),
@@ -632,7 +786,7 @@ fn handle_in(
         )
       {
         Error(_) -> {
-          let logger = internal.logger("beryl.coordinator")
+          let logger = coordinator_logger(state)
           logger
           |> log.warn("Channel rate limited", [
             #("socket_id", socket_id),
@@ -656,14 +810,52 @@ fn handle_in_inner(
   ref: Option(String),
 ) -> actor.Next(State, Message) {
   case dict.get(state.sockets, socket_id) {
-    Error(_) -> actor.continue(state)
+    Error(_) -> {
+      let logger = coordinator_logger(state)
+      logger
+      |> log.debug("Inbound message ignored", [
+        #("socket_id", socket_id),
+        #("topic", topic_name),
+        #("event", event),
+        #("reason", "socket_not_found"),
+      ])
+      actor.continue(state)
+    }
     Ok(socket_info) -> {
       case set.contains(socket_info.subscribed_topics, topic_name) {
-        False -> actor.continue(state)
+        False -> {
+          let logger = coordinator_logger(state)
+          logger
+          |> log.debug("Inbound message ignored", [
+            #("socket_id", socket_id),
+            #("topic", topic_name),
+            #("event", event),
+            #("reason", "topic_not_joined"),
+          ])
+          actor.continue(state)
+        }
         True -> {
           case find_handler(state.handlers, topic_name) {
-            None -> actor.continue(state)
+            None -> {
+              let logger = coordinator_logger(state)
+              logger
+              |> log.debug("Inbound message ignored", [
+                #("socket_id", socket_id),
+                #("topic", topic_name),
+                #("event", event),
+                #("reason", "handler_not_found"),
+              ])
+              actor.continue(state)
+            }
             Some(handler) -> {
+              let logger = coordinator_logger(state)
+              logger
+              |> log.debug("Inbound message routed", [
+                #("socket_id", socket_id),
+                #("topic", topic_name),
+                #("event", event),
+                #("ref", optional_string(ref)),
+              ])
               let assigns =
                 dict.get(socket_info.channel_assigns, topic_name)
                 |> result.unwrap(dynamic.nil())
@@ -679,12 +871,25 @@ fn handle_in_inner(
 
               case handler.handle_in(event, payload, ctx) {
                 NoReplyErased(new_assigns) -> {
+                  logger
+                  |> log.debug("Channel callback returned no reply", [
+                    #("socket_id", socket_id),
+                    #("topic", topic_name),
+                    #("event", event),
+                  ])
                   let state =
                     update_assigns(state, socket_id, topic_name, new_assigns)
                   actor.continue(state)
                 }
 
                 ReplyErased(_reply_event, reply_payload, new_assigns) -> {
+                  logger
+                  |> log.debug("Channel callback returned reply", [
+                    #("socket_id", socket_id),
+                    #("topic", topic_name),
+                    #("event", event),
+                    #("ref", optional_string(ref)),
+                  ])
                   case ref {
                     Some(r) -> {
                       let reply =
@@ -695,7 +900,8 @@ fn handle_in_inner(
                           codec.StatusOk,
                           reply_payload,
                         )
-                      send_frame(socket_info, reply)
+                      let _ =
+                        send_frame_logged(state, socket_info, topic_name, reply)
                       Nil
                     }
                     None -> Nil
@@ -706,19 +912,33 @@ fn handle_in_inner(
                 }
 
                 PushErased(push_event, push_payload, new_assigns) -> {
+                  logger
+                  |> log.debug("Channel callback returned push", [
+                    #("socket_id", socket_id),
+                    #("topic", topic_name),
+                    #("event", event),
+                    #("push_event", push_event),
+                  ])
                   let msg =
                     state.config.codec.encode_push(
                       topic_name,
                       push_event,
                       push_payload,
                     )
-                  send_frame(socket_info, msg)
+                  let _ = send_frame_logged(state, socket_info, topic_name, msg)
                   let state =
                     update_assigns(state, socket_id, topic_name, new_assigns)
                   actor.continue(state)
                 }
 
                 StopErased(reason) -> {
+                  logger
+                  |> log.debug("Channel callback stopped channel", [
+                    #("socket_id", socket_id),
+                    #("topic", topic_name),
+                    #("event", event),
+                    #("reason", stop_reason(reason)),
+                  ])
                   let state =
                     terminate_channel(state, socket_id, topic_name, reason)
                   actor.continue(state)
@@ -739,14 +959,47 @@ fn handle_info(
   message: Dynamic,
 ) -> actor.Next(State, Message) {
   case dict.get(state.sockets, socket_id) {
-    Error(_) -> actor.continue(state)
+    Error(_) -> {
+      let logger = coordinator_logger(state)
+      logger
+      |> log.debug("Handle info ignored", [
+        #("socket_id", socket_id),
+        #("topic", topic_name),
+        #("reason", "socket_not_found"),
+      ])
+      actor.continue(state)
+    }
     Ok(socket_info) -> {
       case set.contains(socket_info.subscribed_topics, topic_name) {
-        False -> actor.continue(state)
+        False -> {
+          let logger = coordinator_logger(state)
+          logger
+          |> log.debug("Handle info ignored", [
+            #("socket_id", socket_id),
+            #("topic", topic_name),
+            #("reason", "topic_not_joined"),
+          ])
+          actor.continue(state)
+        }
         True -> {
           case find_handler(state.handlers, topic_name) {
-            None -> actor.continue(state)
+            None -> {
+              let logger = coordinator_logger(state)
+              logger
+              |> log.debug("Handle info ignored", [
+                #("socket_id", socket_id),
+                #("topic", topic_name),
+                #("reason", "handler_not_found"),
+              ])
+              actor.continue(state)
+            }
             Some(handler) -> {
+              let logger = coordinator_logger(state)
+              logger
+              |> log.debug("Handle info routed", [
+                #("socket_id", socket_id),
+                #("topic", topic_name),
+              ])
               let assigns =
                 dict.get(socket_info.channel_assigns, topic_name)
                 |> result.unwrap(dynamic.nil())
@@ -762,6 +1015,12 @@ fn handle_info(
 
               case handler.handle_info(message, ctx) {
                 NoReplyErased(new_assigns) -> {
+                  logger
+                  |> log.debug("Channel callback returned no reply", [
+                    #("socket_id", socket_id),
+                    #("topic", topic_name),
+                    #("callback", "handle_info"),
+                  ])
                   let state =
                     update_assigns(state, socket_id, topic_name, new_assigns)
                   actor.continue(state)
@@ -769,6 +1028,13 @@ fn handle_info(
 
                 ReplyErased(reply_event, reply_payload, new_assigns)
                 | PushErased(reply_event, reply_payload, new_assigns) -> {
+                  logger
+                  |> log.debug("Channel callback returned push", [
+                    #("socket_id", socket_id),
+                    #("topic", topic_name),
+                    #("callback", "handle_info"),
+                    #("push_event", reply_event),
+                  ])
                   // No ref correlation in handle_info, so reply and push are
                   // wire-identical: both become a server-initiated push.
                   let msg =
@@ -777,13 +1043,20 @@ fn handle_info(
                       reply_event,
                       reply_payload,
                     )
-                  send_frame(socket_info, msg)
+                  let _ = send_frame_logged(state, socket_info, topic_name, msg)
                   let state =
                     update_assigns(state, socket_id, topic_name, new_assigns)
                   actor.continue(state)
                 }
 
                 StopErased(reason) -> {
+                  logger
+                  |> log.debug("Channel callback stopped channel", [
+                    #("socket_id", socket_id),
+                    #("topic", topic_name),
+                    #("callback", "handle_info"),
+                    #("reason", stop_reason(reason)),
+                  ])
                   let state =
                     terminate_channel(state, socket_id, topic_name, reason)
                   actor.continue(state)
@@ -820,7 +1093,7 @@ fn handle_raw_binary_with_rate_limit(
     rate_limit.check_optional(state.config.message_limiter, "msg:" <> socket_id)
   {
     Error(_) -> {
-      let logger = internal.logger("beryl.coordinator")
+      let logger = coordinator_logger(state)
       logger
       |> log.warn("Binary message rate limited", [
         #("socket_id", socket_id),
@@ -839,7 +1112,7 @@ fn handle_route_binary_frame(
 ) -> actor.Next(State, Message) {
   case decode_binary(data) {
     Error(err) -> {
-      let logger = internal.logger("beryl.coordinator")
+      let logger = coordinator_logger(state)
       logger
       |> log.warn("Failed to decode binary wire protocol message", [
         #("socket_id", socket_id),
@@ -857,13 +1130,36 @@ fn handle_raw_binary_in_inner(
   data: BitArray,
 ) -> actor.Next(State, Message) {
   case dict.get(state.sockets, socket_id) {
-    Error(_) -> actor.continue(state)
+    Error(_) -> {
+      let logger = coordinator_logger(state)
+      logger
+      |> log.debug("Binary message ignored", [
+        #("socket_id", socket_id),
+        #("reason", "socket_not_found"),
+      ])
+      actor.continue(state)
+    }
     Ok(socket_info) -> {
       let state =
         set.fold(socket_info.subscribed_topics, state, fn(st, topic_name) {
           case find_handler(st.handlers, topic_name) {
-            None -> st
+            None -> {
+              let logger = coordinator_logger(st)
+              logger
+              |> log.debug("Binary message ignored", [
+                #("socket_id", socket_id),
+                #("topic", topic_name),
+                #("reason", "handler_not_found"),
+              ])
+              st
+            }
             Some(handler) -> {
+              let logger = coordinator_logger(st)
+              logger
+              |> log.debug("Binary message routed", [
+                #("socket_id", socket_id),
+                #("topic", topic_name),
+              ])
               let assigns =
                 dict.get(socket_info.channel_assigns, topic_name)
                 |> result.unwrap(dynamic.nil())
@@ -878,30 +1174,58 @@ fn handle_raw_binary_in_inner(
                 )
 
               case handler.handle_binary(data, ctx) {
-                NoReplyErased(new_assigns) ->
+                NoReplyErased(new_assigns) -> {
+                  logger
+                  |> log.debug("Channel callback returned no reply", [
+                    #("socket_id", socket_id),
+                    #("topic", topic_name),
+                    #("callback", "handle_binary"),
+                  ])
                   update_assigns(st, socket_id, topic_name, new_assigns)
+                }
                 ReplyErased(_event, reply_payload, new_assigns) -> {
+                  logger
+                  |> log.debug("Channel callback returned reply", [
+                    #("socket_id", socket_id),
+                    #("topic", topic_name),
+                    #("callback", "handle_binary"),
+                  ])
                   let msg =
                     state.config.codec.encode_push(
                       topic_name,
                       "binary_reply",
                       reply_payload,
                     )
-                  send_frame(socket_info, msg)
+                  let _ = send_frame_logged(st, socket_info, topic_name, msg)
                   update_assigns(st, socket_id, topic_name, new_assigns)
                 }
                 PushErased(push_event, push_payload, new_assigns) -> {
+                  logger
+                  |> log.debug("Channel callback returned push", [
+                    #("socket_id", socket_id),
+                    #("topic", topic_name),
+                    #("callback", "handle_binary"),
+                    #("push_event", push_event),
+                  ])
                   let msg =
                     state.config.codec.encode_push(
                       topic_name,
                       push_event,
                       push_payload,
                     )
-                  send_frame(socket_info, msg)
+                  let _ = send_frame_logged(st, socket_info, topic_name, msg)
                   update_assigns(st, socket_id, topic_name, new_assigns)
                 }
-                StopErased(reason) ->
+                StopErased(reason) -> {
+                  logger
+                  |> log.debug("Channel callback stopped channel", [
+                    #("socket_id", socket_id),
+                    #("topic", topic_name),
+                    #("callback", "handle_binary"),
+                    #("reason", stop_reason(reason)),
+                  ])
                   terminate_channel(st, socket_id, topic_name, reason)
+                }
               }
             }
           }
@@ -924,7 +1248,13 @@ fn handle_heartbeat(
       let new_sockets = dict.insert(state.sockets, socket_id, updated_socket)
 
       let reply = state.config.codec.encode_heartbeat_reply(ref)
-      send_frame(socket_info, reply)
+      let _ = send_frame_logged(state, socket_info, "__heartbeat__", reply)
+      let logger = coordinator_logger(state)
+      logger
+      |> log.debug("Heartbeat handled", [
+        #("socket_id", socket_id),
+        #("ref", optional_string(ref)),
+      ])
       actor.continue(State(..state, sockets: new_sockets))
     }
   }
@@ -944,7 +1274,7 @@ fn handle_check_heartbeats(state: State) -> actor.Next(State, Message) {
       }
     })
 
-  let logger = internal.logger("beryl.coordinator")
+  let logger = coordinator_logger(state)
   list.each(stale_socket_ids, fn(socket_id) {
     logger
     |> log.warn("Evicting socket due to heartbeat timeout", [
@@ -976,6 +1306,18 @@ fn disconnect_socket(
   case dict.get(state.sockets, socket_id) {
     Error(_) -> state
     Ok(socket_info) -> {
+      let logger = coordinator_logger(state)
+      logger
+      |> log.debug(
+        "Socket disconnected",
+        list.append(
+          [
+            #("socket_id", socket_id),
+            #("reason", stop_reason(reason)),
+          ],
+          joined_topics_metadata(socket_info),
+        ),
+      )
       let state =
         set.fold(socket_info.subscribed_topics, state, fn(st, topic_name) {
           terminate_channel(st, socket_id, topic_name, reason)
@@ -1011,10 +1353,18 @@ fn handle_broadcast(
   }
 
   let msg = state.config.codec.encode_push(topic_name, event, payload)
+  let logger = coordinator_logger(state)
+  logger
+  |> log.debug("Broadcast dispatched", [
+    #("topic", topic_name),
+    #("event", event),
+    #("recipient_count", int.to_string(list.length(recipients))),
+    #("except", optional_string(except)),
+  ])
   list.each(recipients, fn(socket_id) {
     case dict.get(state.sockets, socket_id) {
       Ok(socket_info) -> {
-        send_frame(socket_info, msg)
+        let _ = send_frame_logged(state, socket_info, topic_name, msg)
         Nil
       }
       Error(_) -> Nil
@@ -1066,6 +1416,13 @@ fn terminate_channel(
         True -> {
           case find_handler(state.handlers, topic_name) {
             Some(handler) -> {
+              let logger = coordinator_logger(state)
+              logger
+              |> log.debug("Channel terminated", [
+                #("socket_id", socket_id),
+                #("topic", topic_name),
+                #("reason", stop_reason(reason)),
+              ])
               let assigns =
                 dict.get(socket_info.channel_assigns, topic_name)
                 |> result.unwrap(dynamic.nil())
@@ -1167,16 +1524,46 @@ fn handle_route_text(
   let codec = state.config.codec
   case codec.decode_text(raw_text) {
     Error(err) -> {
-      let logger = internal.logger("beryl.coordinator")
+      let logger = coordinator_logger(state)
       logger
-      |> log.warn("Failed to decode wire protocol message", [
-        #("socket_id", socket_id),
-        #("error", codec.format_decode_error(err)),
-        #("frame_preview", string.slice(raw_text, 0, 200)),
-      ])
+      |> log.warn(
+        "Failed to decode wire protocol message",
+        list.append(
+          [
+            #("socket_id", socket_id),
+            #("error", codec.format_decode_error(err)),
+          ],
+          internal.preview_metadata(
+            "frame_preview",
+            raw_text,
+            internal_logging(state.config.logging),
+          ),
+        ),
+      )
       actor.continue(state)
     }
-    Ok(msg) -> dispatch_inbound(state, socket_id, msg)
+    Ok(msg) -> {
+      let logger = coordinator_logger(state)
+      logger
+      |> log.debug(
+        "Inbound text frame decoded",
+        list.append(
+          [
+            #("socket_id", socket_id),
+            #("topic", msg.topic),
+            #("event", inbound_kind(msg.kind)),
+            #("ref", optional_string(msg.ref)),
+            #("join_ref", optional_string(msg.join_ref)),
+          ],
+          internal.preview_metadata(
+            "frame_preview",
+            raw_text,
+            internal_logging(state.config.logging),
+          ),
+        ),
+      )
+      dispatch_inbound(state, socket_id, msg)
+    }
   }
 }
 

--- a/src/beryl/internal.gleam
+++ b/src/beryl/internal.gleam
@@ -4,6 +4,7 @@
 import birch
 import birch/level
 import birch/logger.{type Logger}
+import gleam/int
 import gleam/string
 
 /// Logging verbosity for Beryl's internal helpers.
@@ -55,10 +56,7 @@ fn to_birch_level(log_level: LogLevel) -> level.Level {
 
 /// Safely truncate a text value for log metadata.
 pub fn safe_preview(text: String, max_length: Int) -> String {
-  let safe_length = case max_length < 0 {
-    True -> 0
-    False -> max_length
-  }
+  let safe_length = int.max(max_length, 0)
   string.slice(text, 0, safe_length)
 }
 

--- a/src/beryl/internal.gleam
+++ b/src/beryl/internal.gleam
@@ -2,7 +2,27 @@
 //// Not part of the public API.
 
 import birch
+import birch/level
 import birch/logger.{type Logger}
+import gleam/string
+
+/// Logging verbosity for Beryl's internal helpers.
+pub type LogLevel {
+  Trace
+  Debug
+  Info
+  Warn
+  Err
+}
+
+/// Logging configuration shared by internal Beryl modules.
+pub type LoggingConfig {
+  LoggingConfig(
+    level: LogLevel,
+    include_payloads: Bool,
+    payload_preview_bytes: Int,
+  )
+}
 
 /// Return a memoized named logger, creating it on first call via persistent_term.
 /// The hot path is a single persistent_term lookup with no allocations.
@@ -14,6 +34,43 @@ pub fn logger(name: String) -> Logger {
       set_cached_logger(name, l)
       l
     }
+  }
+}
+
+/// Build a named logger using the supplied Beryl logging configuration.
+pub fn logger_with_config(name: String, config: LoggingConfig) -> Logger {
+  birch.new(name)
+  |> birch.with_level(to_birch_level(config.level))
+}
+
+fn to_birch_level(log_level: LogLevel) -> level.Level {
+  case log_level {
+    Trace -> level.Trace
+    Debug -> level.Debug
+    Info -> level.Info
+    Warn -> level.Warn
+    Err -> level.Err
+  }
+}
+
+/// Safely truncate a text value for log metadata.
+pub fn safe_preview(text: String, max_length: Int) -> String {
+  let safe_length = case max_length < 0 {
+    True -> 0
+    False -> max_length
+  }
+  string.slice(text, 0, safe_length)
+}
+
+/// Return bounded preview metadata only when payload logging is enabled.
+pub fn preview_metadata(
+  key: String,
+  text: String,
+  config: LoggingConfig,
+) -> List(#(String, String)) {
+  case config.include_payloads {
+    True -> [#(key, safe_preview(text, config.payload_preview_bytes))]
+    False -> []
   }
 }
 

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -138,6 +138,7 @@ fn start_supervised(
       message_limiter: message_limiter,
       join_limiter: join_limiter,
       channel_limiter: channel_limiter,
+      logging: beryl.to_coordinator_logging(config.channels.logging),
     )
 
   // Build the supervisor with rest-for-one strategy.

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -138,7 +138,7 @@ fn start_supervised(
       message_limiter: message_limiter,
       join_limiter: join_limiter,
       channel_limiter: channel_limiter,
-      logging: beryl.to_coordinator_logging(config.channels.logging),
+      logging: coordinator_logging(config.channels.logging),
     )
 
   // Build the supervisor with rest-for-one strategy.
@@ -245,6 +245,26 @@ fn start_supervised(
       ))
     }
   }
+}
+
+fn coordinator_log_level(level: beryl.LogLevel) -> coordinator.LogLevel {
+  case level {
+    beryl.Trace -> coordinator.Trace
+    beryl.Debug -> coordinator.Debug
+    beryl.Info -> coordinator.Info
+    beryl.Warn -> coordinator.Warn
+    beryl.Err -> coordinator.Err
+  }
+}
+
+fn coordinator_logging(
+  logging: beryl.LoggingConfig,
+) -> coordinator.LoggingConfig {
+  coordinator.LoggingConfig(
+    level: coordinator_log_level(logging.level),
+    include_payloads: logging.include_payloads,
+    payload_preview_bytes: logging.payload_preview_bytes,
+  )
 }
 
 /// Stop the supervisor and all its children

--- a/test/heartbeat_test.gleam
+++ b/test/heartbeat_test.gleam
@@ -22,6 +22,11 @@ fn start_coordinator_with_heartbeat(
       message_limiter: None,
       join_limiter: None,
       channel_limiter: None,
+      logging: coordinator.LoggingConfig(
+        level: coordinator.Info,
+        include_payloads: False,
+        payload_preview_bytes: 200,
+      ),
     )
   let assert Ok(coord) = coordinator.start_with_config(config)
   coord
@@ -234,6 +239,11 @@ pub fn zero_timeout_with_checking_enabled_returns_error_test() {
       message_limiter: None,
       join_limiter: None,
       channel_limiter: None,
+      logging: coordinator.LoggingConfig(
+        level: coordinator.Info,
+        include_payloads: False,
+        payload_preview_bytes: 200,
+      ),
     )
   coordinator.start_with_config(config)
   |> should.be_error
@@ -249,6 +259,11 @@ pub fn negative_timeout_with_checking_enabled_returns_error_test() {
       message_limiter: None,
       join_limiter: None,
       channel_limiter: None,
+      logging: coordinator.LoggingConfig(
+        level: coordinator.Info,
+        include_payloads: False,
+        payload_preview_bytes: 200,
+      ),
     )
   coordinator.start_with_config(config)
   |> should.be_error
@@ -264,6 +279,11 @@ pub fn zero_timeout_with_checking_disabled_is_ok_test() {
       message_limiter: None,
       join_limiter: None,
       channel_limiter: None,
+      logging: coordinator.LoggingConfig(
+        level: coordinator.Info,
+        include_payloads: False,
+        payload_preview_bytes: 200,
+      ),
     )
   coordinator.start_with_config(config)
   |> should.be_ok
@@ -278,6 +298,11 @@ pub fn positive_timeout_with_checking_enabled_is_ok_test() {
       message_limiter: None,
       join_limiter: None,
       channel_limiter: None,
+      logging: coordinator.LoggingConfig(
+        level: coordinator.Info,
+        include_payloads: False,
+        payload_preview_bytes: 200,
+      ),
     )
   coordinator.start_with_config(config)
   |> should.be_ok
@@ -292,6 +317,11 @@ pub fn start_named_validates_heartbeat_timeout_test() {
       message_limiter: None,
       join_limiter: None,
       channel_limiter: None,
+      logging: coordinator.LoggingConfig(
+        level: coordinator.Info,
+        include_payloads: False,
+        payload_preview_bytes: 200,
+      ),
     )
   coordinator.start_named(config, process.new_name("test-coordinator"))
   |> should.be_error

--- a/test/heartbeat_test.gleam
+++ b/test/heartbeat_test.gleam
@@ -16,17 +16,9 @@ fn start_coordinator_with_heartbeat(
 ) -> process.Subject(coordinator.Message) {
   let config =
     coordinator.CoordinatorConfig(
-      codec: wire.phoenix_codec(),
+      ..coordinator.config(wire.phoenix_codec()),
       heartbeat_check_interval_ms: check_interval_ms,
       heartbeat_timeout_ms: timeout_ms,
-      message_limiter: None,
-      join_limiter: None,
-      channel_limiter: None,
-      logging: coordinator.LoggingConfig(
-        level: coordinator.Info,
-        include_payloads: False,
-        payload_preview_bytes: 200,
-      ),
     )
   let assert Ok(coord) = coordinator.start_with_config(config)
   coord
@@ -233,17 +225,9 @@ pub fn heartbeat_reply_still_sent_test() {
 pub fn zero_timeout_with_checking_enabled_returns_error_test() {
   let config =
     coordinator.CoordinatorConfig(
-      codec: wire.phoenix_codec(),
+      ..coordinator.config(wire.phoenix_codec()),
       heartbeat_check_interval_ms: 50,
       heartbeat_timeout_ms: 0,
-      message_limiter: None,
-      join_limiter: None,
-      channel_limiter: None,
-      logging: coordinator.LoggingConfig(
-        level: coordinator.Info,
-        include_payloads: False,
-        payload_preview_bytes: 200,
-      ),
     )
   coordinator.start_with_config(config)
   |> should.be_error
@@ -253,17 +237,9 @@ pub fn zero_timeout_with_checking_enabled_returns_error_test() {
 pub fn negative_timeout_with_checking_enabled_returns_error_test() {
   let config =
     coordinator.CoordinatorConfig(
-      codec: wire.phoenix_codec(),
+      ..coordinator.config(wire.phoenix_codec()),
       heartbeat_check_interval_ms: 50,
       heartbeat_timeout_ms: -1,
-      message_limiter: None,
-      join_limiter: None,
-      channel_limiter: None,
-      logging: coordinator.LoggingConfig(
-        level: coordinator.Info,
-        include_payloads: False,
-        payload_preview_bytes: 200,
-      ),
     )
   coordinator.start_with_config(config)
   |> should.be_error
@@ -273,17 +249,9 @@ pub fn negative_timeout_with_checking_enabled_returns_error_test() {
 pub fn zero_timeout_with_checking_disabled_is_ok_test() {
   let config =
     coordinator.CoordinatorConfig(
-      codec: wire.phoenix_codec(),
+      ..coordinator.config(wire.phoenix_codec()),
       heartbeat_check_interval_ms: 0,
       heartbeat_timeout_ms: 0,
-      message_limiter: None,
-      join_limiter: None,
-      channel_limiter: None,
-      logging: coordinator.LoggingConfig(
-        level: coordinator.Info,
-        include_payloads: False,
-        payload_preview_bytes: 200,
-      ),
     )
   coordinator.start_with_config(config)
   |> should.be_ok
@@ -292,17 +260,9 @@ pub fn zero_timeout_with_checking_disabled_is_ok_test() {
 pub fn positive_timeout_with_checking_enabled_is_ok_test() {
   let config =
     coordinator.CoordinatorConfig(
-      codec: wire.phoenix_codec(),
+      ..coordinator.config(wire.phoenix_codec()),
       heartbeat_check_interval_ms: 50,
       heartbeat_timeout_ms: 5000,
-      message_limiter: None,
-      join_limiter: None,
-      channel_limiter: None,
-      logging: coordinator.LoggingConfig(
-        level: coordinator.Info,
-        include_payloads: False,
-        payload_preview_bytes: 200,
-      ),
     )
   coordinator.start_with_config(config)
   |> should.be_ok
@@ -311,17 +271,9 @@ pub fn positive_timeout_with_checking_enabled_is_ok_test() {
 pub fn start_named_validates_heartbeat_timeout_test() {
   let config =
     coordinator.CoordinatorConfig(
-      codec: wire.phoenix_codec(),
+      ..coordinator.config(wire.phoenix_codec()),
       heartbeat_check_interval_ms: 50,
       heartbeat_timeout_ms: 0,
-      message_limiter: None,
-      join_limiter: None,
-      channel_limiter: None,
-      logging: coordinator.LoggingConfig(
-        level: coordinator.Info,
-        include_payloads: False,
-        payload_preview_bytes: 200,
-      ),
     )
   coordinator.start_named(config, process.new_name("test-coordinator"))
   |> should.be_error

--- a/test/logging_test.gleam
+++ b/test/logging_test.gleam
@@ -1,0 +1,279 @@
+import beryl
+import beryl/channel
+import beryl/coordinator
+import beryl/internal
+import beryl/wire
+import birch
+import birch/handler
+import birch/level
+import birch/record.{type LogRecord}
+import gleam/erlang/process
+import gleam/json
+import gleam/option.{None}
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+pub fn default_logging_preserves_info_without_payloads_test() {
+  let config = beryl.config(wire.phoenix_codec())
+
+  config.logging.level
+  |> should.equal(beryl.Info)
+  config.logging.include_payloads
+  |> should.be_false
+  config.logging.payload_preview_bytes
+  |> should.equal(200)
+}
+
+pub fn with_logging_replaces_logging_config_test() {
+  let logging =
+    beryl.logging_config(level: beryl.Debug, include_payloads: True)
+    |> beryl.with_payload_preview_bytes(bytes: 64)
+
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_logging(logging)
+
+  config.logging.level
+  |> should.equal(beryl.Debug)
+  config.logging.include_payloads
+  |> should.be_true
+  config.logging.payload_preview_bytes
+  |> should.equal(64)
+}
+
+pub fn channels_start_accepts_debug_logging_config_test() {
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_logging(beryl.logging_config(
+      level: beryl.Debug,
+      include_payloads: False,
+    ))
+
+  let assert Ok(channels) = beryl.start(config)
+
+  channels.config.logging.level
+  |> should.equal(beryl.Debug)
+  channels.config.logging.include_payloads
+  |> should.be_false
+}
+
+pub fn coordinator_config_has_safe_logging_defaults_test() {
+  let config = coordinator.config(wire.phoenix_codec())
+
+  config.logging.level
+  |> should.equal(coordinator.Info)
+  config.logging.include_payloads
+  |> should.be_false
+  config.logging.payload_preview_bytes
+  |> should.equal(200)
+}
+
+pub fn payload_preview_bytes_never_negative_test() {
+  let logging =
+    beryl.logging_config(level: beryl.Debug, include_payloads: True)
+    |> beryl.with_payload_preview_bytes(bytes: -1)
+
+  logging.payload_preview_bytes
+  |> should.equal(0)
+}
+
+pub fn preview_metadata_omits_payloads_by_default_test() {
+  let logging =
+    internal.LoggingConfig(
+      level: internal.Debug,
+      include_payloads: False,
+      payload_preview_bytes: 200,
+    )
+
+  internal.preview_metadata(
+    "payload_preview",
+    "{\"secret\":\"token\"}",
+    logging,
+  )
+  |> should.equal([])
+}
+
+pub fn preview_metadata_bounds_payloads_when_enabled_test() {
+  let logging =
+    internal.LoggingConfig(
+      level: internal.Debug,
+      include_payloads: True,
+      payload_preview_bytes: 3,
+    )
+
+  internal.preview_metadata("payload_preview", "abcdef", logging)
+  |> should.equal([#("payload_preview", "abc")])
+}
+
+pub fn debug_decode_log_omits_frame_preview_by_default_test() {
+  let logs = process.new_subject()
+  birch.configure([
+    birch.config_level(level.Debug),
+    birch.config_handlers([
+      handler.new_with_record_write(name: "test-capture", write: fn(log_record) {
+        process.send(logs, log_record)
+      }),
+    ]),
+  ])
+
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_logging(beryl.logging_config(
+      level: beryl.Debug,
+      include_payloads: False,
+    ))
+  let assert Ok(channels) = beryl.start(config)
+
+  process.send(
+    channels.coordinator,
+    coordinator.SocketConnected("logging-socket", fn(_) { Ok(Nil) }, fn(_) {
+      Ok(Nil)
+    }),
+  )
+  coordinator.route_message(
+    channels.coordinator,
+    "logging-socket",
+    "[null,\"ref\",\"room:lobby\",\"phx_join\",{\"secret\":\"token\"}]",
+  )
+
+  let assert Ok(log_record) =
+    receive_log(logs, "Inbound text frame decoded", 10)
+  log_record.logger_name
+  |> should.equal("beryl.coordinator")
+  record.get_metadata(log_record, "socket_id")
+  |> should.equal(Ok("logging-socket"))
+  record.get_metadata(log_record, "topic")
+  |> should.equal(Ok("room:lobby"))
+  record.get_metadata(log_record, "frame_preview")
+  |> should.equal(Error(Nil))
+}
+
+pub fn debug_join_missing_handler_logs_routing_and_send_test() {
+  let logs = process.new_subject()
+  birch.configure([
+    birch.config_level(level.Debug),
+    birch.config_handlers([
+      handler.new_with_record_write(name: "test-capture", write: fn(log_record) {
+        process.send(logs, log_record)
+      }),
+    ]),
+  ])
+
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_logging(beryl.logging_config(
+      level: beryl.Debug,
+      include_payloads: False,
+    ))
+  let assert Ok(channels) = beryl.start(config)
+
+  process.send(
+    channels.coordinator,
+    coordinator.SocketConnected(
+      "missing-handler-socket",
+      fn(_) { Ok(Nil) },
+      fn(_) { Ok(Nil) },
+    ),
+  )
+  coordinator.route_message(
+    channels.coordinator,
+    "missing-handler-socket",
+    "[null,\"ref\",\"room:missing\",\"phx_join\",{}]",
+  )
+
+  let assert Ok(missing_log) = receive_log(logs, "Join handler missing", 10)
+  record.get_metadata(missing_log, "socket_id")
+  |> should.equal(Ok("missing-handler-socket"))
+  record.get_metadata(missing_log, "topic")
+  |> should.equal(Ok("room:missing"))
+
+  let assert Ok(send_log) = receive_log(logs, "Outbound frame sent", 10)
+  record.get_metadata(send_log, "socket_id")
+  |> should.equal(Ok("missing-handler-socket"))
+  record.get_metadata(send_log, "topic")
+  |> should.equal(Ok("room:missing"))
+  record.get_metadata(send_log, "frame_kind")
+  |> should.equal(Ok("text"))
+}
+
+pub fn debug_channel_callback_logs_push_result_test() {
+  let logs = process.new_subject()
+  birch.configure([
+    birch.config_level(level.Debug),
+    birch.config_handlers([
+      handler.new_with_record_write(name: "test-capture", write: fn(log_record) {
+        process.send(logs, log_record)
+      }),
+    ]),
+  ])
+
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_logging(beryl.logging_config(
+      level: beryl.Debug,
+      include_payloads: False,
+    ))
+  let assert Ok(channels) = beryl.start(config)
+  let handler =
+    channel.new(fn(_, _, socket) { channel.JoinOk(reply: None, socket: socket) })
+    |> channel.with_handle_in(fn(_, _, socket) {
+      channel.Push(
+        event: "server_event",
+        payload: json.object([]),
+        socket: socket,
+      )
+    })
+  beryl.register(channels, "room:*", handler)
+  |> should.equal(Ok(Nil))
+
+  process.send(
+    channels.coordinator,
+    coordinator.SocketConnected("callback-log-socket", fn(_) { Ok(Nil) }, fn(_) {
+      Ok(Nil)
+    }),
+  )
+  coordinator.route_message(
+    channels.coordinator,
+    "callback-log-socket",
+    "[null,\"join-ref\",\"room:lobby\",\"phx_join\",{}]",
+  )
+  coordinator.route_message(
+    channels.coordinator,
+    "callback-log-socket",
+    "[\"join-ref\",\"msg-ref\",\"room:lobby\",\"client_event\",{}]",
+  )
+
+  let assert Ok(push_log) =
+    receive_log(logs, "Channel callback returned push", 20)
+  record.get_metadata(push_log, "socket_id")
+  |> should.equal(Ok("callback-log-socket"))
+  record.get_metadata(push_log, "topic")
+  |> should.equal(Ok("room:lobby"))
+  record.get_metadata(push_log, "event")
+  |> should.equal(Ok("client_event"))
+}
+
+fn receive_log(
+  logs: process.Subject(LogRecord),
+  message: String,
+  attempts: Int,
+) -> Result(LogRecord, Nil) {
+  case attempts <= 0 {
+    True -> Error(Nil)
+    False -> {
+      case process.receive(logs, 500) {
+        Ok(log_record) -> {
+          case log_record.message == message {
+            True -> Ok(log_record)
+            False -> receive_log(logs, message, attempts - 1)
+          }
+        }
+        Error(_) -> Error(Nil)
+      }
+    }
+  }
+}

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -66,6 +66,29 @@ This page lists common symptoms with targeted diagnosis steps. Start from your s
 
 ---
 
+## Enable Beryl debug diagnostics
+
+Beryl uses Birch loggers under the `beryl.*` namespaces. Normal configurations keep production output quiet, but you can opt into detailed coordinator lifecycle diagnostics while debugging channel integration issues:
+
+```gleam
+let config =
+  beryl.config(wire.phoenix_codec())
+  |> beryl.with_logging(beryl.logging_config(
+    level: beryl.Debug,
+    include_payloads: False,
+  ))
+```
+
+Debug logs cover frame decode, join routing, callback results, reply/push send outcomes, disconnects, heartbeat decisions, broadcasts, and rate limiting. Payload and frame previews are omitted by default to reduce accidental sensitive-data exposure. If you need bounded previews locally, enable them explicitly:
+
+```gleam
+let logging =
+  beryl.logging_config(level: beryl.Debug, include_payloads: True)
+  |> beryl.with_payload_preview_bytes(bytes: 100)
+```
+
+---
+
 ## Broadcasts are not received by clients
 
 **Symptoms:** `beryl.broadcast` is called server-side but connected clients do not receive the event.


### PR DESCRIPTION
## Summary

- add public Beryl logging config via `beryl.with_logging`
- add opt-in coordinator debug diagnostics for decode, routing, callback, send, heartbeat, disconnect, terminate, broadcast, and rate-limit boundaries
- keep payload and frame previews disabled by default, with bounded previews when explicitly enabled
- document the troubleshooting workflow and add a changie fragment

## Validation

- `just ci`

Closes #62
