### PR TITLE
chore(examples/showcase): temporarily hide collab_docs demo

### DIFF
--- a/.changes/unreleased/Changed-20260523-104815.yaml
+++ b/.changes/unreleased/Changed-20260523-104815.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Examples — temporarily hide the collab_docs demo from the `examples/showcase` deployment. The card on the landing page and the `/docs` route are removed; the handler is still registered in `showcase.main`, so re-enabling is a small, localized change to `showcase/router.gleam`. Standalone `examples/collab_docs` is unaffected.
+time: 2026-05-23T10:48:15.673972-07:00

--- a/examples/showcase/src/showcase/router.gleam
+++ b/examples/showcase/src/showcase/router.gleam
@@ -28,7 +28,10 @@ pub fn handle_request(
     ["healthz"] -> healthz()
     ["cursors", ..] -> cursors_router.handle_request(req, ctx.cursors)
     ["chat", ..] -> chatrooms_router.handle_request(req, ctx.chatrooms)
-    ["docs", ..] -> collab_docs_router.handle_request(req, ctx.collab_docs)
+    // TODO: re-enable the collab_docs demo. The handler is still
+    // registered in showcase.main so reinstating the route + landing
+    // card is a one-line change.
+    // ["docs", ..] -> collab_docs_router.handle_request(req, ctx.collab_docs)
     _ -> static.not_found()
   }
 }
@@ -116,11 +119,6 @@ fn landing_page() -> Response(ResponseData) {
       <span class=\"emoji\">💬</span>
       <h2>Chat rooms</h2>
       <p>Multi-room chat with typing indicators, presence sidebar, and named groups.</p>
-    </a>
-    <a class=\"card\" href=\"/docs\">
-      <span class=\"emoji\">📝</span>
-      <h2>Collaborative CRDT docs</h2>
-      <p>Concurrent edits to shared document blocks backed by lattice CRDTs.</p>
     </a>
   </main>
   <footer>


### PR DESCRIPTION
## Summary

Temporarily hides the `collab_docs` demo from the `examples/showcase` Railway deployment.

- Landing page no longer shows the "Collaborative CRDT docs" card.
- The `/docs` route is removed from the showcase router (returns 404).
- The handler is **still registered** in `showcase.main` and `Context` still carries `collab_docs`, so re-enabling is a tiny localized revert of the route case and the card markup in `showcase/router.gleam`. A TODO comment in the router calls this out at the exact spot.
- Standalone `examples/collab_docs` (`cd examples/collab_docs && gleam run`) is unaffected.

## Verification

- `gleam check` clean.
- Local `gleam run`: `/`, `/healthz`, `/cursors`, `/chat` return 200; `/docs` and `/docs/static/style.css` return 404; landing HTML links only to `/cursors` and `/chat`.
