### PR TITLE
fix(commitlint): allow release commit type

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -15,6 +15,7 @@
         "build",
         "ci",
         "chore",
+        "release",
         "revert"
       ]
     ],


### PR DESCRIPTION
## Summary
- allow `release` in commitlint's type enum so release automation and release PRs follow the conventional type list
- keep the branch validated against the repository CI checks before opening the PR

## Test Plan
- [x] `just ci`
