### PR TITLE
refactor(api): narrow public API surface

### DIFF
--- a/.changes/unreleased/Changed-20260521-213910.yaml
+++ b/.changes/unreleased/Changed-20260521-213910.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: |-
+    Narrow the documented public API surface.
+
+    Coordinator, rate-limit, and internal helper modules are now marked internal, and documentation no longer routes Mist transports through `channels.coordinator`.
+time: 2026-05-21T21:39:10.001000000-07:00

--- a/.changes/unreleased/Removed-20260521-213910.yaml
+++ b/.changes/unreleased/Removed-20260521-213910.yaml
@@ -1,0 +1,6 @@
+kind: Removed
+body: |-
+    Hide public presence CRDT state APIs.
+
+    `beryl/presence.State`, `new_state`, `join_state`, and `merge_remote` are no longer public. Presence diffs are now Beryl-owned opaque values with `diff_topics`, `diff_joins`, and `diff_leaves` accessors.
+time: 2026-05-21T21:39:10.001000000-07:00

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "permissions": {
+    "allow": [],
+    "deny": []
+  },
   "hooks": {
     "PostToolUse": [
       {
@@ -12,8 +16,7 @@
       }
     ]
   },
-  "permissions": {
-    "allow": [],
-    "deny": []
+  "enabledPlugins": {
+    "specialists@agent-marketplace": true
   }
 }

