### PR TITLE
chore(deps): track aquamarine via main branch

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -27,7 +27,7 @@ mist = ">= 6.0.0 and < 7.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
-aquamarine = { git = "https://github.com/tylerbutler/aquamarine.git", ref = "04627517b473dad006e3c46c5c9b07b30602f0ad" }
+aquamarine = { git = "https://github.com/tylerbutler/aquamarine.git", ref = "main" }
 gluegun = { git = "https://github.com/tylerbutler/gluegun.git", ref = "532af1ac0308ff93c8a957467dbb638859593c93" }
 phoenix_channel_fixtures = { git = "https://github.com/tylerbutler/phoenix_channel_fixtures.git", ref = "7daccb856d17db6278980277237c201b2acdcdf1" }
 qcheck = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -40,7 +40,7 @@ packages = [
 ]
 
 [requirements]
-aquamarine = { git = "https://github.com/tylerbutler/aquamarine.git", ref = "04627517b473dad006e3c46c5c9b07b30602f0ad" }
+aquamarine = { git = "https://github.com/tylerbutler/aquamarine.git", ref = "main" }
 envoy = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_crypto = { version = ">= 1.5.1 and < 2.0.0" }
 gleam_erlang = { version = ">= 0.29.0 and < 2.0.0" }


### PR DESCRIPTION
## Summary
Switches the Aquamarine git dependency from the pinned commit to the `main` branch in the project manifests.

