### PR TITLE
fix(api)!: cap channel rate buckets

### DIFF
--- a/.changes/unreleased/Security-20260625-192333.yaml
+++ b/.changes/unreleased/Security-20260625-192333.yaml
@@ -1,0 +1,6 @@
+kind: Security
+body: |-
+  Prevent channel rate limiting from creating unbounded buckets for client-controlled topics.
+
+  BREAKING: `beryl.Config` includes `channel_rate_max_keys_per_socket` so the cap can be configured.
+time: 2026-06-25T19:23:33.710384495-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -138,6 +138,9 @@ pub type Config {
     channel_rate: Int,
     /// Per-channel message burst capacity (0 = defaults to channel_rate)
     channel_burst: Int,
+    /// Maximum active per-channel rate-limit buckets per socket.
+    /// Values <= 0 disable the cap.
+    channel_rate_max_keys_per_socket: Int,
     /// Logging configuration for Beryl diagnostics
     logging: LoggingConfig,
   )
@@ -177,6 +180,7 @@ pub fn config(codec: codec.Codec) -> Config {
     join_burst: 0,
     channel_rate: 0,
     channel_burst: 0,
+    channel_rate_max_keys_per_socket: 1000,
     logging: logging_config(level: Info, include_payloads: False),
   )
 }
@@ -234,13 +238,27 @@ pub fn with_join_rate(
   Config(..config, join_rate: rate, join_burst: burst)
 }
 
-/// Configure per-channel message rate limiting
+/// Configure per-channel message rate limiting.
+///
+/// The limiter applies only after a socket has joined a topic. Active
+/// per-socket channel buckets are capped by default; use
+/// `with_channel_rate_max_keys_per_socket` to adjust the cap.
 pub fn with_channel_rate(
   config: Config,
   per_second rate: Int,
   burst burst: Int,
 ) -> Config {
   Config(..config, channel_rate: rate, channel_burst: burst)
+}
+
+/// Configure the maximum active per-channel rate-limit buckets per socket.
+///
+/// Values <= 0 disable the cap. The default is 1000.
+pub fn with_channel_rate_max_keys_per_socket(
+  config: Config,
+  max_keys max_keys: Int,
+) -> Config {
+  Config(..config, channel_rate_max_keys_per_socket: max_keys)
 }
 
 /// Channels system handle.
@@ -329,6 +347,7 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
       message_limiter: message_limiter,
       join_limiter: join_limiter,
       channel_limiter: channel_limiter,
+      channel_limiter_max_keys_per_socket: config.channel_rate_max_keys_per_socket,
       logging: coordinator_logging(config.logging),
     )
 

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -116,6 +116,8 @@ pub type CoordinatorConfig {
     join_limiter: Option(RateLimiter),
     /// Per-channel message rate limiter (None = unlimited)
     channel_limiter: Option(RateLimiter),
+    /// Maximum active channel-limiter keys per socket. Values <= 0 disable the cap.
+    channel_limiter_max_keys_per_socket: Int,
     /// Logging configuration for coordinator diagnostics.
     logging: LoggingConfig,
   )
