### PR TITLE
feat(wire): add roost codec switch

### DIFF
--- a/.changes/unreleased/Added-20260520-203836.yaml
+++ b/.changes/unreleased/Added-20260520-203836.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: |-
+    Opt-in Roost-backed Phoenix wire codec.
+
+    Set `BERYL_PHOENIX_CODEC=roost` before constructing `wire.phoenix_codec()` to use Roost for Phoenix frame encoding and decoding while keeping Beryl's native codec as the default.
+time: 2026-05-20T20:38:36.000000000-07:00

--- a/gleam.toml
+++ b/gleam.toml
@@ -3,7 +3,7 @@ version = "0.1.0"
 description = "Type-safe real-time channels and presence for Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "tylerbutler", repo = "beryl" }
-gleam = ">= 1.3.0"
+gleam = ">= 1.13.0"
 target = "erlang"
 
 [dependencies]
@@ -14,6 +14,8 @@ gleam_json = ">= 3.0.0 and < 4.0.0"
 gleam_crypto = ">= 1.5.1 and < 2.0.0"
 gleam_http = ">= 4.3.0 and < 5.0.0"
 mist = ">= 6.0.0 and < 7.0.0"
+roost = { git = "https://github.com/tylerbutler/roost.git", ref = "7dd796e83d8b0fcb8732cfac35707f3fbc8eeaed" }
+envoy = ">= 1.0.0 and < 2.0.0"
 
 birch = ">= 0.2.1 and < 1.0.0"
 lattice_presence = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,6 +3,7 @@
 
 packages = [
   { name = "birch", version = "0.2.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "simplifile"], otp_app = "birch", source = "hex", outer_checksum = "20CCDACA9E2A17E1D7F2C35322E619E7DDF98774FDC598D01AD5F414928E6261" },
+  { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_crypto", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "2DE9E4EF53CF6FEE049D4F765731F7178F7A11AEFAE00EEE63BF7536B354AD3F" },
@@ -24,11 +25,13 @@ packages = [
   { name = "phoenix_channel_fixtures", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], source = "git", repo = "https://github.com/tylerbutler/phoenix_channel_fixtures.git", commit = "7daccb856d17db6278980277237c201b2acdcdf1" },
   { name = "prng", version = "5.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "prng", source = "hex", outer_checksum = "29DA88BCFB54D06DD1472951DF101E9524878056D139DA2616B04350B403CE10" },
   { name = "qcheck", version = "1.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_regexp", "gleam_stdlib", "gleam_yielder", "prng"], otp_app = "qcheck", source = "hex", outer_checksum = "BD9B18C1602FBC667E3E139ED270458F8C743ED791F892CC90989CE10478C4FA" },
+  { name = "roost", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], source = "git", repo = "https://github.com/tylerbutler/roost.git", commit = "7dd796e83d8b0fcb8732cfac35707f3fbc8eeaed" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
 ]
 
 [requirements]
 birch = { version = ">= 0.2.1 and < 1.0.0" }
+envoy = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_crypto = { version = ">= 1.5.1 and < 2.0.0" }
 gleam_erlang = { version = ">= 0.29.0 and < 2.0.0" }
 gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
@@ -40,3 +43,4 @@ lattice_presence = { version = ">= 1.0.0 and < 2.0.0" }
 mist = { version = ">= 6.0.0 and < 7.0.0" }
 phoenix_channel_fixtures = { git = "https://github.com/tylerbutler/phoenix_channel_fixtures.git", ref = "7daccb856d17db6278980277237c201b2acdcdf1" }
 qcheck = { version = ">= 1.0.0 and < 2.0.0" }
+roost = { git = "https://github.com/tylerbutler/roost.git", ref = "7dd796e83d8b0fcb8732cfac35707f3fbc8eeaed" }

--- a/src/beryl/wire.gleam
+++ b/src/beryl/wire.gleam
@@ -16,23 +16,150 @@ import beryl/wire/codec.{
   type ReplyStatus, Codec, Event, Heartbeat, Inbound, InvalidFormat, InvalidJson,
   Join, Leave, StatusError, StatusOk, TextFrame,
 }
+import envoy
 import gleam/dict
 import gleam/dynamic.{type Dynamic}
 import gleam/dynamic/decode
 import gleam/json
 import gleam/list
 import gleam/option.{type Option, None, Some}
+import roost/frame as roost_frame
 
 const expected_array_message = "Expected array of 5 elements [join_ref, ref, topic, event, payload]"
 
+const phoenix_codec_env = "BERYL_PHOENIX_CODEC"
+
+type PhoenixCodecImplementation {
+  NativePhoenixCodec
+  RoostPhoenixCodec
+}
+
+fn phoenix_codec_implementation() -> PhoenixCodecImplementation {
+  case envoy.get(phoenix_codec_env) {
+    Ok("roost") -> RoostPhoenixCodec
+    _ -> NativePhoenixCodec
+  }
+}
+
 /// The canonical Phoenix wire codec. Pass to `beryl.config/1`.
+///
+/// By default this uses Beryl's native Phoenix implementation. Set
+/// `BERYL_PHOENIX_CODEC=roost` before constructing the codec to opt into the
+/// Roost-backed implementation.
 pub fn phoenix_codec() -> Codec {
+  case phoenix_codec_implementation() {
+    NativePhoenixCodec -> native_phoenix_codec()
+    RoostPhoenixCodec -> roost_phoenix_codec()
+  }
+}
+
+fn native_phoenix_codec() -> Codec {
   Codec(
     decode_text: decode_message,
     decode_binary: None,
     encode_reply: reply_json,
     encode_push: push,
     encode_heartbeat_reply: heartbeat_reply,
+  )
+}
+
+fn roost_phoenix_codec() -> Codec {
+  Codec(
+    decode_text: decode_message_with_roost,
+    decode_binary: None,
+    encode_reply: reply_json_with_roost,
+    encode_push: push_with_roost,
+    encode_heartbeat_reply: heartbeat_reply_with_roost,
+  )
+}
+
+fn decode_message_with_roost(
+  json_string: String,
+) -> Result(Inbound, DecodeError) {
+  case roost_frame.decode(json_string) {
+    Ok(frame) ->
+      Ok(Inbound(
+        join_ref: frame.join_ref,
+        ref: frame.ref,
+        topic: frame.topic,
+        kind: classify_phoenix_event_with_roost(frame.event),
+        payload: frame.payload,
+      ))
+    Error(roost_frame.InvalidJson(reason)) -> Error(InvalidJson(reason))
+    Error(roost_frame.InvalidFormat(reason)) -> Error(InvalidFormat(reason))
+  }
+}
+
+fn classify_phoenix_event_with_roost(event: String) -> InboundKind {
+  case event {
+    event if event == roost_frame.join_event -> Join
+    event if event == roost_frame.leave_event -> Leave
+    event if event == roost_frame.heartbeat_event -> Heartbeat
+    other -> Event(other)
+  }
+}
+
+fn reply_status_to_roost(status: ReplyStatus) -> roost_frame.ReplyStatus {
+  case status {
+    StatusOk -> roost_frame.StatusOk
+    StatusError -> roost_frame.StatusError
+  }
+}
+
+fn reply_status_string(status: ReplyStatus) -> String {
+  case status {
+    StatusOk -> "ok"
+    StatusError -> "error"
+  }
+}
+
+fn push_with_roost(topic: String, event: String, payload: json.Json) -> Frame {
+  TextFrame(roost_frame.encode(
+    join_ref: None,
+    ref: None,
+    topic: topic,
+    event: event,
+    payload: payload,
+  ))
+}
+
+fn reply_json_with_roost(
+  join_ref: Option(String),
+  ref: Option(String),
+  topic: String,
+  status: ReplyStatus,
+  response: json.Json,
+) -> Frame {
+  case ref {
+    Some(ref) ->
+      TextFrame(roost_frame.encode_reply(
+        join_ref: join_ref,
+        ref: ref,
+        topic: topic,
+        status: reply_status_to_roost(status),
+        response: response,
+      ))
+    None ->
+      TextFrame(roost_frame.encode(
+        join_ref: join_ref,
+        ref: None,
+        topic: topic,
+        event: roost_frame.reply_event,
+        payload: json.object([
+          #("status", json.string(reply_status_string(status))),
+          #("response", response),
+        ]),
+      ))
+  }
+}
+
+fn heartbeat_reply_with_roost(ref: Option(String)) -> Frame {
+  reply_json_with_roost(
+    None,
+    ref,
+    roost_frame.heartbeat_topic,
+    StatusOk,
+    json.object([]),
   )
 }
 

--- a/test/wire_codec_test.gleam
+++ b/test/wire_codec_test.gleam
@@ -2,13 +2,16 @@
 
 import beryl/wire
 import beryl/wire/codec
+import envoy
 import gleam/dynamic
 import gleam/dynamic/decode
 import gleam/json
 import gleam/list
-import gleam/option.{None, Some}
+import gleam/option.{type Option, None, Some}
 import gleeunit/should
 import phoenix_channel_fixtures/frame as fixtures
+
+const phoenix_codec_env = "BERYL_PHOENIX_CODEC"
 
 // === Phoenix codec ===
 
@@ -52,6 +55,63 @@ pub fn phoenix_codec_reply_accepts_missing_ref_test() {
   |> should.equal(
     "[null,null,\"room:1\",\"phx_reply\",{\"status\":\"ok\",\"response\":{}}]",
   )
+}
+
+pub fn phoenix_codec_defaults_to_native_implementation_test() {
+  with_env_value(phoenix_codec_env, None, fn() {
+    let phoenix = wire.phoenix_codec()
+
+    let assert Error(codec.InvalidFormat(reason)) =
+      phoenix.decode_text("[null,\"1\",123,\"event\",{}]")
+
+    reason
+    |> should.equal(
+      "Expected array of 5 elements [join_ref, ref, topic, event, payload]",
+    )
+  })
+}
+
+pub fn phoenix_codec_uses_roost_when_env_is_roost_test() {
+  with_env_value(phoenix_codec_env, Some("roost"), fn() {
+    let phoenix = wire.phoenix_codec()
+
+    let assert Error(codec.InvalidFormat(reason)) =
+      phoenix.decode_text("[null,\"1\",123,\"event\",{}]")
+
+    reason |> should.equal("Expected topic to be a string")
+  })
+}
+
+pub fn phoenix_codec_uses_native_when_env_is_unknown_test() {
+  with_env_value(phoenix_codec_env, Some("native"), fn() {
+    let phoenix = wire.phoenix_codec()
+
+    let assert Error(codec.InvalidFormat(reason)) =
+      phoenix.decode_text("[null,\"1\",123,\"event\",{}]")
+
+    reason
+    |> should.equal(
+      "Expected array of 5 elements [join_ref, ref, topic, event, payload]",
+    )
+  })
+}
+
+pub fn roost_phoenix_codec_preserves_missing_ref_reply_shape_test() {
+  with_env_value(phoenix_codec_env, Some("roost"), fn() {
+    let phoenix = wire.phoenix_codec()
+
+    phoenix.encode_reply(
+      Some("join-ref"),
+      None,
+      "room:1",
+      codec.StatusOk,
+      json.object([]),
+    )
+    |> text_frame()
+    |> should.equal(
+      "[\"join-ref\",null,\"room:1\",\"phx_reply\",{\"status\":\"ok\",\"response\":{}}]",
+    )
+  })
 }
 
 // === Inbound shape ===
@@ -175,6 +235,23 @@ pub fn phoenix_codec_rejects_shared_invalid_fixtures_test() {
 fn text_frame(frame: codec.Frame) -> String {
   let assert codec.TextFrame(text) = frame
   text
+}
+
+fn with_env_value(name: String, value: Option(String), run: fn() -> a) -> a {
+  let previous = envoy.get(name)
+  case value {
+    Some(value) -> envoy.set(name, value)
+    None -> envoy.unset(name)
+  }
+
+  let result = run()
+
+  case previous {
+    Ok(value) -> envoy.set(name, value)
+    Error(Nil) -> envoy.unset(name)
+  }
+
+  result
 }
 
 fn phoenix_kind(event: String) -> codec.InboundKind {

--- a/website/src/content/docs/guides/websocket.md
+++ b/website/src/content/docs/guides/websocket.md
@@ -98,6 +98,8 @@ Pass `wire.phoenix_codec()` to `beryl.config` to use the Phoenix JSON array form
 
 Applications can pass a custom codec to `beryl.config(codec)` to use another text framing or a binary framing. Codec-produced outbound frames are sent as text or binary WebSocket frames according to the codec result.
 
+By default, `wire.phoenix_codec()` uses Beryl's native Phoenix wire implementation. For compatibility testing, set `BERYL_PHOENIX_CODEC=roost` before constructing the codec to opt into the Roost-backed implementation. The public `beryl/wire/codec.Codec` API and wire format remain unchanged.
+
 | Field | Type | Description |
 |-------|------|-------------|
 | `join_ref` | `string \| null` | Reference from the join (for reply routing) |


### PR DESCRIPTION
## Summary

- add Roost and Envoy dependencies for an opt-in Phoenix codec experiment
- keep Beryl's native Phoenix codec as the default
- select the Roost-backed codec with `BERYL_PHOENIX_CODEC=roost`
- document the switch and add a changie fragment

Closes #59.

## Validation

- `gleam deps download`
- `just check`
- `gleam test -- --filter "phoenix_codec"`
- `gleam test -- --filter "json_contract"`
- `unset BERYL_PHOENIX_CODEC && just format-check && just check && just test && BERYL_PHOENIX_CODEC=roost gleam test -- --filter "phoenix_codec" && BERYL_PHOENIX_CODEC=roost gleam test -- --filter "json_contract" && just build-strict`
- `just format-check && just check && just test`
