### PR TITLE
fix(api): make channels opaque

### DIFF
--- a/.changes/unreleased/Changed-20260624-112231.yaml
+++ b/.changes/unreleased/Changed-20260624-112231.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Make `beryl.Channels` opaque so coordinator internals are no longer part of the public API.
+time: 2026-06-24T11:22:31.700112-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -228,19 +228,39 @@ pub fn with_channel_rate(
   Config(..config, channel_rate: rate, channel_burst: burst)
 }
 
-/// Channels system handle
+/// Channels system handle.
 ///
-/// This is the main entry point for interacting with the channels system.
-/// Pass this to channel handlers and the WebSocket transport.
-pub type Channels {
+/// This opaque handle is returned by `start` and passed to registration,
+/// broadcast, bridge, group, supervisor, and transport functions. Its internal
+/// actor protocol is intentionally hidden so Beryl can evolve coordinator
+/// internals without breaking application code.
+pub opaque type Channels {
   Channels(
-    /// The coordinator actor subject - pass to transport.mist.upgrade()
     coordinator: Subject(coordinator.Message),
-    /// Configuration
     config: Config,
-    /// Optional PubSub for distributed messaging
     pubsub: Option(PubSub),
   )
+}
+
+// nolint: unused_exports -- package-internal constructor for supervised coordinators; hidden from public docs with @internal
+@internal
+pub fn channels_from_coordinator(
+  coordinator coordinator: Subject(coordinator.Message),
+  config config: Config,
+) -> Channels {
+  Channels(coordinator: coordinator, config: config, pubsub: config.pubsub)
+}
+
+// nolint: unused_exports -- package-internal accessor for transports/tests; hidden from public docs with @internal
+@internal
+pub fn coordinator_subject(channels: Channels) -> Subject(coordinator.Message) {
+  channels.coordinator
+}
+
+// nolint: unused_exports -- package-internal accessor for transport codec negotiation; hidden from public docs with @internal
+@internal
+pub fn configured_codec(channels: Channels) -> codec.Codec {
+  channels.config.codec
 }
 
 /// Errors when starting channels
@@ -304,7 +324,7 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
   case coordinator_result {
     Error(_) -> Error(CoordinatorStartFailed)
     Ok(coord) ->
-      Ok(Channels(coordinator: coord, config: config, pubsub: config.pubsub))
+      Ok(channels_from_coordinator(coordinator: coord, config: config))
   }
 }
 

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -222,10 +222,9 @@ fn start_supervised(
       // their names, so named_subject will route messages correctly.
       let coord_subject = process.named_subject(coordinator_name)
       let channels =
-        beryl.Channels(
+        beryl.channels_from_coordinator(
           coordinator: coord_subject,
           config: config.channels,
-          pubsub: config.channels.pubsub,
         )
 
       let pres = case presence_name {

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -204,17 +204,17 @@ fn negotiate_codec(
   request: Request(Connection),
 ) -> Result(Codec, Nil) {
   case request_vsn(request) {
-    None -> Ok(channels.config.codec)
+    None -> Ok(beryl.configured_codec(channels))
     Some(vsn) ->
       case list.key_find(config.serializers, vsn) {
         Ok(codec) -> Ok(codec)
         Error(Nil) ->
           case vsn == default_vsn {
-            True -> Ok(channels.config.codec)
+            True -> Ok(beryl.configured_codec(channels))
             False ->
               case config.reject_unknown_vsn {
                 True -> Error(Nil)
-                False -> Ok(channels.config.codec)
+                False -> Ok(beryl.configured_codec(channels))
               }
           }
       }
@@ -291,7 +291,7 @@ pub fn upgrade_connection(
 ) -> Response(ResponseData) {
   let codec =
     negotiate_codec(default_config(""), channels, request)
-    |> result.unwrap(channels.config.codec)
+    |> result.unwrap(beryl.configured_codec(channels))
   do_upgrade(request, channels, codec, dynamic.nil())
 }
 
@@ -308,7 +308,12 @@ fn do_upgrade(
       on_message(state, message, connection)
     },
     on_init: fn(connection) {
-      on_init(connection, channels.coordinator, codec, connect_assigns)
+      on_init(
+        connection,
+        beryl.coordinator_subject(channels),
+        codec,
+        connect_assigns,
+      )
     },
     on_close: on_close,
   )

--- a/test/beryl_test.gleam
+++ b/test/beryl_test.gleam
@@ -181,7 +181,7 @@ pub fn segment_wildcard_registered_channel_routes_matching_topic_test() {
   let sent_messages = process.new_subject()
 
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       "segment-socket",
       fn(text) {
@@ -209,7 +209,7 @@ pub fn segment_wildcard_registered_channel_routes_matching_topic_test() {
   |> should.equal(Ok(Nil))
 
   coordinator.route_message(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "segment-socket",
     "[null,\"join-ref\",\"document:tenant-a:ops\",\"phx_join\",{}]",
   )
@@ -224,7 +224,7 @@ pub fn segment_wildcard_registered_channel_rejects_wrong_segment_test() {
   let sent_messages = process.new_subject()
 
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       "segment-reject-socket",
       fn(text) {
@@ -246,7 +246,7 @@ pub fn segment_wildcard_registered_channel_rejects_wrong_segment_test() {
   |> should.equal(Ok(Nil))
 
   coordinator.route_message(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "segment-reject-socket",
     "[null,\"join-ref\",\"document:tenant-a:view\",\"phx_join\",{}]",
   )
@@ -272,7 +272,7 @@ pub fn send_info_routes_message_to_joined_channel_test() {
   let sent_messages = process.new_subject()
 
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       "socket-info",
       fn(text) {
@@ -305,7 +305,7 @@ pub fn send_info_routes_message_to_joined_channel_test() {
   |> should.equal(Ok(Nil))
 
   coordinator.route_message(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "socket-info",
     "[null,\"join-ref\",\"room:lobby\",\"phx_join\",{}]",
   )
@@ -333,7 +333,7 @@ pub fn send_info_typed_message_round_trips_without_cast_test() {
   let sent_messages = process.new_subject()
 
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       "socket-typed-info",
       fn(text) {
@@ -367,7 +367,7 @@ pub fn send_info_typed_message_round_trips_without_cast_test() {
   |> should.equal(Ok(Nil))
 
   coordinator.route_message(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "socket-typed-info",
     "[null,\"join-ref\",\"room:lobby\",\"phx_join\",{}]",
   )
@@ -387,7 +387,7 @@ pub fn send_info_reply_result_pushes_message_to_client_test() {
   let sent_messages = process.new_subject()
 
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       "socket-info-reply",
       fn(text) {
@@ -416,7 +416,7 @@ pub fn send_info_reply_result_pushes_message_to_client_test() {
   |> should.equal(Ok(Nil))
 
   coordinator.route_message(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "socket-info-reply",
     "[null,\"join-ref\",\"room:lobby\",\"phx_join\",{}]",
   )
@@ -439,7 +439,7 @@ pub fn connect_assigns_visible_in_channel_join_test() {
 
   // Seed socket-level assigns as if produced by the transport on_connect hook.
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       "auth-socket",
       fn(text) {
@@ -465,7 +465,7 @@ pub fn connect_assigns_visible_in_channel_join_test() {
   |> should.equal(Ok(Nil))
 
   coordinator.route_message(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "auth-socket",
     "[null,\"join-ref\",\"room:lobby\",\"phx_join\",{}]",
   )
@@ -695,6 +695,18 @@ pub fn extract_topic_id_test() {
 
   beryl.extract_topic_id(topic.Exact("room:lobby"), "room:lobby")
   |> should.equal(Error(Nil))
+}
+
+pub fn channels_handle_remains_usable_after_start_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+
+  let handler =
+    channel.new(fn(_topic, _payload, socket) {
+      channel.JoinOk(reply: option.None, socket: socket)
+    })
+
+  beryl.register(channels, "opaque:*", handler)
+  |> should.equal(Ok(Nil))
 }
 
 pub fn topic_namespace_test() {

--- a/test/binary_codec_test.gleam
+++ b/test/binary_codec_test.gleam
@@ -157,7 +157,7 @@ pub fn binary_codec_routes_join_message_and_reply_over_binary_test() {
   let assert Ok(channels) = beryl.start(beryl.config(binary_test_codec()))
 
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       "socket-1",
       fn(text) {
@@ -200,7 +200,7 @@ pub fn binary_codec_routes_join_message_and_reply_over_binary_test() {
   beryl.register(channels, "room:*", handler) |> should.equal(Ok(Nil))
 
   coordinator.route_binary(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "socket-1",
     bit_array.from_string("J|join-ref|join-1|room:lobby|{\"user\":\"alice\"}"),
   )
@@ -211,7 +211,7 @@ pub fn binary_codec_routes_join_message_and_reply_over_binary_test() {
   |> should.equal(Ok("R|join-1|room:lobby|ok|{\"joined\":true}"))
 
   coordinator.route_binary(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "socket-1",
     bit_array.from_string("E|event-1|room:lobby|ping|{\"body\":\"hi\"}"),
   )
@@ -232,7 +232,7 @@ pub fn binary_codec_event_consumes_one_message_rate_token_test() {
   let assert Ok(channels) = beryl.start(config)
 
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       "socket-1",
       fn(_) { Ok(Nil) },
@@ -256,14 +256,14 @@ pub fn binary_codec_event_consumes_one_message_rate_token_test() {
   beryl.register(channels, "room:*", handler) |> should.equal(Ok(Nil))
 
   coordinator.route_binary(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "socket-1",
     bit_array.from_string("J|join-ref|join-1|room:lobby|{}"),
   )
   let assert Ok(_join_reply_bits) = process.receive(sent_binary, 500)
 
   coordinator.route_binary(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "socket-1",
     bit_array.from_string("E|event-1|room:lobby|ping|{}"),
   )
@@ -272,7 +272,7 @@ pub fn binary_codec_event_consumes_one_message_rate_token_test() {
   |> should.equal(Ok("R|event-1|room:lobby|ok|{\"ok\":true}"))
 
   coordinator.route_binary(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "socket-1",
     bit_array.from_string("E|event-2|room:lobby|ping|{}"),
   )
@@ -287,7 +287,7 @@ pub fn binary_codec_broadcast_uses_binary_send_test() {
   let assert Ok(channels) = beryl.start(beryl.config(binary_test_codec()))
 
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       "socket-1",
       fn(text) {
@@ -311,7 +311,7 @@ pub fn binary_codec_broadcast_uses_binary_send_test() {
   beryl.register(channels, "room:*", handler) |> should.equal(Ok(Nil))
 
   coordinator.route_binary(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "socket-1",
     bit_array.from_string("J|join-ref|join-1|room:lobby|{}"),
   )
@@ -336,7 +336,7 @@ pub fn phoenix_codec_without_binary_decoder_preserves_raw_binary_handler_test() 
   let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
 
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       "socket-1",
       fn(text) {
@@ -361,14 +361,14 @@ pub fn phoenix_codec_without_binary_decoder_preserves_raw_binary_handler_test() 
   beryl.register(channels, "room:*", handler) |> should.equal(Ok(Nil))
 
   coordinator.route_message(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "socket-1",
     "[null,\"join-ref\",\"room:lobby\",\"phx_join\",{}]",
   )
   let assert Ok(_join_reply) = process.receive(sent_text, 500)
 
   coordinator.route_binary(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "socket-1",
     bit_array.from_string("raw"),
   )

--- a/test/bridge_test.gleam
+++ b/test/bridge_test.gleam
@@ -19,7 +19,7 @@ fn start_channels_with_socket(
   let sent_messages = process.new_subject()
 
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       socket_id,
       fn(text) {
@@ -59,7 +59,7 @@ pub fn bridge_forwards_subject_values_to_handle_info_test() {
   |> should.equal(Ok(Nil))
 
   coordinator.route_message(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "bridge-sock",
     "[null,\"join-ref\",\"room:lobby\",\"phx_join\",{}]",
   )

--- a/test/broadcast_test.gleam
+++ b/test/broadcast_test.gleam
@@ -37,7 +37,7 @@ fn register_test_channel(channels: beryl.Channels) -> Nil {
 
   let reply = process.new_subject()
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.RegisterChannel("room:*", handler, reply),
   )
   let assert Ok(Ok(Nil)) = process.receive(reply, 500)
@@ -55,7 +55,7 @@ fn connect_socket(
   }
 
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       socket_id,
       send,
@@ -75,7 +75,7 @@ fn join_topic(
   sent: process.Subject(String),
 ) -> Nil {
   coordinator.route_message(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     socket_id,
     "[null,\"join-ref\",\"" <> topic_name <> "\",\"phx_join\",{}]",
   )

--- a/test/logging_test.gleam
+++ b/test/logging_test.gleam
@@ -103,12 +103,8 @@ pub fn channels_start_accepts_debug_logging_config_test() {
       include_payloads: False,
     ))
 
-  let assert Ok(channels) = beryl.start(config)
-
-  channels.config.logging.level
-  |> should.equal(beryl.Debug)
-  channels.config.logging.include_payloads
-  |> should.be_false
+  beryl.start(config)
+  |> should.be_ok
 }
 
 pub fn coordinator_config_has_safe_logging_defaults_test() {
@@ -171,7 +167,7 @@ pub fn debug_decode_log_omits_frame_preview_by_default_test() {
   let assert Ok(channels) = beryl.start(config)
 
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       "logging-socket",
       fn(_) { Ok(Nil) },
@@ -181,7 +177,7 @@ pub fn debug_decode_log_omits_frame_preview_by_default_test() {
     ),
   )
   coordinator.route_message(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "logging-socket",
     "[null,\"ref\",\"room:lobby\",\"phx_join\",{\"secret\":\"token\"}]",
   )
@@ -211,7 +207,7 @@ pub fn debug_join_missing_handler_logs_routing_and_send_test() {
   let assert Ok(channels) = beryl.start(config)
 
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       "missing-handler-socket",
       fn(_) { Ok(Nil) },
@@ -221,7 +217,7 @@ pub fn debug_join_missing_handler_logs_routing_and_send_test() {
     ),
   )
   coordinator.route_message(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "missing-handler-socket",
     "[null,\"ref\",\"room:missing\",\"phx_join\",{}]",
   )
@@ -265,7 +261,7 @@ pub fn debug_channel_callback_logs_push_result_test() {
   |> should.equal(Ok(Nil))
 
   process.send(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     coordinator.SocketConnected(
       "callback-log-socket",
       fn(_) { Ok(Nil) },
@@ -275,12 +271,12 @@ pub fn debug_channel_callback_logs_push_result_test() {
     ),
   )
   coordinator.route_message(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "callback-log-socket",
     "[null,\"join-ref\",\"room:lobby\",\"phx_join\",{}]",
   )
   coordinator.route_message(
-    channels.coordinator,
+    beryl.coordinator_subject(channels),
     "callback-log-socket",
     "[\"join-ref\",\"msg-ref\",\"room:lobby\",\"client_event\",{}]",
   )

--- a/test/supervisor_test.gleam
+++ b/test/supervisor_test.gleam
@@ -149,7 +149,8 @@ pub fn stop_shuts_down_supervisor_and_children_test() {
 
   // Get PIDs before stopping
   let sup_pid = supervised.supervisor_pid
-  let assert Ok(coord_pid) = get_subject_pid(supervised.channels.coordinator)
+  let assert Ok(coord_pid) =
+    get_subject_pid(beryl.coordinator_subject(supervised.channels))
 
   // Stop the supervisor
   supervisor.stop(supervised)
@@ -206,7 +207,8 @@ pub fn supervised_coordinator_restarts_on_crash_test() {
     beryl.register(supervised.channels, "pre-crash:*", handler)
 
   // Kill the coordinator process
-  let assert Ok(name) = process.subject_name(supervised.channels.coordinator)
+  let assert Ok(name) =
+    process.subject_name(beryl.coordinator_subject(supervised.channels))
   let coord_subject = process.named_subject(name)
 
   // Send an exit signal to crash the coordinator
@@ -256,7 +258,8 @@ pub fn coordinator_crash_resets_presence_state_test() {
   presence.list(pres, "room:cascade") |> should.not_equal([])
 
   // Get coordinator PID and kill it
-  let assert Ok(name) = process.subject_name(supervised.channels.coordinator)
+  let assert Ok(name) =
+    process.subject_name(beryl.coordinator_subject(supervised.channels))
   let coord_subject = process.named_subject(name)
   let assert Ok(old_coord_pid) = get_subject_pid(coord_subject)
 
@@ -311,7 +314,8 @@ pub fn coordinator_crash_resets_groups_state_test() {
   group.list_groups(grps) |> should.equal(["team:cascade"])
 
   // Get coordinator PID and kill it
-  let assert Ok(name) = process.subject_name(supervised.channels.coordinator)
+  let assert Ok(name) =
+    process.subject_name(beryl.coordinator_subject(supervised.channels))
   let coord_subject = process.named_subject(name)
   let assert Ok(old_coord_pid) = get_subject_pid(coord_subject)
 
@@ -370,7 +374,7 @@ pub fn independent_presence_crash_does_not_affect_coordinator_test() {
 
   // Get coordinator PID before
   let assert Ok(coord_pid_before) =
-    get_subject_pid(supervised.channels.coordinator)
+    get_subject_pid(beryl.coordinator_subject(supervised.channels))
 
   // Kill the presence process directly
   let assert Ok(old_pres_pid) = get_subject_pid(pres.subject)
@@ -390,7 +394,7 @@ pub fn independent_presence_crash_does_not_affect_coordinator_test() {
 
   // Coordinator should still be the same process (not restarted)
   let assert Ok(coord_pid_after) =
-    get_subject_pid(supervised.channels.coordinator)
+    get_subject_pid(beryl.coordinator_subject(supervised.channels))
   coord_pid_after |> should.equal(coord_pid_before)
 
   // Coordinator should still be functional with its existing state
@@ -424,7 +428,7 @@ pub fn independent_groups_crash_does_not_affect_coordinator_test() {
 
   // Get coordinator PID before
   let assert Ok(coord_pid_before) =
-    get_subject_pid(supervised.channels.coordinator)
+    get_subject_pid(beryl.coordinator_subject(supervised.channels))
 
   // Kill the groups process directly
   let assert Ok(old_grps_pid) = get_subject_pid(grps.subject)
@@ -444,7 +448,7 @@ pub fn independent_groups_crash_does_not_affect_coordinator_test() {
 
   // Coordinator should still be the same process (not restarted)
   let assert Ok(coord_pid_after) =
-    get_subject_pid(supervised.channels.coordinator)
+    get_subject_pid(beryl.coordinator_subject(supervised.channels))
   coord_pid_after |> should.equal(coord_pid_before)
 
   // Coordinator should still be functional

--- a/website/src/content/docs/reference/api/beryl-transport-mist.md
+++ b/website/src/content/docs/reference/api/beryl-transport-mist.md
@@ -21,9 +21,22 @@ Configuration for the Mist WebSocket transport
 pub type TransportConfig(a) {
   TransportConfig(
     path: String,
-    on_connect: option.Option(fn(request.Request(http.Connection)) -> Result(a, Nil))
+    on_connect: option.Option(fn(request.Request(http.Connection)) -> Result(a, Nil)),
+    serializers: List(#(String, codec.Codec)),
+    reject_unknown_vsn: Bool
   )
 }
+```
+
+## Constants
+
+### `default_vsn`
+
+Phoenix `vsn` value used by the historical JSON serializer. Connections
+ that omit `vsn` or send this value use the coordinator's configured codec.
+
+```gleam
+pub const default_vsn: String
 ```
 
 ## Functions
@@ -93,6 +106,27 @@ pub fn upgrade(
 ) -> response.Response(mist.ResponseData)
 ```
 
+### `upgrade_connection`
+
+Alternative: upgrade any request to WebSocket (caller handles path matching)
+
+ Note: This function does not invoke the `on_connect` callback from
+ `TransportConfig`. Sockets upgraded this way start with empty (`Nil`)
+ assigns. If you need authentication or seeded assigns, either use `upgrade`
+ with a full config or call your auth check before this function.
+
+ The connection's serializer is negotiated from `?vsn=...`, but no custom
+ serializers are registered, so the coordinator's configured codec is always
+ used. Use `upgrade` with a configured `TransportConfig` to enable
+ per-`vsn` serializers.
+
+```gleam
+pub fn upgrade_connection(
+  request.Request(http.Connection),
+  beryl.Channels
+) -> response.Response(mist.ResponseData)
+```
+
 ### `with_on_connect`
 
 Set a socket-level connect/authentication callback on the transport config.
@@ -108,4 +142,41 @@ pub fn with_on_connect(
   TransportConfig(a),
   fn(request.Request(http.Connection)) -> Result(b, Nil)
 ) -> TransportConfig(b)
+```
+
+### `with_reject_unknown_vsn`
+
+Reject upgrade requests whose `vsn` has no registered serializer.
+
+ When set, an unknown `vsn` (other than `default_vsn`) responds with
+ `400 Bad Request` instead of falling back to the configured codec.
+
+```gleam
+pub fn with_reject_unknown_vsn(
+  TransportConfig(a),
+  Bool
+) -> TransportConfig(a)
+```
+
+### `with_serializer`
+
+Register a serializer for a Phoenix `vsn` value.
+
+ Incoming connections that request this `vsn` (via `?vsn=...`) use the
+ supplied codec for the lifetime of the connection. This is how a
+ MessagePack codec is wired to `vsn=3.0.0`:
+
+ ```gleam
+ mist_transport.default_config("/socket")
+ |> mist_transport.with_serializer("3.0.0", my_msgpack_codec())
+ ```
+
+ Registering the same `vsn` twice keeps the most recently added codec.
+
+```gleam
+pub fn with_serializer(
+  TransportConfig(a),
+  String,
+  codec.Codec
+) -> TransportConfig(a)
 ```

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -58,19 +58,15 @@ Beryl - Type-safe real-time communication
 
 ### `Channels`
 
-Channels system handle
+Channels system handle.
 
- This is the main entry point for interacting with the channels system.
- Pass this to channel handlers and the WebSocket transport.
+ This opaque handle is returned by `start` and passed to registration,
+ broadcast, bridge, group, supervisor, and transport functions. Its internal
+ actor protocol is intentionally hidden so Beryl can evolve coordinator
+ internals without breaking application code.
 
 ```gleam
-pub type Channels {
-  Channels(
-    coordinator: process.Subject(coordinator.Message),
-    config: Config,
-    pubsub: option.Option(pubsub.PubSub)
-  )
-}
+pub type Channels
 ```
 
 ### `Config`
@@ -112,11 +108,10 @@ pub type LoggingConfig {
 
 ### `LogLevel`
 
-Logging verbosity for Beryl's internal palabres loggers.
+Logging verbosity for Beryl's internal loggers.
 
 ```gleam
 pub type LogLevel {
-  Trace
   Debug
   Info
   Warn

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -43,7 +43,7 @@ This page lists common symptoms with targeted diagnosis steps. Start from your s
 
 2. **Is `beryl.Channels` passed to the transport?** The `mist_transport.upgrade` call must receive the same `channels` value that was registered against:
    ```gleam
-   use <- mist_transport.upgrade(req, channels.coordinator, config)
+   use <- mist_transport.upgrade(req, channels, config)
    ```
 
 3. **Join callback panics or crashes.** A panic in `join` terminates the coordinator actor. Under unsupervised `beryl.start`, the coordinator dies and no more joins are processed. Use `beryl/supervisor.start` so the coordinator restarts, then fix the panic.


### PR DESCRIPTION
## Summary

- Make `beryl.Channels` opaque so consumers cannot construct it or access coordinator internals.
- Add narrow package-internal helpers for transport/supervisor integration.
- Update tests, troubleshooting docs, generated reference docs, and changelog fragment.
