### PR TITLE
chore(claude): replace claude-flow hooks with gleam format hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,187 +1,19 @@
 {
   "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "^(Write|Edit|MultiEdit)$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx @claude-flow/cli hooks pre-edit --file \"$TOOL_INPUT_file_path\"",
-            "timeout": 5000,
-            "continueOnError": true
-          }
-        ]
-      },
-      {
-        "matcher": "^Bash$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx @claude-flow/cli hooks pre-command --command \"$TOOL_INPUT_command\"",
-            "timeout": 5000,
-            "continueOnError": true
-          }
-        ]
-      },
-      {
-        "matcher": "^Task$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx @claude-flow/cli hooks pre-task --description \"$TOOL_INPUT_prompt\"",
-            "timeout": 5000,
-            "continueOnError": true
-          }
-        ]
-      },
-      {
-        "matcher": "^(Grep|Glob|Read)$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx @claude-flow/cli hooks pre-search --pattern \"$TOOL_INPUT_pattern\"",
-            "timeout": 2000,
-            "continueOnError": true
-          }
-        ]
-      }
-    ],
     "PostToolUse": [
       {
-        "matcher": "^(Write|Edit|MultiEdit)$",
+        "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",
-            "command": "npx @claude-flow/cli hooks post-edit --file \"$TOOL_INPUT_file_path\" --success \"$TOOL_SUCCESS\" --train-patterns",
-            "timeout": 5000,
-            "continueOnError": true
-          }
-        ]
-      },
-      {
-        "matcher": "^Bash$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx @claude-flow/cli hooks post-command --command \"$TOOL_INPUT_command\" --success \"$TOOL_SUCCESS\" --exit-code \"$TOOL_EXIT_CODE\"",
-            "timeout": 5000,
-            "continueOnError": true
-          }
-        ]
-      },
-      {
-        "matcher": "^Task$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx @claude-flow/cli hooks post-task --agent-id \"$TOOL_RESULT_agent_id\" --success \"$TOOL_SUCCESS\" --analyze",
-            "timeout": 5000,
-            "continueOnError": true
-          }
-        ]
-      },
-      {
-        "matcher": "^(Grep|Glob)$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx @claude-flow/cli hooks post-search --cache-results",
-            "timeout": 2000,
-            "continueOnError": true
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx @claude-flow/cli hooks route --task \"$PROMPT\" --include-explanation",
-            "timeout": 5000,
-            "continueOnError": true
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx @claude-flow/cli hooks session-start --session-id \"$SESSION_ID\" --load-context",
-            "timeout": 10000,
-            "continueOnError": true
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "Evaluate task completion. Consider:\n1. Were all requested changes made?\n2. Did builds/tests pass?\n3. Is follow-up work needed?\n\nRespond with {\"decision\": \"stop\"} if complete, or {\"decision\": \"continue\", \"reason\": \"...\"} if more work is needed."
-          }
-        ]
-      }
-    ],
-    "Notification": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx @claude-flow/cli hooks notify --message \"$NOTIFICATION_MESSAGE\" --swarm-status",
-            "timeout": 3000,
-            "continueOnError": true
-          }
-        ]
-      }
-    ],
-    "PermissionRequest": [
-      {
-        "matcher": "^mcp__claude-flow__.*$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo '{\"decision\": \"allow\", \"reason\": \"claude-flow MCP tool auto-approved\"}'",
-            "timeout": 1000
-          }
-        ]
-      },
-      {
-        "matcher": "^Bash\\(npx @?claude-flow.*\\)$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo '{\"decision\": \"allow\", \"reason\": \"claude-flow CLI auto-approved\"}'",
-            "timeout": 1000
+            "command": "file=$(jq -r '.tool_input.file_path // empty'); [[ -n \"$file\" && \"$file\" == *.gleam && -f \"$file\" ]] && gleam format \"$file\" || true"
           }
         ]
       }
     ]
   },
   "permissions": {
-    "allow": [
-      "Bash(npx claude-flow*)",
-      "Bash(npx @claude-flow/*)",
-      "mcp__claude-flow__*"
-    ],
+    "allow": [],
     "deny": []
-  },
-  "claudeFlow": {
-    "version": "3.0.0",
-    "enabled": true,
-    "swarm": {
-      "topology": "hierarchical-mesh",
-      "maxAgents": 15
-    },
-    "memory": {
-      "backend": "hybrid",
-      "enableHNSW": true
-    },
-    "neural": {
-      "enabled": true
-    }
   }
 }


### PR DESCRIPTION
## Summary
- Remove the claude-flow hook stack, `claudeFlow` config block, and associated permission allowlist from `.claude/settings.json`. Those hooks fired `npx` subprocesses on every Write/Edit/Bash/Task/Grep/Glob/Read call plus a model-prompted Stop hook on every turn, adding latency without contributing to a Gleam project.
- Add a single PostToolUse hook that runs `gleam format` on edited `.gleam` files. Reads the tool-input JSON via `jq`, guards on path/file existence, and trails with `|| true` so a format failure never blocks tool execution.