### PR TITLE
feat: bridge an external OTP actor stream to a socket

### DIFF
--- a/.changes/unreleased/Added-20260612-204509.yaml
+++ b/.changes/unreleased/Added-20260612-204509.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'Channels — new `beryl/bridge` module forwards an external OTP actor''s message stream to a socket channel. `bridge.start` spawns a forwarder process that maps each value received on its `Subject` and delivers it via `beryl.send_info` to a socket/topic''s `handle_info`; `bridge.subject` exposes the subject to wire up a domain actor, and `bridge.stop` tears the forwarder down. The forwarder also monitors the owning channel process, so it is cleaned up automatically if that process dies — removing the error-prone per-socket forwarder boilerplate (#92).'
+time: 2026-06-12T20:45:09.000000-07:00

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ flowchart TD
 - **Presence** — Distributed presence tracking using a CRDT (add-wins observed-remove set)
 - **Groups** — Named channel groups for multi-topic broadcasting
 - **PubSub** — pg-based distributed publish/subscribe
+- **Actor bridge** — forward an external OTP actor's stream to a socket with `beryl/bridge`
 - **WebSocket transport** — Mist integration with Phoenix-compatible wire protocol
 
 ## Examples
@@ -130,6 +131,66 @@ Three runnable demos are included in the `examples/` directory:
 | [`examples/collab_docs`](examples/collab_docs/) | Client-side CRDT document blocks, segment wildcards, conflict resolution |
 
 See the [Examples page](https://beryl.tylerbutler.com/examples/) in the docs for a full comparison.
+
+## Recipe: bridge an external actor to a socket
+
+A long-lived domain actor (for example a per-document session) often emits
+updates that need to be pushed to each joined socket. The `beryl/bridge` module
+removes the per-socket forwarder boilerplate: start a bridge in `join`, subscribe
+your actor to the bridge's `Subject`, and stop it in `terminate`. Each value the
+actor emits is translated and delivered to the channel's `handle_info` callback
+via `beryl.send_info`. The forwarder also monitors the channel process, so it is
+cleaned up automatically if that process dies — no leaked processes.
+
+```gleam
+import beryl
+import beryl/bridge.{type Bridge}
+import beryl/channel.{type Channel}
+import beryl/socket
+import gleam/dynamic/decode
+import gleam/json
+import gleam/option.{None}
+
+// Messages emitted by your domain actor.
+pub type DocEvent {
+  Updated(version: Int)
+}
+
+pub type Assigns {
+  Assigns(bridge: Bridge(DocEvent))
+}
+
+fn new_channel(channels: beryl.Channels, doc_actor) -> Channel(Assigns) {
+  channel.new(fn(topic, _payload, socket) {
+    // Forward every DocEvent emitted by the actor to this socket/topic.
+    let b =
+      bridge.start(
+        channels: channels,
+        socket_id: socket.id(socket),
+        topic: topic,
+        with: fn(event) { event },
+      )
+    // Hand the bridge's subject to the domain actor as its subscriber.
+    doc.subscribe(doc_actor, bridge.subject(b))
+    channel.JoinOk(reply: None, socket: socket.set_assigns(socket, Assigns(b)))
+  })
+  |> channel.with_handle_info(fn(message, socket) {
+    case decode.run(message, doc_event_decoder()) {
+      Ok(Updated(version)) ->
+        channel.Push(
+          "doc_updated",
+          json.object([#("version", json.int(version))]),
+          socket,
+        )
+      _ -> channel.NoReply(socket)
+    }
+  })
+  // Always stop the bridge on terminate for prompt, deterministic cleanup.
+  |> channel.with_terminate(fn(_reason, socket) {
+    bridge.stop(socket.get_assigns(socket).bridge)
+  })
+}
+```
 
 ## Releases & changelog
 

--- a/src/beryl/bridge.gleam
+++ b/src/beryl/bridge.gleam
@@ -1,0 +1,169 @@
+//// Bridge - Forward an external OTP actor's message stream to a socket channel.
+////
+//// A common pattern is a long-lived domain actor (e.g. a per-document session)
+//// that emits updates which need to be pushed to each joined socket. Wiring
+//// this up by hand requires per-socket boilerplate: spawn a forwarder process
+//// holding a `Subject`, subscribe it to the domain actor, translate each
+//// message and call `beryl.send_info`, then tear the process down on
+//// `terminate`.
+////
+//// `bridge` packages that plumbing into a single helper. Start a bridge inside
+//// a channel `join`, store the handle in the socket assigns, subscribe the
+//// returned `Subject` to your domain actor, and stop the bridge in `terminate`.
+//// The forwarder also monitors the owning channel process, so it is cleaned up
+//// automatically if that process dies — no leaked processes.
+////
+//// ## Example
+////
+//// ```gleam
+//// import beryl
+//// import beryl/bridge.{type Bridge}
+//// import beryl/channel
+//// import beryl/socket
+////
+//// // Messages emitted by your domain actor.
+//// pub type DocEvent {
+////   Updated(version: Int)
+//// }
+////
+//// pub type Assigns {
+////   Assigns(bridge: Bridge(DocEvent))
+//// }
+////
+//// fn join(channels, doc_actor, topic, _payload, socket) {
+////   // Forward each DocEvent to this socket's `handle_info` callback.
+////   let b =
+////     bridge.start(
+////       channels: channels,
+////       socket_id: socket.id(socket),
+////       topic: topic,
+////       with: fn(event) { event },
+////     )
+////   // Subscribe the domain actor to the bridge's subject.
+////   doc.subscribe(doc_actor, bridge.subject(b))
+////   channel.JoinOk(reply: None, socket: socket.set_assigns(socket, Assigns(b)))
+//// }
+////
+//// fn terminate(_reason, socket) {
+////   bridge.stop(socket.get_assigns(socket).bridge)
+//// }
+//// ```
+
+import beryl.{type Channels}
+import gleam/erlang/process.{type Pid, type Subject}
+
+/// How long `start` waits for the forwarder process to report its subjects
+/// before giving up. The handshake is local and effectively instant; the
+/// timeout only guards against a forwarder that failed to spawn.
+const handshake_timeout_ms = 5000
+
+/// A handle to a running bridge forwarder process.
+///
+/// `message` is the type emitted by the external actor and received on the
+/// bridge's `Subject`. Obtain that subject with `subject` to wire it up to a
+/// domain actor, and call `stop` to tear the forwarder down.
+pub opaque type Bridge(message) {
+  Bridge(pid: Pid, subject: Subject(message), control: Subject(Control))
+}
+
+/// Internal control messages for the forwarder loop.
+type Control {
+  Stop
+}
+
+/// Unified event type selected by the forwarder loop.
+type Event(message) {
+  Forward(message)
+  Stopped
+  OwnerDown
+}
+
+/// Start a bridge that forwards values from an external `Subject` to a socket's
+/// channel as `handle_info` messages.
+///
+/// The returned `Bridge` owns a freshly spawned forwarder process. Pass
+/// `subject(bridge)` to the external/domain actor so it delivers its stream to
+/// the forwarder; each received value is mapped with `transform` and delivered
+/// via `beryl.send_info(channels, socket_id, topic, transform(value))`.
+///
+/// Use `transform` to translate the domain message into whatever your channel's
+/// `handle_info` expects. If no translation is needed, pass the identity
+/// function `fn(value) { value }`.
+///
+/// The forwarder monitors the calling (channel) process and exits if it dies,
+/// so a missed `stop` will not leak a process. Always call `stop` from your
+/// channel's `terminate` for prompt, deterministic cleanup.
+pub fn start(
+  channels channels: Channels,
+  socket_id socket_id: String,
+  topic topic: String,
+  with transform: fn(message) -> info,
+) -> Bridge(message) {
+  let ready = process.new_subject()
+  let owner = process.self()
+
+  let pid =
+    process.spawn_unlinked(fn() {
+      // Subjects must be created in the process that receives on them, so the
+      // forwarder makes them here and hands them back to the caller.
+      let data = process.new_subject()
+      let control = process.new_subject()
+      let monitor = process.monitor(owner)
+
+      let selector =
+        process.new_selector()
+        |> process.select_map(data, Forward)
+        |> process.select_map(control, fn(_) { Stopped })
+        |> process.select_specific_monitor(monitor, fn(_) { OwnerDown })
+
+      process.send(ready, #(data, control))
+      forward_loop(selector, channels, socket_id, topic, transform)
+    })
+
+  let assert Ok(#(data, control)) = process.receive(ready, handshake_timeout_ms)
+
+  Bridge(pid: pid, subject: data, control: control)
+}
+
+fn forward_loop(
+  selector: process.Selector(Event(message)),
+  channels: Channels,
+  socket_id: String,
+  topic: String,
+  transform: fn(message) -> info,
+) -> Nil {
+  case process.selector_receive_forever(selector) {
+    Forward(value) -> {
+      beryl.send_info(channels, socket_id, topic, transform(value))
+      forward_loop(selector, channels, socket_id, topic, transform)
+    }
+    // `stop` was called, or the owning channel process went down — exit
+    // normally so the forwarder is cleaned up.
+    Stopped -> Nil
+    OwnerDown -> Nil
+  }
+}
+
+/// The `Subject` the external actor should send its stream to.
+///
+/// Hand this to your domain actor (e.g. as its subscriber) so each emitted
+/// value is forwarded to the bridged socket/topic.
+pub fn subject(bridge: Bridge(message)) -> Subject(message) {
+  bridge.subject
+}
+
+/// The forwarder process id.
+///
+/// Exposed for diagnostics and supervision; you normally only need `subject`
+/// and `stop`.
+pub fn pid(bridge: Bridge(message)) -> Pid {
+  bridge.pid
+}
+
+/// Stop the bridge's forwarder process.
+///
+/// Call this from your channel's `terminate` callback. It is safe to call more
+/// than once and after the forwarder has already exited.
+pub fn stop(bridge: Bridge(message)) -> Nil {
+  process.send(bridge.control, Stop)
+}

--- a/test/bridge_test.gleam
+++ b/test/bridge_test.gleam
@@ -1,0 +1,134 @@
+import beryl
+import beryl/bridge
+import beryl/channel
+import beryl/coordinator
+import beryl/wire
+import gleam/dynamic/decode
+import gleam/erlang/process
+import gleam/json
+import gleam/option
+import gleam/string
+import gleeunit/should
+import test_helpers.{wait_until}
+
+fn start_channels_with_socket(
+  socket_id: String,
+) -> #(beryl.Channels, process.Subject(String)) {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let sent_messages = process.new_subject()
+
+  process.send(
+    channels.coordinator,
+    coordinator.SocketConnected(
+      socket_id,
+      fn(text) {
+        process.send(sent_messages, text)
+        Ok(Nil)
+      },
+      fn(_) { Ok(Nil) },
+    ),
+  )
+
+  #(channels, sent_messages)
+}
+
+fn notify_channel() -> channel.Channel(Nil) {
+  channel.new(fn(_topic, _payload, socket) {
+    channel.JoinOk(reply: option.None, socket: socket)
+  })
+  |> channel.with_handle_info(fn(message, socket) {
+    case decode.run(message, decode.string) {
+      Ok(text) ->
+        channel.Push(
+          "server_notify",
+          json.object([#("text", json.string(text))]),
+          socket,
+        )
+      _ -> channel.NoReply(socket)
+    }
+  })
+}
+
+pub fn bridge_forwards_subject_values_to_handle_info_test() {
+  let #(channels, sent_messages) = start_channels_with_socket("bridge-sock")
+
+  beryl.register(channels, "room:*", notify_channel())
+  |> should.equal(Ok(Nil))
+
+  coordinator.route_message(
+    channels.coordinator,
+    "bridge-sock",
+    "[null,\"join-ref\",\"room:lobby\",\"phx_join\",{}]",
+  )
+
+  let assert Ok(join_reply) = process.receive(sent_messages, 500)
+  join_reply |> string.contains("phx_reply") |> should.be_true
+
+  // Bridge an external stream (here, a plain Subject standing in for a domain
+  // actor) to this socket/topic, translating each value before forwarding.
+  let b =
+    bridge.start(
+      channels: channels,
+      socket_id: "bridge-sock",
+      topic: "room:lobby",
+      with: fn(n: Int) { "tick-" <> string.inspect(n) },
+    )
+
+  process.send(bridge.subject(b), 1)
+
+  let assert Ok(push) = process.receive(sent_messages, 500)
+  push |> string.contains("server_notify") |> should.be_true
+  push |> string.contains("tick-1") |> should.be_true
+
+  // A second value is forwarded too — the forwarder loops.
+  process.send(bridge.subject(b), 2)
+  let assert Ok(push2) = process.receive(sent_messages, 500)
+  push2 |> string.contains("tick-2") |> should.be_true
+
+  bridge.stop(b)
+}
+
+pub fn bridge_stop_tears_down_forwarder_test() {
+  let #(channels, _sent) = start_channels_with_socket("bridge-stop-sock")
+
+  let b =
+    bridge.start(
+      channels: channels,
+      socket_id: "bridge-stop-sock",
+      topic: "room:lobby",
+      with: fn(x: String) { x },
+    )
+
+  let pid = bridge.pid(b)
+  process.is_alive(pid) |> should.be_true
+
+  bridge.stop(b)
+
+  wait_until(fn() { !process.is_alive(pid) }, 1000, 10)
+  process.is_alive(pid) |> should.be_false
+}
+
+pub fn bridge_cleans_up_when_owner_dies_test() {
+  let #(channels, _sent) = start_channels_with_socket("bridge-owner-sock")
+
+  let pid_back = process.new_subject()
+
+  // Start the bridge from a short-lived owner process. When that process
+  // exits, the monitored forwarder should exit too — no leak even without an
+  // explicit stop.
+  process.spawn_unlinked(fn() {
+    let b =
+      bridge.start(
+        channels: channels,
+        socket_id: "bridge-owner-sock",
+        topic: "room:lobby",
+        with: fn(x: String) { x },
+      )
+    process.send(pid_back, bridge.pid(b))
+  })
+
+  let assert Ok(forwarder) = process.receive(pid_back, 1000)
+
+  wait_until(fn() { !process.is_alive(forwarder) }, 1000, 10)
+  process.is_alive(forwarder) |> should.be_false
+}


### PR DESCRIPTION
## Summary

Implements #92 — a first-class way to bridge an external OTP actor's message stream to a channel socket, removing the error-prone per-socket forwarder boilerplate (spawn a forwarder process holding a `Subject`, subscribe it to the domain actor, translate each message and call `beryl.send_info`, handle lifecycle/cleanup on `terminate`).

New module `beryl/bridge`:

- **`bridge.start(channels:, socket_id:, topic:, with:)`** — spawns a forwarder process. Each value received on the bridge's `Subject` is mapped with the `with` transform and delivered via `beryl.send_info` to the socket/topic's `handle_info`.
- **`bridge.subject(bridge)`** — exposes the `Subject` so a domain actor can be subscribed to it.
- **`bridge.stop(bridge)`** — tears the forwarder down (call from `terminate`; safe to call repeatedly / after exit).
- **`bridge.pid(bridge)`** — forwarder pid, for diagnostics/supervision.

### Lifecycle / no leak

The forwarder is spawned **unlinked** (so a crash in the user's `transform` cannot take down the coordinator) but **monitors the owning channel process**. If that process dies without an explicit `stop`, the monitor fires and the forwarder exits — no leaked process. `stop` provides prompt, deterministic teardown for the normal `terminate` path.

### Forward-compatible with #91 (typed info)

`bridge` is generic over the external message type and the forwarded `info` type (`with: fn(message) -> info`), so it slots cleanly into a future `Channel(assigns, info)` typed-info parameter without API changes. It works today against the current `Dynamic` info path.

## Docs & changelog

- Added a **"Recipe: bridge an external actor to a socket"** section to `README.md` plus a Features bullet.
- Added a changie `Added` fragment.

## Tests

New `test/bridge_test.gleam`:

- `bridge_forwards_subject_values_to_handle_info_test` — values sent to the bridge subject are translated and delivered to `handle_info` (and the forwarder loops for subsequent values).
- `bridge_stop_tears_down_forwarder_test` — `stop` exits the forwarder process.
- `bridge_cleans_up_when_owner_dies_test` — when the owning process dies without `stop`, the monitored forwarder is cleaned up (no leak).

## Validation

Commands run locally (from `CLAUDE.md` / issue acceptance):

```
gleam format --check src test      # clean
gleam build --warnings-as-errors   # Compiled, no warnings
gleam test                         # 169 passed, no failures
```

Closes #92
