### PR TITLE
fix(api): make send_info type-safe

### DIFF
--- a/.changes/unreleased/Changed-20260624-153703.yaml
+++ b/.changes/unreleased/Changed-20260624-153703.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: |-
+    Make send_info require a typed registered channel handle.
+
+    Registering a channel now returns RegisteredChannel(assigns, info), and send_info dispatches through that handle so incompatible info messages fail at compile time.
+time: 2026-06-24T15:37:03.051794024-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -69,6 +69,20 @@ import gleam/result
 type ChannelHandler =
   coordinator.ChannelHandler
 
+/// A typed handle returned when a channel is registered.
+///
+/// Pass this handle to `send_info` so the compiler can prove that the message
+/// matches the receiving channel's `info` type. The handle also identifies the
+/// exact registered channel used for a joined socket/topic pair.
+pub opaque type RegisteredChannel(assigns, info) {
+  RegisteredChannel(
+    coordinator: Subject(coordinator.Message),
+    id: Int,
+    handle_info: fn(info, coordinator.SocketContext) ->
+      coordinator.HandleResultErased,
+  )
+}
+
 /// Errors when registering a channel handler.
 pub type RegisterError {
   /// A handler is already registered for this exact topic pattern.
@@ -348,25 +362,33 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
 /// })
 ///
 /// // Register it with a legacy prefix wildcard
-/// beryl.register(channels, "chat:*", chat_channel)
+/// let assert Ok(chat) = beryl.register(channels, "chat:*", chat_channel)
 ///
 /// // Exact topic
-/// beryl.register(channels, "room:lobby", lobby_channel)
+/// let assert Ok(lobby) = beryl.register(channels, "room:lobby", lobby_channel)
 ///
 /// // Segment-aware wildcard
-/// beryl.register(channels, "document:*:ops", ops_channel)
+/// let assert Ok(ops) = beryl.register(channels, "document:*:ops", ops_channel)
 /// ```
 pub fn register(
   channels: Channels,
   pattern: String,
   handler: Channel(assigns, info),
-) -> Result(Nil, RegisterError) {
+) -> Result(RegisteredChannel(assigns, info), RegisterError) {
+  let handle_info = typed_handle_info(handler)
   // Convert typed Channel to type-erased ChannelHandler
   let erased_handler = erase_channel_types(pattern, handler)
 
   // Register with coordinator
   process.call(channels.coordinator, 5000, fn(reply) {
     coordinator.RegisterChannel(pattern, erased_handler, reply)
+  })
+  |> result.map(fn(id) {
+    RegisteredChannel(
+      coordinator: channels.coordinator,
+      id: id,
+      handle_info: handle_info,
+    )
   })
   |> result.map_error(map_register_error)
 }
@@ -489,31 +511,25 @@ pub fn broadcast_from(
   }
 }
 
-/// Send a server-originated OTP message to a joined channel context.
+/// Send a typed server-originated OTP message to a joined channel context.
 ///
-/// The message is delivered to the channel's `handle_info` callback for the
-/// specific socket/topic pair as the typed `info` value — the receiving handler
-/// matches on it directly without any `Dynamic` decode or unsafe cast. If the
-/// socket is not connected, the topic is not joined, or no handler matches the
-/// topic, the message is ignored.
-///
-/// Note: a single `Channels` system may host channels with different `info`
-/// types, so this function accepts a generic message and the matching channel's
-/// `handle_info` recovers the concrete type. Send a value whose type matches the
-/// target channel's `info` parameter.
+/// The `registered` handle carries the receiving channel's `info` type, so the
+/// compiler rejects messages for incompatible channels. The coordinator also
+/// verifies that the socket/topic pair was joined through that same registered
+/// channel before dispatching the callback. If the socket is not connected, the
+/// topic is not joined, or the registered channel does not match the joined
+/// channel, the message is ignored.
 pub fn send_info(
-  channels: Channels,
+  registered: RegisteredChannel(assigns, info),
   socket_id: String,
   topic_name: String,
-  message: a,
+  message: info,
 ) -> Nil {
   process.send(
-    channels.coordinator,
-    coordinator.HandleInfo(
-      socket_id,
-      topic_name,
-      unsafe_coerce_to_dynamic(message),
-    ),
+    registered.coordinator,
+    coordinator.HandleInfo(socket_id, topic_name, registered.id, fn(ctx) {
+      registered.handle_info(message, ctx)
+    }),
   )
 }
 
