### PR TITLE
feat: add beryl.stop

### DIFF
--- a/.changes/unreleased/Added-20260703-090714.yaml
+++ b/.changes/unreleased/Added-20260703-090714.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add beryl.stop for unsupervised channel teardown.
+time: 2026-07-03T09:07:14.188751993-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -482,8 +482,8 @@ pub fn stop(channels: Channels) -> Nil {
 
 fn stop_coordinator(coordinator: Subject(coordinator.Message)) -> Nil {
   let should_send = case process.subject_owner(coordinator) {
-    Error(Nil) -> False
     Ok(pid) -> process.is_alive(pid)
+    _ -> False
   }
 
   use <- bool.guard(when: !should_send, return: Nil)

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -455,6 +455,31 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
   }
 }
 
+/// Stop an unsupervised channels system.
+///
+/// This shuts down the coordinator actor started by `start` and any auxiliary
+/// limiter actors owned by the `Channels` handle. Joined channel handlers
+/// receive `channel.Shutdown` in their `terminate` callback before the
+/// coordinator exits. After this call the `Channels` handle should no longer be
+/// used.
+pub fn stop(channels: Channels) -> Nil {
+  stop_coordinator(channels.coordinator)
+  connection_limit.stop_optional(channels.connection_limiter)
+}
+
+fn stop_coordinator(coordinator: Subject(coordinator.Message)) -> Nil {
+  let should_send = case process.subject_owner(coordinator) {
+    Error(Nil) -> False
+    Ok(pid) -> process.is_alive(pid)
+  }
+
+  use <- bool.guard(when: !should_send, return: Nil)
+  let reply = process.new_subject()
+  process.send(coordinator, coordinator.Stop(reply))
+  let _stop_result = process.receive(reply, 5000)
+  Nil
+}
+
 /// Register a channel handler for a topic pattern
 ///
 /// Patterns can be exact matches like "room:lobby", legacy prefix wildcards

--- a/src/beryl/connection_limit.gleam
+++ b/src/beryl/connection_limit.gleam
@@ -30,6 +30,7 @@ type Message {
     reply: Subject(Result(Permit, Nil)),
   )
   Release(ip: String)
+  Stop(reply: Subject(Nil))
 }
 
 fn handle_message(
@@ -56,6 +57,10 @@ fn handle_message(
       }
     }
     Release(ip) -> actor.continue(release_ip(state, ip))
+    Stop(reply) -> {
+      process.send(reply, Nil)
+      actor.stop()
+    }
   }
 }
 
@@ -127,6 +132,26 @@ fn release(permit: Permit) -> Nil {
 pub fn release_optional(permit: Option(Permit)) -> Nil {
   case permit {
     Some(permit) -> release(permit)
+    None -> Nil
+  }
+}
+
+fn stop(limiter: ConnectionLimiter) -> Nil {
+  let should_send = case process.subject_owner(limiter.subject) {
+    Error(Nil) -> False
+    Ok(pid) -> process.is_alive(pid)
+  }
+
+  use <- bool.guard(when: !should_send, return: Nil)
+  let reply = process.new_subject()
+  process.send(limiter.subject, Stop(reply))
+  let _stop_result = process.receive(reply, registry_call_timeout_ms)
+  Nil
+}
+
+pub fn stop_optional(limiter: Option(ConnectionLimiter)) -> Nil {
+  case limiter {
+    Some(limiter) -> stop(limiter)
     None -> Nil
   }
 }

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -336,6 +336,7 @@ pub type Message {
   RemoteBroadcast(pubsub.Message)
   // Heartbeat timeout enforcement
   CheckHeartbeats
+  Stop(reply: Subject(Nil))
 }
 
 /// Erlang monotonic time in milliseconds
@@ -511,7 +512,31 @@ fn handle_message(
     RemoteBroadcast(pubsub_msg) -> handle_remote_broadcast(state, pubsub_msg)
 
     CheckHeartbeats -> handle_check_heartbeats(state)
+
+    Stop(reply) -> handle_stop(state, reply)
   }
+}
+
+fn handle_stop(
+  state: State,
+  reply: Subject(Nil),
+) -> actor.Next(State, Message) {
+  let logger = coordinator_logger(state)
+  logger
+  |> log.info("Coordinator stopping", [
+    #("socket_count", int.to_string(dict.size(state.sockets))),
+  ])
+
+  dict.keys(state.sockets)
+  |> list.fold(state, fn(st, socket_id) {
+    disconnect_socket(st, socket_id, channel.Shutdown)
+  })
+
+  rate_limit.stop_optional(state.config.message_limiter)
+  rate_limit.stop_optional(state.config.join_limiter)
+  rate_limit.stop_optional(state.config.channel_limiter)
+  process.send(reply, Nil)
+  actor.stop()
 }
 
 fn handle_register_channel(

--- a/src/beryl/rate_limit.gleam
+++ b/src/beryl/rate_limit.gleam
@@ -314,7 +314,6 @@ pub fn bucket_count_by_prefix(limiter: RateLimiter, prefix: String) -> Int {
   )
 }
 
