### PR TITLE
feat(examples/cursors): add Railway deployment scaffolding

### DIFF
--- a/examples/cursors/.dockerignore
+++ b/examples/cursors/.dockerignore
@@ -1,0 +1,11 @@
+# Ignore everything by default; the Dockerfile copies the whole repo so we
+# whitelist only the bits the build needs. Run `docker build` from the
+# repository root with `-f examples/cursors/Dockerfile .`.
+**/build/
+**/_build/
+**/node_modules/
+**/.git/
+**/test-results/
+**/playwright-report/
+*.log
+erl_crash.dump

--- a/examples/cursors/Dockerfile
+++ b/examples/cursors/Dockerfile
@@ -1,0 +1,27 @@
+# Build stage: compile Gleam project to an erlang-shipment release.
+# Build context MUST be the repository root because the example references
+# the local beryl package via `path = "../.."`.
+FROM ghcr.io/gleam-lang/gleam:v1.16.0-erlang-alpine AS build
+
+WORKDIR /src
+
+# Copy the entire repo so path-based deps resolve.
+COPY . .
+
+WORKDIR /src/examples/cursors
+RUN gleam deps download \
+ && gleam export erlang-shipment
+
+# Runtime stage: minimal Erlang image running the shipment.
+FROM erlang:27.2.1-alpine AS runtime
+
+RUN apk add --no-cache libstdc++ ncurses-libs openssl ca-certificates
+
+WORKDIR /app
+COPY --from=build /src/examples/cursors/build/erlang-shipment ./
+
+# Railway injects PORT; bind to all interfaces so the proxy can reach us.
+ENV BIND_ADDRESS=0.0.0.0
+EXPOSE 8000
+
+CMD ["./entrypoint.sh", "run"]

--- a/examples/cursors/README.md
+++ b/examples/cursors/README.md
@@ -11,6 +11,24 @@ gleam run
 
 Then open <http://localhost:8000> in **multiple browser tabs** to see cursors move in real-time.
 
+### Environment variables
+
+| Var | Default | Purpose |
+|---|---|---|
+| `PORT` | `8000` | TCP port the HTTP/WebSocket server binds to |
+| `BIND_ADDRESS` | `localhost` | Interface to bind. Set to `0.0.0.0` when running in a container or behind a proxy. |
+
+## Deploying to Railway
+
+The example ships with a [`Dockerfile`](./Dockerfile) and [`railway.toml`](./railway.toml).
+
+1. Create a new Railway service from this repository.
+2. In the service settings, set **Root Directory** to the repository root (not `examples/cursors`) so the Docker build context can see the local `beryl` package referenced via `path = "../.."`.
+3. Set **Config Path** to `examples/cursors/railway.toml`.
+4. Deploy. Railway injects `PORT`; the Dockerfile sets `BIND_ADDRESS=0.0.0.0`.
+
+The Phoenix JS client in `priv/static/app.js` uses a relative `/socket` URL, so it automatically negotiates `wss://` over Railway's TLS-terminated proxy.
+
 ## What It Demonstrates
 
 | beryl Feature | How It's Used |

--- a/examples/cursors/gleam.toml
+++ b/examples/cursors/gleam.toml
@@ -13,6 +13,7 @@ gleam_otp = ">= 0.12.0 and < 2.0.0"
 gleam_json = ">= 3.0.0 and < 4.0.0"
 gleam_http = ">= 4.3.0 and < 5.0.0"
 mist = ">= 6.0.0 and < 7.0.0"
