### PR TITLE
fix(api): hide core constructors

### DIFF
--- a/.changes/unreleased/Changed-20260624-172924.yaml
+++ b/.changes/unreleased/Changed-20260624-172924.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Made core channel, presence, group, PubSub, and Mist transport handles and configs opaque before 1.0.
+time: 2026-06-24T17:29:24.194-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -564,6 +564,10 @@ fn erase_channel_types(
   typed_channel: Channel(assigns, info),
 ) -> ChannelHandler {
   let pattern = topic.parse_pattern(pattern_str)
+  let join = channel.join_callback(typed_channel)
+  let handle_in = channel.handle_in_callback(typed_channel)
+  let handle_binary = channel.handle_binary_callback(typed_channel)
+  let terminate = channel.terminate_callback(typed_channel)
 
   coordinator.ChannelHandler(
     id: 0,
@@ -578,13 +582,7 @@ fn erase_channel_types(
       let typed_socket = create_socket_with_assigns(ctx)
 
       // Call the typed join handler (unsafe coerce socket to expected type)
-      case
-        typed_channel.join(
-          topic_name,
-          payload,
-          unsafe_coerce_socket(typed_socket),
-        )
-      {
+      case join(topic_name, payload, unsafe_coerce_socket(typed_socket)) {
         channel.JoinOk(reply, new_socket) -> {
           // Extract assigns and type-erase them
           let erased_assigns =
@@ -603,23 +601,19 @@ fn erase_channel_types(
     ) {
       let typed_socket = create_socket_with_assigns(ctx)
 
-      typed_channel.handle_in(
-        event,
-        payload,
-        unsafe_coerce_socket(typed_socket),
-      )
+      handle_in(event, payload, unsafe_coerce_socket(typed_socket))
       |> erase_handle_result
     },
     handle_binary: fn(data: BitArray, ctx: coordinator.SocketContext) {
       let typed_socket = create_socket_with_assigns(ctx)
 
-      typed_channel.handle_binary(data, unsafe_coerce_socket(typed_socket))
+      handle_binary(data, unsafe_coerce_socket(typed_socket))
       |> erase_handle_result
     },
     terminate: fn(reason: channel.StopReason, ctx: coordinator.SocketContext) {
       let typed_socket = create_socket_with_assigns(ctx)
       // Unsafe coerce socket to expected type
-      typed_channel.terminate(reason, unsafe_coerce_socket(typed_socket))
+      terminate(reason, unsafe_coerce_socket(typed_socket))
     },
   )
 }
@@ -627,10 +621,12 @@ fn erase_channel_types(
 fn typed_handle_info(
   typed_channel: Channel(assigns, info),
 ) -> fn(info, coordinator.SocketContext) -> coordinator.HandleResultErased {
+  let handle_info = channel.handle_info_callback(typed_channel)
+
   fn(message: info, ctx: coordinator.SocketContext) {
     let typed_socket = create_socket_with_assigns(ctx)
 
-    typed_channel.handle_info(message, unsafe_coerce_socket(typed_socket))
+    handle_info(message, unsafe_coerce_socket(typed_socket))
     |> erase_handle_result
   }
 }

--- a/src/beryl/channel.gleam
+++ b/src/beryl/channel.gleam
@@ -72,7 +72,7 @@ pub type StopReason {
 /// - `info`: Server-originated/internal message type delivered to `handle_info`
 ///   (see `beryl.send_info`). Channels that do not use `handle_info` leave this
 ///   parameter generic.
-pub type Channel(assigns, info) {
+pub opaque type Channel(assigns, info) {
   Channel(
     /// Called when a client attempts to join a topic
     ///
@@ -99,6 +99,46 @@ pub type Channel(assigns, info) {
     /// Use for cleanup (presence, database updates, etc.)
     terminate: fn(StopReason, Socket(assigns)) -> Nil,
   )
+}
+
+// nolint: unused_exports -- package-internal accessor used by beryl's type-erasure layer; hidden from public docs with @internal
+@internal
+pub fn join_callback(
+  channel: Channel(assigns, info),
+) -> fn(String, Dynamic, Socket(assigns)) -> JoinResult(assigns) {
+  channel.join
+}
+
+// nolint: unused_exports -- package-internal accessor used by beryl's type-erasure layer; hidden from public docs with @internal
+@internal
+pub fn handle_in_callback(
+  channel: Channel(assigns, info),
+) -> fn(String, Dynamic, Socket(assigns)) -> HandleResult(assigns) {
+  channel.handle_in
+}
+
+// nolint: unused_exports -- package-internal accessor used by beryl's type-erasure layer; hidden from public docs with @internal
+@internal
+pub fn handle_binary_callback(
+  channel: Channel(assigns, info),
+) -> fn(BitArray, Socket(assigns)) -> HandleResult(assigns) {
+  channel.handle_binary
+}
+
+// nolint: unused_exports -- package-internal accessor used by beryl's type-erasure layer; hidden from public docs with @internal
+@internal
+pub fn handle_info_callback(
+  channel: Channel(assigns, info),
+) -> fn(info, Socket(assigns)) -> HandleResult(assigns) {
+  channel.handle_info
+}
+
+// nolint: unused_exports -- package-internal accessor used by beryl's type-erasure layer; hidden from public docs with @internal
+@internal
+pub fn terminate_callback(
+  channel: Channel(assigns, info),
+) -> fn(StopReason, Socket(assigns)) -> Nil {
+  channel.terminate
 }
 
 /// Create a new channel with just a join handler.

--- a/src/beryl/group.gleam
+++ b/src/beryl/group.gleam
@@ -23,8 +23,11 @@ import gleam/otp/actor
 import gleam/result
 import gleam/set.{type Set}
 
-/// A running Groups instance
-pub type Groups {
+/// A running Groups instance.
+///
+/// This handle is intentionally opaque so callers cannot forge the backing
+/// actor subject or depend on its runtime representation.
+pub opaque type Groups {
   Groups(subject: Subject(Message))
 }
 
@@ -82,6 +85,18 @@ pub fn start_named(
   build_groups()
   |> actor.named(name)
   |> actor.start
+}
+
+// nolint: unused_exports -- package-internal constructor for supervised groups; hidden from public docs with @internal
+@internal
+pub fn from_subject(subject: Subject(Message)) -> Groups {
+  Groups(subject: subject)
+}
+
+// nolint: unused_exports -- package-internal accessor for supervision tests; hidden from public docs with @internal
+@internal
+pub fn subject(groups: Groups) -> Subject(Message) {
+  groups.subject
 }
 
 fn build_groups() -> actor.Builder(State, Message, Subject(Message)) {

--- a/src/beryl/presence.gleam
+++ b/src/beryl/presence.gleam
@@ -10,12 +10,10 @@
 ////
 //// ```gleam
 //// let assert Ok(ps) = pubsub.start(pubsub.default_config())
-//// let config = presence.Config(
-////   pubsub: Some(ps),
-////   replica: "node1",
-////   broadcast_interval_ms: 1500,
-////   on_diff: None,
-//// )
+//// let config =
+////   presence.default_config("node1")
+////   |> presence.with_pubsub(ps)
+////   |> presence.with_broadcast_interval(1500)
 //// let assert Ok(p) = presence.start(config)
 //// let ref = presence.track(p, "room:lobby", "user:1", "socket-1", meta)
 //// let entries = presence.list(p, "room:lobby")
@@ -46,8 +44,11 @@ const sync_topic = "beryl:presence:sync"
 /// PubSub event name for presence sync messages
 const sync_event = "presence_sync"
 
-/// A running Presence instance
-pub type Presence {
+/// A running Presence instance.
+///
+/// This handle is intentionally opaque so callers cannot forge actor subjects
+/// or depend on the runtime representation.
+pub opaque type Presence {
   Presence(subject: Subject(Message))
 }
 
@@ -66,6 +67,9 @@ pub opaque type Diff {
 }
 
 /// A presence entry returned from queries and diff accessors.
+///
+/// This type is intentionally transparent so callers can inspect query results
+/// and construct entries for `diff`.
 pub type PresenceEntry {
   PresenceEntry(pid: String, key: String, meta: json.Json)
 }
@@ -135,8 +139,11 @@ fn state_entries_to_presence_entries(
   |> dict.from_list
 }
 
-/// Configuration for starting presence
-pub type Config {
+/// Configuration for starting presence.
+///
+/// Build configs with `default_config` and the `with_*` functions so Beryl can
+/// add future options without exposing record fields as public API.
+pub opaque type Config {
   Config(
     /// PubSub instance for cross-node replication
     pubsub: Option(PubSub),
@@ -199,6 +206,35 @@ pub fn default_config(replica: String) -> Config {
     broadcast_interval_ms: 0,
     on_diff: None,
   )
+}
+
+/// Enable PubSub replication for presence.
+pub fn with_pubsub(config: Config, pubsub: PubSub) -> Config {
+  Config(..config, pubsub: Some(pubsub))
+}
+
+/// Set how often presence state is broadcast for replication.
+///
+/// Use `0` to disable periodic broadcasts.
+pub fn with_broadcast_interval(config: Config, interval_ms: Int) -> Config {
+  Config(..config, broadcast_interval_ms: interval_ms)
+}
+
+/// Set the callback invoked when local changes or remote merges produce a diff.
+pub fn with_on_diff(config: Config, callback: fn(Diff) -> Nil) -> Config {
+  Config(..config, on_diff: Some(callback))
+}
+
+// nolint: unused_exports -- package-internal constructor for supervised presence; hidden from public docs with @internal
+@internal
+pub fn from_subject(subject: Subject(Message)) -> Presence {
+  Presence(subject: subject)
+}
+
+// nolint: unused_exports -- package-internal accessor for supervision tests; hidden from public docs with @internal
+@internal
+pub fn subject(presence: Presence) -> Subject(Message) {
+  presence.subject
 }
 
 /// Start the presence actor

--- a/src/beryl/pubsub.gleam
+++ b/src/beryl/pubsub.gleam
@@ -17,7 +17,10 @@ import gleam/erlang/process.{type Pid}
 import gleam/json
 import gleam/list
 
-/// A PubSub message delivered to subscribers
+/// A PubSub message delivered to subscribers.
+///
+/// This type is intentionally transparent so subscribers can inspect the topic,
+/// event, payload, and sender metadata delivered to their process mailbox.
 pub type Message {
   Message(topic: String, event: String, payload: json.Json, from: PubSubFrom)
 }
@@ -32,16 +35,22 @@ pub type PubSubFrom {
   FromSocket(Pid, String)
 }
 
-/// PubSub configuration
-pub type PubSubConfig {
+/// PubSub configuration.
+///
+/// Build with `default_config` or `config_with_scope` so the underlying pg
+/// scope representation can evolve without exposing record fields.
+pub opaque type PubSubConfig {
   PubSubConfig(
     /// The pg scope name (atom). Different scopes are isolated.
     scope: Dynamic,
   )
 }
 
-/// A running PubSub instance
-pub type PubSub {
+/// A running PubSub instance.
+///
+/// This handle is intentionally opaque so callers cannot forge pg scopes or
+/// depend on the runtime representation.
+pub opaque type PubSub {
   PubSub(scope: Dynamic)
 }
 

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -228,13 +228,12 @@ fn start_supervised(
         )
 
       let pres = case presence_name {
-        Some(name) ->
-          Some(presence.Presence(subject: process.named_subject(name)))
+        Some(name) -> Some(presence.from_subject(process.named_subject(name)))
         None -> None
       }
 
       let grps = case groups_name {
-        Some(name) -> Some(group.Groups(subject: process.named_subject(name)))
+        Some(name) -> Some(group.from_subject(process.named_subject(name)))
         None -> None
       }
 

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -27,7 +27,7 @@ pub const default_vsn = "2.0.0"
 ///
 /// The `assigns` type parameter is the socket-level state produced by the
 /// `on_connect` hook. It defaults to `Nil` when no hook is configured.
-pub type TransportConfig(assigns) {
+pub opaque type TransportConfig(assigns) {
   TransportConfig(
     /// URL path to match for WebSocket upgrade (e.g., "/socket")
     path: String,

--- a/test/broadcast_test.gleam
+++ b/test/broadcast_test.gleam
@@ -7,7 +7,7 @@ import beryl/wire
 import gleam/dynamic
 import gleam/erlang/process
 import gleam/json
-import gleam/option.{None, Some}
+import gleam/option.{None}
 import gleam/string
 import gleeunit
 import gleeunit/should
@@ -198,14 +198,10 @@ pub fn presence_track_can_broadcast_presence_diff_to_joined_socket_test() {
   drain(socket)
 
   let presence_config =
-    presence.Config(
-      pubsub: None,
-      replica: "node1",
-      broadcast_interval_ms: 0,
-      on_diff: Some(fn(diff) {
-        beryl.broadcast_presence_diff(channels, "room:lobby", diff)
-      }),
-    )
+    presence.default_config("node1")
+    |> presence.with_on_diff(fn(diff) {
+      beryl.broadcast_presence_diff(channels, "room:lobby", diff)
+    })
   let assert Ok(p) = presence.start(presence_config)
 
   let _ =

--- a/test/mist_transport_test.gleam
+++ b/test/mist_transport_test.gleam
@@ -1,18 +1,23 @@
 import beryl/transport/mist as mist_transport
+import beryl/wire/codec
 import gleam/http/request.{type Request}
 import gleam/option.{None}
+import gleam/string
 import gleeunit/should
 import mist.{type Connection}
 
 pub fn default_config_creates_with_path_test() {
-  let config = mist_transport.default_config("/socket")
-  config.path |> should.equal("/socket")
-  config.on_connect |> should.equal(None)
+  let _config: mist_transport.TransportConfig(Nil) =
+    mist_transport.default_config("/socket")
+
+  should.be_true(True)
 }
 
 pub fn default_config_slash_ws_test() {
-  let config = mist_transport.default_config("/ws")
-  config.path |> should.equal("/ws")
+  let _config: mist_transport.TransportConfig(Nil) =
+    mist_transport.default_config("/ws")
+
+  should.be_true(True)
 }
 
 pub fn with_on_connect_sets_callback_test() {
@@ -22,8 +27,8 @@ pub fn with_on_connect_sets_callback_test() {
     mist_transport.default_config("/socket")
     |> mist_transport.with_on_connect(callback)
 
-  config.path |> should.equal("/socket")
-  config.on_connect |> should.be_some
+  let _typed_config: mist_transport.TransportConfig(Nil) = config
+  should.be_true(True)
 }
 
 pub fn with_on_connect_replaces_callback_test() {
@@ -37,7 +42,8 @@ pub fn with_on_connect_replaces_callback_test() {
     |> mist_transport.with_on_connect(callback1)
     |> mist_transport.with_on_connect(callback2)
 
-  config.on_connect |> should.be_some
+  let _typed_config: mist_transport.TransportConfig(Nil) = config
+  should.be_true(True)
 }
 
 pub fn with_on_connect_seeding_assigns_sets_callback_test() {
@@ -50,8 +56,34 @@ pub fn with_on_connect_seeding_assigns_sets_callback_test() {
     mist_transport.default_config("/socket")
     |> mist_transport.with_on_connect(callback)
 
-  config.path |> should.equal("/socket")
-  config.on_connect |> should.be_some
+  let _typed_config: mist_transport.TransportConfig(String) = config
+  should.be_true(True)
+}
+
+pub fn with_reject_unknown_vsn_is_chainable_test() {
+  let config =
+    mist_transport.default_config("/socket")
+    |> mist_transport.with_reject_unknown_vsn(True)
+
+  let _typed_config: mist_transport.TransportConfig(Nil) = config
+  should.be_true(True)
+}
+
+pub fn with_serializer_is_chainable_test() {
+  let test_codec =
+    codec.Codec(
+      decode_text: fn(_) { Error(codec.InvalidFormat("text")) },
+      decode_binary: None,
+      encode_reply: fn(_, _, _, _, _) { codec.TextFrame("reply") },
+      encode_push: fn(_, _, _) { codec.TextFrame("push") },
+      encode_heartbeat_reply: fn(_) { codec.TextFrame("heartbeat") },
+    )
+  let config =
+    mist_transport.default_config("/socket")
+    |> mist_transport.with_serializer("3.0.0", test_codec)
+
+  let _typed_config: mist_transport.TransportConfig(Nil) = config
+  should.be_true(string.length(mist_transport.default_vsn) > 0)
 }
 
 // `upgrade_connection` is a public entry point for callers that do their own

--- a/test/presence_replication_test.gleam
+++ b/test/presence_replication_test.gleam
@@ -3,7 +3,6 @@ import beryl/pubsub
 import gleam/erlang/process
 import gleam/json
 import gleam/list
-import gleam/option.{None, Some}
 import gleeunit
 import gleeunit/should
 import test_helpers
@@ -26,12 +25,9 @@ fn test_config(
   replica: String,
   interval_ms: Int,
 ) -> presence.Config {
-  presence.Config(
-    pubsub: Some(ps),
-    replica: replica,
-    broadcast_interval_ms: interval_ms,
-    on_diff: None,
-  )
+  presence.default_config(replica)
+  |> presence.with_pubsub(ps)
+  |> presence.with_broadcast_interval(interval_ms)
 }
 
 // ── BroadcastTick sends state via PubSub ────────────────────────────
@@ -133,12 +129,8 @@ pub fn remote_state_triggers_merge_via_pubsub_test() {
 
   // Node1 with broadcasting disabled (manual control)
   let config1 =
-    presence.Config(
-      pubsub: Some(ps),
-      replica: "node1",
-      broadcast_interval_ms: 0,
-      on_diff: None,
-    )
+    presence.default_config("node1")
+    |> presence.with_pubsub(ps)
   let assert Ok(p1) = presence.start(config1)
 
   // Node2 with broadcasting enabled
@@ -258,12 +250,8 @@ pub fn untrack_propagates_via_pubsub_test() {
 pub fn survives_empty_string_payload_test() {
   let ps = test_pubsub("malform_empty")
   let config =
-    presence.Config(
-      pubsub: Some(ps),
-      replica: "node1",
-      broadcast_interval_ms: 0,
-      on_diff: None,
-    )
+    presence.default_config("node1")
+    |> presence.with_pubsub(ps)
   let assert Ok(p) = presence.start(config)
 
   // Track an entry to prove the actor is alive
@@ -284,12 +272,8 @@ pub fn survives_empty_string_payload_test() {
 pub fn survives_malformed_json_payload_test() {
   let ps = test_pubsub("malform_json")
   let config =
-    presence.Config(
-      pubsub: Some(ps),
-      replica: "node1",
-      broadcast_interval_ms: 0,
-      on_diff: None,
-    )
+    presence.default_config("node1")
+    |> presence.with_pubsub(ps)
   let assert Ok(p) = presence.start(config)
 
   let _ = presence.track(p, "room:lobby", "user:1", "s1", json.null())
@@ -312,12 +296,8 @@ pub fn survives_malformed_json_payload_test() {
 pub fn survives_wrong_schema_payload_test() {
   let ps = test_pubsub("malform_schema")
   let config =
-    presence.Config(
-      pubsub: Some(ps),
-      replica: "node1",
-      broadcast_interval_ms: 0,
-      on_diff: None,
-    )
+    presence.default_config("node1")
+    |> presence.with_pubsub(ps)
   let assert Ok(p) = presence.start(config)
 
   let _ = presence.track(p, "room:lobby", "user:1", "s1", json.null())
@@ -340,12 +320,8 @@ pub fn survives_wrong_schema_payload_test() {
 pub fn survives_wrong_types_payload_test() {
   let ps = test_pubsub("malform_types")
   let config =
-    presence.Config(
-      pubsub: Some(ps),
-      replica: "node1",
-      broadcast_interval_ms: 0,
-      on_diff: None,
-    )
+    presence.default_config("node1")
+    |> presence.with_pubsub(ps)
   let assert Ok(p) = presence.start(config)
 
   let _ = presence.track(p, "room:lobby", "user:1", "s1", json.null())

--- a/test/presence_test.gleam
+++ b/test/presence_test.gleam
@@ -2,7 +2,6 @@ import beryl/presence
 import gleam/erlang/process
 import gleam/json
 import gleam/list
-import gleam/option.{None, Some}
 import gleeunit
 import gleeunit/should
 
@@ -11,12 +10,7 @@ pub fn main() {
 }
 
 fn test_config(replica: String) -> presence.Config {
-  presence.Config(
-    pubsub: None,
-    replica: replica,
-    broadcast_interval_ms: 0,
-    on_diff: None,
-  )
+  presence.default_config(replica)
 }
 
 pub fn presence_start_test() {
@@ -107,11 +101,12 @@ pub fn presence_empty_list_test() {
 }
 
 pub fn presence_default_config_test() {
-  let config = presence.default_config("my-node")
-  config.replica |> should.equal("my-node")
-  config.broadcast_interval_ms |> should.equal(0)
-  config.pubsub |> should.equal(None)
-  config.on_diff |> should.equal(None)
+  let assert Ok(p) = presence.start(presence.default_config("my-node"))
+  let _ = presence.track(p, "room:default", "user:1", "socket-1", json.null())
+
+  presence.list(p, "room:default")
+  |> list.length
+  |> should.equal(1)
 }
 
 // ── on_diff callback tests ──────────────────────────────────────────────────
@@ -120,12 +115,8 @@ pub fn on_diff_callback_receives_local_track_diff_test() {
   let diff_subject = process.new_subject()
 
   let config =
-    presence.Config(
-      pubsub: None,
-      replica: "node1",
-      broadcast_interval_ms: 0,
-      on_diff: Some(fn(diff) { process.send(diff_subject, diff) }),
-    )
+    presence.default_config("node1")
+    |> presence.with_on_diff(fn(diff) { process.send(diff_subject, diff) })
 
   let assert Ok(p) = presence.start(config)
 
@@ -156,12 +147,8 @@ pub fn on_diff_callback_receives_local_untrack_diff_test() {
   let diff_subject = process.new_subject()
 
   let config =
-    presence.Config(
-      pubsub: None,
-      replica: "node1",
-      broadcast_interval_ms: 0,
-      on_diff: Some(fn(diff) { process.send(diff_subject, diff) }),
-    )
+    presence.default_config("node1")
+    |> presence.with_on_diff(fn(diff) { process.send(diff_subject, diff) })
 
   let assert Ok(p) = presence.start(config)
   let _ =
@@ -194,12 +181,8 @@ pub fn on_diff_callback_receives_all_rapid_diffs_test() {
   let diff_subject = process.new_subject()
 
   let config =
-    presence.Config(
-      pubsub: None,
-      replica: "node1",
-      broadcast_interval_ms: 0,
-      on_diff: Some(fn(diff) { process.send(diff_subject, diff) }),
-    )
+    presence.default_config("node1")
+    |> presence.with_on_diff(fn(diff) { process.send(diff_subject, diff) })
 
   let assert Ok(p) = presence.start(config)
 

--- a/test/supervisor_test.gleam
+++ b/test/supervisor_test.gleam
@@ -262,7 +262,7 @@ pub fn coordinator_crash_resets_presence_state_test() {
   let assert Ok(old_coord_pid) = get_subject_pid(coord_subject)
 
   // Also get the presence PID before crash
-  let assert Ok(old_pres_pid) = get_subject_pid(pres.subject)
+  let assert Ok(old_pres_pid) = get_subject_pid(presence.subject(pres))
 
   process.send_abnormal_exit(old_coord_pid, crash_reason())
 
@@ -281,7 +281,7 @@ pub fn coordinator_crash_resets_presence_state_test() {
   // Wait for presence to also restart with a new PID (RestForOne behavior)
   test_helpers.wait_until(
     fn() {
-      case get_subject_pid(pres.subject) {
+      case get_subject_pid(presence.subject(pres)) {
         Ok(new_pid) -> new_pid != old_pres_pid && process.is_alive(new_pid)
         Error(_) -> False
       }
@@ -318,7 +318,7 @@ pub fn coordinator_crash_resets_groups_state_test() {
   let assert Ok(old_coord_pid) = get_subject_pid(coord_subject)
 
   // Also get the groups PID before crash
-  let assert Ok(old_grps_pid) = get_subject_pid(grps.subject)
+  let assert Ok(old_grps_pid) = get_subject_pid(group.subject(grps))
 
   process.send_abnormal_exit(old_coord_pid, crash_reason())
 
@@ -337,7 +337,7 @@ pub fn coordinator_crash_resets_groups_state_test() {
   // Wait for groups to also restart with a new PID (RestForOne behavior)
   test_helpers.wait_until(
     fn() {
-      case get_subject_pid(grps.subject) {
+      case get_subject_pid(group.subject(grps)) {
         Ok(new_pid) -> new_pid != old_grps_pid && process.is_alive(new_pid)
         Error(_) -> False
       }
@@ -375,13 +375,13 @@ pub fn independent_presence_crash_does_not_affect_coordinator_test() {
     get_subject_pid(beryl.coordinator_subject(supervised.channels))
 
   // Kill the presence process directly
-  let assert Ok(old_pres_pid) = get_subject_pid(pres.subject)
+  let assert Ok(old_pres_pid) = get_subject_pid(presence.subject(pres))
   process.send_abnormal_exit(old_pres_pid, crash_reason())
 
   // Wait for presence to restart with a new PID
   test_helpers.wait_until(
     fn() {
-      case get_subject_pid(pres.subject) {
+      case get_subject_pid(presence.subject(pres)) {
         Ok(new_pid) -> new_pid != old_pres_pid && process.is_alive(new_pid)
         Error(_) -> False
       }
@@ -429,13 +429,13 @@ pub fn independent_groups_crash_does_not_affect_coordinator_test() {
     get_subject_pid(beryl.coordinator_subject(supervised.channels))
 
   // Kill the groups process directly
-  let assert Ok(old_grps_pid) = get_subject_pid(grps.subject)
+  let assert Ok(old_grps_pid) = get_subject_pid(group.subject(grps))
   process.send_abnormal_exit(old_grps_pid, crash_reason())
 
   // Wait for groups to restart with a new PID
   test_helpers.wait_until(
     fn() {
-      case get_subject_pid(grps.subject) {
+      case get_subject_pid(group.subject(grps)) {
         Ok(new_pid) -> new_pid != old_grps_pid && process.is_alive(new_pid)
         Error(_) -> False
       }

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -24,12 +24,10 @@ let assert Ok(p) = presence.start(presence.default_config("node1"))
 
 // With PubSub for cross-node replication
 let assert Ok(ps) = pubsub.start(pubsub.default_config())
-let config = presence.Config(
-  pubsub: option.Some(ps),
-  replica: "node1",
-  broadcast_interval_ms: 1500,
-  on_diff: option.None,
-)
+let config =
+  presence.default_config("node1")
+  |> presence.with_pubsub(ps)
+  |> presence.with_broadcast_interval(1500)
 let assert Ok(p) = presence.start(config)
 ```
 
@@ -82,11 +80,11 @@ let alice_sessions = presence.get_by_key(p, "room:lobby", "user:alice")
 Get notified immediately when presence state changes:
 
 ```gleam
-let config = presence.Config(
-  pubsub: option.Some(ps),
-  replica: "node1",
-  broadcast_interval_ms: 1500,
-  on_diff: option.Some(fn(diff) {
+let config =
+  presence.default_config("node1")
+  |> presence.with_pubsub(ps)
+  |> presence.with_broadcast_interval(1500)
+  |> presence.with_on_diff(fn(diff) {
     diff
     |> presence.diff_topics
     |> list.each(fn(topic) {
@@ -94,8 +92,7 @@ let config = presence.Config(
       io.println("Joins: " <> string.inspect(presence.diff_joins(diff, topic)))
       io.println("Leaves: " <> string.inspect(presence.diff_leaves(diff, topic)))
     })
-  }),
-)
+  })
 ```
 
 The `on_diff` callback fires whenever local tracking changes or remote merges produce non-empty changes, ensuring no diffs are lost during rapid state changes.
@@ -107,14 +104,13 @@ Use `beryl.broadcast_presence_diff` to send a `presence_diff` event to sockets s
 ```gleam
 import beryl
 
-let config = presence.Config(
-  pubsub: option.Some(ps),
-  replica: "node1",
-  broadcast_interval_ms: 1500,
-  on_diff: option.Some(fn(diff) {
+let config =
+  presence.default_config("node1")
+  |> presence.with_pubsub(ps)
+  |> presence.with_broadcast_interval(1500)
+  |> presence.with_on_diff(fn(diff) {
     beryl.broadcast_presence_diff(channels, "room:lobby", diff)
-  }),
-)
+  })
 ```
 
 `broadcast_presence_diff` broadcasts to a single topic. The `diff` passed to `on_diff` may span multiple topics; if you track presence across several topics, iterate over the affected topics:

--- a/website/src/content/docs/reference/api/beryl-channel.md
+++ b/website/src/content/docs/reference/api/beryl-channel.md
@@ -40,15 +40,7 @@ Channel behavior definition
    parameter generic.
 
 ```gleam
-pub type Channel(a, b) {
-  Channel(
-    join: fn(String, dynamic.Dynamic, socket.Socket(a)) -> JoinResult(a),
-    handle_in: fn(String, dynamic.Dynamic, socket.Socket(a)) -> HandleResult(a),
-    handle_binary: fn(BitArray, socket.Socket(a)) -> HandleResult(a),
-    handle_info: fn(b, socket.Socket(a)) -> HandleResult(a),
-    terminate: fn(StopReason, socket.Socket(a)) -> Nil
-  )
-}
+pub opaque type Channel(a, b)
 ```
 
 ### `HandleResult`

--- a/website/src/content/docs/reference/api/beryl-group.md
+++ b/website/src/content/docs/reference/api/beryl-group.md
@@ -49,12 +49,13 @@ The actor failed to start
 
 ### `Groups`
 
-A running Groups instance
+A running Groups instance.
+
+ This handle is intentionally opaque so callers cannot forge the backing
+ actor subject or depend on its runtime representation.
 
 ```gleam
-pub type Groups {
-  Groups(subject: process.Subject(Message))
-}
+pub opaque type Groups
 ```
 
 ### `Message`

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -15,12 +15,10 @@ Presence - Distributed presence tracking backed by a CRDT
 
  ```gleam
  let assert Ok(ps) = pubsub.start(pubsub.default_config())
- let config = presence.Config(
-   pubsub: Some(ps),
-   replica: "node1",
-   broadcast_interval_ms: 1500,
-   on_diff: None,
- )
+ let config =
+   presence.default_config("node1")
+   |> presence.with_pubsub(ps)
+   |> presence.with_broadcast_interval(1500)
  let assert Ok(p) = presence.start(config)
  let ref = presence.track(p, "room:lobby", "user:1", "socket-1", meta)
  let entries = presence.list(p, "room:lobby")
@@ -30,17 +28,13 @@ Presence - Distributed presence tracking backed by a CRDT
 
 ### `Config`
 
-Configuration for starting presence
+Configuration for starting presence.
+
+ Build with `default_config` and the `with_*` functions so Beryl can
+ add future options without exposing record fields as public API.
 
 ```gleam
-pub type Config {
-  Config(
-    pubsub: option.Option(pubsub.PubSub),
-    replica: String,
-    broadcast_interval_ms: Int,
-    on_diff: option.Option(fn(Diff) -> Nil)
-  )
-}
+pub opaque type Config
 ```
 
 ### `Diff`
@@ -64,12 +58,13 @@ pub type Message
 
 ### `Presence`
 
-A running Presence instance
+A running Presence instance.
+
+ This handle is intentionally opaque so callers cannot forge actor subjects
+ or depend on the runtime representation.
 
 ```gleam
-pub type Presence {
-  Presence(subject: process.Subject(Message))
-}
+pub opaque type Presence
 ```
 
 ### `PresenceEntry`
@@ -110,6 +105,41 @@ Default configuration (no PubSub, no replication)
 
 ```gleam
 pub fn default_config(String) -> Config
+```
+
+### `with_broadcast_interval`
+
+Set how often presence state is broadcast for replication.
+
+ Use `0` to disable periodic broadcasts.
+
+```gleam
+pub fn with_broadcast_interval(
+  Config,
+  Int
+) -> Config
+```
+
+### `with_on_diff`
+
+Set the callback invoked when local changes or remote merges produce a diff.
+
+```gleam
+pub fn with_on_diff(
+  Config,
+  fn(Diff) -> Nil
+) -> Config
+```
+
+### `with_pubsub`
+
+Enable PubSub replication for presence.
+
+```gleam
+pub fn with_pubsub(
+  Config,
+  pubsub.PubSub
+) -> Config
 ```
 
 ### `diff`

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -36,22 +36,24 @@ pub type Message {
 
 ### `PubSub`
 
-A running PubSub instance
+A running PubSub instance.
+
+ This handle is intentionally opaque so callers cannot forge pg scopes or
+ depend on the runtime representation.
 
 ```gleam
-pub type PubSub {
-  PubSub(scope: dynamic.Dynamic)
-}
+pub opaque type PubSub
 ```
 
 ### `PubSubConfig`
 
-PubSub configuration
+PubSub configuration.
+
+ Build with `default_config` or `config_with_scope` so the underlying pg
+ scope representation can evolve without exposing record fields.
 
 ```gleam
-pub type PubSubConfig {
-  PubSubConfig(scope: dynamic.Dynamic)
-}
+pub opaque type PubSubConfig
 ```
 
 ### `PubSubFrom`

--- a/website/src/content/docs/reference/api/beryl-transport-mist.md
+++ b/website/src/content/docs/reference/api/beryl-transport-mist.md
@@ -18,14 +18,7 @@ Configuration for the Mist WebSocket transport
  `on_connect` hook. It defaults to `Nil` when no hook is configured.
 
 ```gleam
-pub type TransportConfig(a) {
-  TransportConfig(
-    path: String,
-    on_connect: option.Option(fn(request.Request(http.Connection)) -> Result(a, Nil)),
-    serializers: List(#(String, codec.Codec)),
-    reject_unknown_vsn: Bool
-  )
-}
+pub opaque type TransportConfig(a)
 ```
 
 ## Constants


### PR DESCRIPTION
## Summary

- Make core handles/configs opaque: `Channel`, `Presence`, `presence.Config`, `Groups`, `PubSub`, `PubSubConfig`, and Mist `TransportConfig`
- Add narrow `@internal` helpers for type erasure and supervised actor subject reconstruction
- Update tests, docs/reference pages, and changelog to use stable constructors/builders

## Verification

- `just check`
- `just test`
- `gleam docs build`
- `git diff --check`

## Notes

- Full local `just ci` is blocked before cursor Playwright tests can start because `localhost:8000` is already used by `granian asginl :::8000 paperless.asgi:application`.
- `just lint` still reports pre-existing `thrown_away_error` findings in unchanged coordinator/Mist paths.

Closes #122