-// nolint: unused_exports -- public lower-level API; remove_optional is a convenience wrapper
 /// Remove rate limit state for an exact key.
 fn remove(limiter: RateLimiter, key: String) -> Nil {
   process.send(limiter.subject, RemoveKey(key))
@@ -362,4 +361,11 @@ pub fn stop(limiter: RateLimiter) -> Nil {
     fn(reply) { RegistryStop(reply) },
     Nil,
   )
+}
+
+pub fn stop_optional(limiter: Option(RateLimiter)) -> Nil {
+  case limiter {
+    Some(limiter) -> stop(limiter)
+    None -> Nil
+  }
 }

--- a/test/beryl_test.gleam
+++ b/test/beryl_test.gleam
@@ -30,6 +30,16 @@ fn text_frame(frame: codec.Frame) -> String {
   text
 }
 
+fn wait_until(predicate: fn() -> Bool, timeout_ms: Int, step_ms: Int) -> Nil {
+  case predicate() || timeout_ms <= 0 {
+    True -> Nil
+    False -> {
+      process.sleep(step_ms)
+      wait_until(predicate, timeout_ms - step_ms, step_ms)
+    }
+  }
+}
+
 pub fn main() {
   gleeunit.main()
 }
@@ -959,6 +969,59 @@ pub fn channels_handle_remains_usable_after_start_test() {
     })
 
   let assert Ok(_) = beryl.register(channels, "opaque:*", handler)
+}
+
+pub fn stop_shuts_down_unsupervised_coordinator_test() {
+  let config =
+    beryl.Config(
+      ..beryl.config(wire.phoenix_codec()),
+      max_connections_per_ip: 1,
+    )
+    |> beryl.with_message_rate(per_second: 10, burst: 10)
+    |> beryl.with_join_rate(per_second: 10, burst: 10)
+    |> beryl.with_channel_rate(per_second: 10, burst: 10)
+  let assert Ok(channels) = beryl.start(config)
+  let assert Ok(coordinator_pid) =
+    process.subject_owner(beryl.coordinator_subject(channels))
+  let sent_messages = process.new_subject()
+  let terminated = process.new_subject()
+  let handler =
+    channel.new(fn(_topic, _payload, socket) {
+      channel.JoinOk(reply: option.None, socket: socket)
+    })
+    |> channel.with_terminate(fn(reason, _socket) {
+      process.send(terminated, reason)
+    })
+
+  process.is_alive(coordinator_pid) |> should.be_true
+  let assert Ok(_) = beryl.register(channels, "stop:*", handler)
+  process.send(
+    beryl.coordinator_subject(channels),
+    coordinator.SocketConnected(
+      "socket-stop",
+      fn(text) {
+        process.send(sent_messages, text)
+        Ok(Nil)
+      },
+      fn(_) { Ok(Nil) },
+      option.None,
+      dynamic.nil(),
+    ),
+  )
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-stop",
+    "[null,\"ref-stop\",\"stop:lobby\",\"phx_join\",{}]",
+  )
+  let assert Ok(_) = process.receive(sent_messages, 500)
+
+  beryl.stop(channels)
+  let assert Ok(reason) = process.receive(terminated, 500)
+  reason |> should.equal(channel.Shutdown)
+  wait_until(fn() { !process.is_alive(coordinator_pid) }, 1000, 10)
+
+  process.is_alive(coordinator_pid) |> should.be_false
+  beryl.stop(channels)
 }
 
 pub fn topic_namespace_test() {


### PR DESCRIPTION
## Summary
- Add public `beryl.stop(channels)` for unsupervised lifecycle teardown
- Stop the coordinator, joined channels with `channel.Shutdown`, and owned limiter actors
- Add regression coverage and a changie entry

Closes #166