### PR TITLE
docs(website): refine splash and add a branded 404

### DIFF
--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -52,7 +52,12 @@ let _ref =
 	</div>
 
 	<div class="bh-copy">
-		<h1 id="_top" data-page-title class="bh-wordmark" set:html={title} />
+		<h1 id="_top" data-page-title class="bh-wordmark">
+			<span class="bh-mark" set:html={title} />
+			<span class="bh-sr-only">
+				: type-safe real-time channels and presence for Gleam
+			</span>
+		</h1>
 		{tagline && <p class="bh-tagline" set:html={tagline} />}
 		{
 			actions.length > 0 && (
@@ -203,9 +208,23 @@ let _ref =
 		color: var(--sl-color-white);
 		margin: 0;
 	}
-	.bh-wordmark::after {
+	.bh-wordmark .bh-mark::after {
 		content: ".";
 		color: var(--beryl-magenta);
+	}
+
+	/* Visually hidden, still read by screen readers and weighted by search:
+	   keeps the bold wordmark while the H1 conveys what beryl actually does. */
+	.bh-sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
 	}
 
 	.bh-tagline {

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -125,9 +125,9 @@ let _ref =
 		position: absolute;
 		display: block;
 		filter: blur(8px);
-		opacity: 0.5;
+		opacity: 0.42;
 		mix-blend-mode: screen;
-		animation: bh-drift 24s ease-in-out 2 both;
+		animation: bh-drift 30s ease-in-out infinite both;
 	}
 	.shard-1 {
 		inset: -8% 38% auto auto;
@@ -269,7 +269,7 @@ let _ref =
 		height: auto;
 		z-index: 2;
 		filter: drop-shadow(0 18px 40px var(--beryl-glow));
-		animation: bh-float 8s ease-in-out 2 both;
+		animation: bh-float 9s ease-in-out 1s infinite both;
 	}
 
 	.bh-code {
@@ -322,10 +322,10 @@ let _ref =
 	@keyframes bh-float {
 		0%,
 		100% {
-			transform: translateY(0) rotate(-1deg);
+			transform: translateY(0) rotate(-0.6deg);
 		}
 		50% {
-			transform: translateY(-8px) rotate(1deg);
+			transform: translateY(-5px) rotate(0.6deg);
 		}
 	}
 	@keyframes bh-drift {
@@ -334,7 +334,7 @@ let _ref =
 			transform: translate3d(0, 0, 0) scale(1);
 		}
 		50% {
-			transform: translate3d(0, -2%, 0) scale(1.03);
+			transform: translate3d(0, -1.2%, 0) scale(1.015);
 		}
 	}
 

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -18,6 +18,12 @@ let gem: ImageMetadata | undefined;
 if (image && "file" in image) gem = image.file;
 else if (image && "dark" in image) gem = image.dark;
 
+// The presence code card, the gem, and the H1 value clause are homepage-only.
+// The splash 404 reuses this Hero (Starlight renders splash pages through the
+// Hero override), so gate those bits on the gem image — only the home hero
+// sets one. Without it we render a clean wordmark + tagline + actions.
+const isHome = Boolean(gem);
+
 // Real beryl: track who's online and fan changes out to the room as
 // Phoenix-compatible presence diffs. Mirrors the Presence guide exactly.
 const snippet = `import beryl
@@ -43,7 +49,7 @@ let _ref =
 `;
 ---
 
-<section class="bh">
+<section class:list={["bh", { "bh--home": isHome }]}>
 	<div class="bh-facets" aria-hidden="true">
 		<span class="shard shard-1"></span>
 		<span class="shard shard-2"></span>
@@ -54,9 +60,9 @@ let _ref =
 	<div class="bh-copy">
 		<h1 id="_top" data-page-title class="bh-wordmark">
 			<span class="bh-mark" set:html={title} />
-			<span class="bh-sr-only">
-				: type-safe real-time channels and presence for Gleam
-			</span>
+			{isHome && (
+				<span class="bh-sr-only">: real-time channels for Gleam</span>
+			)}
 		</h1>
 		{tagline && <p class="bh-tagline" set:html={tagline} />}
 		{
@@ -87,24 +93,26 @@ let _ref =
 		}
 	</div>
 
-	<div class="bh-stage">
-		{
-			gem && (
-				<Image
-					src={gem}
-					alt={image && "alt" in image ? image.alt : ""}
-					width={220}
-					height={220}
-					loading="eager"
-					decoding="async"
-					class="bh-gem"
-				/>
-			)
-		}
-		<div class="bh-code">
-			<Code code={snippet} lang="gleam" title="presence.gleam" />
-		</div>
-	</div>
+	{
+		isHome && (
+			<div class="bh-stage">
+				{gem && (
+					<Image
+						src={gem}
+						alt={image && "alt" in image ? image.alt : ""}
+						width={220}
+						height={220}
+						loading="eager"
+						decoding="async"
+						class="bh-gem"
+					/>
+				)}
+				<div class="bh-code">
+					<Code code={snippet} lang="gleam" title="presence.gleam" />
+				</div>
+			</div>
+		)
+	}
 </section>
 
 <style>
@@ -361,19 +369,19 @@ let _ref =
 	/* Hold the single-column (full-width code) layout through tablet
 	   portrait (incl. 1024px iPad Pro); only split on true desktop widths. */
 	@media (min-width: 68rem) {
-		.bh {
+		.bh--home {
 			grid-template-columns: 5fr 6fr;
 			gap: clamp(2rem, 4vw, 4rem);
 			padding-block: clamp(2.5rem, 7vmin, 6rem);
 		}
-		.bh-copy {
+		.bh--home .bh-copy {
 			text-align: start;
 			align-items: flex-start;
 		}
-		.bh-actions {
+		.bh--home .bh-actions {
 			justify-content: flex-start;
 		}
-		.bh-stage {
+		.bh--home .bh-stage {
 			justify-content: flex-end;
 		}
 	}

--- a/website/src/content/docs/404.md
+++ b/website/src/content/docs/404.md
@@ -1,0 +1,19 @@
+---
+title: "404"
+template: splash
+editUrl: false
+pagefind: false
+hero:
+  tagline: That page slipped through a facet. Check the URL, or jump back to something solid below.
+  actions:
+    - text: Back to home
+      link: /
+      icon: right-arrow
+      variant: primary
+    - text: Quick Start
+      link: /quick-start/
+      variant: secondary
+    - text: Browse the docs
+      link: /introduction/
+      variant: minimal
+---

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -21,9 +21,18 @@ import { Aside } from '@astrojs/starlight/components';
 ## Get started
 
 <style lang="css">{`
+  /* Contained surface module so the ordered path reads as a distinct block,
+     not a second open hairline list like the feature ledger below. */
+  .beryl-path {
+    margin-top: 1.75rem;
+    border: 1px solid var(--beryl-hairline);
+    border-radius: 16px;
+    background: var(--beryl-surface);
+    padding: 0.3rem clamp(1.1rem, 3.5vw, 1.9rem);
+  }
   .beryl-path ol {
     list-style: none;
-    margin: 1.75rem 0 0;
+    margin: 0;
     padding: 0;
     counter-reset: step;
   }
@@ -31,7 +40,11 @@ import { Aside } from '@astrojs/starlight/components';
     counter-increment: step;
     position: relative;
     padding: 1.4rem 0 1.5rem 2.9rem;
-    border-top: 1px solid var(--beryl-hairline);
+    border-top: 1px solid
+      color-mix(in oklch, var(--beryl-hairline) 60%, transparent);
+  }
+  .beryl-path li:first-child {
+    border-top: none;
   }
   /* Real ordered sequence, so the leading numeral carries information. */
   .beryl-path li::before {

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -11,29 +11,96 @@ hero:
       link: /quick-start/
       icon: right-arrow
       variant: primary
-    - text: See examples
-      link: /examples/
-      icon: external
-      variant: secondary
     - text: What is beryl?
       link: /introduction/
-      variant: minimal
+      variant: secondary
 ---
 
-import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+import { Aside } from '@astrojs/starlight/components';
 
-<Aside type="caution" title="Pre-1.0 Software">
-beryl is not yet 1.0. The API is unstable, features may be removed in minor releases, and quality should not be considered production-ready. We welcome usage and feedback in the meantime!
-</Aside>
+## Get started
 
-## Where to start
+<style lang="css">{`
+  .beryl-path ol {
+    list-style: none;
+    margin: 1.75rem 0 0;
+    padding: 0;
+    counter-reset: step;
+  }
+  .beryl-path li {
+    counter-increment: step;
+    position: relative;
+    padding: 1.4rem 0 1.5rem 2.9rem;
+    border-top: 1px solid var(--beryl-hairline);
+  }
+  /* Real ordered sequence, so the leading numeral carries information. */
+  .beryl-path li::before {
+    content: counter(step, decimal-leading-zero);
+    position: absolute;
+    left: 0;
+    top: 1.5rem;
+    font-family: var(--beryl-font-display);
+    font-weight: 700;
+    font-size: 1.05rem;
+    letter-spacing: -0.02em;
+    font-variant-numeric: tabular-nums;
+    color: var(--sl-color-accent);
+  }
+  .beryl-path h3 {
+    font-family: var(--beryl-font-display);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+    font-size: clamp(1.15rem, 1.05rem + 0.5vw, 1.4rem);
+    margin: 0 0 0.4rem;
+    color: var(--sl-color-white);
+  }
+  .beryl-path p {
+    margin: 0;
+    max-width: 62ch;
+    color: var(--sl-color-gray-2);
+    text-wrap: pretty;
+  }
+  .beryl-path .beryl-path__cmd {
+    margin: 0.7rem 0 0.2rem;
+  }
+  .beryl-path .beryl-path__cmd code {
+    font-size: 0.95em;
+    background: var(--beryl-surface);
+    border: 1px solid var(--beryl-hairline);
+    color: var(--sl-color-white);
+    padding: 0.4em 0.75em;
+    border-radius: 8px;
+  }
+  .beryl-path__go {
+    display: inline-block;
+    margin-top: 0.75rem;
+    font-weight: 600;
+    color: var(--sl-color-accent);
+  }
+`}
+</style>
 
-<CardGrid>
-	<LinkCard title="Install" href="/installation/" description="Add beryl and its BEAM dependencies to your Gleam project." />
-	<LinkCard title="Quick Start" href="/quick-start/" description="Build your first channel end-to-end: server callbacks, WebSocket transport, and a Phoenix JS client." />
-	<LinkCard title="Guides" href="/guides/channels/" description="Go deeper on channels, presence, PubSub, groups, supervision, and the WebSocket transport." />
-	<LinkCard title="API docs" href="https://hexdocs.pm/beryl/" description="Generated reference for every public beryl module on HexDocs." />
-</CardGrid>
+<div class="beryl-path">
+	<ol>
+		<li>
+			<h3>Install beryl</h3>
+			<p>Add beryl and its BEAM dependencies to your Gleam project.</p>
+			<p class="beryl-path__cmd"><code>gleam add beryl</code></p>
+			<a class="beryl-path__go" href="/installation/">Installation guide →</a>
+		</li>
+		<li>
+			<h3>Build your first channel</h3>
+			<p>Wire up server callbacks, the WebSocket transport, and a Phoenix JS client, end to end, in one sitting.</p>
+			<a class="beryl-path__go" href="/quick-start/">Open the Quick Start →</a>
+		</li>
+		<li>
+			<h3>See it running</h3>
+			<p>Browse complete, runnable examples, then go deeper in the <a href="/guides/channels/">guides</a> or the <a href="https://hexdocs.pm/beryl/">API reference</a>.</p>
+			<a class="beryl-path__go" href="/examples/">View examples →</a>
+		</li>
+	</ol>
+</div>
 
 ## Features
 
@@ -108,6 +175,13 @@ beryl is not yet 1.0. The API is unstable, features may be removed in minor rele
   .beryl-feature code {
     font-size: 0.85em;
   }
+  .beryl-feature__link {
+    display: inline-block;
+    margin-top: 0.8rem;
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--sl-color-accent);
+  }
 
   @media (min-width: 50rem) {
     .beryl-features {
@@ -142,18 +216,26 @@ beryl is not yet 1.0. The API is unstable, features may be removed in minor rele
 <div class="beryl-features">
 	<article class="beryl-feature beryl-feature--lead">
 		<h3>Real-time channels</h3>
-		<p>Define channels with typed callbacks and pattern-matched topics. Join, leave, and broadcast with compile-time guarantees on socket state — the Gleam compiler holds you to your own assigns type.</p>
+		<p>Define channels with typed callbacks and pattern-matched topics. Join, leave, and broadcast with compile-time guarantees on socket state: the Gleam compiler holds you to your own assigns type.</p>
+		<a class="beryl-feature__link" href="/guides/channels/">Channels guide →</a>
 	</article>
 	<article class="beryl-feature">
 		<h3>Presence tracking</h3>
 		<p>Know who's online with a CRDT-backed presence system. An add-wins observed-remove set resolves joins and leaves automatically across distributed nodes.</p>
+		<a class="beryl-feature__link" href="/guides/presence/">Presence guide →</a>
 	</article>
 	<article class="beryl-feature">
 		<h3>PubSub on OTP</h3>
 		<p>Distributed publish/subscribe powered by Erlang's <code>pg</code> process groups. Works across cluster nodes with zero configuration.</p>
+		<a class="beryl-feature__link" href="/guides/pubsub/">PubSub guide →</a>
 	</article>
 	<article class="beryl-feature">
 		<h3>Phoenix-compatible wire</h3>
 		<p>A JSON array wire format compatible with Phoenix client libraries, with first-class WebSocket support via Mist integration.</p>
+		<a class="beryl-feature__link" href="/guides/websocket/">WebSocket guide →</a>
 	</article>
 </div>
+
+<Aside type="note" title="Pre-1.0">
+beryl is pre-1.0: the API can change between minor releases and it isn't production-hardened yet. Build with it and tell us what breaks; that feedback is shaping 1.0.
+</Aside>


### PR DESCRIPTION
Refines the docs-site splash and adds a branded 404, working through the issues surfaced by four `$impeccable critique` passes (score 35 → 36, all P0/P1/P2 cleared). Website-only; no library/API changes, so no changie fragment.

## What changed

**Splash (`index.mdx`, `Hero.astro`)**
- **Distilled CTAs.** Hero trimmed to two buttons (Quick Start + What is beryl?). The parallel "Where to start" card grid that repeated the hero is replaced by a genuine 3-step ordered **Get started** path (`01 Install → 02 Build your first channel → 03 See it running`), which also surfaces `gleam add beryl` for power users.
- **Pre-1.0 notice.** Moved from directly under the hero to the page end and downgraded from a yellow caution to a confident note.
- **Hero motion.** Removed the freezing `2`-iteration count for a slow, low-amplitude infinite idle; the gem settles before it floats so the code stays the hero.
- **Feature ledger** rows now link to their guides (Channels / Presence / PubSub / WebSocket).
- **Get started path** wrapped in a contained surface module so it reads distinctly from the open hairline ledger on mobile.
- **Hero H1** carries a (short, screen-reader-only) value clause so the strongest semantic element conveys what beryl does, with the morganite period glued to the visible wordmark so it still renders `beryl.`.

**Branded 404 (`404.md`)**
- New splash 404 (`404.`) over the faceted hero with confident copy and Home / Quick Start / Docs actions.
- The presence code card, gem, and H1 value clause are now homepage-only, so the 404 (and any imageless splash hero) renders a clean wordmark + tagline + CTAs; the desktop two-column split is scoped to the home hero.

## Verification
- `astro build` passes; **all internal links valid**.
- Impeccable detector clean on all changed sources (built HTML shows only the documented `single-font` false positive — three faces load via external CSS).
- Confirmed in built output: 404 has no presence card / no clause leak; homepage retains both.

> Note: validated via build + built-HTML review; no browser automation this session. A quick visual check of the splash at ~375px/~768px and the `/404` page before merge is worth it.
