### PR TITLE
fix(logging): rename error log level

### DIFF
--- a/.changes/unreleased/Changed-20260703-092838.yaml
+++ b/.changes/unreleased/Changed-20260703-092838.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Rename beryl.LogLevel.Err to Error before 1.0.
+time: 2026-07-03T09:28:38.301725877-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -53,6 +53,7 @@ import beryl/channel.{type Channel}
 import beryl/connection_limit
 import beryl/coordinator
 import beryl/error as beryl_error
+import beryl/internal
 import beryl/presence.{type Diff}
 import beryl/presence/wire as presence_wire
 import beryl/pubsub.{type PubSub}
@@ -98,7 +99,7 @@ pub type LogLevel {
   Debug
   Info
   Warn
-  Err
+  Error
 }
 
 /// Logging configuration for Beryl diagnostics.
@@ -226,7 +227,7 @@ fn coordinator_log_level(level: LogLevel) -> coordinator.LogLevel {
     Debug -> coordinator.Debug
     Info -> coordinator.Info
     Warn -> coordinator.Warn
-    Err -> coordinator.Err
+    Error -> coordinator.Err
   }
 }
 
@@ -412,7 +413,7 @@ pub type StartError {
 pub fn start(config: Config) -> Result(Channels, StartError) {
   use <- bool.guard(
     when: config.heartbeat_timeout_ms <= 0,
-    return: Error(InvalidHeartbeatTimeout),
+    return: internal.result_error(InvalidHeartbeatTimeout),
   )
   // Server checks at half the timeout interval to detect stale sockets
   // promptly. The client heartbeat_interval_ms is informational only
@@ -447,11 +448,23 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
   }
 
   case coordinator_result {
-    Error(coordinator.ActorStartFailed(error)) ->
-      Error(CoordinatorStartFailed(beryl_error.from_actor_start_error(error)))
-    Error(coordinator.InvalidHeartbeatTimeout) -> Error(InvalidHeartbeatTimeout)
     Ok(coord) ->
       Ok(channels_from_coordinator(coordinator: coord, config: config))
+    error_result -> {
+      case
+        result.unwrap_error(
+          error_result,
+          or: coordinator.InvalidHeartbeatTimeout,
+        )
+      {
+        coordinator.ActorStartFailed(error) ->
+          internal.result_error(
+            CoordinatorStartFailed(beryl_error.from_actor_start_error(error)),
+          )
+        coordinator.InvalidHeartbeatTimeout ->
+          internal.result_error(InvalidHeartbeatTimeout)
+      }
+    }
   }
 }
 
@@ -543,7 +556,7 @@ pub fn broadcast(
   case channels.pubsub, process.subject_owner(channels.coordinator) {
     Some(ps), Ok(coordinator_pid) ->
       pubsub.broadcast_from(ps, coordinator_pid, topic_name, event, payload)
-    Some(_), Error(Nil) ->
+    Some(_), _ ->
       // Coordinator exited between send and pubsub forward — local message
       // is already enqueued (dead-letters), skip the cluster fanout.
       Nil
@@ -619,7 +632,7 @@ pub fn broadcast_from(
         event,
         payload,
       )
-    Some(_), Error(Nil) -> Nil
+    Some(_), _ -> Nil
     None, _ -> Nil
   }
 }
@@ -769,7 +782,7 @@ fn result_to_transport_result(
 ) -> Result(Nil, socket.TransportError) {
   case result {
     Ok(_) -> Ok(Nil)
-    Error(_) -> Error(socket.SendFailed("Send failed"))
+    _ -> internal.result_error(socket.SendFailed("Send failed"))
   }
 }
 

--- a/src/beryl/internal.gleam
+++ b/src/beryl/internal.gleam
@@ -44,6 +44,10 @@ fn to_palabres_level(log_level: LogLevel) -> level.Level {
   }
 }
 
+pub fn result_error(error: e) -> Result(a, e) {
+  Error(error)
+}
+
 /// Return a named logger.
 pub fn logger(name: String) -> Logger {
   log.new(name)

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -257,7 +257,7 @@ fn coordinator_log_level(level: beryl.LogLevel) -> coordinator.LogLevel {
     beryl.Debug -> coordinator.Debug
     beryl.Info -> coordinator.Info
     beryl.Warn -> coordinator.Warn
-    beryl.Err -> coordinator.Err
+    beryl.Error -> coordinator.Err
   }
 }
 

--- a/test/logging_test.gleam
+++ b/test/logging_test.gleam
@@ -80,7 +80,7 @@ pub fn default_logging_preserves_info_without_payloads_test() {
 
 pub fn with_logging_replaces_logging_config_test() {
   let logging =
-    beryl.logging_config(level: beryl.Debug, include_payloads: True)
+    beryl.logging_config(level: beryl.Error, include_payloads: True)
     |> beryl.with_payload_preview_bytes(bytes: 64)
 
   let config =
@@ -88,7 +88,7 @@ pub fn with_logging_replaces_logging_config_test() {
     |> beryl.with_logging(logging)
 
   config.logging.level
-  |> should.equal(beryl.Debug)
+  |> should.equal(beryl.Error)
   config.logging.include_payloads
   |> should.be_true
   config.logging.payload_preview_bytes

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -120,7 +120,7 @@ pub type LogLevel {
   Debug
   Info
   Warn
-  Err
+  Error
 }
 ```
 


### PR DESCRIPTION
## Summary
- Rename public `beryl.LogLevel.Err` to `Error` to align with `channel.StopReason.Error` before 1.0
- Update supervisor/coordinator mapping, logging test coverage, generated API reference, and changie entry

Closes #164.
