### PR TITLE
fix(examples/cursors): install git in Dockerfile build stage

### DIFF
--- a/.changes/unreleased/Fixed-20260522-150900.yaml
+++ b/.changes/unreleased/Fixed-20260522-150900.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Install `git` in the cursors example Dockerfile so `gleam deps download` can resolve hex dependencies on clean builds (e.g. Railway).
+time: 2026-05-22T15:09:00.000000-07:00

--- a/examples/cursors/Dockerfile
+++ b/examples/cursors/Dockerfile
@@ -1,12 +1,29 @@
 # Build stage: compile Gleam project to an erlang-shipment release.
-# Build context MUST be the repository root because the example references
-# the local beryl package via `path = "../.."`.
+#
+# IMPORTANT: Build context MUST be the repository root, because the example
+# references the local beryl package via `path = "../.."`.
+#
+# Build from the repo root with:
+#   docker build -f examples/cursors/Dockerfile -t beryl-cursors .
+#
+# Running `docker build .` from inside examples/cursors/ will fail to resolve
+# the local beryl dependency.
 FROM ghcr.io/gleam-lang/gleam:v1.16.0-erlang-alpine AS build
+
+# git is required by `gleam deps download` for resolving dependencies.
+RUN apk add --no-cache git
 
 WORKDIR /src
 
-# Copy the entire repo so path-based deps resolve.
+# Copy the entire repo so path-based deps resolve. Verify the parent beryl
+# package is present; fail fast with a clear message if the build context
+# is wrong (e.g. someone ran `docker build .` from examples/cursors/).
 COPY . .
+RUN test -f /src/gleam.toml && grep -q '^name = "beryl"' /src/gleam.toml || ( \
+  echo "ERROR: build context does not contain the beryl repository root."; \
+  echo "Run from the repo root: docker build -f examples/cursors/Dockerfile ."; \
+  exit 1 \
+)
 
 WORKDIR /src/examples/cursors
 RUN gleam deps download \

--- a/examples/cursors/README.md
+++ b/examples/cursors/README.md
@@ -18,6 +18,20 @@ Then open <http://localhost:8000> in **multiple browser tabs** to see cursors mo
 | `PORT` | `8000` | TCP port the HTTP/WebSocket server binds to |
 | `BIND_ADDRESS` | `localhost` | Interface to bind. Set to `0.0.0.0` when running in a container or behind a proxy. |
 
+## Building with Docker locally
+
+The Dockerfile depends on the local `beryl` package via `path = "../.."`, so the
+build context **must be the repository root**, not `examples/cursors`:
+
+```bash
+# From the repository root:
+docker build -f examples/cursors/Dockerfile -t beryl-cursors .
+docker run --rm -p 8000:8000 beryl-cursors
+```
+
+Running `docker build .` from inside `examples/cursors/` will fail because the
+parent `beryl` source is outside the build context.
+
 ## Deploying to Railway
 
 The example ships with a [`Dockerfile`](./Dockerfile) and [`railway.toml`](./railway.toml).

--- a/justfile
+++ b/justfile
@@ -128,6 +128,10 @@ examples-test: examples-build
     pnpm -C examples/chatrooms test
     pnpm -C examples/collab_docs test
 
+# Build the cursors example Docker image (must run from repo root for path-based beryl dep)
+examples-cursors-docker tag="beryl-cursors":
+    docker build -f examples/cursors/Dockerfile -t {{tag}} .
+
 # === MAINTENANCE ===
 
 # Remove build artifacts


### PR DESCRIPTION
## Summary

Fixes the cursors example Docker build (used by Railway deployment), which was failing with:

```
error: Program not found
The program `git` was not found. Is it installed?
```

The `ghcr.io/gleam-lang/gleam:*-erlang-alpine` image does not include `git`, but `gleam deps download` needs it to resolve hex dependencies on a clean build. Local builds happened to work because the dep cache was already populated; Railway builds always start clean and failed.

## Changes

- **`examples/cursors/Dockerfile`**: `apk add --no-cache git` in the build stage. Also added a fail-fast check + comments clarifying that the build context must be the repository root (the example depends on `beryl` via `path = "../.."`).
- **`justfile`**: new `examples-cursors-docker [tag]` recipe so contributors don't have to remember the `-f` / context dance.
- **`examples/cursors/README.md`**: documented the local Docker build command.
- **Changelog**: `Fixed` fragment.

## Verification

```bash
just examples-cursors-docker beryl-cursors-clean
# and
docker build --no-cache --pull -f examples/cursors/Dockerfile -t beryl-cursors-clean .
```

Both succeed end-to-end, including `gleam deps download` and `gleam export erlang-shipment`.
