### PR TITLE
fix(api)!: normalize public errors

### DIFF
--- a/.changes/unreleased/Changed-20260624-210858.yaml
+++ b/.changes/unreleased/Changed-20260624-210858.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: |-
+    Normalize public error types before 1.0.
+
+    Public fallible APIs now use Beryl-owned error types, named transport connect rejection, infallible PubSub startup, and clearer topic/group errors instead of dependency-shaped errors or meaningful Result(_, Nil).
+time: 2026-06-24T21:08:58.337527258-07:00

--- a/examples/chatrooms/src/chatrooms.gleam
+++ b/examples/chatrooms/src/chatrooms.gleam
@@ -49,7 +49,7 @@ pub fn main() {
     |> mist_transport.with_on_connect(fn(req) {
       case get_query_param(req, "token") {
         Ok("beryl-demo") -> Ok(Nil)
-        _ -> Error(Nil)
+        _ -> Error(mist_transport.ConnectRejected)
       }
     })
 

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -27,7 +27,7 @@
 ////
 //// pub fn main() {
 ////   // Optional: start PubSub for distributed messaging
-////   let assert Ok(ps) = pubsub.start(pubsub.default_config())
+////   let ps = pubsub.start(pubsub.default_config())
 ////
 ////   // Start channels system (with or without PubSub)
 ////   let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
@@ -51,6 +51,7 @@
 
 import beryl/channel.{type Channel}
 import beryl/coordinator
+import beryl/error as beryl_error
 import beryl/presence.{type Diff}
 import beryl/presence/wire as presence_wire
 import beryl/pubsub.{type PubSub}
@@ -279,7 +280,8 @@ pub fn configured_codec(channels: Channels) -> codec.Codec {
 
 /// Errors when starting channels
 pub type StartError {
-  CoordinatorStartFailed
+  /// The coordinator actor failed to start.
+  CoordinatorStartFailed(beryl_error.StartFailure)
   /// heartbeat_timeout_ms must be > 0 (it is used to derive the check interval)
   InvalidHeartbeatTimeout
 }
@@ -336,7 +338,9 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
   }
 
   case coordinator_result {
-    Error(_) -> Error(CoordinatorStartFailed)
+    Error(coordinator.ActorStartFailed(error)) ->
+      Error(CoordinatorStartFailed(beryl_error.from_actor_start_error(error)))
+    Error(coordinator.InvalidHeartbeatTimeout) -> Error(InvalidHeartbeatTimeout)
     Ok(coord) ->
       Ok(channels_from_coordinator(coordinator: coord, config: config))
   }
@@ -547,7 +551,7 @@ pub fn send_info(
 pub fn extract_topic_id(
   pattern: topic.TopicPattern,
   topic_name: String,
-) -> Result(String, Nil) {
+) -> Result(String, topic.ExtractError) {
   topic.extract_id(pattern, topic_name)
 }
 

--- a/src/beryl/error.gleam
+++ b/src/beryl/error.gleam
@@ -1,0 +1,44 @@
+//// Shared Beryl-owned error helpers.
+
+import gleam/erlang/process
+import gleam/otp/actor
+
+/// A stable description of an internal Beryl actor startup failure.
+///
+/// This type hides OTP's `actor.StartError` so public APIs do not expose
+/// dependency-specific error constructors.
+pub opaque type StartFailure {
+  StartFailure(reason: StartFailureReason)
+}
+
+type StartFailureReason {
+  StartTimedOut
+  StartFailed(String)
+  StartExited(String)
+}
+
+/// Convert a startup failure to a human-readable diagnostic string.
+pub fn describe_start_failure(failure: StartFailure) -> String {
+  case failure.reason {
+    StartTimedOut -> "actor init timed out"
+    StartFailed(reason) -> "actor init failed: " <> reason
+    StartExited(reason) -> "actor init exited: " <> reason
+  }
+}
+
+@internal
+pub fn from_actor_start_error(error: actor.StartError) -> StartFailure {
+  case error {
+    actor.InitTimeout -> StartFailure(StartTimedOut)
+    actor.InitFailed(reason) -> StartFailure(StartFailed(reason))
+    actor.InitExited(reason) -> StartFailure(StartExited(exit_reason(reason)))
+  }
+}
+
+fn exit_reason(reason: process.ExitReason) -> String {
+  case reason {
+    process.Normal -> "normal"
+    process.Killed -> "killed"
+    process.Abnormal(_) -> "abnormal"
+  }
+}

--- a/src/beryl/group.gleam
+++ b/src/beryl/group.gleam
@@ -15,6 +15,7 @@
 //// ```
 
 import beryl
+import beryl/error as beryl_error
 import gleam/dict.{type Dict}
 import gleam/erlang/process.{type Subject}
 import gleam/json
@@ -34,11 +35,15 @@ pub opaque type Groups {
 /// Errors from group operations
 pub type GroupError {
   /// The group already exists
-  AlreadyExists
+  GroupAlreadyExists
   /// The group was not found
-  NotFound
+  GroupNotFound
+}
+
+/// Errors when starting the groups actor.
+pub type GroupStartError {
   /// The actor failed to start
-  StartFailed
+  GroupActorStartFailed(beryl_error.StartFailure)
 }
 
 /// Messages the groups actor handles
@@ -71,14 +76,17 @@ type State {
 }
 
 /// Start the groups actor
-pub fn start() -> Result(Groups, GroupError) {
+pub fn start() -> Result(Groups, GroupStartError) {
   build_groups()
   |> actor.start
   |> result.map(fn(started) { Groups(subject: started.data) })
-  |> result.replace_error(StartFailed)
+  |> result.map_error(fn(error) {
+    GroupActorStartFailed(beryl_error.from_actor_start_error(error))
+  })
 }
 
 /// Start the groups actor with a registered name (for supervision)
+@internal
 pub fn start_named(
   name: process.Name(Message),
 ) -> Result(actor.Started(Subject(Message)), actor.StartError) {
@@ -174,7 +182,7 @@ fn handle_message(
     Create(name, reply) -> {
       case dict.has_key(state.groups, name) {
         True -> {
-          process.send(reply, Error(AlreadyExists))
+          process.send(reply, Error(GroupAlreadyExists))
           actor.continue(state)
         }
         False -> {
@@ -188,7 +196,7 @@ fn handle_message(
     Delete(name, reply) -> {
       case dict.has_key(state.groups, name) {
         False -> {
-          process.send(reply, Error(NotFound))
+          process.send(reply, Error(GroupNotFound))
           actor.continue(state)
         }
         True -> {
@@ -202,7 +210,7 @@ fn handle_message(
     Add(group_name, topic, reply) -> {
       case dict.get(state.groups, group_name) {
         Error(Nil) -> {
-          process.send(reply, Error(NotFound))
+          process.send(reply, Error(GroupNotFound))
           actor.continue(state)
         }
         Ok(topics) -> {
@@ -217,7 +225,7 @@ fn handle_message(
     Remove(group_name, topic, reply) -> {
       case dict.get(state.groups, group_name) {
         Error(Nil) -> {
-          process.send(reply, Error(NotFound))
+          process.send(reply, Error(GroupNotFound))
           actor.continue(state)
         }
         Ok(topics) -> {
@@ -232,7 +240,7 @@ fn handle_message(
     GetTopics(group_name, reply) -> {
       case dict.get(state.groups, group_name) {
         Error(Nil) -> {
-          process.send(reply, Error(NotFound))
+          process.send(reply, Error(GroupNotFound))
           actor.continue(state)
         }
         Ok(topics) -> {

--- a/src/beryl/presence.gleam
+++ b/src/beryl/presence.gleam
@@ -9,7 +9,7 @@
 //// ## Example
 ////
 //// ```gleam
-//// let assert Ok(ps) = pubsub.start(pubsub.default_config())
+//// let ps = pubsub.start(pubsub.default_config())
 //// let config =
 ////   presence.default_config("node1")
 ////   |> presence.with_pubsub(ps)
@@ -19,6 +19,7 @@
 //// let entries = presence.list(p, "room:lobby")
 //// ```
 
+import beryl/error as beryl_error
 import beryl/internal
 import beryl/log
 import beryl/pubsub.{type PubSub}
@@ -159,8 +160,8 @@ pub opaque type Config {
 
 /// Errors from presence operations
 pub type PresenceError {
-  /// The actor failed to start, wrapping the underlying OTP start error
-  StartFailed(actor.StartError)
+  /// The presence actor failed to start.
+  PresenceStartFailed(beryl_error.StartFailure)
 }
 
 /// Messages the presence actor handles
@@ -242,10 +243,13 @@ pub fn start(config: Config) -> Result(Presence, PresenceError) {
   build_presence(config)
   |> actor.start
   |> result.map(fn(started) { Presence(subject: started.data) })
-  |> result.map_error(StartFailed)
+  |> result.map_error(fn(error) {
+    PresenceStartFailed(beryl_error.from_actor_start_error(error))
+  })
 }
 
 /// Start the presence actor with a registered name (for supervision)
+@internal
 pub fn start_named(
   config: Config,
   name: process.Name(Message),

--- a/src/beryl/pubsub.gleam
+++ b/src/beryl/pubsub.gleam
@@ -7,7 +7,7 @@
 //// ## Quick Start
 ////
 //// ```gleam
-//// let assert Ok(ps) = pubsub.start(pubsub.default_config())
+//// let ps = pubsub.start(pubsub.default_config())
 //// pubsub.subscribe(ps, "room:lobby")
 //// pubsub.broadcast(ps, "room:lobby", "new_msg", json.string("hello"))
 //// ```
@@ -54,11 +54,6 @@ pub opaque type PubSub {
   PubSub(scope: Dynamic)
 }
 
-/// Errors when starting PubSub
-pub type StartError {
-  PgStartFailed
-}
-
 // ── FFI declarations ────────────────────────────────────────────────────────
 
 @external(erlang, "beryl_pubsub_ffi", "start_pg_scope")
@@ -98,11 +93,11 @@ pub fn config_with_scope(name: String) -> PubSubConfig {
 ///
 /// This starts a pg scope. If the scope is already started (e.g., by another
 /// node or previous call), this is a no-op.
-pub fn start(config: PubSubConfig) -> Result(PubSub, StartError) {
+pub fn start(config: PubSubConfig) -> PubSub {
   // pg:start returns {ok, Pid} or {error, {already_started, Pid}}
   // Both are success cases for us
   let _start_result = ffi_start_pg_scope(config.scope)
-  Ok(PubSub(scope: config.scope))
+  PubSub(scope: config.scope)
 }
 
 /// Subscribe the current process to a topic

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -28,6 +28,7 @@
 
 import beryl
 import beryl/coordinator
+import beryl/error as beryl_error
 import beryl/group
 import beryl/internal
 import beryl/log
@@ -70,7 +71,7 @@ pub type SupervisedChannels {
 /// Errors when starting the supervised system
 pub type StartError {
   /// The supervisor failed to start
-  SupervisorStartFailed(actor.StartError)
+  SupervisorStartFailed(beryl_error.StartFailure)
   /// heartbeat_timeout_ms must be > 0
   InvalidHeartbeatTimeout
 }
@@ -200,7 +201,7 @@ fn start_supervised(
     Error(err) -> {
       logger
       |> log.error("Supervisor failed to start", [])
-      Error(SupervisorStartFailed(err))
+      Error(SupervisorStartFailed(beryl_error.from_actor_start_error(err)))
     }
     Ok(started) -> {
       let presence_enabled = case config.presence {
@@ -307,7 +308,8 @@ pub fn child_spec(
       case start(config) {
         Ok(supervised) ->
           Ok(actor.Started(pid: supervised.supervisor_pid, data: supervised))
-        Error(SupervisorStartFailed(err)) -> Error(err)
+        Error(SupervisorStartFailed(failure)) ->
+          Error(actor.InitFailed(beryl_error.describe_start_failure(failure)))
         Error(InvalidHeartbeatTimeout) -> Error(actor.InitTimeout)
       }
     },

--- a/src/beryl/topic.gleam
+++ b/src/beryl/topic.gleam
@@ -7,6 +7,7 @@
 
 import gleam/bool
 import gleam/list
+import gleam/result
 import gleam/string
 
 /// Topic pattern for routing
@@ -97,6 +98,18 @@ fn segment_parts_match(
   })
 }
 
+/// Errors from extracting wildcard values from a topic pattern.
+pub type ExtractError {
+  /// The pattern has no wildcard to extract.
+  NoWildcard
+  /// The topic does not match the pattern.
+  TopicMismatch
+  /// `extract_id` expected exactly one wildcard value but found this many.
+  ExpectedOneWildcard(Int)
+  /// `namespace` was called with an empty topic.
+  EmptyNamespace
+}
+
 /// Extract the wildcard portion from a topic
 ///
 /// ## Examples
@@ -105,21 +118,25 @@ fn segment_parts_match(
 /// extract_id(Wildcard("room:"), "room:lobby") // -> Ok("lobby")
 /// extract_id(Wildcard("doc:"), "doc:abc:123") // -> Ok("abc:123")
 /// extract_id(SegmentWildcard(["doc", "*", "ops"]), "doc:abc:ops") // -> Ok("abc")
-/// extract_id(Exact("room:lobby"), "room:lobby") // -> Error(Nil)
+/// extract_id(Exact("room:lobby"), "room:lobby") // -> Error(NoWildcard)
 /// ```
-pub fn extract_id(pattern: TopicPattern, topic: String) -> Result(String, Nil) {
+pub fn extract_id(
+  pattern: TopicPattern,
+  topic: String,
+) -> Result(String, ExtractError) {
   case pattern {
-    Exact(_) -> Error(Nil)
+    Exact(_) -> Error(NoWildcard)
     Wildcard(prefix) -> {
       case string.starts_with(topic, prefix) {
         True -> Ok(string.drop_start(topic, string.length(prefix)))
-        False -> Error(Nil)
+        False -> Error(TopicMismatch)
       }
     }
     SegmentWildcard(_) ->
       case extract_wildcards(pattern, topic) {
         Ok([id]) -> Ok(id)
-        _ -> Error(Nil)
+        Ok(values) -> Error(ExpectedOneWildcard(list.length(values)))
+        Error(error) -> Error(error)
       }
   }
 }
@@ -138,25 +155,25 @@ pub fn extract_id(pattern: TopicPattern, topic: String) -> Result(String, Nil) {
 pub fn extract_wildcards(
   pattern: TopicPattern,
   topic: String,
-) -> Result(List(String), Nil) {
+) -> Result(List(String), ExtractError) {
   case pattern {
     Exact(p) ->
       case p == topic {
         True -> Ok([])
-        False -> Error(Nil)
+        False -> Error(TopicMismatch)
       }
 
     Wildcard(prefix) ->
       case string.starts_with(topic, prefix) {
         True -> Ok([string.drop_start(topic, string.length(prefix))])
-        False -> Error(Nil)
+        False -> Error(TopicMismatch)
       }
 
     SegmentWildcard(pattern_parts) -> {
       let topic_parts = segments(topic)
 
       case segment_parts_match(pattern_parts, topic_parts) {
-        False -> Error(Nil)
+        False -> Error(TopicMismatch)
         True -> Ok(collect_wildcard_values(pattern_parts, topic_parts))
       }
     }
@@ -194,12 +211,17 @@ pub fn segments(topic: String) -> List(String) {
 ///
 /// ```gleam
 /// namespace("room:lobby") // -> Ok("room")
-/// namespace("") // -> Error(Nil)
+/// namespace("") // -> Error(EmptyNamespace)
 /// ```
-pub fn namespace(topic: String) -> Result(String, Nil) {
-  topic
-  |> segments
-  |> list.first
+pub fn namespace(topic: String) -> Result(String, ExtractError) {
+  case string.is_empty(topic) {
+    True -> Error(EmptyNamespace)
+    False ->
+      topic
+      |> segments
+      |> list.first
+      |> result.map_error(fn(_) { EmptyNamespace })
+  }
 }
 
 /// Build a topic from segments

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -37,10 +37,10 @@ pub opaque type TransportConfig(assigns) {
     /// Runs the Phoenix `UserSocket.connect/3` analogue: it authenticates the
     /// whole connection a single time and can reject it before any channel
     /// join. Return `Ok(assigns)` to allow the connection and seed initial
-    /// socket assigns (visible to channels at join), or `Error(Nil)` to reject
+    /// socket assigns (visible to channels at join), or `Error(ConnectRejected)` to reject
     /// with a 403 Forbidden response. When None, all connections are allowed
     /// and assigns start empty (`Nil`).
-    on_connect: Option(fn(Request(Connection)) -> Result(assigns, Nil)),
+    on_connect: Option(fn(Request(Connection)) -> Result(assigns, ConnectError)),
     /// Per-connection serializers keyed by Phoenix `vsn` query value. The
     /// `vsn` query parameter from the upgrade request selects the codec used
     /// to decode inbound frames and encode replies/pushes for that socket.
@@ -54,6 +54,12 @@ pub opaque type TransportConfig(assigns) {
     /// default), unknown `vsn` values fall back to the configured codec.
     reject_unknown_vsn: Bool,
   )
+}
+
+/// Errors returned from a transport `on_connect` callback.
+pub type ConnectError {
+  /// Reject the WebSocket upgrade with `403 Forbidden`.
+  ConnectRejected
 }
 
 /// Create a default transport config with no connect hook.
@@ -73,12 +79,12 @@ pub fn default_config(path: String) -> TransportConfig(Nil) {
 ///
 /// The callback receives the HTTP request before the WebSocket upgrade and
 /// runs once per socket. Return `Ok(assigns)` to allow the connection and seed
-/// initial socket assigns that channels can read at join time, or `Error(Nil)`
-/// to reject the connection with a 403 Forbidden response before any channel
-/// join occurs.
+/// initial socket assigns that channels can read at join time, or
+/// `Error(ConnectRejected)` to reject the connection with a 403 Forbidden
+/// response before any channel join occurs.
 pub fn with_on_connect(
   config: TransportConfig(a),
-  callback: fn(Request(Connection)) -> Result(assigns, Nil),
+  callback: fn(Request(Connection)) -> Result(assigns, ConnectError),
 ) -> TransportConfig(assigns) {
   TransportConfig(
     path: config.path,
@@ -169,7 +175,7 @@ pub fn upgrade(
                 config,
                 unsafe_coerce_to_dynamic(assigns),
               )
-            Error(Nil) ->
+            Error(ConnectRejected) ->
               response.new(403)
               |> response.set_body(mist.Bytes(bytes_tree.new()))
           }

--- a/test/beryl_test.gleam
+++ b/test/beryl_test.gleam
@@ -1,6 +1,7 @@
 import beryl
 import beryl/channel
 import beryl/coordinator
+import beryl/error as beryl_error
 import beryl/group
 import beryl/socket
 import beryl/topic
@@ -119,7 +120,7 @@ pub fn extract_wildcards_from_segment_pattern_test() {
   |> should.equal(Ok(["tenant-a", "doc-42"]))
 
   topic.extract_wildcards(pattern, "document:tenant-a")
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(topic.TopicMismatch))
 }
 
 pub fn extract_id_from_single_segment_wildcard_test() {
@@ -132,7 +133,7 @@ pub fn extract_id_from_single_segment_wildcard_test() {
     topic.parse_pattern("document:*:*"),
     "document:tenant-a:doc-42",
   )
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(topic.ExpectedOneWildcard(2)))
 }
 
 pub fn extract_id_test() {
@@ -145,7 +146,7 @@ pub fn extract_id_test() {
   |> should.equal(Ok("abc:123"))
 
   topic.extract_id(topic.Exact("room:lobby"), "room:lobby")
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(topic.NoWildcard))
 }
 
 pub fn segments_test() {
@@ -692,7 +693,13 @@ pub fn extract_topic_id_test() {
   |> should.equal(Ok("lobby"))
 
   beryl.extract_topic_id(topic.Exact("room:lobby"), "room:lobby")
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(topic.NoWildcard))
+}
+
+pub fn start_failure_description_is_public_test() {
+  let describe = beryl_error.describe_start_failure
+  should.be_true(True)
+  let _ = describe
 }
 
 pub fn channels_handle_remains_usable_after_start_test() {

--- a/test/broadcast_test.gleam
+++ b/test/broadcast_test.gleam
@@ -135,8 +135,7 @@ pub fn broadcast_from_local_only_excludes_socket_test() {
 }
 
 pub fn broadcast_from_with_pubsub_excludes_socket_on_remote_coordinator_test() {
-  let assert Ok(ps) =
-    pubsub.start(pubsub.config_with_scope("test_broadcast_from_pubsub"))
+  let ps = pubsub.start(pubsub.config_with_scope("test_broadcast_from_pubsub"))
   let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
   let assert Ok(origin_channels) = beryl.start(config)
   let assert Ok(remote_channels) = beryl.start(config)
@@ -226,8 +225,7 @@ pub fn presence_track_can_broadcast_presence_diff_to_joined_socket_test() {
 }
 
 pub fn broadcast_presence_diff_with_pubsub_delivers_to_remote_coordinator_test() {
-  let assert Ok(ps) =
-    pubsub.start(pubsub.config_with_scope("test_presence_diff_pubsub"))
+  let ps = pubsub.start(pubsub.config_with_scope("test_presence_diff_pubsub"))
   let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
   let assert Ok(origin_channels) = beryl.start(config)
   let assert Ok(remote_channels) = beryl.start(config)

--- a/test/group_test.gleam
+++ b/test/group_test.gleam
@@ -33,7 +33,7 @@ pub fn group_already_exists_test() {
   should.be_error(result)
 
   case result {
-    Error(group.AlreadyExists) -> Nil
+    Error(group.GroupAlreadyExists) -> Nil
     _ -> should.fail()
   }
 }
@@ -81,7 +81,7 @@ pub fn group_not_found_test() {
   let result = group.add(groups, "nonexistent", "room:test")
   should.be_error(result)
   case result {
-    Error(group.NotFound) -> Nil
+    Error(group.GroupNotFound) -> Nil
     _ -> should.fail()
   }
 
@@ -113,7 +113,7 @@ pub fn group_delete_nonexistent_test() {
   let result = group.delete(groups, "nonexistent")
   should.be_error(result)
   case result {
-    Error(group.NotFound) -> Nil
+    Error(group.GroupNotFound) -> Nil
     _ -> should.fail()
   }
 }

--- a/test/mist_transport_test.gleam
+++ b/test/mist_transport_test.gleam
@@ -21,7 +21,12 @@ pub fn default_config_slash_ws_test() {
 }
 
 pub fn with_on_connect_sets_callback_test() {
-  let callback = fn(_req: Request(Connection)) -> Result(Nil, Nil) { Ok(Nil) }
+  let callback = fn(_req: Request(Connection)) -> Result(
+    Nil,
+    mist_transport.ConnectError,
+  ) {
+    Ok(Nil)
+  }
 
   let config =
     mist_transport.default_config("/socket")
@@ -32,9 +37,17 @@ pub fn with_on_connect_sets_callback_test() {
 }
 
 pub fn with_on_connect_replaces_callback_test() {
-  let callback1 = fn(_req: Request(Connection)) -> Result(Nil, Nil) { Ok(Nil) }
-  let callback2 = fn(_req: Request(Connection)) -> Result(Nil, Nil) {
-    Error(Nil)
+  let callback1 = fn(_req: Request(Connection)) -> Result(
+    Nil,
+    mist_transport.ConnectError,
+  ) {
+    Ok(Nil)
+  }
+  let callback2 = fn(_req: Request(Connection)) -> Result(
+    Nil,
+    mist_transport.ConnectError,
+  ) {
+    Error(mist_transport.ConnectRejected)
   }
 
   let config =
@@ -48,7 +61,10 @@ pub fn with_on_connect_replaces_callback_test() {
 
 pub fn with_on_connect_seeding_assigns_sets_callback_test() {
   // on_connect may return seeded socket-level assigns, not just Nil.
-  let callback = fn(_req: Request(Connection)) -> Result(String, Nil) {
+  let callback = fn(_req: Request(Connection)) -> Result(
+    String,
+    mist_transport.ConnectError,
+  ) {
     Ok("user-123")
   }
 

--- a/test/phoenix_contract_test.gleam
+++ b/test/phoenix_contract_test.gleam
@@ -452,7 +452,7 @@ pub fn on_connect_rejects_connection_without_token_test() {
     |> mist_transport.with_on_connect(fn(req) {
       case auth_query(req, "token") {
         Ok("secret") -> Ok(Nil)
-        _ -> Error(Nil)
+        _ -> Error(mist_transport.ConnectRejected)
       }
     })
   let #(port, server_pid) = start_auth_server(channels, config)
@@ -486,7 +486,10 @@ pub fn on_connect_seeds_assigns_visible_at_join_test() {
 
   let config =
     mist_transport.default_config("/socket/websocket")
-    |> mist_transport.with_on_connect(fn(req) { auth_query(req, "token") })
+    |> mist_transport.with_on_connect(fn(req) {
+      auth_query(req, "token")
+      |> result.map_error(fn(_) { mist_transport.ConnectRejected })
+    })
   let #(port, server_pid) = start_auth_server(channels, config)
 
   let assert Ok(client) =

--- a/test/presence_replication_test.gleam
+++ b/test/presence_replication_test.gleam
@@ -16,8 +16,7 @@ pub fn main() {
 /// Create a unique PubSub scope per test to avoid cross-test interference
 fn test_pubsub(name: String) -> pubsub.PubSub {
   let config = pubsub.config_with_scope("test_presence_repl_" <> name)
-  let assert Ok(ps) = pubsub.start(config)
-  ps
+  pubsub.start(config)
 }
 
 fn test_config(

--- a/test/pubsub_test.gleam
+++ b/test/pubsub_test.gleam
@@ -24,18 +24,18 @@ pub fn main() {
 
 pub fn pubsub_start_test() {
   let config = pubsub.config_with_scope("test_pubsub_start")
-  let result = pubsub.start(config)
-  should.be_ok(result)
+  let _ps: pubsub.PubSub = pubsub.start(config)
+  should.be_true(True)
 }
 
 pub fn pubsub_start_default_config_test() {
-  let result = pubsub.start(pubsub.default_config())
-  should.be_ok(result)
+  let _ps: pubsub.PubSub = pubsub.start(pubsub.default_config())
+  should.be_true(True)
 }
 
 pub fn pubsub_subscribe_and_count_test() {
   let config = pubsub.config_with_scope("test_pubsub_sub")
-  let assert Ok(ps) = pubsub.start(config)
+  let ps = pubsub.start(config)
 
   pubsub.subscribe(ps, "room:lobby")
   pubsub.subscriber_count(ps, "room:lobby") |> should.equal(1)
@@ -46,7 +46,7 @@ pub fn pubsub_subscribe_and_count_test() {
 
 pub fn pubsub_unsubscribe_test() {
   let config = pubsub.config_with_scope("test_pubsub_unsub")
-  let assert Ok(ps) = pubsub.start(config)
+  let ps = pubsub.start(config)
 
   pubsub.subscribe(ps, "room:lobby")
   pubsub.subscriber_count(ps, "room:lobby") |> should.equal(1)
@@ -57,7 +57,7 @@ pub fn pubsub_unsubscribe_test() {
 
 pub fn pubsub_subscribers_returns_pids_test() {
   let config = pubsub.config_with_scope("test_pubsub_pids")
-  let assert Ok(ps) = pubsub.start(config)
+  let ps = pubsub.start(config)
 
   pubsub.subscribe(ps, "room:lobby")
   let subs = pubsub.subscribers(ps, "room:lobby")
@@ -69,7 +69,7 @@ pub fn pubsub_subscribers_returns_pids_test() {
 
 pub fn pubsub_broadcast_delivers_message_test() {
   let config = pubsub.config_with_scope("test_pubsub_bcast")
-  let assert Ok(ps) = pubsub.start(config)
+  let ps = pubsub.start(config)
 
   pubsub.subscribe(ps, "room:lobby")
 
@@ -89,7 +89,7 @@ pub fn pubsub_broadcast_delivers_message_test() {
 
 pub fn pubsub_broadcast_from_excludes_sender_test() {
   let config = pubsub.config_with_scope("test_pubsub_bcast_from")
-  let assert Ok(ps) = pubsub.start(config)
+  let ps = pubsub.start(config)
 
   pubsub.subscribe(ps, "room:lobby")
 
@@ -108,7 +108,7 @@ pub fn pubsub_broadcast_from_excludes_sender_test() {
 
 pub fn pubsub_no_subscribers_is_noop_test() {
   let config = pubsub.config_with_scope("test_pubsub_nosubs")
-  let assert Ok(ps) = pubsub.start(config)
+  let ps = pubsub.start(config)
 
   // Broadcast to topic with no subscribers - should not crash
   pubsub.broadcast(ps, "room:empty", "event", json.null())
@@ -117,7 +117,7 @@ pub fn pubsub_no_subscribers_is_noop_test() {
 
 pub fn pubsub_multiple_topics_test() {
   let config = pubsub.config_with_scope("test_pubsub_multi")
-  let assert Ok(ps) = pubsub.start(config)
+  let ps = pubsub.start(config)
 
   pubsub.subscribe(ps, "room:lobby")
   pubsub.subscribe(ps, "room:private")

--- a/website/src/content/docs/architecture/overview.md
+++ b/website/src/content/docs/architecture/overview.md
@@ -33,7 +33,7 @@ beryl is organized into several layers, each building on the one below it.
 The foundation layer. Uses Erlang's `pg` module for distributed process groups. Processes subscribe to topics and receive broadcast messages. Works across Erlang cluster nodes automatically.
 
 ```gleam
-let assert Ok(ps) = pubsub.start(pubsub.default_config())
+let ps = pubsub.start(pubsub.default_config())
 pubsub.subscribe(ps, "room:lobby")
 pubsub.broadcast(ps, "room:lobby", "event", payload)
 ```

--- a/website/src/content/docs/guides/error-handling.md
+++ b/website/src/content/docs/guides/error-handling.md
@@ -32,7 +32,7 @@ The coordinator discards the socket's join record on rejection — the client re
 
 ## Connection-level authentication rejection
 
-`on_connect` in the transport config rejects the WebSocket upgrade before any topic join occurs. Return `Error(Nil)` to send an HTTP 403 response:
+`on_connect` in the transport config rejects the WebSocket upgrade before any topic join occurs. Return `Error(mist_transport.ConnectRejected)` to send an HTTP 403 response:
 
 ```gleam
 let config =
@@ -40,7 +40,7 @@ let config =
   |> mist_transport.with_on_connect(fn(req) {
     case extract_token(req) {
       Ok(_) -> Ok(Nil)
-      Error(_) -> Error(Nil)  // → HTTP 403, connection refused
+      Error(_) -> Error(mist_transport.ConnectRejected)  // → HTTP 403, connection refused
     }
   })
 ```
@@ -128,9 +128,8 @@ Group operations (`create`, `delete`, `add`, `remove`, `topics`) return `Result(
 ```gleam
 case group.create(groups, name) {
   Ok(Nil) -> Nil
-  Error(group.AlreadyExists) -> Nil  // idempotent: treat as success if desired
-  Error(group.NotFound) -> Nil       // shouldn't happen for create
-  Error(group.StartFailed) -> panic  // only returned by group.start(); unreachable here
+  Error(group.GroupAlreadyExists) -> Nil  // idempotent: treat as success if desired
+  Error(group.GroupNotFound) -> Nil       // shouldn't happen for create
 }
 ```
 
@@ -150,13 +149,13 @@ case supervisor.start(config) {
     panic
   }
   Error(supervisor.SupervisorStartFailed(err)) -> {
-    // OTP actor spawn failure — log and exit gracefully
+    // Internal actor startup failure — log and exit gracefully
     panic
   }
 }
 ```
 
-`InvalidHeartbeatTimeout` is always a configuration mistake. `SupervisorStartFailed` wraps the underlying `actor.StartError`.
+`InvalidHeartbeatTimeout` is always a configuration mistake. `SupervisorStartFailed` wraps a Beryl-owned startup failure; use `beryl/error.describe_start_failure` to format it for logs.
 
 ## send_info silent ignoring
 

--- a/website/src/content/docs/guides/groups.md
+++ b/website/src/content/docs/guides/groups.md
@@ -24,20 +24,20 @@ let assert Ok(groups) = group.start()
 // Create a group
 let assert Ok(Nil) = group.create(groups, "team:engineering")
 
-// Error: AlreadyExists if the name is taken
+// Error: GroupAlreadyExists if the name is taken
 case group.create(groups, "team:engineering") {
   Ok(Nil) -> Nil
-  Error(group.AlreadyExists) -> Nil  // already there
+  Error(group.GroupAlreadyExists) -> Nil  // already there
   Error(_) -> Nil
 }
 
 // Delete a group (removes it and all its topic memberships)
 let assert Ok(Nil) = group.delete(groups, "team:engineering")
 
-// Error: NotFound if it doesn't exist
+// Error: GroupNotFound if it doesn't exist
 case group.delete(groups, "team:gone") {
   Ok(Nil) -> Nil
-  Error(group.NotFound) -> Nil
+  Error(group.GroupNotFound) -> Nil
   Error(_) -> Nil
 }
 ```
@@ -54,7 +54,7 @@ let assert Ok(Nil) = group.add(groups, "team:engineering", "room:infra")
 // Remove one topic
 let assert Ok(Nil) = group.remove(groups, "team:engineering", "room:infra")
 
-// Both add and remove return Error(NotFound) if the group doesn't exist
+// Both add and remove return Error(GroupNotFound) if the group doesn't exist
 ```
 
 Adding the same topic twice is a no-op (topics are stored in a set).
@@ -65,7 +65,7 @@ Adding the same topic twice is a no-op (topics are stored in a set).
 // List all topics in a group
 case group.topics(groups, "team:engineering") {
   Ok(topic_set) -> set.to_list(topic_set)  // ["room:frontend", "room:backend"]
-  Error(group.NotFound) -> []
+  Error(group.GroupNotFound) -> []
   Error(_) -> []
 }
 
@@ -90,16 +90,16 @@ group.broadcast(
 This is equivalent to calling `beryl.broadcast` on each topic in the group in sequence.
 
 :::note[Missing group is a no-op]
-`group.broadcast` never returns an error. Broadcasting to a group that does not exist (or has no topics) silently does nothing. If you need to confirm a group exists before broadcasting, call `group.topics` first and handle `NotFound`.
+`group.broadcast` never returns an error. Broadcasting to a group that does not exist (or has no topics) silently does nothing. If you need to confirm a group exists before broadcasting, call `group.topics` first and handle `GroupNotFound`.
 :::
 
 ## Error reference
 
 | Error | When |
 |-------|------|
-| `AlreadyExists` | `create` called for a name already in use |
-| `NotFound` | `delete`, `add`, `remove`, or `topics` called for an unknown group name |
-| `StartFailed` | `group.start()` — the OTP actor failed to initialize |
+| `GroupAlreadyExists` | `create` called for a name already in use |
+| `GroupNotFound` | `delete`, `add`, `remove`, or `topics` called for an unknown group name |
+| `GroupActorStartFailed` | `group.start()` — the internal group actor failed to initialize |
 
 ## Full example: team rooms
 

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -23,7 +23,7 @@ import beryl/pubsub
 let assert Ok(p) = presence.start(presence.default_config("node1"))
 
 // With PubSub for cross-node replication
-let assert Ok(ps) = pubsub.start(pubsub.default_config())
+let ps = pubsub.start(pubsub.default_config())
 let config =
   presence.default_config("node1")
   |> presence.with_pubsub(ps)

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -10,10 +10,10 @@ beryl's PubSub layer provides distributed publish/subscribe messaging built on E
 import beryl/pubsub
 
 // Default scope ("beryl_pubsub")
-let assert Ok(ps) = pubsub.start(pubsub.default_config())
+let ps = pubsub.start(pubsub.default_config())
 
 // Custom scope (isolates process groups)
-let assert Ok(ps) = pubsub.start(pubsub.config_with_scope("my_app_pubsub"))
+let ps = pubsub.start(pubsub.config_with_scope("my_app_pubsub"))
 ```
 
 The scope maps to a `pg` scope atom. Different scopes are completely isolated from each other.
@@ -108,7 +108,7 @@ The channel system uses PubSub internally for distributed broadcasts when config
 import beryl
 import beryl/wire
 
-let assert Ok(ps) = pubsub.start(pubsub.default_config())
+let ps = pubsub.start(pubsub.default_config())
 let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
 let assert Ok(channels) = beryl.start(config)
 

--- a/website/src/content/docs/guides/supervision.md
+++ b/website/src/content/docs/guides/supervision.md
@@ -128,7 +128,7 @@ static_supervisor.new(static_supervisor.OneForOne)
 
 ```gleam
 pub type StartError {
-  SupervisorStartFailed(actor.StartError)
+  SupervisorStartFailed(error.StartFailure)
   InvalidHeartbeatTimeout   // heartbeat_timeout_ms must be > 0
 }
 ```

--- a/website/src/content/docs/guides/websocket.md
+++ b/website/src/content/docs/guides/websocket.md
@@ -61,15 +61,15 @@ let config =
   |> mist_transport.with_on_connect(fn(req: Request(mist.Connection)) {
     // Check auth token, session, etc.
     case validate_token(req) {
-      Ok(_user) -> Ok(Nil)    // Allow connection
-      Error(_) -> Error(Nil)  // Reject with 403
+      Ok(_user) -> Ok(Nil)                              // Allow connection
+      Error(_) -> Error(mist_transport.ConnectRejected)  // Reject with 403
     }
   })
 
 use <- mist_transport.upgrade(req, channels, config)
 ```
 
-Returning `Error(Nil)` sends an HTTP 403 before the WebSocket upgrade. See [Connection-level authentication rejection](/guides/error-handling#connection-level-authentication-rejection) for the client-visible error shape and [Authentication failures](/troubleshooting#authentication-failures) for diagnosis steps.
+Returning `Error(mist_transport.ConnectRejected)` sends an HTTP 403 before the WebSocket upgrade. See [Connection-level authentication rejection](/guides/error-handling#connection-level-authentication-rejection) for the client-visible error shape and [Authentication failures](/troubleshooting#authentication-failures) for diagnosis steps.
 
 ### Seeding initial assigns
 
@@ -85,8 +85,8 @@ let config =
   |> mist_transport.with_on_connect(fn(req: Request(mist.Connection)) {
     // Validate once, derive socket state, reject on failure.
     case validate_token(req) {
-      Ok(user_id) -> Ok(user_id)  // Seed assigns (here: the user id)
-      Error(_) -> Error(Nil)      // Reject with 403
+      Ok(user_id) -> Ok(user_id)                       // Seed assigns
+      Error(_) -> Error(mist_transport.ConnectRejected) // Reject with 403
     }
   })
 ```

--- a/website/src/content/docs/migration.md
+++ b/website/src/content/docs/migration.md
@@ -69,7 +69,7 @@ type-signature change.
 
 ### WebSocket authentication hook
 
-The Mist transport config now accepts an `on_connect` callback. Return `Error(Nil)` to reject the upgrade with a 403 before the WebSocket handshake completes, or `Ok(assigns)` to allow it and seed initial socket-level assigns visible to channels at join time (return `Ok(Nil)` for none). See [WebSocket Transport → Seeding initial assigns](/guides/websocket#seeding-initial-assigns).
+The Mist transport config accepts an `on_connect` callback. Return `Error(mist_transport.ConnectRejected)` to reject the upgrade with a 403 before the WebSocket handshake completes, or `Ok(assigns)` to allow it and seed initial socket-level assigns visible to channels at join time (return `Ok(Nil)` for none). See [WebSocket Transport → Seeding initial assigns](/guides/websocket#seeding-initial-assigns).
 
 ---
 

--- a/website/src/content/docs/reference/api/beryl-bridge.md
+++ b/website/src/content/docs/reference/api/beryl-bridge.md
@@ -35,11 +35,11 @@ Bridge - Forward an external OTP actor's message stream to a socket channel.
    Assigns(bridge: Bridge(DocEvent))
  }
 
- fn join(channels, doc_actor, topic, _payload, socket) {
+ fn join(registered_channel, doc_actor, topic, _payload, socket) {
    // Forward each DocEvent to this socket's `handle_info` callback.
    let b =
      bridge.start(
-       channels: channels,
+       channel: registered_channel,
        socket_id: socket.id(socket),
        topic: topic,
        with: fn(event) { event },
@@ -89,7 +89,7 @@ Start a bridge that forwards values from an external `Subject` to a socket's
  The returned `Bridge` owns a freshly spawned forwarder process. Pass
  `subject(bridge)` to the external/domain actor so it delivers its stream to
  the forwarder; each received value is mapped with `transform` and delivered
- via `beryl.send_info(channels, socket_id, topic, transform(value))`.
+ via `beryl.send_info(channel, socket_id, topic, transform(value))`.
 
  Use `transform` to translate the domain message into whatever your channel's
  `handle_info` expects. If no translation is needed, pass the identity
@@ -101,11 +101,11 @@ Start a bridge that forwards values from an external `Subject` to a socket's
 
 ```gleam
 pub fn start(
-  channels: beryl.Channels,
+  channel: beryl.RegisteredChannel(a, b),
   socket_id: String,
   topic: String,
-  with: fn(a) -> b
-) -> Bridge(a)
+  with: fn(c) -> b
+) -> Bridge(c)
 ```
 
 ### `stop`

--- a/website/src/content/docs/reference/api/beryl-channel.md
+++ b/website/src/content/docs/reference/api/beryl-channel.md
@@ -40,7 +40,7 @@ Channel behavior definition
    parameter generic.
 
 ```gleam
-pub opaque type Channel(a, b)
+pub type Channel(a, b)
 ```
 
 ### `HandleResult`

--- a/website/src/content/docs/reference/api/beryl-error.md
+++ b/website/src/content/docs/reference/api/beryl-error.md
@@ -1,0 +1,29 @@
+---
+title: beryl/error
+description: Shared Beryl-owned error helpers.
+---
+
+Shared Beryl-owned error helpers.
+
+## Types
+
+### `StartFailure`
+
+A stable description of an internal Beryl actor startup failure.
+
+ This type hides OTP's `actor.StartError` so public APIs do not expose
+ dependency-specific error constructors.
+
+```gleam
+pub type StartFailure
+```
+
+## Functions
+
+### `describe_start_failure`
+
+Convert a startup failure to a human-readable diagnostic string.
+
+```gleam
+pub fn describe_start_failure(StartFailure) -> String
+```

--- a/website/src/content/docs/reference/api/beryl-group.md
+++ b/website/src/content/docs/reference/api/beryl-group.md
@@ -27,25 +27,20 @@ Errors from group operations
 
 ```gleam
 pub type GroupError {
-  AlreadyExists
-  NotFound
-  StartFailed
+  GroupAlreadyExists
+  GroupNotFound
 }
 ```
 
 #### Constructors
 
-##### `AlreadyExists`
+##### `GroupAlreadyExists`
 
 The group already exists
 
-##### `NotFound`
+##### `GroupNotFound`
 
 The group was not found
-
-##### `StartFailed`
-
-The actor failed to start
 
 ### `Groups`
 
@@ -55,8 +50,24 @@ A running Groups instance.
  actor subject or depend on its runtime representation.
 
 ```gleam
-pub opaque type Groups
+pub type Groups
 ```
+
+### `GroupStartError`
+
+Errors when starting the groups actor.
+
+```gleam
+pub type GroupStartError {
+  GroupActorStartFailed(error.StartFailure)
+}
+```
+
+#### Constructors
+
+##### `GroupActorStartFailed(error.StartFailure)`
+
+The actor failed to start
 
 ### `Message`
 
@@ -144,15 +155,7 @@ pub fn remove(
 Start the groups actor
 
 ```gleam
-pub fn start() -> Result(Groups, GroupError)
-```
-
-### `start_named`
-
-Start the groups actor with a registered name (for supervision)
-
-```gleam
-pub fn start_named(process.Name(Message)) -> Result(actor.Started(process.Subject(Message)), actor.StartError)
+pub fn start() -> Result(Groups, GroupStartError)
 ```
 
 ### `topics`

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -14,7 +14,7 @@ Presence - Distributed presence tracking backed by a CRDT
  ## Example
 
  ```gleam
- let assert Ok(ps) = pubsub.start(pubsub.default_config())
+ let ps = pubsub.start(pubsub.default_config())
  let config =
    presence.default_config("node1")
    |> presence.with_pubsub(ps)
@@ -30,11 +30,11 @@ Presence - Distributed presence tracking backed by a CRDT
 
 Configuration for starting presence.
 
- Build with `default_config` and the `with_*` functions so Beryl can
+ Build configs with `default_config` and the `with_*` functions so Beryl can
  add future options without exposing record fields as public API.
 
 ```gleam
-pub opaque type Config
+pub type Config
 ```
 
 ### `Diff`
@@ -64,12 +64,15 @@ A running Presence instance.
  or depend on the runtime representation.
 
 ```gleam
-pub opaque type Presence
+pub type Presence
 ```
 
 ### `PresenceEntry`
 
 A presence entry returned from queries and diff accessors.
+
+ This type is intentionally transparent so callers can inspect query results
+ and construct entries for `diff`.
 
 ```gleam
 pub type PresenceEntry {
@@ -87,15 +90,15 @@ Errors from presence operations
 
 ```gleam
 pub type PresenceError {
-  StartFailed(actor.StartError)
+  PresenceStartFailed(error.StartFailure)
 }
 ```
 
 #### Constructors
 
-##### `StartFailed(actor.StartError)`
+##### `PresenceStartFailed(error.StartFailure)`
 
-The actor failed to start, wrapping the underlying OTP start error
+The presence actor failed to start.
 
 ## Functions
 
@@ -105,41 +108,6 @@ Default configuration (no PubSub, no replication)
 
 ```gleam
 pub fn default_config(String) -> Config
-```
-
-### `with_broadcast_interval`
-
-Set how often presence state is broadcast for replication.
-
- Use `0` to disable periodic broadcasts.
-
-```gleam
-pub fn with_broadcast_interval(
-  Config,
-  Int
-) -> Config
-```
-
-### `with_on_diff`
-
-Set the callback invoked when local changes or remote merges produce a diff.
-
-```gleam
-pub fn with_on_diff(
-  Config,
-  fn(Diff) -> Nil
-) -> Config
-```
-
-### `with_pubsub`
-
-Enable PubSub replication for presence.
-
-```gleam
-pub fn with_pubsub(
-  Config,
-  pubsub.PubSub
-) -> Config
 ```
 
 ### `diff`
@@ -217,17 +185,6 @@ Start the presence actor
 pub fn start(Config) -> Result(Presence, PresenceError)
 ```
 
-### `start_named`
-
-Start the presence actor with a registered name (for supervision)
-
-```gleam
-pub fn start_named(
-  Config,
-  process.Name(Message)
-) -> Result(actor.Started(process.Subject(Message)), actor.StartError)
-```
-
 ### `track`
 
 Track a presence in a topic
@@ -266,4 +223,39 @@ pub fn untrack_all(
   Presence,
   String
 ) -> Nil
+```
+
+### `with_broadcast_interval`
+
+Set how often presence state is broadcast for replication.
+
+ Use `0` to disable periodic broadcasts.
+
+```gleam
+pub fn with_broadcast_interval(
+  Config,
+  Int
+) -> Config
+```
+
+### `with_on_diff`
+
+Set the callback invoked when local changes or remote merges produce a diff.
+
+```gleam
+pub fn with_on_diff(
+  Config,
+  fn(Diff) -> Nil
+) -> Config
+```
+
+### `with_pubsub`
+
+Enable PubSub replication for presence.
+
+```gleam
+pub fn with_pubsub(
+  Config,
+  pubsub.PubSub
+) -> Config
 ```

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -12,7 +12,7 @@ PubSub - Distributed publish/subscribe using Erlang pg
  ## Quick Start
 
  ```gleam
- let assert Ok(ps) = pubsub.start(pubsub.default_config())
+ let ps = pubsub.start(pubsub.default_config())
  pubsub.subscribe(ps, "room:lobby")
  pubsub.broadcast(ps, "room:lobby", "new_msg", json.string("hello"))
  ```
@@ -21,7 +21,10 @@ PubSub - Distributed publish/subscribe using Erlang pg
 
 ### `Message`
 
-A PubSub message delivered to subscribers
+A PubSub message delivered to subscribers.
+
+ This type is intentionally transparent so subscribers can inspect the topic,
+ event, payload, and sender metadata delivered to their process mailbox.
 
 ```gleam
 pub type Message {
@@ -42,7 +45,7 @@ A running PubSub instance.
  depend on the runtime representation.
 
 ```gleam
-pub opaque type PubSub
+pub type PubSub
 ```
 
 ### `PubSubConfig`
@@ -53,7 +56,7 @@ PubSub configuration.
  scope representation can evolve without exposing record fields.
 
 ```gleam
-pub opaque type PubSubConfig
+pub type PubSubConfig
 ```
 
 ### `PubSubFrom`
@@ -87,16 +90,6 @@ Broadcast originated from a specific process
 )`
 
 Broadcast originated from a process and should exclude a socket ID
-
-### `StartError`
-
-Errors when starting PubSub
-
-```gleam
-pub type StartError {
-  PgStartFailed
-}
-```
 
 ## Functions
 
@@ -180,7 +173,7 @@ Start a PubSub instance
  node or previous call), this is a no-op.
 
 ```gleam
-pub fn start(PubSubConfig) -> Result(PubSub, StartError)
+pub fn start(PubSubConfig) -> PubSub
 ```
 
 ### `subscribe`

--- a/website/src/content/docs/reference/api/beryl-supervisor.md
+++ b/website/src/content/docs/reference/api/beryl-supervisor.md
@@ -39,14 +39,14 @@ Errors when starting the supervised system
 
 ```gleam
 pub type StartError {
-  SupervisorStartFailed(actor.StartError)
+  SupervisorStartFailed(error.StartFailure)
   InvalidHeartbeatTimeout
 }
 ```
 
 #### Constructors
 
-##### `SupervisorStartFailed(actor.StartError)`
+##### `SupervisorStartFailed(error.StartFailure)`
 
 The supervisor failed to start
 

--- a/website/src/content/docs/reference/api/beryl-topic.md
+++ b/website/src/content/docs/reference/api/beryl-topic.md
@@ -12,6 +12,37 @@ Topic - Pattern matching for channel routing
 
 ## Types
 
+### `ExtractError`
+
+Errors from extracting wildcard values from a topic pattern.
+
+```gleam
+pub type ExtractError {
+  NoWildcard
+  TopicMismatch
+  ExpectedOneWildcard(Int)
+  EmptyNamespace
+}
+```
+
+#### Constructors
+
+##### `NoWildcard`
+
+The pattern has no wildcard to extract.
+
+##### `TopicMismatch`
+
+The topic does not match the pattern.
+
+##### `ExpectedOneWildcard(Int)`
+
+`extract_id` expected exactly one wildcard value but found this many.
+
+##### `EmptyNamespace`
+
+`namespace` was called with an empty topic.
+
 ### `TopicError`
 
 ```gleam
@@ -60,14 +91,14 @@ Extract the wildcard portion from a topic
  extract_id(Wildcard("room:"), "room:lobby") // -> Ok("lobby")
  extract_id(Wildcard("doc:"), "doc:abc:123") // -> Ok("abc:123")
  extract_id(SegmentWildcard(["doc", "*", "ops"]), "doc:abc:ops") // -> Ok("abc")
- extract_id(Exact("room:lobby"), "room:lobby") // -> Error(Nil)
+ extract_id(Exact("room:lobby"), "room:lobby") // -> Error(NoWildcard)
  ```
 
 ```gleam
 pub fn extract_id(
   TopicPattern,
   String
-) -> Result(String, Nil)
+) -> Result(String, ExtractError)
 ```
 
 ### `extract_wildcards`
@@ -88,7 +119,7 @@ Extract values captured by wildcard segments.
 pub fn extract_wildcards(
   TopicPattern,
   String
-) -> Result(List(String), Nil)
+) -> Result(List(String), ExtractError)
 ```
 
 ### `from_segments`
@@ -136,11 +167,11 @@ Get the first segment (namespace) of a topic
 
  ```gleam
  namespace("room:lobby") // -> Ok("room")
- namespace("") // -> Error(Nil)
+ namespace("") // -> Error(EmptyNamespace)
  ```
 
 ```gleam
-pub fn namespace(String) -> Result(String, Nil)
+pub fn namespace(String) -> Result(String, ExtractError)
 ```
 
 ### `parse_pattern`

--- a/website/src/content/docs/reference/api/beryl-transport-mist.md
+++ b/website/src/content/docs/reference/api/beryl-transport-mist.md
@@ -10,6 +10,22 @@ Mist WebSocket Transport - Direct Mist integration for beryl
 
 ## Types
 
+### `ConnectError`
+
+Errors returned from a transport `on_connect` callback.
+
+```gleam
+pub type ConnectError {
+  ConnectRejected
+}
+```
+
+#### Constructors
+
+##### `ConnectRejected`
+
+Reject the WebSocket upgrade with `403 Forbidden`.
+
 ### `TransportConfig`
 
 Configuration for the Mist WebSocket transport
@@ -18,7 +34,7 @@ Configuration for the Mist WebSocket transport
  `on_connect` hook. It defaults to `Nil` when no hook is configured.
 
 ```gleam
-pub opaque type TransportConfig(a)
+pub type TransportConfig(a)
 ```
 
 ## Constants
@@ -126,14 +142,14 @@ Set a socket-level connect/authentication callback on the transport config.
 
  The callback receives the HTTP request before the WebSocket upgrade and
  runs once per socket. Return `Ok(assigns)` to allow the connection and seed
- initial socket assigns that channels can read at join time, or `Error(Nil)`
- to reject the connection with a 403 Forbidden response before any channel
- join occurs.
+ initial socket assigns that channels can read at join time, or
+ `Error(ConnectRejected)` to reject the connection with a 403 Forbidden
+ response before any channel join occurs.
 
 ```gleam
 pub fn with_on_connect(
   TransportConfig(a),
-  fn(request.Request(http.Connection)) -> Result(b, Nil)
+  fn(request.Request(http.Connection)) -> Result(b, ConnectError)
 ) -> TransportConfig(b)
 ```
 

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -32,7 +32,7 @@ Beryl - Type-safe real-time communication
 
  pub fn main() {
    // Optional: start PubSub for distributed messaging
-   let assert Ok(ps) = pubsub.start(pubsub.default_config())
+   let ps = pubsub.start(pubsub.default_config())
 
    // Start channels system (with or without PubSub)
    let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
@@ -119,6 +119,18 @@ pub type LogLevel {
 }
 ```
 
+### `RegisteredChannel`
+
+A typed handle returned when a channel is registered.
+
+ Pass this handle to `send_info` so the compiler can prove that the message
+ matches the receiving channel's `info` type. The handle also identifies the
+ exact registered channel used for a joined socket/topic pair.
+
+```gleam
+pub type RegisteredChannel(a, b)
+```
+
 ### `RegisterError`
 
 Errors when registering a channel handler.
@@ -146,12 +158,16 @@ Errors when starting channels
 
 ```gleam
 pub type StartError {
-  CoordinatorStartFailed
+  CoordinatorStartFailed(error.StartFailure)
   InvalidHeartbeatTimeout
 }
 ```
 
 #### Constructors
+
+##### `CoordinatorStartFailed(error.StartFailure)`
+
+The coordinator actor failed to start.
 
 ##### `InvalidHeartbeatTimeout`
 
@@ -271,7 +287,7 @@ Get the topic ID from a topic using wildcard extraction
 pub fn extract_topic_id(
   topic.TopicPattern,
   String
-) -> Result(String, Nil)
+) -> Result(String, topic.ExtractError)
 ```
 
 ### `logging_config`
@@ -311,13 +327,13 @@ Register a channel handler for a topic pattern
  })
 
  // Register it with a legacy prefix wildcard
- beryl.register(channels, "chat:*", chat_channel)
+ let assert Ok(chat) = beryl.register(channels, "chat:*", chat_channel)
 
  // Exact topic
- beryl.register(channels, "room:lobby", lobby_channel)
+ let assert Ok(lobby) = beryl.register(channels, "room:lobby", lobby_channel)
 
  // Segment-aware wildcard
- beryl.register(channels, "document:*:ops", ops_channel)
+ let assert Ok(ops) = beryl.register(channels, "document:*:ops", ops_channel)
  ```
 
 ```gleam
@@ -325,30 +341,26 @@ pub fn register(
   Channels,
   String,
   channel.Channel(a, b)
-) -> Result(Nil, RegisterError)
+) -> Result(RegisteredChannel(a, b), RegisterError)
 ```
 
 ### `send_info`
 
-Send a server-originated OTP message to a joined channel context.
+Send a typed server-originated OTP message to a joined channel context.
 
- The message is delivered to the channel's `handle_info` callback for the
- specific socket/topic pair as the typed `info` value — the receiving handler
- matches on it directly without any `Dynamic` decode or unsafe cast. If the
- socket is not connected, the topic is not joined, or no handler matches the
- topic, the message is ignored.
-
- Note: a single `Channels` system may host channels with different `info`
- types, so this function accepts a generic message and the matching channel's
- `handle_info` recovers the concrete type. Send a value whose type matches the
- target channel's `info` parameter.
+ The `registered` handle carries the receiving channel's `info` type, so the
+ compiler rejects messages for incompatible channels. The coordinator also
+ verifies that the socket/topic pair was joined through that same registered
+ channel before dispatching the callback. If the socket is not connected, the
+ topic is not joined, or the registered channel does not match the joined
+ channel, the message is ignored.
 
 ```gleam
 pub fn send_info(
-  Channels,
+  RegisteredChannel(a, b),
   String,
   String,
-  a
+  b
 ) -> Nil
 ```
 

--- a/website/src/content/docs/reference/api/index.md
+++ b/website/src/content/docs/reference/api/index.md
@@ -16,6 +16,7 @@ Pages under `/reference/api/` are generated from Gleam's docs metadata and refle
 | [`beryl`](/reference/api/beryl/) | Beryl - Type-safe real-time communication |
 | [`beryl/bridge`](/reference/api/beryl-bridge/) | Bridge - Forward an external OTP actor's message stream to a socket channel. |
 | [`beryl/channel`](/reference/api/beryl-channel/) | Channel - Topic-based message handlers |
+| [`beryl/error`](/reference/api/beryl-error/) | Shared Beryl-owned error helpers. |
 | [`beryl/group`](/reference/api/beryl-group/) | Channel Groups - Named collections of topics for multi-topic broadcasting |
 | [`beryl/presence`](/reference/api/beryl-presence/) | Presence - Distributed presence tracking backed by a CRDT |
 | [`beryl/presence/wire`](/reference/api/beryl-presence-wire/) | Phoenix-compatible wire encoding for presence diffs. |

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -22,7 +22,7 @@ This page lists common symptoms with targeted diagnosis steps. Start from your s
    ```
    Raw WebSocket clients (non-Phoenix) connect directly to the path with no suffix.
 
-3. **on_connect rejection.** If you configured `with_on_connect`, a returning `Error(Nil)` sends an HTTP 403 before the upgrade. Check your auth logic and incoming headers.
+3. **on_connect rejection.** If you configured `with_on_connect`, returning `Error(mist_transport.ConnectRejected)` sends an HTTP 403 before the upgrade. Check your auth logic and incoming headers.
 
 4. **Reverse proxy not forwarding upgrade headers.** See [Reverse proxy / nginx](#reverse-proxy--nginx) below.
 
@@ -101,7 +101,7 @@ let logging =
 
 3. **Single-node vs. multi-node.** Without PubSub, broadcasts are local to the node. If your deployment runs multiple BEAM nodes, configure PubSub:
    ```gleam
-   let assert Ok(ps) = pubsub.start(pubsub.default_config())
+   let ps = pubsub.start(pubsub.default_config())
    let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
    ```
 


### PR DESCRIPTION
## Summary
- add Beryl-owned public startup and topic/connect error types
- make PubSub start infallible and split group start/operation errors
- update examples, guides, generated reference docs, tests, and changie

BREAKING CHANGE: public error types and fallible API signatures now use Beryl-owned errors instead of dependency-shaped errors or meaningful Nil failures.

Closes #123