### PR TITLE
fix(examples/cursors): pin docker build stage to OTP 27

### DIFF
--- a/.changes/unreleased/Fixed-20260523-095243.yaml
+++ b/.changes/unreleased/Fixed-20260523-095243.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix cursors example Docker build OTP version mismatch. The upstream gleam build image ships OTP 28, but the runtime image uses OTP 27, causing 'corrupt atom table' errors that surfaced as 'cursors@@main:run/1 undef' at boot on Railway. Build stage now uses the same erlang:27.2.1-alpine base and installs the pinned Gleam binary from GitHub releases.
+time: 2026-05-23T09:52:43.260437-07:00

--- a/examples/cursors/Dockerfile
+++ b/examples/cursors/Dockerfile
@@ -8,10 +8,27 @@
 #
 # Running `docker build .` from inside examples/cursors/ will fail to resolve
 # the local beryl dependency.
-FROM ghcr.io/gleam-lang/gleam:v1.16.0-erlang-alpine AS build
+# Pin the build stage to the same Erlang/OTP version as the runtime stage so
+# the generated .beam files load cleanly. The upstream
+# `ghcr.io/gleam-lang/gleam:v1.16.0-erlang-alpine` image ships OTP 28, whose
+# atom-table encoding cannot be loaded by OTP 27 ("corrupt atom table" →
+# `cursors@@main:run/1` undef at boot). Building Gleam on top of the same
+# erlang:27.2.1-alpine base we use at runtime avoids that mismatch.
+FROM erlang:27.2.1-alpine AS build
 
-# git is required by `gleam deps download` for resolving dependencies.
-RUN apk add --no-cache git
+ARG GLEAM_VERSION=v1.16.0
+
+# git is required by `gleam deps download`; rebar3 is required to compile
+# Erlang/OTP dependencies (e.g. hpack, gramps).
+RUN apk add --no-cache git rebar3 curl ca-certificates \
+ && case "$(uname -m)" in \
+      aarch64) GLEAM_ARCH=aarch64-unknown-linux-musl ;; \
+      x86_64)  GLEAM_ARCH=x86_64-unknown-linux-musl ;; \
+      *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL "https://github.com/gleam-lang/gleam/releases/download/${GLEAM_VERSION}/gleam-${GLEAM_VERSION}-${GLEAM_ARCH}.tar.gz" \
+      | tar -xz -C /usr/local/bin gleam \
+ && gleam --version
 
 WORKDIR /src
 


### PR DESCRIPTION
## Summary

Fixes the Railway deployment of the cursors example crashing at boot with:

```
Error! Failed to eval: cursors@@main:run(cursors)
Runtime terminating during boot ({undef,[{'cursors@@main',run,[cursors],[]}, ...
```

## Root cause

The build stage used `ghcr.io/gleam-lang/gleam:v1.16.0-erlang-alpine`, which ships **Erlang/OTP 28**. The runtime stage uses `erlang:27.2.1-alpine` (OTP 27 — matching `.tool-versions`). OTP 28 emits a newer atom-table encoding that OTP 27 cannot load, so every module — including the auto-generated `cursors@@main` — failed with `corrupt atom table` and the entrypoint exited as `undef` at boot.

Verified by loading the beam directly inside the runtime image:

```
> code:load_file('cursors@@main').
{error,badfile}
=ERROR REPORT====
beam/beam_load.c(150): Error loading module 'cursors@@main':
  corrupt atom table
```

## Fix

`examples/cursors/Dockerfile`: switch the build stage to the same `erlang:27.2.1-alpine` base used at runtime, and install the pinned Gleam binary (`v1.16.0`, musl, arch-aware via `uname -m`) from GitHub releases. Also installs `rebar3` for OTP deps (`hpack`, `gramps`).

## Verification

Locally on the same image Railway will build:

- `docker build -f examples/cursors/Dockerfile .` → succeeds
- `docker run ... beryl-cursors` → boots cleanly, logs `Listening on 0.0.0.0:8000`
- `curl /healthz` → `ok`

## Changelog

Added `.changes/unreleased/Fixed-*.yaml` via `changie new`.