@@ -132,6 +134,7 @@ pub fn config(codec: Codec) -> CoordinatorConfig {
     message_limiter: None,
     join_limiter: None,
     channel_limiter: None,
+    channel_limiter_max_keys_per_socket: 1000,
     logging: LoggingConfig(
       level: Info,
       include_payloads: False,
@@ -574,6 +577,10 @@ fn handle_socket_disconnected(
     Error(Nil) -> [#("socket_id", socket_id)]
   }
   logger |> log.info("Socket disconnected", metadata)
+  actor.continue(disconnect_socket(state, socket_id, channel.Normal))
+}
+
+fn remove_socket_rate_limits(state: State, socket_id: String) -> Nil {
   rate_limit.remove_by_prefix_optional(
     state.config.message_limiter,
     "msg:" <> socket_id,
@@ -586,7 +593,6 @@ fn handle_socket_disconnected(
     state.config.channel_limiter,
     "ch:" <> socket_id <> ":",
   )
-  actor.continue(disconnect_socket(state, socket_id, channel.Normal))
 }
 
 fn handle_join(
@@ -740,30 +746,12 @@ fn handle_in(
       actor.continue(state)
     }
     Ok(_) -> {
-      // Check per-channel message rate limit
-      case
-        rate_limit.check_optional(
-          state.config.channel_limiter,
-          "ch:" <> socket_id <> ":" <> topic_name,
-        )
-      {
-        Error(Nil) -> {
-          let logger = coordinator_logger(state)
-          logger
-          |> log.warn("Channel rate limited", [
-            #("socket_id", socket_id),
-            #("topic", topic_name),
-          ])
-          actor.continue(state)
-        }
-        Ok(_) ->
-          handle_in_inner(state, socket_id, topic_name, event, payload, ref)
-      }
+      handle_in_subscribed(state, socket_id, topic_name, event, payload, ref)
     }
   }
 }
 
-fn handle_in_inner(
+fn handle_in_subscribed(
   state: State,
   socket_id: String,
   topic_name: String,
@@ -797,7 +785,7 @@ fn handle_in_inner(
           actor.continue(state)
         }
         True ->
-          route_in_to_handler(
+          handle_in_rate_limited(
             state,
             socket_info,
             socket_id,
@@ -808,6 +796,45 @@ fn handle_in_inner(
           )
       }
     }
+  }
+}
+
+fn handle_in_rate_limited(
+  state: State,
+  socket_info: SocketInfo,
+  socket_id: String,
+  topic_name: String,
+  event: String,
+  payload: Dynamic,
+  ref: Option(String),
+) -> actor.Next(State, Message) {
+  case
+    rate_limit.check_capped_optional(
+      state.config.channel_limiter,
+      "ch:" <> socket_id <> ":" <> topic_name,
+      "ch:" <> socket_id <> ":",
+      state.config.channel_limiter_max_keys_per_socket,
+    )
+  {
+    Error(Nil) -> {
+      let logger = coordinator_logger(state)
+      logger
+      |> log.warn("Channel rate limited", [
+        #("socket_id", socket_id),
+        #("topic", topic_name),
+      ])
+      actor.continue(state)
+    }
+    Ok(_) ->
+      route_in_to_handler(
+        state,
+        socket_info,
+        socket_id,
+        topic_name,
+        event,
+        payload,
+        ref,
+      )
   }
 }
 
@@ -1019,6 +1046,7 @@ fn disconnect_socket(
   case dict.get(state.sockets, socket_id) {
     Error(Nil) -> state
     Ok(socket_info) -> {
+      remove_socket_rate_limits(state, socket_id)
       let logger = coordinator_logger(state)
       logger
       |> log.debug(

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -1675,6 +1675,11 @@ fn do_terminate_channel(
     None -> Nil
   }
 
+  rate_limit.remove_optional(
+    state.config.channel_limiter,
+    "ch:" <> socket_id <> ":" <> topic_name,
+  )
+
   let new_subscribed = set.delete(socket_info.subscribed_topics, topic_name)
   let new_assigns = dict.delete(socket_info.channel_assigns, topic_name)
   let new_channel_ids = dict.delete(socket_info.channel_ids, topic_name)

--- a/src/beryl/rate_limit.gleam
+++ b/src/beryl/rate_limit.gleam
@@ -128,6 +128,14 @@ type RegistryState {
 
 type RegistryMsg {
   Check(key: String, reply: Subject(Result(Nil, Nil)))
+  CheckCapped(
+    key: String,
+    prefix: String,
+    max_keys: Int,
+    reply: Subject(Result(Nil, Nil)),
+  )
+  Count(reply: Subject(Int))
+  CountByPrefix(prefix: String, reply: Subject(Int))
   RemoveByPrefix(prefix: String)
   RegistryStop
 }
@@ -141,6 +149,19 @@ fn handle_registry_msg(
 
     Check(key, reply) -> actor.continue(check_key(state, key, reply))
 
+    CheckCapped(key, prefix, max_keys, reply) ->
+      actor.continue(check_key_capped(state, key, prefix, max_keys, reply))
+
+    Count(reply) -> {
+      process.send(reply, list.length(dict.to_list(state.buckets)))
+      actor.continue(state)
+    }
+
+    CountByPrefix(prefix, reply) -> {
+      process.send(reply, count_by_prefix(state.buckets, prefix))
+      actor.continue(state)
+    }
+
     RemoveByPrefix(prefix) -> {
       let #(to_remove, to_keep) =
         dict.to_list(state.buckets)
@@ -149,6 +170,15 @@ fn handle_registry_msg(
       actor.continue(RegistryState(..state, buckets: dict.from_list(to_keep)))
     }
   }
+}
+
+fn count_by_prefix(
+  buckets: Dict(String, Subject(BucketMsg)),
+  prefix: String,
+) -> Int {
+  dict.to_list(buckets)
+  |> list.filter(fn(entry) { string_starts_with(entry.0, prefix) })
+  |> list.length
 }
 
 fn check_key(
@@ -175,6 +205,30 @@ fn check_key(
           state
         }
       }
+  }
+}
+
+fn check_key_capped(
+  state: RegistryState,
+  key: String,
+  prefix: String,
+  max_keys: Int,
+  reply: Subject(Result(Nil, Nil)),
+) -> RegistryState {
+  case dict.get(state.buckets, key) {
+    Ok(bucket) -> {
+      hit_bucket(bucket, reply)
+      state
+    }
+    Error(Nil) -> {
+      case max_keys > 0 && count_by_prefix(state.buckets, prefix) >= max_keys {
+        True -> {
+          process.send(reply, Error(Nil))
+          state
+        }
+        False -> check_key(state, key, reply)
+      }
+    }
   }
 }
 
@@ -231,6 +285,18 @@ pub fn check(limiter: RateLimiter, key: String) -> Result(Nil, Nil) {
   process.call(limiter.subject, 100, fn(reply) { Check(key, reply) })
 }
 
+/// Check if a request is allowed, rejecting new keys after a per-prefix cap.
+pub fn check_capped(
+  limiter: RateLimiter,
+  key: String,
+  prefix: String,
+  max_keys: Int,
+) -> Result(Nil, Nil) {
+  process.call(limiter.subject, 100, fn(reply) {
+    CheckCapped(key: key, prefix: prefix, max_keys: max_keys, reply: reply)
+  })
+}
+
 /// Check an optional rate limiter. If None, always allows.
 pub fn check_optional(
   limiter: Option(RateLimiter),
@@ -240,6 +306,31 @@ pub fn check_optional(
     None -> Ok(Nil)
     Some(l) -> check(l, key)
   }
+}
+
+/// Check an optional rate limiter with a per-prefix key cap.
+pub fn check_capped_optional(
+  limiter: Option(RateLimiter),
+  key: String,
+  prefix: String,
+  max_keys: Int,
+) -> Result(Nil, Nil) {
+  case limiter {
+    None -> Ok(Nil)
+    Some(l) -> check_capped(l, key, prefix, max_keys)
+  }
+}
+
+/// Return the number of active token buckets in the registry.
+pub fn bucket_count(limiter: RateLimiter) -> Int {
+  process.call(limiter.subject, 100, fn(reply) { Count(reply: reply) })
+}
+
+/// Return the number of active token buckets matching a key prefix.
+pub fn bucket_count_by_prefix(limiter: RateLimiter, prefix: String) -> Int {
+  process.call(limiter.subject, 100, fn(reply) {
+    CountByPrefix(prefix: prefix, reply: reply)
+  })
 }
 
 /// Remove all rate limit state for keys matching a prefix.

--- a/src/beryl/rate_limit.gleam
+++ b/src/beryl/rate_limit.gleam
@@ -136,6 +136,7 @@ type RegistryMsg {
   )
   Count(reply: Subject(Int))
   CountByPrefix(prefix: String, reply: Subject(Int))
+  RemoveKey(key: String)
   RemoveByPrefix(prefix: String)
   RegistryStop
 }
@@ -160,6 +161,16 @@ fn handle_registry_msg(
     CountByPrefix(prefix, reply) -> {
       process.send(reply, count_by_prefix(state.buckets, prefix))
       actor.continue(state)
+    }
+
+    RemoveKey(key) -> {
+      case dict.get(state.buckets, key) {
+        Ok(bucket) -> process.send(bucket, BucketShutdown)
+        Error(Nil) -> Nil
+      }
+      actor.continue(
+        RegistryState(..state, buckets: dict.delete(state.buckets, key)),
+      )
     }
 
     RemoveByPrefix(prefix) -> {
@@ -331,6 +342,19 @@ pub fn bucket_count_by_prefix(limiter: RateLimiter, prefix: String) -> Int {
   process.call(limiter.subject, 100, fn(reply) {
     CountByPrefix(prefix: prefix, reply: reply)
   })
+}
+
+/// Remove rate limit state for an exact key.
+pub fn remove(limiter: RateLimiter, key: String) -> Nil {
+  process.send(limiter.subject, RemoveKey(key))
+}
+
+/// Remove rate limit state for an exact key (optional limiter).
+pub fn remove_optional(limiter: Option(RateLimiter), key: String) -> Nil {
+  case limiter {
+    None -> Nil
+    Some(l) -> remove(l, key)
+  }
 }
 
 /// Remove all rate limit state for keys matching a prefix.

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -141,6 +141,7 @@ fn start_supervised(
       message_limiter: message_limiter,
       join_limiter: join_limiter,
       channel_limiter: channel_limiter,
+      channel_limiter_max_keys_per_socket: config.channels.channel_rate_max_keys_per_socket,
       logging: coordinator_logging(config.channels.logging),
     )
 

--- a/test/beryl_test.gleam
+++ b/test/beryl_test.gleam
@@ -688,6 +688,20 @@ pub fn with_channel_rate_sets_fields_test() {
   cfg.channel_burst |> should.equal(14)
 }
 
+pub fn channel_rate_max_keys_defaults_to_1000_test() {
+  let cfg = beryl.config(wire.phoenix_codec())
+
+  cfg.channel_rate_max_keys_per_socket |> should.equal(1000)
+}
+
+pub fn with_channel_rate_max_keys_per_socket_sets_field_test() {
+  let cfg =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_channel_rate_max_keys_per_socket(max_keys: 42)
+
+  cfg.channel_rate_max_keys_per_socket |> should.equal(42)
+}
+
 pub fn extract_topic_id_test() {
   beryl.extract_topic_id(topic.Wildcard("room:"), "room:lobby")
   |> should.equal(Ok("lobby"))

--- a/test/channel_rate_limit_security_test.gleam
+++ b/test/channel_rate_limit_security_test.gleam
@@ -101,6 +101,40 @@ pub fn heartbeat_eviction_removes_channel_buckets_test() {
   rate_limit.stop(limiter)
 }
 
+pub fn leave_removes_channel_bucket_so_cap_recovers_test() {
+  let assert Ok(limiter) =
+    rate_limit.start(rate_limit.config(per_second: 1000, burst: 1000))
+  let assert Ok(coord) =
+    coordinator.start_with_config(
+      coordinator.CoordinatorConfig(
+        ..coordinator.config(wire.phoenix_codec()),
+        channel_limiter: option.Some(limiter),
+        channel_limiter_max_keys_per_socket: 2,
+      ),
+    )
+  let sent = process.new_subject()
+  let assert Ok(_) = register_test_channel(coord, sent)
+
+  connect(coord, sent, "socket-leave")
+  join(coord, "socket-leave", "room:one")
+  join(coord, "socket-leave", "room:two")
+  event(coord, "socket-leave", "room:one", "ref-one")
+  event(coord, "socket-leave", "room:two", "ref-two")
+  process.sleep(20)
+  rate_limit.bucket_count(limiter) |> should.equal(2)
+
+  leave(coord, "socket-leave", "room:one", "leave-one")
+  join(coord, "socket-leave", "room:three")
+  process.sleep(20)
+  drain(sent)
+  event(coord, "socket-leave", "room:three", "ref-three")
+  process.sleep(20)
+
+  let assert Ok("handled") = process.receive(sent, 100)
+  rate_limit.bucket_count(limiter) |> should.equal(2)
+  rate_limit.stop(limiter)
+}
+
 fn send_unjoined_events(
   coord: process.Subject(coordinator.Message),
   remaining: Int,
@@ -172,6 +206,32 @@ fn event(
       <> topic
       <> "\",\"client_event\",{}]",
   )
+}
+
+fn leave(
+  coord: process.Subject(coordinator.Message),
+  socket_id: String,
+  topic: String,
+  ref: String,
+) -> Nil {
+  coordinator.route_message(
+    coord,
+    socket_id,
+    "[\"join-"
+      <> topic
+      <> "\",\""
+      <> ref
+      <> "\",\""
+      <> topic
+      <> "\",\"phx_leave\",{}]",
+  )
+}
+
+fn drain(subject: process.Subject(String)) -> Nil {
+  case process.receive(subject, 0) {
+    Ok(_) -> drain(subject)
+    Error(Nil) -> Nil
+  }
 }
 
 fn register_test_channel(

--- a/test/channel_rate_limit_security_test.gleam
+++ b/test/channel_rate_limit_security_test.gleam
@@ -1,0 +1,206 @@
+import beryl/coordinator
+import beryl/rate_limit
+import beryl/topic
+import beryl/wire
+import gleam/dynamic
+import gleam/erlang/process
+import gleam/int
+import gleam/json
+import gleam/option
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+pub fn unjoined_events_do_not_create_channel_buckets_test() {
+  let assert Ok(limiter) =
+    rate_limit.start(rate_limit.config(per_second: 1000, burst: 1000))
+  let assert Ok(coord) =
+    coordinator.start_with_config(
+      coordinator.CoordinatorConfig(
+        ..coordinator.config(wire.phoenix_codec()),
+        channel_limiter: option.Some(limiter),
+        channel_limiter_max_keys_per_socket: 1000,
+      ),
+    )
+
+  process.send(
+    coord,
+    coordinator.SocketConnected(
+      "socket-131",
+      fn(_) { Ok(Nil) },
+      fn(_) { Ok(Nil) },
+      option.None,
+      dynamic.nil(),
+    ),
+  )
+
+  send_unjoined_events(coord, 50)
+  process.sleep(50)
+
+  rate_limit.bucket_count(limiter) |> should.equal(0)
+  rate_limit.stop(limiter)
+}
+
+pub fn joined_topics_cannot_exceed_channel_bucket_cap_test() {
+  let assert Ok(limiter) =
+    rate_limit.start(rate_limit.config(per_second: 1000, burst: 1000))
+  let assert Ok(coord) =
+    coordinator.start_with_config(
+      coordinator.CoordinatorConfig(
+        ..coordinator.config(wire.phoenix_codec()),
+        channel_limiter: option.Some(limiter),
+        channel_limiter_max_keys_per_socket: 2,
+      ),
+    )
+  let sent = process.new_subject()
+  let assert Ok(_) = register_test_channel(coord, sent)
+
+  connect(coord, sent, "socket-cap")
+  join(coord, "socket-cap", "room:one")
+  join(coord, "socket-cap", "room:two")
+  join(coord, "socket-cap", "room:three")
+
+  event(coord, "socket-cap", "room:one", "ref-one")
+  event(coord, "socket-cap", "room:two", "ref-two")
+  event(coord, "socket-cap", "room:three", "ref-three")
+  process.sleep(50)
+
+  rate_limit.bucket_count(limiter) |> should.equal(2)
+  rate_limit.stop(limiter)
+}
+
+pub fn heartbeat_eviction_removes_channel_buckets_test() {
+  let assert Ok(limiter) =
+    rate_limit.start(rate_limit.config(per_second: 1000, burst: 1000))
+  let assert Ok(coord) =
+    coordinator.start_with_config(
+      coordinator.CoordinatorConfig(
+        ..coordinator.config(wire.phoenix_codec()),
+        heartbeat_timeout_ms: 20,
+        channel_limiter: option.Some(limiter),
+        channel_limiter_max_keys_per_socket: 1000,
+      ),
+    )
+  let sent = process.new_subject()
+  let assert Ok(_) = register_test_channel(coord, sent)
+
+  connect(coord, sent, "socket-heartbeat")
+  join(coord, "socket-heartbeat", "room:one")
+  event(coord, "socket-heartbeat", "room:one", "ref-one")
+  process.sleep(20)
+  rate_limit.bucket_count(limiter) |> should.equal(1)
+
+  process.sleep(30)
+  process.send(coord, coordinator.CheckHeartbeats)
+  process.sleep(20)
+
+  rate_limit.bucket_count(limiter) |> should.equal(0)
+  rate_limit.stop(limiter)
+}
+
+fn send_unjoined_events(
+  coord: process.Subject(coordinator.Message),
+  remaining: Int,
+) -> Nil {
+  case remaining <= 0 {
+    True -> Nil
+    False -> {
+      let topic = "room:unjoined-" <> int.to_string(remaining)
+      coordinator.route_message(
+        coord,
+        "socket-131",
+        "[null,\"ref-"
+          <> int.to_string(remaining)
+          <> "\",\""
+          <> topic
+          <> "\",\"event\",{}]",
+      )
+      send_unjoined_events(coord, remaining - 1)
+    }
+  }
+}
+
+fn connect(
+  coord: process.Subject(coordinator.Message),
+  sent: process.Subject(String),
+  socket_id: String,
+) -> Nil {
+  process.send(
+    coord,
+    coordinator.SocketConnected(
+      socket_id,
+      fn(text) {
+        process.send(sent, text)
+        Ok(Nil)
+      },
+      fn(_) { Ok(Nil) },
+      option.None,
+      dynamic.nil(),
+    ),
+  )
+}
+
+fn join(
+  coord: process.Subject(coordinator.Message),
+  socket_id: String,
+  topic: String,
+) -> Nil {
+  coordinator.route_message(
+    coord,
+    socket_id,
+    "[null,\"join-" <> topic <> "\",\"" <> topic <> "\",\"phx_join\",{}]",
+  )
+}
+
+fn event(
+  coord: process.Subject(coordinator.Message),
+  socket_id: String,
+  topic: String,
+  ref: String,
+) -> Nil {
+  coordinator.route_message(
+    coord,
+    socket_id,
+    "[\"join-"
+      <> topic
+      <> "\",\""
+      <> ref
+      <> "\",\""
+      <> topic
+      <> "\",\"client_event\",{}]",
+  )
+}
+
+fn register_test_channel(
+  coord: process.Subject(coordinator.Message),
+  sent: process.Subject(String),
+) -> Result(Int, coordinator.RegisterError) {
+  let reply = process.new_subject()
+  process.send(
+    coord,
+    coordinator.RegisterChannel(
+      "room:*",
+      coordinator.ChannelHandler(
+        id: 0,
+        pattern: topic.Wildcard("room:"),
+        join: fn(_topic, _payload, ctx) {
+          coordinator.JoinOkErased(option.Some(json.object([])), ctx.assigns)
+        },
+        handle_in: fn(_event, _payload, ctx) {
+          process.send(sent, "handled")
+          coordinator.NoReplyErased(ctx.assigns)
+        },
+        handle_binary: fn(_data, ctx) { coordinator.NoReplyErased(ctx.assigns) },
+        terminate: fn(_, _) { Nil },
+      ),
+      reply,
+    ),
+  )
+  case process.receive(reply, 500) {
+    Ok(result) -> result
+    Error(Nil) -> Error(coordinator.InvalidPattern("timeout"))
+  }
+}

--- a/test/rate_limit_test.gleam
+++ b/test/rate_limit_test.gleam
@@ -147,3 +147,37 @@ pub fn remove_by_prefix_optional_none_is_noop_test() {
   // Should not crash
   rate_limit.remove_by_prefix_optional(option.None, "anything")
 }
+
+pub fn bucket_count_reports_active_keys_test() {
+  let assert Ok(limiter) =
+    rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
+
+  rate_limit.bucket_count(limiter) |> should.equal(0)
+  should.be_ok(rate_limit.check(limiter, "socket:one"))
+  should.be_ok(rate_limit.check(limiter, "socket:two"))
+  rate_limit.bucket_count(limiter) |> should.equal(2)
+
+  rate_limit.remove_by_prefix(limiter, "socket:")
+  process.sleep(10)
+  rate_limit.bucket_count(limiter) |> should.equal(0)
+
+  rate_limit.stop(limiter)
+}
+
+pub fn check_capped_rejects_new_keys_after_cap_test() {
+  let assert Ok(limiter) =
+    rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
+
+  should.be_ok(rate_limit.check_capped(limiter, "socket:one", "socket:", 2))
+  should.be_ok(rate_limit.check_capped(limiter, "socket:two", "socket:", 2))
+  should.be_error(rate_limit.check_capped(limiter, "socket:three", "socket:", 2))
+  rate_limit.bucket_count(limiter) |> should.equal(2)
+
+  should.be_ok(rate_limit.check_capped(limiter, "other:one", "other:", 2))
+  rate_limit.bucket_count(limiter) |> should.equal(3)
+  rate_limit.bucket_count_by_prefix(limiter, "socket:") |> should.equal(2)
+
+  should.be_ok(rate_limit.check_capped(limiter, "socket:one", "socket:", 2))
+
+  rate_limit.stop(limiter)
+}


### PR DESCRIPTION
## Summary
- validate socket topic subscription before allocating per-channel limiter buckets
- cap active per-socket channel limiter buckets with a configurable default of 1000
- clean limiter buckets on leave, disconnect, and heartbeat eviction

## Breaking change
- `beryl.Config` now includes `channel_rate_max_keys_per_socket`; direct constructor callers must set it.

Closes #131