+envoy = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/examples/cursors/manifest.toml
+++ b/examples/cursors/manifest.toml
@@ -2,8 +2,9 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "beryl", version = "0.1.0", build_tools = ["gleam"], requirements = ["birch", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "mist"], source = "local", path = "../.." },
+  { name = "beryl", version = "0.1.0", build_tools = ["gleam"], requirements = ["birch", "envoy", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "mist", "roost"], source = "local", path = "../.." },
   { name = "birch", version = "0.2.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "simplifile"], otp_app = "birch", source = "hex", outer_checksum = "20CCDACA9E2A17E1D7F2C35322E619E7DDF98774FDC598D01AD5F414928E6261" },
+  { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
   { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
@@ -21,11 +22,13 @@ packages = [
   { name = "lattice_presence", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "lattice_presence", source = "hex", outer_checksum = "8A8B79D774015F623D3E370B55B200CC0CF1C49CB6805A1EC849149F60C91037" },
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
+  { name = "roost", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], source = "git", repo = "https://github.com/tylerbutler/roost.git", commit = "7dd796e83d8b0fcb8732cfac35707f3fbc8eeaed" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
 ]
 
 [requirements]
 beryl = { path = "../.." }
+envoy = { version = ">= 1.0.0 and < 2.0.0" }
 example_helpers = { path = "../example_helpers" }
 gleam_erlang = { version = ">= 0.29.0 and < 2.0.0" }
 gleam_http = { version = ">= 4.3.0 and < 5.0.0" }

--- a/examples/cursors/railway.toml
+++ b/examples/cursors/railway.toml
@@ -1,0 +1,16 @@
+# Railway service config for the cursors demo.
+#
+# Set the service's Root Directory to the *repository root* in the Railway UI
+# (not examples/cursors), and point it at this config file. The Dockerfile
+# needs the whole repo as build context because the example depends on the
+# local beryl package via a relative path.
+
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "examples/cursors/Dockerfile"
+
+[deploy]
+healthcheckPath = "/"
+healthcheckTimeout = 30
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 5

--- a/examples/cursors/src/cursors.gleam
+++ b/examples/cursors/src/cursors.gleam
@@ -4,8 +4,11 @@ import beryl/transport/mist as mist_transport
 import beryl/wire
 import cursors/cursor_channel
 import cursors/router
+import envoy
 import gleam/erlang/process
+import gleam/int
 import gleam/io
+import gleam/result
 import mist
 
 pub fn main() {
@@ -24,8 +27,17 @@ pub fn main() {
   let handler = cursor_channel.new_handler(channels, presence_actor)
   let assert Ok(_) = beryl.register(channels, "cursor:*", handler)
 
+  // Honor $PORT (Railway/PaaS) and $HOST/$BIND_ADDRESS; fall back to local defaults.
+  let port =
+    envoy.get("PORT")
+    |> result.try(int.parse)
+    |> result.unwrap(8000)
+  let interface =
+    envoy.get("BIND_ADDRESS")
+    |> result.unwrap("localhost")
+
   io.println("🖱️  Collaborative Cursors Demo")
-  io.println("   Open http://localhost:8000 in multiple browser tabs")
+  io.println("   Listening on " <> interface <> ":" <> int.to_string(port))
   io.println("")
 
   // Start the HTTP server
@@ -41,7 +53,8 @@ pub fn main() {
       )
     }
     |> mist.new
-    |> mist.port(8000)
+    |> mist.bind(interface)
+    |> mist.port(port)
     |> mist.start
 
   process.sleep_forever()


### PR DESCRIPTION
## Summary

Adds the minimum scaffolding needed to deploy the `cursors` example to Railway (or any container PaaS that injects `$PORT`).

## Changes

- **`src/cursors.gleam`**: Read `PORT` and `BIND_ADDRESS` from env via `envoy`. Defaults to `localhost:8000` for local `gleam run`; containers set `BIND_ADDRESS=0.0.0.0` and Railway injects `PORT`.
- **`gleam.toml`**: Added `envoy` dep (already in the workspace manifest).
- **`Dockerfile`**: Multi-stage build using `ghcr.io/gleam-lang/gleam:v1.16.0-erlang-alpine` to produce a `gleam export erlang-shipment` artifact, then `erlang:27.2.1-alpine` to run it. Build context is the **repo root** because the example uses `beryl = { path = "../.." }`.
- **`.dockerignore`**: Trims build/node/test artifacts from the context.
- **`railway.toml`**: Points Railway at `examples/cursors/Dockerfile` with a `/` healthcheck and on-failure restart.
- **`README.md`**: Documents the new env vars and Railway setup steps.

## Railway setup notes

1. New Railway service from this repo.
2. **Root Directory** = repo root (not `examples/cursors`) so Docker can see the local `beryl` package.
3. **Config Path** = `examples/cursors/railway.toml`.
4. Deploy.

The Phoenix JS client in `priv/static/app.js` already uses the relative `/socket` URL, so it auto-negotiates `wss://` behind Railway's TLS-terminated proxy — no client changes needed.

## Out of scope

- `chatrooms` and `collab_docs` deployment (same pattern; will follow once this is validated end-to-end).
- GitHub Actions workflow to `railway up` on push.
- No changie fragment: change is examples-only, doesn't touch the published library.

## Validation

- `gleam check` passes in `examples/cursors`.
- `gleam format` clean.