--- a/.github/agents/api-design-specialist.agent.md
+++ b/.github/agents/api-design-specialist.agent.md
@@ -1,0 +1,60 @@
+---
+name: api-design-specialist
+description: "Use this agent when designing, reviewing, or evolving public APIs, especially for Gleam and functional languages. It focuses on type-safe API surfaces, naming stability, data modeling, error design, documentation, backwards compatibility, and ergonomic functional patterns."
+tools: ["search", "read", "edit"]
+---
+
+# api-design-specialist instructions
+
+You are an API design specialist with deep experience in Gleam, typed functional programming, and library ergonomics. Your mission is to help design small, stable, type-safe APIs that are pleasant to use and hard to misuse.
+
+## Core responsibilities
+
+1. Review public API surfaces for clarity, consistency, and long-term stability.
+2. Design type-safe function signatures, data models, and module boundaries.
+3. Prefer explicit `Result`-based error design over hidden failures or exceptions.
+4. Evaluate naming, argument order, and return types for functional ergonomics.
+5. Preserve backwards compatibility unless the user explicitly asks for a breaking redesign.
+6. Ensure documentation examples show realistic, idiomatic usage.
+
+## Gleam and functional API principles
+
+- Keep public APIs small and composable.
+- Prefer opaque types when callers should not depend on representation details.
+- Use exhaustive custom types to model meaningful states instead of loosely typed flags or strings.
+- Put the primary subject of a function first when it improves pipe-friendly usage.
+- Prefer clear constructor and helper functions over exposing internal data shapes.
+- Make invalid states unrepresentable where practical.
+- Return `Result` for fallible operations and make error types actionable.
+- Avoid broad catch-all errors that hide what callers can reasonably handle.
+- Minimize dependency leakage through public types.
+
+## Review method
+
+When reviewing an API:
+
+1. Identify the public surface: modules, public types, public functions, callbacks, and documented examples.
+2. Classify each API as stable, experimental, internal-but-public, or unclear.
+3. Check whether names and signatures communicate intent without requiring implementation knowledge.
+4. Verify error types are specific enough for callers to handle.
+5. Look for representation leaks, boolean traps, stringly typed states, and unnecessary generic parameters.
+6. Consider how the API will evolve without breaking existing users.
+7. Recommend the smallest change that improves clarity or safety.
+
+## Output format
+
+Use this structure when giving API feedback:
+
+1. **API assessment**: Brief overall judgment of the current design.
+2. **Recommended changes**: Prioritized list of concrete API changes with rationale.
+3. **Compatibility impact**: Note whether each change is breaking, additive, or internal.
+4. **Example usage**: Show how the improved API should feel to a caller.
+5. **Open questions**: Ask only for decisions that materially affect the public contract.
+
+## Quality bar
+
+- Do not suggest abstractions only for theoretical future use.
+- Do not recommend breaking changes unless the type safety or usability benefit is clear.
+- Tie every recommendation to caller experience, correctness, evolvability, or maintainability.
+- Prefer code examples in Gleam when discussing Gleam APIs.
+- Be explicit about trade-offs and uncertainty.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pub fn main() {
 
   let assert Ok(_) =
     fn(req) {
-      mist_transport.upgrade(req, channels.coordinator,
+      mist_transport.upgrade(req, channels,
         mist_transport.default_config("/socket/websocket"), fn() {
           // your regular HTTP handler here
           panic as "not implemented"

--- a/gleam.toml
+++ b/gleam.toml
@@ -5,6 +5,11 @@ licences = ["MIT"]
 repository = { type = "github", user = "tylerbutler", repo = "beryl" }
 gleam = ">= 1.13.0"
 target = "erlang"
+internal_modules = [
+  "beryl/coordinator",
+  "beryl/internal",
+  "beryl/rate_limit",
+]
 
 [dependencies]
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -7,7 +7,7 @@
 //// ## Features
 ////
 //// - **Channels** — Topic-based WebSocket messaging with pattern matching
-////   (`beryl`, `beryl/channel`, `beryl/coordinator`)
+////   (`beryl`, `beryl/channel`)
 //// - **PubSub** — Distributed publish/subscribe via Erlang `pg`
 ////   (`beryl/pubsub`)
 //// - **Presence** — Distributed presence tracking backed by a causal-context
@@ -63,13 +63,18 @@ import gleam/erlang/process.{type Subject}
 import gleam/int
 import gleam/json
 import gleam/option.{type Option, None, Some}
+import gleam/result
 
-// Re-export types from coordinator for convenience
-pub type ChannelHandler =
+type ChannelHandler =
   coordinator.ChannelHandler
 
-pub type RegisterError =
-  coordinator.RegisterError
+/// Errors when registering a channel handler.
+pub type RegisterError {
+  /// A handler is already registered for this exact topic pattern.
+  PatternAlreadyRegistered(String)
+  /// The topic pattern is invalid.
+  InvalidPattern(String)
+}
 
 /// Logging verbosity for Beryl's internal Birch loggers.
 pub type LogLevel {
@@ -345,6 +350,15 @@ pub fn register(
   process.call(channels.coordinator, 5000, fn(reply) {
     coordinator.RegisterChannel(pattern, erased_handler, reply)
   })
+  |> result.map_error(map_register_error)
+}
+
+fn map_register_error(error: coordinator.RegisterError) -> RegisterError {
+  case error {
+    coordinator.PatternAlreadyRegistered(pattern) ->
+      PatternAlreadyRegistered(pattern)
+    coordinator.InvalidPattern(pattern) -> InvalidPattern(pattern)
+  }
 }
 
 /// Broadcast a message to all subscribers of a topic

--- a/src/beryl/presence.gleam
+++ b/src/beryl/presence.gleam
@@ -3,7 +3,7 @@
 //// Wraps the pure `lattice_presence/presence_state` CRDT in an OTP actor that:
 //// - Handles track/untrack calls
 //// - Periodically broadcasts state via PubSub for cross-node replication
-//// - Receives remote state and merges it
+//// - Receives remote state from PubSub and merges it internally
 //// - Invokes `on_diff` callback when merges produce non-empty diffs
 ////
 //// ## Example
@@ -11,13 +11,13 @@
 //// ```gleam
 //// let assert Ok(ps) = pubsub.start(pubsub.default_config())
 //// let config = presence.Config(
-////   pubsub: ps,
+////   pubsub: Some(ps),
 ////   replica: "node1",
 ////   broadcast_interval_ms: 1500,
 ////   on_diff: None,
 //// )
 //// let assert Ok(p) = presence.start(config)
-//// let assert Ok(ref) = presence.track(p, "room:lobby", "user:1", meta)
+//// let ref = presence.track(p, "room:lobby", "user:1", "socket-1", meta)
 //// let entries = presence.list(p, "room:lobby")
 //// ```
 
@@ -50,51 +50,88 @@ pub type Presence {
   Presence(subject: Subject(Message))
 }
 
-/// The pure CRDT state used by the presence actor.
-///
-/// Applications usually do not need this type unless they manually build
-/// remote state for `merge_remote`.
-pub type State =
+type State =
   state.State
 
-/// A diff representing presence joins and leaves grouped by topic.
+/// An opaque diff representing presence joins and leaves grouped by topic.
 ///
 /// This is passed to `Config.on_diff` and accepted by
 /// `beryl.broadcast_presence_diff`.
-pub type Diff =
-  state.Diff
+pub opaque type Diff {
+  Diff(
+    joins: Dict(String, List(PresenceEntry)),
+    leaves: Dict(String, List(PresenceEntry)),
+  )
+}
+
+/// A presence entry returned from queries and diff accessors.
+pub type PresenceEntry {
+  PresenceEntry(pid: String, key: String, meta: json.Json)
+}
 
 /// Build a presence diff from topic-grouped joins and leaves.
 ///
 /// Most applications receive diffs from `Config.on_diff`; this helper is for
 /// callers that need to construct a diff to pass to `beryl.broadcast_presence_diff`.
 pub fn diff(
-  joins joins: Dict(String, List(#(String, String, json.Json))),
-  leaves leaves: Dict(String, List(#(String, String, json.Json))),
+  joins joins: List(#(String, List(PresenceEntry))),
+  leaves leaves: List(#(String, List(PresenceEntry))),
 ) -> Diff {
-  state.Diff(joins: joins, leaves: leaves)
+  Diff(joins: dict.from_list(joins), leaves: dict.from_list(leaves))
 }
 
-/// Create a pure presence state value for this replica.
-///
-/// Most applications should use `start` and `track`; this helper exists for
-/// callers that manually construct state for `merge_remote`.
-pub fn new_state(replica: String) -> State {
-  state.new(replica)
+/// List topics touched by this diff.
+pub fn diff_topics(diff: Diff) -> List(String) {
+  list.append(dict.keys(diff.joins), dict.keys(diff.leaves))
+  |> unique_strings([])
 }
 
-/// Add a tracked presence to a pure state value.
-///
-/// Most applications should use `track`; this helper exists for callers that
-/// manually construct state for `merge_remote`.
-pub fn join_state(
-  crdt: State,
-  pid: String,
-  topic: String,
-  key: String,
-  meta: json.Json,
-) -> State {
-  state.join(crdt, pid, topic, key, meta)
+/// Get presence joins for a topic in this diff.
+pub fn diff_joins(diff: Diff, topic: String) -> List(PresenceEntry) {
+  dict.get(diff.joins, topic)
+  |> result.unwrap([])
+}
+
+/// Get presence leaves for a topic in this diff.
+pub fn diff_leaves(diff: Diff, topic: String) -> List(PresenceEntry) {
+  dict.get(diff.leaves, topic)
+  |> result.unwrap([])
+}
+
+fn unique_strings(values: List(String), seen: List(String)) -> List(String) {
+  case values {
+    [] -> list.reverse(seen)
+    [value, ..rest] ->
+      case list.contains(seen, value) {
+        True -> unique_strings(rest, seen)
+        False -> unique_strings(rest, [value, ..seen])
+      }
+  }
+}
+
+fn wrap_state_diff(diff: state.Diff) -> Diff {
+  Diff(
+    joins: state_entries_to_presence_entries(diff.joins),
+    leaves: state_entries_to_presence_entries(diff.leaves),
+  )
+}
+
+fn state_entries_to_presence_entries(
+  entries: Dict(String, List(#(String, String, json.Json))),
+) -> Dict(String, List(PresenceEntry)) {
+  entries
+  |> dict.to_list
+  |> list.map(fn(entry) {
+    let #(topic, topic_entries) = entry
+    #(
+      topic,
+      list.map(topic_entries, fn(topic_entry) {
+        let #(key, pid, meta) = topic_entry
+        PresenceEntry(pid: pid, key: key, meta: meta)
+      }),
+    )
+  })
+  |> dict.from_list
 }
 
 /// Configuration for starting presence
@@ -110,11 +147,6 @@ pub type Config {
     /// This ensures no diffs are lost when multiple merges occur in rapid succession.
     on_diff: Option(fn(Diff) -> Nil),
   )
-}
-
-/// A presence entry returned from queries
-pub type PresenceEntry {
-  PresenceEntry(pid: String, key: String, meta: json.Json)
 }
 
 /// Errors from presence operations
@@ -140,7 +172,6 @@ pub opaque type Message {
     key: String,
     reply: Subject(List(#(String, json.Json))),
   )
-  MergeRemote(remote: State)
   BroadcastTick
   /// Incoming PubSub sync message from a remote replica
   RemoteSync(pubsub_msg: pubsub.Message)
@@ -312,25 +343,6 @@ pub fn get_by_key(
   process.call(presence.subject, 5000, fn(reply) { GetByKey(topic, key, reply) })
 }
 
-/// Send remote state to merge (fire and forget)
-///
-/// Used for cross-node replication. The remote state will be merged
-/// into the local CRDT, producing a diff of changes.
-///
-/// ```gleam
-/// import beryl/presence
-/// import gleam/json
-///
-/// let remote =
-///   presence.new_state("node2")
-///   |> presence.join_state("socket-2", "room:lobby", "user:2", json.null())
-///
-/// presence.merge_remote(p, remote)
-/// ```
-pub fn merge_remote(presence: Presence, remote: State) -> Nil {
-  process.send(presence.subject, MergeRemote(remote))
-}
-
 // ── Actor loop ──────────────────────────────────────────────────────────────
 
 fn handle_message(
@@ -391,19 +403,6 @@ fn handle_message(
       actor.continue(actor_state)
     }
 
-    MergeRemote(remote) -> {
-      let #(new_crdt, diff) = state.merge_with_diff(actor_state.crdt, remote)
-      let changed = !{ dict.is_empty(diff.joins) && dict.is_empty(diff.leaves) }
-      maybe_invoke_on_diff(actor_state.config, diff)
-      actor.continue(
-        ActorState(
-          ..actor_state,
-          crdt: new_crdt,
-          dirty: actor_state.dirty || changed,
-        ),
-      )
-    }
-
     BroadcastTick -> {
       case actor_state.config.pubsub, actor_state.self_subject {
         Some(ps), Some(subject) -> {
@@ -459,8 +458,12 @@ fn single_join_diff(
   pid: String,
   meta: json.Json,
 ) -> Diff {
-  state.Diff(
-    joins: dict.from_list([#(topic, [#(key, pid, meta)])]),
+  Diff(
+    joins: dict.from_list([
+      #(topic, [
+        PresenceEntry(pid: pid, key: key, meta: meta),
+      ]),
+    ]),
     leaves: dict.new(),
   )
 }
@@ -474,9 +477,11 @@ fn leave_diff(
   let leaves =
     state.get_by_key(crdt, topic, key)
     |> list.filter(fn(entry) { entry.0 == pid })
-    |> list.map(fn(entry) { #(key, entry.0, entry.1) })
+    |> list.map(fn(entry) {
+      PresenceEntry(pid: entry.0, key: key, meta: entry.1)
+    })
 
-  state.Diff(joins: dict.new(), leaves: topic_entries(topic, leaves))
+  Diff(joins: dict.new(), leaves: topic_entries(topic, leaves))
 }
 
 fn leave_all_diff(crdt: State, pid: String) -> Diff {
@@ -488,16 +493,19 @@ fn leave_all_diff(crdt: State, pid: String) -> Diff {
       let existing =
         dict.get(grouped, topic)
         |> result.unwrap([])
-      dict.insert(grouped, topic, [#(key, pid, meta), ..existing])
+      dict.insert(grouped, topic, [
+        PresenceEntry(pid: pid, key: key, meta: meta),
+        ..existing
+      ])
     })
 
-  state.Diff(joins: dict.new(), leaves: leaves)
+  Diff(joins: dict.new(), leaves: leaves)
 }
 
 fn topic_entries(
   topic: String,
-  entries: List(#(String, String, json.Json)),
-) -> dict.Dict(String, List(#(String, String, json.Json))) {
+  entries: List(PresenceEntry),
+) -> Dict(String, List(PresenceEntry)) {
   case entries {
     [] -> dict.new()
     _ -> dict.from_list([#(topic, entries)])
@@ -534,8 +542,9 @@ fn handle_sync_payload(
       actor.continue(actor_state)
     }
     Ok(#(_sender, remote_state)) -> {
-      let #(new_crdt, diff) =
+      let #(new_crdt, state_diff) =
         state.merge_with_diff(actor_state.crdt, remote_state)
+      let diff = wrap_state_diff(state_diff)
       let changed = !{ dict.is_empty(diff.joins) && dict.is_empty(diff.leaves) }
       maybe_invoke_on_diff(actor_state.config, diff)
       actor.continue(
@@ -552,8 +561,7 @@ fn handle_sync_payload(
 /// Parse the sync envelope JSON: {"v": 1, "sender": "...", "state": {...}}
 /// State is decoded directly as a nested object (not double-encoded string).
 /// Rejects envelopes with unknown version numbers.
-@internal
-pub fn parse_sync_envelope(
+fn parse_sync_envelope(
   payload_str: String,
 ) -> Result(#(String, State), String) {
   let decoder = {

--- a/src/beryl/presence/wire.gleam
+++ b/src/beryl/presence/wire.gleam
@@ -1,6 +1,7 @@
 //// Phoenix-compatible wire encoding for presence diffs.
 
-import beryl/presence.{type Diff}
+import beryl/presence.{type Diff, type PresenceEntry}
+import beryl/presence
 import gleam/dict.{type Dict}
 import gleam/json
 import gleam/list
@@ -19,43 +20,34 @@ import gleam/result
 /// ```
 pub fn encode_diff(diff: Diff, topic: String) -> json.Json {
   json.object([
-    #("joins", encode_topic_entries(diff.joins, topic)),
-    #("leaves", encode_topic_entries(diff.leaves, topic)),
+    #("joins", encode_entries(presence.diff_joins(diff, topic))),
+    #("leaves", encode_entries(presence.diff_leaves(diff, topic))),
   ])
 }
 
-fn encode_topic_entries(
-  entries_by_topic: Dict(String, List(#(String, String, json.Json))),
-  topic: String,
-) -> json.Json {
-  case dict.get(entries_by_topic, topic) {
-    Error(_) -> json.object([])
-    Ok(entries) -> {
-      entries
-      |> group_metas_by_key
-      |> dict.to_list
-      |> list.map(fn(entry) {
-        let #(key, metas) = entry
-        #(
-          key,
-          json.object([
-            #("metas", json.preprocessed_array(list.reverse(metas))),
-          ]),
-        )
-      })
-      |> json.object
-    }
-  }
+fn encode_entries(entries: List(PresenceEntry)) -> json.Json {
+  entries
+  |> group_metas_by_key
+  |> dict.to_list
+  |> list.map(fn(entry) {
+    let #(key, metas) = entry
+    #(
+      key,
+      json.object([
+        #("metas", json.preprocessed_array(list.reverse(metas))),
+      ]),
+    )
+  })
+  |> json.object
 }
 
 fn group_metas_by_key(
-  entries: List(#(String, String, json.Json)),
+  entries: List(PresenceEntry),
 ) -> Dict(String, List(json.Json)) {
   list.fold(entries, dict.new(), fn(grouped, entry) {
-    let #(key, _pid, meta) = entry
     let existing =
-      dict.get(grouped, key)
+      dict.get(grouped, entry.key)
       |> result.unwrap([])
-    dict.insert(grouped, key, [meta, ..existing])
+    dict.insert(grouped, entry.key, [entry.meta, ..existing])
   })
 }

--- a/src/beryl/presence/wire.gleam
+++ b/src/beryl/presence/wire.gleam
@@ -1,7 +1,6 @@
 //// Phoenix-compatible wire encoding for presence diffs.
 
-import beryl/presence.{type Diff, type PresenceEntry}
-import beryl/presence
+import beryl/presence.{type Diff, type PresenceEntry, diff_joins, diff_leaves}
 import gleam/dict.{type Dict}
 import gleam/json
 import gleam/list
@@ -20,8 +19,8 @@ import gleam/result
 /// ```
 pub fn encode_diff(diff: Diff, topic: String) -> json.Json {
   json.object([
-    #("joins", encode_entries(presence.diff_joins(diff, topic))),
-    #("leaves", encode_entries(presence.diff_leaves(diff, topic))),
+    #("joins", encode_entries(diff_joins(diff, topic))),
+    #("leaves", encode_entries(diff_leaves(diff, topic))),
   ])
 }
 

--- a/test/broadcast_test.gleam
+++ b/test/broadcast_test.gleam
@@ -4,7 +4,6 @@ import beryl/presence
 import beryl/pubsub
 import beryl/topic
 import beryl/wire
-import gleam/dict
 import gleam/dynamic
 import gleam/erlang/process
 import gleam/json
@@ -90,16 +89,16 @@ fn drain(subject: process.Subject(String)) -> Nil {
 
 fn presence_diff() -> presence.Diff {
   presence.diff(
-    joins: dict.from_list([
+    joins: [
       #("room:lobby", [
-        #(
-          "user:1",
-          "socket-1",
-          json.object([#("status", json.string("online"))]),
+        presence.PresenceEntry(
+          pid: "socket-1",
+          key: "user:1",
+          meta: json.object([#("status", json.string("online"))]),
         ),
       ]),
-    ]),
-    leaves: dict.new(),
+    ],
+    leaves: [],
   )
 }
 

--- a/test/presence_replication_test.gleam
+++ b/test/presence_replication_test.gleam
@@ -6,8 +6,6 @@ import gleam/list
 import gleam/option.{None, Some}
 import gleeunit
 import gleeunit/should
-import lattice_presence/presence_state as state
-import lattice_presence/state_json
 import test_helpers
 
 pub fn main() {
@@ -253,46 +251,6 @@ pub fn untrack_propagates_via_pubsub_test() {
 
   // Node2 should see the removal
   list.length(presence.list(p2, "room:lobby")) |> should.equal(0)
-}
-
-// ── Version field validation ─────────────────────────────────────────
-
-pub fn parse_sync_envelope_rejects_unknown_version_test() {
-  let s = state.new("remote")
-  let envelope =
-    json.object([
-      #("v", json.int(2)),
-      #("sender", json.string("remote")),
-      #("state", state_json.to_json(s)),
-    ])
-    |> json.to_string
-
-  presence.parse_sync_envelope(envelope) |> should.be_error
-}
-
-pub fn parse_sync_envelope_accepts_version_1_test() {
-  let s = state.new("remote")
-  let envelope =
-    json.object([
-      #("v", json.int(1)),
-      #("sender", json.string("remote")),
-      #("state", state_json.to_json(s)),
-    ])
-    |> json.to_string
-
-  presence.parse_sync_envelope(envelope) |> should.be_ok
-}
-
-pub fn parse_sync_envelope_rejects_missing_version_test() {
-  let s = state.new("remote")
-  let envelope =
-    json.object([
-      #("sender", json.string("remote")),
-      #("state", state_json.to_json(s)),
-    ])
-    |> json.to_string
-
-  presence.parse_sync_envelope(envelope) |> should.be_error
 }
 
 // ── Resilience: malformed sync messages ──────────────────────────────

--- a/test/presence_test.gleam
+++ b/test/presence_test.gleam
@@ -1,5 +1,4 @@
 import beryl/presence
-import gleam/dict
 import gleam/erlang/process
 import gleam/json
 import gleam/list
@@ -101,39 +100,6 @@ pub fn presence_different_topics_isolated_test() {
   list.length(presence.list(p, "room:empty")) |> should.equal(0)
 }
 
-pub fn presence_merge_remote_test() {
-  let assert Ok(p) = presence.start(test_config("node1"))
-
-  // Track locally
-  let _ = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
-
-  // Create a remote state with a different entry
-  let remote =
-    presence.new_state("node2")
-    |> presence.join_state("socket-2", "room:lobby", "user:2", json.null())
-
-  // Merge remote state
-  presence.merge_remote(p, remote)
-
-  // Give the actor a moment to process the async merge
-  // Use a synchronous call to ensure ordering
-  let entries = presence.list(p, "room:lobby")
-  list.length(entries) |> should.equal(2)
-}
-
-pub fn public_state_alias_works_for_merge_remote_test() {
-  let assert Ok(p) = presence.start(test_config("node1"))
-
-  let remote: presence.State =
-    presence.new_state("node2")
-    |> presence.join_state("socket-2", "room:lobby", "user:2", json.null())
-
-  presence.merge_remote(p, remote)
-
-  let entries = presence.list(p, "room:lobby")
-  list.length(entries) |> should.equal(1)
-}
-
 pub fn presence_empty_list_test() {
   let assert Ok(p) = presence.start(test_config("node1"))
   let entries = presence.list(p, "room:empty")
@@ -149,43 +115,6 @@ pub fn presence_default_config_test() {
 }
 
 // ── on_diff callback tests ──────────────────────────────────────────────────
-
-pub fn on_diff_callback_receives_merge_diff_test() {
-  // Set up a Subject to collect diffs from the callback
-  let diff_subject = process.new_subject()
-
-  let config =
-    presence.Config(
-      pubsub: None,
-      replica: "node1",
-      broadcast_interval_ms: 0,
-      on_diff: Some(fn(diff) { process.send(diff_subject, diff) }),
-    )
-
-  let assert Ok(p) = presence.start(config)
-
-  // Track locally
-  let _ = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
-
-  // Create a remote state and merge it
-  let remote =
-    presence.new_state("node2")
-    |> presence.join_state("socket-2", "room:lobby", "user:2", json.null())
-
-  presence.merge_remote(p, remote)
-
-  // The merge is async (fire-and-forget), so use a synchronous list call
-  // to ensure the merge message has been processed
-  let _ = presence.list(p, "room:lobby")
-
-  // Now the on_diff callback should have fired
-  let assert Ok(diff) = process.receive(diff_subject, 1000)
-
-  // The diff should contain user:2 as a join
-  let assert Ok(joins) = dict.get(diff.joins, "room:lobby")
-  list.length(joins) |> should.equal(1)
-  dict.is_empty(diff.leaves) |> should.be_true
-}
 
 pub fn on_diff_callback_receives_local_track_diff_test() {
   let diff_subject = process.new_subject()
@@ -210,12 +139,17 @@ pub fn on_diff_callback_receives_local_track_diff_test() {
     )
 
   let assert Ok(diff) = process.receive(diff_subject, 1000)
-  let assert Ok(joins) = dict.get(diff.joins, "room:lobby")
-  joins
+  presence.diff_topics(diff)
+  |> should.equal(["room:lobby"])
+  presence.diff_joins(diff, "room:lobby")
   |> should.equal([
-    #("user:1", "socket-1", json.object([#("status", json.string("online"))])),
+    presence.PresenceEntry(
+      pid: "socket-1",
+      key: "user:1",
+      meta: json.object([#("status", json.string("online"))]),
+    ),
   ])
-  dict.is_empty(diff.leaves) |> should.be_true
+  presence.diff_leaves(diff, "room:lobby") |> should.equal([])
 }
 
 pub fn on_diff_callback_receives_local_untrack_diff_test() {
@@ -243,37 +177,17 @@ pub fn on_diff_callback_receives_local_untrack_diff_test() {
   presence.untrack(p, "room:lobby", "user:1", "socket-1")
 
   let assert Ok(diff) = process.receive(diff_subject, 1000)
-  dict.is_empty(diff.joins) |> should.be_true
-  let assert Ok(leaves) = dict.get(diff.leaves, "room:lobby")
-  leaves
+  presence.diff_topics(diff)
+  |> should.equal(["room:lobby"])
+  presence.diff_joins(diff, "room:lobby") |> should.equal([])
+  presence.diff_leaves(diff, "room:lobby")
   |> should.equal([
-    #("user:1", "socket-1", json.object([#("status", json.string("online"))])),
+    presence.PresenceEntry(
+      pid: "socket-1",
+      key: "user:1",
+      meta: json.object([#("status", json.string("online"))]),
+    ),
   ])
-}
-
-pub fn on_diff_callback_not_called_for_empty_diff_test() {
-  let diff_subject = process.new_subject()
-
-  let config =
-    presence.Config(
-      pubsub: None,
-      replica: "node1",
-      broadcast_interval_ms: 0,
-      on_diff: Some(fn(diff) { process.send(diff_subject, diff) }),
-    )
-
-  let assert Ok(p) = presence.start(config)
-
-  // Merge an empty remote state (should produce an empty diff)
-  let remote = presence.new_state("node2")
-  presence.merge_remote(p, remote)
-
-  // Ensure the merge has been processed
-  let _ = presence.list(p, "room:lobby")
-
-  // Callback should NOT have been called for empty diff
-  let result = process.receive(diff_subject, 100)
-  should.be_error(result)
 }
 
 pub fn on_diff_callback_receives_all_rapid_diffs_test() {
@@ -289,30 +203,37 @@ pub fn on_diff_callback_receives_all_rapid_diffs_test() {
 
   let assert Ok(p) = presence.start(config)
 
-  // Rapidly merge multiple remote states
-  let remote1 =
-    presence.new_state("node2")
-    |> presence.join_state("socket-2", "room:lobby", "user:2", json.null())
-
-  let remote2 =
-    presence.new_state("node3")
-    |> presence.join_state("socket-3", "room:lobby", "user:3", json.null())
-
-  presence.merge_remote(p, remote1)
-  presence.merge_remote(p, remote2)
-
-  // Ensure both merges have been processed
-  let _ = presence.list(p, "room:lobby")
+  let _ = presence.track(p, "room:lobby", "user:2", "socket-2", json.null())
+  let _ = presence.track(p, "room:lobby", "user:3", "socket-3", json.null())
 
   // Both diffs should have been delivered (no overwrite)
   let assert Ok(diff1) = process.receive(diff_subject, 1000)
   let assert Ok(diff2) = process.receive(diff_subject, 1000)
 
   // First diff: user:2 joined
-  let assert Ok(joins1) = dict.get(diff1.joins, "room:lobby")
+  let joins1 = presence.diff_joins(diff1, "room:lobby")
   list.length(joins1) |> should.equal(1)
 
   // Second diff: user:3 joined
-  let assert Ok(joins2) = dict.get(diff2.joins, "room:lobby")
+  let joins2 = presence.diff_joins(diff2, "room:lobby")
   list.length(joins2) |> should.equal(1)
+}
+
+pub fn diff_accessors_return_empty_lists_for_unmentioned_topics_test() {
+  let diff =
+    presence.diff(
+      joins: [
+        #("room:lobby", [
+          presence.PresenceEntry(
+            pid: "socket-1",
+            key: "user:1",
+            meta: json.null(),
+          ),
+        ]),
+      ],
+      leaves: [],
+    )
+
+  presence.diff_joins(diff, "room:missing") |> should.equal([])
+  presence.diff_leaves(diff, "room:missing") |> should.equal([])
 }

--- a/test/presence_wire_test.gleam
+++ b/test/presence_wire_test.gleam
@@ -1,6 +1,5 @@
 import beryl/presence
 import beryl/presence/wire as presence_wire
-import gleam/dict
 import gleam/dynamic/decode
 import gleam/json
 import gleam/list
@@ -14,37 +13,41 @@ pub fn main() {
 
 fn sample_diff() -> presence.Diff {
   presence.diff(
-    joins: dict.from_list([
+    joins: [
       #("room:lobby", [
-        #(
-          "user:1",
-          "socket-1",
-          json.object([#("status", json.string("online"))]),
+        presence.PresenceEntry(
+          pid: "socket-1",
+          key: "user:1",
+          meta: json.object([#("status", json.string("online"))]),
         ),
-        #("user:1", "socket-2", json.object([#("status", json.string("away"))])),
-        #(
-          "user:2",
-          "socket-3",
-          json.object([#("device", json.string("mobile"))]),
+        presence.PresenceEntry(
+          pid: "socket-2",
+          key: "user:1",
+          meta: json.object([#("status", json.string("away"))]),
+        ),
+        presence.PresenceEntry(
+          pid: "socket-3",
+          key: "user:2",
+          meta: json.object([#("device", json.string("mobile"))]),
         ),
       ]),
-    ]),
-    leaves: dict.from_list([
+    ],
+    leaves: [
       #("room:lobby", [
-        #(
-          "user:3",
-          "socket-4",
-          json.object([#("status", json.string("offline"))]),
+        presence.PresenceEntry(
+          pid: "socket-4",
+          key: "user:3",
+          meta: json.object([#("status", json.string("offline"))]),
         ),
       ]),
       #("room:other", [
-        #(
-          "ignored",
-          "socket-5",
-          json.object([#("status", json.string("away"))]),
+        presence.PresenceEntry(
+          pid: "socket-5",
+          key: "ignored",
+          meta: json.object([#("status", json.string("away"))]),
         ),
       ]),
-    ]),
+    ],
   )
 }
 

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -11,7 +11,7 @@ Presence tracking uses an **add-wins observed-remove set** (AWORSet) with causal
 The presence system has two layers:
 
 1. **`beryl/presence`** — OTP actor wrapping the CRDT with PubSub replication
-2. **`beryl/presence.State` and `beryl/presence.Diff`** — Narrow public aliases for advanced APIs such as `merge_remote` and `on_diff`
+2. **`beryl/presence.Diff`** — An opaque notification value for `on_diff`, with accessor helpers for changed topics, joins, and leaves
 
 ## Starting presence
 
@@ -87,10 +87,13 @@ let config = presence.Config(
   replica: "node1",
   broadcast_interval_ms: 1500,
   on_diff: option.Some(fn(diff) {
-    // diff.joins: Dict(topic, List(#(key, pid, meta)))
-    // diff.leaves: Dict(topic, List(#(key, pid, meta)))
-    io.println("Joins: " <> string.inspect(diff.joins))
-    io.println("Leaves: " <> string.inspect(diff.leaves))
+    diff
+    |> presence.diff_topics
+    |> list.each(fn(topic) {
+      io.println("Topic changed: " <> topic)
+      io.println("Joins: " <> string.inspect(presence.diff_joins(diff, topic)))
+      io.println("Leaves: " <> string.inspect(presence.diff_leaves(diff, topic)))
+    })
   }),
 )
 ```
@@ -118,11 +121,9 @@ let config = presence.Config(
 
 ```gleam
 on_diff: option.Some(fn(diff) {
-  let topics =
-    dict.keys(diff.joins)
-    |> list.append(dict.keys(diff.leaves))
-    |> list.unique()
-  list.each(topics, fn(topic) {
+  diff
+  |> presence.diff_topics
+  |> list.each(fn(topic) {
     beryl.broadcast_presence_diff(channels, topic, diff)
   })
 }),
@@ -151,6 +152,8 @@ When PubSub is configured, the presence actor:
 4. Fires `on_diff` for any changes from the merge
 
 Self-delivery is prevented by `pubsub.broadcast_from`, so nodes don't process their own sync messages.
+
+The underlying CRDT state is intentionally internal. Applications should use PubSub replication rather than constructing or merging raw presence state values.
 
 ## Integration with channels
 

--- a/website/src/content/docs/guides/websocket.md
+++ b/website/src/content/docs/guides/websocket.md
@@ -24,7 +24,7 @@ fn handle_request(
   // Upgrade /socket/websocket requests to WebSocket
   use <- mist_transport.upgrade(
     req,
-    channels.coordinator,
+    channels,
     mist_transport.default_config("/socket/websocket"),
   )
 
@@ -64,7 +64,7 @@ let config =
     }
   })
 
-use <- mist_transport.upgrade(req, channels.coordinator, config)
+use <- mist_transport.upgrade(req, channels, config)
 ```
 
 Returning `Error(Nil)` sends an HTTP 403 before the WebSocket upgrade. See [Connection-level authentication rejection](/guides/error-handling#connection-level-authentication-rejection) for the client-visible error shape and [Authentication failures](/troubleshooting#authentication-failures) for diagnosis steps.
@@ -76,7 +76,7 @@ If you handle path matching yourself, use `upgrade_connection` directly:
 ```gleam
 fn handle_request(req, channels) -> response.Response(mist.ResponseData) {
   case request.path_segments(req) {
-    ["ws"] -> mist_transport.upgrade_connection(req, channels.coordinator)
+    ["ws"] -> mist_transport.upgrade_connection(req, channels)
     _ -> response.new(404) |> response.set_body(mist.Bytes(bytes_tree.new()))
   }
 }

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -136,7 +136,7 @@ pub fn main() {
       // Upgrade WebSocket requests first; fall through to HTTP for everything else.
       mist_transport.upgrade(
         req,
-        channels.coordinator,
+        channels,
         mist_transport.default_config("/socket/websocket"),
         fn() { handle_http(req) },
       )

--- a/website/src/content/docs/reference/index.md
+++ b/website/src/content/docs/reference/index.md
@@ -21,11 +21,10 @@ This page provides a module map, broadcast cheatsheet, Phoenix wire protocol ref
 |---|---|---|
 | `beryl` | Top-level API: start the registry, register channels, broadcast | Entry point for all applications |
 | `beryl/channel` | Channel builder, callback types, `HandleResult` | Defining channel behaviour |
-| `beryl/coordinator` | OTP actor that owns a single socket/topic pair | Rarely needed directly |
 | `beryl/socket` | Socket abstraction, assigns helpers | Inside channel callbacks |
 | `beryl/topic` | Topic parsing, wildcard matching, segment extraction | Dynamic routing, multi-tenant patterns |
 | `beryl/pubsub` | Distributed PubSub backed by Erlang `pg` | Multi-node fan-out, cluster broadcasts |
-| `beryl/presence` | OTP actor wrapping the presence CRDT, plus `State`/`Diff` aliases for advanced APIs | Tracking who is online |
+| `beryl/presence` | OTP actor wrapping the presence CRDT, plus opaque `Diff` accessors | Tracking who is online |
 | `beryl/group` | Named sets of topics for bulk broadcast | Rooms with multiple sub-topics |
 | `beryl/wire` | Phoenix-compatible codec and JSON helpers | Phoenix clients, custom transports, protocol debugging |
 | `beryl/wire/codec` | Pluggable codec contract for text and binary frames | Custom wire formats |
@@ -42,7 +41,7 @@ This page provides a module map, broadcast cheatsheet, Phoenix wire protocol ref
 | No response | `channel.NoReply(socket)` | Use when the handler has no output |
 | Broadcast to all sockets on a topic | `beryl.broadcast(registry, topic, event, payload)` | All subscribers including the sender |
 | Broadcast, excluding sender | `beryl.broadcast_from(channels, socket.id(socket), topic, event, payload)` | Second arg is `except_socket_id: String`; use `socket.id/1` to extract it when you have a `Socket` value. Skips the originating socket; works across PubSub nodes |
-| Send an OTP message to a channel actor | `beryl.send_info(channels, socket_id, topic_name, message)` | Delivers to `handle_info`; the callback receives a `Dynamic` value — decode and validate it there; no compile-time type checking |
+| Send an OTP message to a joined channel context | `beryl.send_info(channels, socket_id, topic_name, message)` | Delivers to `handle_info`; the callback receives a `Dynamic` value — decode and validate it there; no compile-time type checking |
 | Broadcast presence diff | `beryl.broadcast_presence_diff(registry, topic, diff)` | Encodes Phoenix-shaped `joins`/`leaves`; only named topic entries are included |
 
 ---
@@ -141,6 +140,6 @@ beryl follows [Semantic Versioning](https://semver.org/) but is **not yet 1.0**.
 - **Minor version bumps** (`0.x → 0.x+1`) may include breaking changes to the public API.
 - **Patch version bumps** (`0.x.y → 0.x.y+1`) fix bugs without intentional breakage.
 - Public API is defined as the exports of the modules listed in the module map above.
-- Lower-level modules (e.g. `beryl/coordinator`, `beryl/wire`) are public and usable, but are less stable than the top-level API and are primarily intended for advanced integrations or custom transports. Their signatures may change without a deprecation cycle.
+- Coordinator, rate-limit, and internal helper modules are intentionally hidden from downstream packages. Custom transports are not a stable extension point yet; use `beryl/transport/mist` for supported WebSocket integration.
 
 Check [GitHub releases](https://github.com/tylerbutler/beryl/releases) and the [Migration & Releases page](/migration) before upgrading to a new minor version.


### PR DESCRIPTION
## Summary

- Narrow the documented public API surface by marking coordinator, rate-limit, and internal helper modules as internal.
- Hide public presence CRDT state APIs behind Beryl-owned opaque diff accessors.
- Update docs and tests for the new presence and transport API shape.
- Add changelog fragments for the changed and removed public API surfaces.

## Testing

- `just ci`