@@ -550,6 +566,7 @@ fn erase_channel_types(
   let pattern = topic.parse_pattern(pattern_str)
 
   coordinator.ChannelHandler(
+    id: 0,
     pattern: pattern,
     join: fn(
       topic_name: String,
@@ -599,21 +616,23 @@ fn erase_channel_types(
       typed_channel.handle_binary(data, unsafe_coerce_socket(typed_socket))
       |> erase_handle_result
     },
-    handle_info: fn(message: Dynamic, ctx: coordinator.SocketContext) {
-      let typed_socket = create_socket_with_assigns(ctx)
-
-      typed_channel.handle_info(
-        unsafe_coerce_from_dynamic(message),
-        unsafe_coerce_socket(typed_socket),
-      )
-      |> erase_handle_result
-    },
     terminate: fn(reason: channel.StopReason, ctx: coordinator.SocketContext) {
       let typed_socket = create_socket_with_assigns(ctx)
       // Unsafe coerce socket to expected type
       typed_channel.terminate(reason, unsafe_coerce_socket(typed_socket))
     },
   )
+}
+
+fn typed_handle_info(
+  typed_channel: Channel(assigns, info),
+) -> fn(info, coordinator.SocketContext) -> coordinator.HandleResultErased {
+  fn(message: info, ctx: coordinator.SocketContext) {
+    let typed_socket = create_socket_with_assigns(ctx)
+
+    typed_channel.handle_info(message, unsafe_coerce_socket(typed_socket))
+    |> erase_handle_result
+  }
 }
 
 fn transport_from_context(ctx: coordinator.SocketContext) -> socket.Transport {
@@ -673,13 +692,6 @@ fn erase_handle_result(
 /// Unsafe coercion to Dynamic - only use for type erasure
 @external(erlang, "beryl_ffi", "identity")
 fn unsafe_coerce_to_dynamic(value: a) -> Dynamic
-
-/// Unsafe coercion from Dynamic back to a concrete type - only use to recover
-/// the typed `info` message at the `handle_info` erasure boundary. The value
-/// originates from `send_info`, which stored a value of the channel's `info`
-/// type as `Dynamic`; this restores it.
-@external(erlang, "beryl_ffi", "identity")
-fn unsafe_coerce_from_dynamic(value: Dynamic) -> a
 
 /// Unsafe coercion of socket types - only use for type erasure
 @external(erlang, "beryl_ffi", "identity")

--- a/src/beryl/bridge.gleam
+++ b/src/beryl/bridge.gleam
@@ -30,11 +30,11 @@
 ////   Assigns(bridge: Bridge(DocEvent))
 //// }
 ////
-//// fn join(channels, doc_actor, topic, _payload, socket) {
+//// fn join(registered_channel, doc_actor, topic, _payload, socket) {
 ////   // Forward each DocEvent to this socket's `handle_info` callback.
 ////   let b =
 ////     bridge.start(
-////       channels: channels,
+////       channel: registered_channel,
 ////       socket_id: socket.id(socket),
 ////       topic: topic,
 ////       with: fn(event) { event },
@@ -49,7 +49,7 @@
 //// }
 //// ```
 
-import beryl.{type Channels}
+import beryl.{type RegisteredChannel}
 import gleam/erlang/process.{type Pid, type Subject}
 
 /// How long `start` waits for the forwarder process to report its subjects
@@ -84,7 +84,7 @@ type Event(message) {
 /// The returned `Bridge` owns a freshly spawned forwarder process. Pass
 /// `subject(bridge)` to the external/domain actor so it delivers its stream to
 /// the forwarder; each received value is mapped with `transform` and delivered
-/// via `beryl.send_info(channels, socket_id, topic, transform(value))`.
+/// via `beryl.send_info(channel, socket_id, topic, transform(value))`.
 ///
 /// Use `transform` to translate the domain message into whatever your channel's
 /// `handle_info` expects. If no translation is needed, pass the identity
@@ -94,7 +94,7 @@ type Event(message) {
 /// so a missed `stop` will not leak a process. Always call `stop` from your
 /// channel's `terminate` for prompt, deterministic cleanup.
 pub fn start(
-  channels channels: Channels,
+  channel channel: RegisteredChannel(assigns, info),
   socket_id socket_id: String,
   topic topic: String,
   with transform: fn(message) -> info,
@@ -117,7 +117,7 @@ pub fn start(
         |> process.select_specific_monitor(monitor, fn(_) { OwnerDown })
 
       process.send(ready, #(data, control))
-      forward_loop(selector, channels, socket_id, topic, transform)
+      forward_loop(selector, channel, socket_id, topic, transform)
     })
 
   let assert Ok(#(data, control)) = process.receive(ready, handshake_timeout_ms)
@@ -127,15 +127,15 @@ pub fn start(
 
 fn forward_loop(
   selector: process.Selector(Event(message)),
-  channels: Channels,
+  channel: RegisteredChannel(assigns, info),
   socket_id: String,
   topic: String,
   transform: fn(message) -> info,
 ) -> Nil {
   case process.selector_receive_forever(selector) {
     Forward(value) -> {
-      beryl.send_info(channels, socket_id, topic, transform(value))
-      forward_loop(selector, channels, socket_id, topic, transform)
+      beryl.send_info(channel, socket_id, topic, transform(value))
+      forward_loop(selector, channel, socket_id, topic, transform)
     }
     // `stop` was called, or the owning channel process went down — exit
     // normally so the forwarder is cleaned up.

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -32,11 +32,11 @@ import gleam/string
 /// The actual typed Channel is converted to this for the registry
 pub type ChannelHandler {
   ChannelHandler(
+    id: Int,
     pattern: TopicPattern,
     join: fn(String, Dynamic, SocketContext) -> JoinResultErased,
     handle_in: fn(String, Dynamic, SocketContext) -> HandleResultErased,
     handle_binary: fn(BitArray, SocketContext) -> HandleResultErased,
-    handle_info: fn(Dynamic, SocketContext) -> HandleResultErased,
     terminate: fn(StopReason, SocketContext) -> Nil,
   )
 }
@@ -192,6 +192,8 @@ type State {
   State(
     /// Pattern -> handler (ordered list for matching)
     handlers: List(ChannelHandler),
+    /// Next unique id assigned to a registered channel handler.
+    next_handler_id: Int,
     /// Socket ID -> socket info
     sockets: Dict(String, SocketInfo),
     /// Topic -> set of socket IDs subscribed
@@ -223,6 +225,8 @@ type SocketInfo {
     subscribed_topics: Set(String),
     /// Per-topic assigns (topic -> Dynamic assigns)
     channel_assigns: Dict(String, Dynamic),
+    /// Per-topic registered channel id (topic -> handler id)
+    channel_ids: Dict(String, Int),
     /// Socket-level assigns seeded by the transport connect hook (type-erased).
     /// Used as the initial assigns visible to a channel at join time.
     connect_assigns: Dynamic,
@@ -278,7 +282,7 @@ pub type Message {
   RegisterChannel(
     pattern: String,
     handler: ChannelHandler,
-    reply: Subject(Result(Nil, RegisterError)),
+    reply: Subject(Result(Int, RegisterError)),
   )
   // Socket lifecycle
   SocketConnected(
@@ -296,7 +300,12 @@ pub type Message {
   SocketDisconnected(socket_id: String)
   // Channel operations
   HandleBinary(socket_id: String, data: BitArray)
-  HandleInfo(socket_id: String, topic: String, message: Dynamic)
+  HandleInfo(
+    socket_id: String,
+    topic: String,
+    channel_id: Int,
+    handle_info: fn(SocketContext) -> HandleResultErased,
+  )
   /// Raw inbound text from the transport, decoded inside the actor using
   /// the configured codec.
   RouteText(socket_id: String, raw_text: String)
@@ -393,6 +402,7 @@ fn build_coordinator(
   let initial_state =
     State(
       handlers: [],
+      next_handler_id: 0,
       sockets: dict.new(),
       topics: dict.new(),
       config: config,
@@ -471,8 +481,8 @@ fn handle_message(
 
     HandleBinary(socket_id, data) -> handle_binary_in(state, socket_id, data)
 
-    HandleInfo(socket_id, topic_name, message) ->
-      handle_info(state, socket_id, topic_name, message)
+    HandleInfo(socket_id, topic_name, channel_id, callback) ->
+      handle_info(state, socket_id, topic_name, channel_id, callback)
 
     RouteText(socket_id, raw_text) ->
       handle_route_text(state, socket_id, raw_text)
@@ -492,7 +502,7 @@ fn handle_register_channel(
   state: State,
   pattern_str: String,
   handler: ChannelHandler,
-  reply: Subject(Result(Nil, RegisterError)),
+  reply: Subject(Result(Int, RegisterError)),
 ) -> actor.Next(State, Message) {
   let pattern = topic.parse_pattern(pattern_str)
   let already_registered =
@@ -504,9 +514,21 @@ fn handle_register_channel(
       actor.continue(state)
     }
     False -> {
-      let new_handlers = list.append(state.handlers, [handler])
-      process.send(reply, Ok(Nil))
-      actor.continue(State(..state, handlers: new_handlers))
+      let handler_id = state.next_handler_id
+      let registered_handler =
+        ChannelHandler(
+          id: handler_id,
+          pattern: pattern,
+          join: handler.join,
+          handle_in: handler.handle_in,
+          handle_binary: handler.handle_binary,
+          terminate: handler.terminate,
+        )
+      let new_handlers = list.append(state.handlers, [registered_handler])
+      process.send(reply, Ok(handler_id))
+      actor.continue(
+        State(..state, handlers: new_handlers, next_handler_id: handler_id + 1),
+      )
     }
   }
 }
@@ -527,6 +549,7 @@ fn handle_socket_connected(
       codec: option.unwrap(codec, state.config.codec),
       subscribed_topics: set.new(),
       channel_assigns: dict.new(),
+      channel_ids: dict.new(),
       connect_assigns: connect_assigns,
       last_heartbeat: monotonic_time_ms(),
     )
@@ -792,7 +815,8 @@ fn handle_info(
   state: State,
   socket_id: String,
   topic_name: String,
-  message: Dynamic,
+  channel_id: Int,
+  callback: fn(SocketContext) -> HandleResultErased,
 ) -> actor.Next(State, Message) {
   case dict.get(state.sockets, socket_id) {
     Error(Nil) -> {
@@ -818,12 +842,13 @@ fn handle_info(
           actor.continue(state)
         }
         True ->
-          route_info_to_handler(
+          route_info_to_registered_handler(
             state,
             socket_info,
             socket_id,
             topic_name,
-            message,
+            channel_id,
+            callback,
           )
       }
     }
@@ -1298,11 +1323,14 @@ fn dispatch_join(
       let new_subscribed = set.insert(socket_info.subscribed_topics, topic_name)
       let new_assigns =
         dict.insert(socket_info.channel_assigns, topic_name, assigns)
+      let new_channel_ids =
+        dict.insert(socket_info.channel_ids, topic_name, handler.id)
       let new_socket_info =
         SocketInfo(
           ..socket_info,
           subscribed_topics: new_subscribed,
           channel_assigns: new_assigns,
+          channel_ids: new_channel_ids,
         )
 
       let existing_topic_subscribers =
@@ -1443,10 +1471,9 @@ fn dispatch_handle_in(
 fn dispatch_handle_info(
   state: State,
   socket_info: SocketInfo,
-  handler: ChannelHandler,
   socket_id: String,
   topic_name: String,
-  message: Dynamic,
+  callback: fn(SocketContext) -> HandleResultErased,
 ) -> actor.Next(State, Message) {
   let logger = coordinator_logger(state)
   logger
@@ -1467,7 +1494,7 @@ fn dispatch_handle_info(
       send_binary: socket_info.send_binary,
     )
 
-  case handler.handle_info(message, ctx) {
+  case callback(ctx) {
     NoReplyErased(new_assigns) -> {
       logger
       |> log.debug("Channel callback returned no reply", [
@@ -1594,7 +1621,7 @@ fn do_terminate_channel(
   topic_name: String,
   reason: StopReason,
 ) -> State {
-  case find_handler(state.handlers, topic_name) {
+  case find_joined_handler(state, socket_info, topic_name) {
     Some(handler) -> {
       let logger = coordinator_logger(state)
       logger
@@ -1622,11 +1649,13 @@ fn do_terminate_channel(
 
   let new_subscribed = set.delete(socket_info.subscribed_topics, topic_name)
   let new_assigns = dict.delete(socket_info.channel_assigns, topic_name)
+  let new_channel_ids = dict.delete(socket_info.channel_ids, topic_name)
   let new_socket_info =
     SocketInfo(
       ..socket_info,
       subscribed_topics: new_subscribed,
       channel_assigns: new_assigns,
+      channel_ids: new_channel_ids,
     )
 
   let topic_subscribers =
@@ -1658,7 +1687,7 @@ fn route_in_to_handler(
   payload: Dynamic,
   ref: Option(String),
 ) -> actor.Next(State, Message) {
-  case find_handler(state.handlers, topic_name) {
+  case find_joined_handler(state, socket_info, topic_name) {
     None -> {
       let logger = coordinator_logger(state)
       logger
@@ -1684,33 +1713,66 @@ fn route_in_to_handler(
   }
 }
 
-fn route_info_to_handler(
+fn route_info_to_registered_handler(
   state: State,
   socket_info: SocketInfo,
   socket_id: String,
   topic_name: String,
-  message: Dynamic,
+  channel_id: Int,
+  callback: fn(SocketContext) -> HandleResultErased,
 ) -> actor.Next(State, Message) {
-  case find_handler(state.handlers, topic_name) {
-    None -> {
+  case dict.get(socket_info.channel_ids, topic_name) {
+    Error(Nil) -> {
       let logger = coordinator_logger(state)
       logger
       |> log.debug("Handle info ignored", [
         #("socket_id", socket_id),
         #("topic", topic_name),
-        #("reason", "handler_not_found"),
+        #("reason", "channel_id_not_found"),
       ])
       actor.continue(state)
     }
-    Some(handler) ->
-      dispatch_handle_info(
-        state,
-        socket_info,
-        handler,
-        socket_id,
-        topic_name,
-        message,
-      )
+    Ok(joined_channel_id) -> {
+      case joined_channel_id == channel_id {
+        True ->
+          dispatch_handle_info(
+            state,
+            socket_info,
+            socket_id,
+            topic_name,
+            callback,
+          )
+        False -> {
+          let logger = coordinator_logger(state)
+          logger
+          |> log.debug("Handle info ignored", [
+            #("socket_id", socket_id),
+            #("topic", topic_name),
+            #("reason", "registered_channel_mismatch"),
+          ])
+          actor.continue(state)
+        }
+      }
+    }
+  }
+}
+
+fn find_handler_by_id(
+  handlers: List(ChannelHandler),
+  handler_id: Int,
+) -> Option(ChannelHandler) {
+  list.find(handlers, fn(h) { h.id == handler_id })
+  |> option.from_result()
+}
+
+fn find_joined_handler(
+  state: State,
+  socket_info: SocketInfo,
+  topic_name: String,
+) -> Option(ChannelHandler) {
+  case dict.get(socket_info.channel_ids, topic_name) {
+    Ok(handler_id) -> find_handler_by_id(state.handlers, handler_id)
+    Error(Nil) -> None
   }
 }
 
@@ -1722,7 +1784,7 @@ fn route_binary_to_handler(
   topic_name: String,
   data: BitArray,
 ) -> State {
-  case find_handler(st.handlers, topic_name) {
+  case find_joined_handler(st, socket_info, topic_name) {
     None -> {
       let logger = coordinator_logger(st)
       logger

--- a/test/beryl_test.gleam
+++ b/test/beryl_test.gleam
@@ -7,7 +7,6 @@ import beryl/topic
 import beryl/wire
 import beryl/wire/codec
 import gleam/dynamic
-import gleam/dynamic/decode
 import gleam/erlang/process
 import gleam/int
 import gleam/json
@@ -205,8 +204,7 @@ pub fn segment_wildcard_registered_channel_routes_matching_topic_test() {
       channel.JoinOk(reply: option.Some(reply), socket: socket)
     })
 
-  beryl.register(channels, "document:*:ops", handler)
-  |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "document:*:ops", handler)
 
   coordinator.route_message(
     beryl.coordinator_subject(channels),
@@ -242,8 +240,7 @@ pub fn segment_wildcard_registered_channel_rejects_wrong_segment_test() {
       channel.JoinOk(reply: option.None, socket: socket)
     })
 
-  beryl.register(channels, "document:*:ops", handler)
-  |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "document:*:ops", handler)
 
   coordinator.route_message(
     beryl.coordinator_subject(channels),
@@ -289,9 +286,9 @@ pub fn send_info_routes_message_to_joined_channel_test() {
     channel.new(fn(_topic, _payload, socket) {
       channel.JoinOk(reply: option.None, socket: socket)
     })
-    |> channel.with_handle_info(fn(message, socket) {
-      case decode.run(message, decode.string) {
-        Ok("notify") ->
+    |> channel.with_handle_info(fn(message: String, socket) {
+      case message {
+        "notify" ->
           channel.Push(
             "server_notify",
             json.object([#("ok", json.bool(True))]),
@@ -301,8 +298,7 @@ pub fn send_info_routes_message_to_joined_channel_test() {
       }
     })
 
-  beryl.register(channels, "room:*", handler)
-  |> should.equal(Ok(Nil))
+  let assert Ok(registered) = beryl.register(channels, "room:*", handler)
 
   coordinator.route_message(
     beryl.coordinator_subject(channels),
@@ -313,7 +309,7 @@ pub fn send_info_routes_message_to_joined_channel_test() {
   let assert Ok(join_reply) = process.receive(sent_messages, 500)
   join_reply |> string.contains("phx_reply") |> should.be_true
 
-  beryl.send_info(channels, "socket-info", "room:lobby", "notify")
+  beryl.send_info(registered, "socket-info", "room:lobby", "notify")
 
   let assert Ok(push) = process.receive(sent_messages, 500)
   push |> string.contains("server_notify") |> should.be_true
@@ -363,8 +359,7 @@ pub fn send_info_typed_message_round_trips_without_cast_test() {
       }
     })
 
-  beryl.register(channels, "room:*", handler)
-  |> should.equal(Ok(Nil))
+  let assert Ok(registered) = beryl.register(channels, "room:*", handler)
 
   coordinator.route_message(
     beryl.coordinator_subject(channels),
@@ -375,7 +370,12 @@ pub fn send_info_typed_message_round_trips_without_cast_test() {
   let assert Ok(join_reply) = process.receive(sent_messages, 500)
   join_reply |> string.contains("phx_reply") |> should.be_true
 
-  beryl.send_info(channels, "socket-typed-info", "room:lobby", Notify("hello"))
+  beryl.send_info(
+    registered,
+    "socket-typed-info",
+    "room:lobby",
+    Notify("hello"),
+  )
 
   let assert Ok(push) = process.receive(sent_messages, 500)
   push |> string.contains("server_notify") |> should.be_true
@@ -412,8 +412,7 @@ pub fn send_info_reply_result_pushes_message_to_client_test() {
       )
     })
 
-  beryl.register(channels, "room:*", handler)
-  |> should.equal(Ok(Nil))
+  let assert Ok(registered) = beryl.register(channels, "room:*", handler)
 
   coordinator.route_message(
     beryl.coordinator_subject(channels),
@@ -424,7 +423,7 @@ pub fn send_info_reply_result_pushes_message_to_client_test() {
   let assert Ok(join_reply) = process.receive(sent_messages, 500)
   join_reply |> string.contains("phx_reply") |> should.be_true
 
-  beryl.send_info(channels, "socket-info-reply", "room:lobby", "reply")
+  beryl.send_info(registered, "socket-info-reply", "room:lobby", "reply")
 
   let assert Ok(push) = process.receive(sent_messages, 500)
   push |> string.contains("server_reply") |> should.be_true
@@ -461,8 +460,7 @@ pub fn connect_assigns_visible_in_channel_join_test() {
       channel.JoinOk(reply: option.Some(reply), socket: socket)
     })
 
-  beryl.register(channels, "room:*", handler)
-  |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "room:*", handler)
 
   coordinator.route_message(
     beryl.coordinator_subject(channels),
@@ -705,8 +703,7 @@ pub fn channels_handle_remains_usable_after_start_test() {
       channel.JoinOk(reply: option.None, socket: socket)
     })
 
-  beryl.register(channels, "opaque:*", handler)
-  |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "opaque:*", handler)
 }
 
 pub fn topic_namespace_test() {

--- a/test/binary_codec_test.gleam
+++ b/test/binary_codec_test.gleam
@@ -197,7 +197,7 @@ pub fn binary_codec_routes_join_message_and_reply_over_binary_test() {
       channel.Reply(event, json.object([#("ok", json.bool(True))]), socket)
     })
 
-  beryl.register(channels, "room:*", handler) |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "room:*", handler)
 
   coordinator.route_binary(
     beryl.coordinator_subject(channels),
@@ -253,7 +253,7 @@ pub fn binary_codec_event_consumes_one_message_rate_token_test() {
       channel.Reply(event, json.object([#("ok", json.bool(True))]), socket)
     })
 
-  beryl.register(channels, "room:*", handler) |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "room:*", handler)
 
   coordinator.route_binary(
     beryl.coordinator_subject(channels),
@@ -308,7 +308,7 @@ pub fn binary_codec_broadcast_uses_binary_send_test() {
       channel.JoinOk(reply: None, socket: socket)
     })
 
-  beryl.register(channels, "room:*", handler) |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "room:*", handler)
 
   coordinator.route_binary(
     beryl.coordinator_subject(channels),
@@ -358,7 +358,7 @@ pub fn phoenix_codec_without_binary_decoder_preserves_raw_binary_handler_test() 
       channel.NoReply(socket)
     })
 
-  beryl.register(channels, "room:*", handler) |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "room:*", handler)
 
   coordinator.route_message(
     beryl.coordinator_subject(channels),

--- a/test/bridge_test.gleam
+++ b/test/bridge_test.gleam
@@ -3,8 +3,7 @@ import beryl/bridge
 import beryl/channel
 import beryl/coordinator
 import beryl/wire
-import gleam/dynamic.{type Dynamic}
-import gleam/dynamic/decode
+import gleam/dynamic
 import gleam/erlang/process
 import gleam/json
 import gleam/option
@@ -35,28 +34,24 @@ fn start_channels_with_socket(
   #(channels, sent_messages)
 }
 
-fn notify_channel() -> channel.Channel(Nil, Dynamic) {
+fn notify_channel() -> channel.Channel(Nil, String) {
   channel.new(fn(_topic, _payload, socket) {
     channel.JoinOk(reply: option.None, socket: socket)
   })
   |> channel.with_handle_info(fn(message, socket) {
-    case decode.run(message, decode.string) {
-      Ok(text) ->
-        channel.Push(
-          "server_notify",
-          json.object([#("text", json.string(text))]),
-          socket,
-        )
-      _ -> channel.NoReply(socket)
-    }
+    channel.Push(
+      "server_notify",
+      json.object([#("text", json.string(message))]),
+      socket,
+    )
   })
 }
 
 pub fn bridge_forwards_subject_values_to_handle_info_test() {
   let #(channels, sent_messages) = start_channels_with_socket("bridge-sock")
 
-  beryl.register(channels, "room:*", notify_channel())
-  |> should.equal(Ok(Nil))
+  let assert Ok(registered) =
+    beryl.register(channels, "room:*", notify_channel())
 
   coordinator.route_message(
     beryl.coordinator_subject(channels),
@@ -71,7 +66,7 @@ pub fn bridge_forwards_subject_values_to_handle_info_test() {
   // actor) to this socket/topic, translating each value before forwarding.
   let b =
     bridge.start(
-      channels: channels,
+      channel: registered,
       socket_id: "bridge-sock",
       topic: "room:lobby",
       with: fn(n: Int) { "tick-" <> string.inspect(n) },
@@ -93,10 +88,12 @@ pub fn bridge_forwards_subject_values_to_handle_info_test() {
 
 pub fn bridge_stop_tears_down_forwarder_test() {
   let #(channels, _sent) = start_channels_with_socket("bridge-stop-sock")
+  let assert Ok(registered) =
+    beryl.register(channels, "room:*", notify_channel())
 
   let b =
     bridge.start(
-      channels: channels,
+      channel: registered,
       socket_id: "bridge-stop-sock",
       topic: "room:lobby",
       with: fn(x: String) { x },
@@ -113,6 +110,8 @@ pub fn bridge_stop_tears_down_forwarder_test() {
 
 pub fn bridge_cleans_up_when_owner_dies_test() {
   let #(channels, _sent) = start_channels_with_socket("bridge-owner-sock")
+  let assert Ok(registered) =
+    beryl.register(channels, "room:*", notify_channel())
 
   let pid_back = process.new_subject()
 
@@ -122,7 +121,7 @@ pub fn bridge_cleans_up_when_owner_dies_test() {
   process.spawn_unlinked(fn() {
     let b =
       bridge.start(
-        channels: channels,
+        channel: registered,
         socket_id: "bridge-owner-sock",
         topic: "room:lobby",
         with: fn(x: String) { x },

--- a/test/broadcast_test.gleam
+++ b/test/broadcast_test.gleam
@@ -19,6 +19,7 @@ pub fn main() {
 fn register_test_channel(channels: beryl.Channels) -> Nil {
   let handler =
     coordinator.ChannelHandler(
+      id: 0,
       pattern: topic.parse_pattern("room:*"),
       join: fn(_topic, _payload, _ctx) {
         coordinator.JoinOkErased(reply: None, assigns: dynamic.nil())
@@ -29,9 +30,6 @@ fn register_test_channel(channels: beryl.Channels) -> Nil {
       handle_binary: fn(_data, ctx) {
         coordinator.NoReplyErased(assigns: ctx.assigns)
       },
-      handle_info: fn(_message, ctx) {
-        coordinator.NoReplyErased(assigns: ctx.assigns)
-      },
       terminate: fn(_reason, _ctx) { Nil },
     )
 
@@ -40,7 +38,7 @@ fn register_test_channel(channels: beryl.Channels) -> Nil {
     beryl.coordinator_subject(channels),
     coordinator.RegisterChannel("room:*", handler, reply),
   )
-  let assert Ok(Ok(Nil)) = process.receive(reply, 500)
+  let assert Ok(Ok(_)) = process.receive(reply, 500)
   Nil
 }
 

--- a/test/heartbeat_test.gleam
+++ b/test/heartbeat_test.gleam
@@ -294,6 +294,7 @@ fn register_handler_with_terminate(
 ) -> Nil {
   let handler =
     coordinator.ChannelHandler(
+      id: 0,
       pattern: topic.parse_pattern(pattern),
       join: fn(_topic, _payload, _ctx) {
         coordinator.JoinOkErased(reply: None, assigns: dynamic.nil())
@@ -304,9 +305,6 @@ fn register_handler_with_terminate(
       handle_binary: fn(_data, ctx) {
         coordinator.NoReplyErased(assigns: ctx.assigns)
       },
-      handle_info: fn(_message, ctx) {
-        coordinator.NoReplyErased(assigns: ctx.assigns)
-      },
       terminate: fn(reason, _ctx) { process.send(terminate_subject, reason) },
     )
 
@@ -315,7 +313,7 @@ fn register_handler_with_terminate(
     coord,
     coordinator.RegisterChannel(pattern, handler, reply_subject),
   )
-  let assert Ok(Ok(Nil)) = process.receive(reply_subject, 500)
+  let assert Ok(Ok(_)) = process.receive(reply_subject, 500)
   Nil
 }
 

--- a/test/logging_test.gleam
+++ b/test/logging_test.gleam
@@ -257,8 +257,7 @@ pub fn debug_channel_callback_logs_push_result_test() {
         socket: socket,
       )
     })
-  beryl.register(channels, "room:*", handler)
-  |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "room:*", handler)
 
   process.send(
     beryl.coordinator_subject(channels),

--- a/test/phoenix_contract_test.gleam
+++ b/test/phoenix_contract_test.gleam
@@ -298,8 +298,8 @@ pub fn json_contract_join_custom_broadcast_heartbeat_leave_test() {
   let serializer = json_serializer()
   let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
   let terminated = process.new_subject()
-  beryl.register(channels, "room:*", contract_channel(channels, terminated))
-  |> should.equal(Ok(Nil))
+  let assert Ok(_) =
+    beryl.register(channels, "room:*", contract_channel(channels, terminated))
   let #(port, server_pid) = start_mist_server(channels)
 
   let client = connect_client(port)
@@ -482,8 +482,7 @@ pub fn on_connect_seeds_assigns_visible_at_join_test() {
         socket: client_socket,
       )
     })
-  beryl.register(channels, "room:*", handler)
-  |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "room:*", handler)
 
   let config =
     mist_transport.default_config("/socket/websocket")

--- a/test/supervisor_test.gleam
+++ b/test/supervisor_test.gleam
@@ -177,8 +177,7 @@ pub fn stop_coordinator_only_test() {
     channel.new(fn(_topic, _payload, socket) {
       channel.JoinOk(reply: None, socket: socket)
     })
-  let assert Ok(Nil) =
-    beryl.register(supervised.channels, "pre-stop:*", handler)
+  let assert Ok(_) = beryl.register(supervised.channels, "pre-stop:*", handler)
 
   let sup_pid = supervised.supervisor_pid
   supervisor.stop(supervised)
@@ -203,8 +202,7 @@ pub fn supervised_coordinator_restarts_on_crash_test() {
     channel.new(fn(_topic, _payload, socket) {
       channel.JoinOk(reply: None, socket: socket)
     })
-  let assert Ok(Nil) =
-    beryl.register(supervised.channels, "pre-crash:*", handler)
+  let assert Ok(_) = beryl.register(supervised.channels, "pre-crash:*", handler)
 
   // Kill the coordinator process
   let assert Ok(name) =
@@ -369,7 +367,7 @@ pub fn independent_presence_crash_does_not_affect_coordinator_test() {
     channel.new(fn(_topic, _payload, socket) {
       channel.JoinOk(reply: None, socket: socket)
     })
-  let assert Ok(Nil) =
+  let assert Ok(_) =
     beryl.register(supervised.channels, "indep-pres:*", handler)
 
   // Get coordinator PID before
@@ -423,7 +421,7 @@ pub fn independent_groups_crash_does_not_affect_coordinator_test() {
     channel.new(fn(_topic, _payload, socket) {
       channel.JoinOk(reply: None, socket: socket)
     })
-  let assert Ok(Nil) =
+  let assert Ok(_) =
     beryl.register(supervised.channels, "indep-grps:*", handler)
 
   // Get coordinator PID before

--- a/test/vsn_negotiation_test.gleam
+++ b/test/vsn_negotiation_test.gleam
@@ -239,8 +239,7 @@ fn msgpack_config() -> mist_transport.TransportConfig(Nil) {
 
 pub fn vsn_3_negotiates_binary_serializer_round_trip_test() {
   let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
-  beryl.register(channels, "room:*", echo_channel())
-  |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "room:*", echo_channel())
   let #(port, server_pid) = start_server(channels, msgpack_config())
 
   let assert Ok(client) = connect_websocket(port, "/socket?vsn=3.0.0")
@@ -333,8 +332,7 @@ pub fn vsn_3_negotiates_binary_serializer_round_trip_test() {
 
 pub fn vsn_2_uses_json_text_serializer_test() {
   let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
-  beryl.register(channels, "room:*", echo_channel())
-  |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "room:*", echo_channel())
   let #(port, server_pid) = start_server(channels, msgpack_config())
 
   let assert Ok(client) = connect_websocket(port, "/socket?vsn=2.0.0")
@@ -360,8 +358,7 @@ pub fn vsn_2_uses_json_text_serializer_test() {
 
 pub fn default_connection_without_vsn_uses_json_test() {
   let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
-  beryl.register(channels, "room:*", echo_channel())
-  |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "room:*", echo_channel())
   let #(port, server_pid) = start_server(channels, msgpack_config())
 
   let assert Ok(client) = connect_websocket(port, "/socket")
@@ -387,8 +384,7 @@ pub fn default_connection_without_vsn_uses_json_test() {
 
 pub fn mixed_serializers_share_one_server_test() {
   let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
-  beryl.register(channels, "room:*", echo_channel())
-  |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "room:*", echo_channel())
   let #(port, server_pid) = start_server(channels, msgpack_config())
 
   // JSON client and binary client connect to the same server concurrently.
@@ -427,8 +423,7 @@ pub fn mixed_serializers_share_one_server_test() {
 
 pub fn unknown_vsn_falls_back_to_json_by_default_test() {
   let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
-  beryl.register(channels, "room:*", echo_channel())
-  |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "room:*", echo_channel())
   let #(port, server_pid) = start_server(channels, msgpack_config())
 
   // vsn=9.9.9 has no registered serializer; default config falls back to JSON.
@@ -454,8 +449,7 @@ pub fn unknown_vsn_falls_back_to_json_by_default_test() {
 
 pub fn unknown_vsn_rejected_when_configured_test() {
   let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
-  beryl.register(channels, "room:*", echo_channel())
-  |> should.equal(Ok(Nil))
+  let assert Ok(_) = beryl.register(channels, "room:*", echo_channel())
   let config =
     msgpack_config()
     |> mist_transport.with_reject_unknown_vsn(True)


### PR DESCRIPTION
## Summary

- add `RegisteredChannel(assigns, info)` as the typed handle returned from `beryl.register`
- make `beryl.send_info` require that handle so the `info` message type is checked at compile time
- track the joined registered channel id in the coordinator so `handle_info`, event, binary, and terminate callbacks dispatch through the exact joined handler
- update bridge and tests for the typed registration handle

Closes #121

## Validation

- `just check && just test`
- `just ci` passes format/check/test/build/example-build steps, then fails in `examples/cursors` Playwright with all 34 browser tests missing expected page elements or routes
