### PR TITLE
ci(release): set release PR title to 'release: <version>'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
+          pr-title-template: 'release: {version}'
           version-files: |
             gleam.toml:version
 


### PR DESCRIPTION
## Summary

Configure the `changie-release` action to title release PRs as `release: <version>` (e.g. `release: v0.1.0`) instead of the default `Release <version>`.

## Changes

- Add `pr-title-template: 'release: {version}'` to the `changie-release` step in `.github/workflows/release.yml`.