### PR TITLE
fix(examples/cursors): make Railway healthcheck pass

### DIFF
--- a/.changes/unreleased/Fixed-20260522-151830.yaml
+++ b/.changes/unreleased/Fixed-20260522-151830.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Cursors example Railway deploy now passes healthchecks by serving a dedicated `/healthz` endpoint and using Railway's default 300s healthcheck timeout (was 30s, too short for Erlang cold start).
+time: 2026-05-22T15:18:30.000000-07:00

--- a/examples/cursors/railway.toml
+++ b/examples/cursors/railway.toml
@@ -10,7 +10,7 @@ builder = "DOCKERFILE"
 dockerfilePath = "examples/cursors/Dockerfile"
 
 [deploy]
-healthcheckPath = "/"
-healthcheckTimeout = 30
+healthcheckPath = "/healthz"
+healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 5

--- a/examples/cursors/src/cursors/router.gleam
+++ b/examples/cursors/src/cursors/router.gleam
@@ -1,6 +1,7 @@
 import beryl
 import beryl/presence
 import example_helpers/static
+import gleam/bytes_tree
 import gleam/http/request.{type Request}
 import gleam/http/response.{type Response}
 import mist.{type Connection, type ResponseData}
@@ -13,16 +14,27 @@ pub fn handle_request(
   req: Request(Connection),
   _ctx: Context,
 ) -> Response(ResponseData) {
-  use <- static.serve_static(
-    req,
-    under: "/static",
-    from: static.priv_static("cursors"),
-  )
-
   case request.path_segments(req) {
-    [] -> index_page()
-    _ -> static.not_found()
+    ["healthz"] -> healthz()
+    _ -> {
+      use <- static.serve_static(
+        req,
+        under: "/static",
+        from: static.priv_static("cursors"),
+      )
+
+      case request.path_segments(req) {
+        [] -> index_page()
+        _ -> static.not_found()
+      }
+    }
   }
+}
+
+fn healthz() -> Response(ResponseData) {
+  response.new(200)
+  |> response.set_header("content-type", "text/plain; charset=utf-8")
+  |> response.set_body(mist.Bytes(bytes_tree.from_string("ok")))
 }
 
 fn index_page() -> Response(ResponseData) {


### PR DESCRIPTION
## Summary

The cursors example failed to deploy on Railway because the healthcheck never succeeded.

Two issues:

1. **`healthcheckTimeout = 30`** — far below Railway's default of 300s. Erlang VM cold start + Gleam app boot + Mist listener can easily exceed 30s on a first deploy, so Railway marked the deployment failed before the app was even listening.
2. **`healthcheckPath = "/"`** routed the healthcheck through `static.serve_static` and `application.priv_directory("cursors")`. Any crash in that path 500s every healthcheck and makes failure modes harder to diagnose.

## Changes

- `examples/cursors/railway.toml`: `healthcheckPath` → `/healthz`, `healthcheckTimeout` 30 → 300.
- `examples/cursors/src/cursors/router.gleam`: add a dedicated `/healthz` route that returns `200 ok` with no dependencies on the static file pipeline.
- changie fragment.

## Verification

- `gleam check` passes.