### PR TITLE
docs: address open pre-1.0 documentation issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,28 @@ jobs:
       - name: Build documentation
         run: just docs
 
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # ratchet:pnpm/action-setup@v6
+        with:
+          package_json_file: website/package.json
+
+      - name: Install website dependencies
+        run: pnpm -C website install --frozen-lockfile
+
+      - name: Test reference docs generator
+        run: just site-reference-test
+
+      - name: Validate reference docs are up to date
+        run: |
+          just site-reference
+          git diff --exit-code -- website/src/content/docs/reference/api \
+            || { echo "::error::Generated reference docs are out of date. Run 'just site-reference' and commit the result."; exit 1; }
+
   examples:
     runs-on: ubuntu-latest
     name: Examples

--- a/DEV.md
+++ b/DEV.md
@@ -194,6 +194,16 @@ test: add edge case tests for topic matching
 4. After merge, changie-release creates a release PR
 5. Merge the release PR to publish a new version
 
+### 1.0 release checklist
+
+One-time steps to perform in the same PR that tags `v1.0.0`:
+
+- Remove (or rewrite) the "beryl is not yet 1.0 / API is unstable" callout at
+  the top of `README.md`.
+- Confirm the documented Gleam version requirement in `README.md` and
+  `website/src/content/docs/installation.md` still matches `gleam.toml`.
+- Verify the publish tarball with `gleam export hex-tarball` before tagging.
+
 ## Troubleshooting
 
 ### Build Errors

--- a/README.md
+++ b/README.md
@@ -147,11 +147,10 @@ via `beryl.send_info`. The forwarder also monitors the channel process, so it is
 cleaned up automatically if that process dies — no leaked processes.
 
 ```gleam
-import beryl
+import beryl.{type RegisteredChannel}
 import beryl/bridge.{type Bridge}
 import beryl/channel.{type Channel}
 import beryl/socket
-import gleam/dynamic/decode
 import gleam/json
 import gleam/option.{None}
 
@@ -164,12 +163,16 @@ pub type Assigns {
   Assigns(bridge: Bridge(DocEvent))
 }
 
-fn new_channel(channels: beryl.Channels, doc_actor) -> Channel(Assigns) {
+// `registered_channel` is the handle returned by `beryl.register`.
+fn new_channel(
+  registered_channel: RegisteredChannel(Assigns, DocEvent),
+  doc_actor,
+) -> Channel(Assigns, DocEvent) {
   channel.new(fn(topic, _payload, socket) {
     // Forward every DocEvent emitted by the actor to this socket/topic.
     let b =
       bridge.start(
-        channels: channels,
+        channel: registered_channel,
         socket_id: socket.id(socket),
         topic: topic,
         with: fn(event) { event },
@@ -178,15 +181,15 @@ fn new_channel(channels: beryl.Channels, doc_actor) -> Channel(Assigns) {
     doc.subscribe(doc_actor, bridge.subject(b))
     channel.JoinOk(reply: None, socket: socket.set_assigns(socket, Assigns(b)))
   })
-  |> channel.with_handle_info(fn(message, socket) {
-    case decode.run(message, doc_event_decoder()) {
-      Ok(Updated(version)) ->
+  // `handle_info` receives the typed `DocEvent` directly — no decode step.
+  |> channel.with_handle_info(fn(event, socket) {
+    case event {
+      Updated(version) ->
         channel.Push(
           "doc_updated",
           json.object([#("version", json.int(version))]),
           socket,
         )
-      _ -> channel.NoReply(socket)
     }
   })
   // Always stop the bridge on terminate for prompt, deterministic cleanup.
@@ -198,16 +201,16 @@ fn new_channel(channels: beryl.Channels, doc_actor) -> Channel(Assigns) {
 
 ## Releases & changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for release notes. Releases follow
-[Conventional Commits](https://www.conventionalcommits.org/) and are managed
-with [changie](https://changie.dev/).
+See the [GitHub Releases](https://github.com/tylerbutler/beryl/releases) page for
+release notes. Releases follow [Conventional Commits](https://www.conventionalcommits.org/)
+and the changelog is managed with [changie](https://changie.dev/).
 
 ## Development
 
 ### Prerequisites
 
 - [Erlang](https://www.erlang.org/) 27+
-- [Gleam](https://gleam.run/) 1.3+
+- [Gleam](https://gleam.run/) 1.13+
 - [just](https://github.com/casey/just) (task runner)
 
 Install tools via [mise](https://mise.jdx.dev/) or [asdf](https://asdf-vm.com/):

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -507,6 +507,9 @@ fn stop_coordinator(coordinator: Subject(coordinator.Message)) -> Nil {
 /// not contain control characters (codepoints 0–31 or 127). Invalid patterns
 /// are rejected with `InvalidPattern`.
 ///
+/// Panics if the coordinator actor is unavailable or does not reply within
+/// 5 seconds (e.g. during a supervisor restart window after a crash).
+///
 /// ## Example
 ///
 /// ```gleam

--- a/src/beryl/connection_limit.gleam
+++ b/src/beryl/connection_limit.gleam
@@ -149,6 +149,7 @@ fn stop(limiter: ConnectionLimiter) -> Nil {
   Nil
 }
 
+/// Stop the connection limiter if one is present; a no-op when `None`.
 pub fn stop_optional(limiter: Option(ConnectionLimiter)) -> Nil {
   case limiter {
     Some(limiter) -> stop(limiter)

--- a/src/beryl/error.gleam
+++ b/src/beryl/error.gleam
@@ -26,6 +26,7 @@ pub fn describe_start_failure(failure: StartFailure) -> String {
   }
 }
 
+/// Convert a `gleam/otp/actor.StartError` into beryl's `StartFailure`.
 pub fn from_actor_start_error(error: actor.StartError) -> StartFailure {
   case error {
     actor.InitTimeout -> StartFailure(StartTimedOut)

--- a/src/beryl/group.gleam
+++ b/src/beryl/group.gleam
@@ -112,16 +112,22 @@ fn build_groups() -> actor.Builder(State, Message, Subject(Message)) {
 }
 
 /// Create a new named group
+///
+/// Panics if the groups actor is unavailable or does not reply within 5 seconds.
 pub fn create(groups: Groups, name: String) -> Result(Nil, GroupError) {
   process.call(groups.subject, 5000, fn(reply) { Create(name, reply) })
 }
 
 /// Delete a group
+///
+/// Panics if the groups actor is unavailable or does not reply within 5 seconds.
 pub fn delete(groups: Groups, name: String) -> Result(Nil, GroupError) {
   process.call(groups.subject, 5000, fn(reply) { Delete(name, reply) })
 }
 
 /// Add a topic to a group
+///
+/// Panics if the groups actor is unavailable or does not reply within 5 seconds.
 pub fn add(
   groups: Groups,
   group_name: String,
@@ -131,6 +137,8 @@ pub fn add(
 }
 
 /// Remove a topic from a group
+///
+/// Panics if the groups actor is unavailable or does not reply within 5 seconds.
 pub fn remove(
   groups: Groups,
   group_name: String,
@@ -142,6 +150,8 @@ pub fn remove(
 }
 
 /// Get all topics in a group
+///
+/// Panics if the groups actor is unavailable or does not reply within 5 seconds.
 pub fn topics(
   groups: Groups,
   group_name: String,
@@ -150,6 +160,8 @@ pub fn topics(
 }
 
 /// List all group names
+///
+/// Panics if the groups actor is unavailable or does not reply within 5 seconds.
 pub fn list_groups(groups: Groups) -> List(String) {
   process.call(groups.subject, 5000, fn(reply) { ListGroups(reply) })
 }

--- a/src/beryl/presence.gleam
+++ b/src/beryl/presence.gleam
@@ -353,6 +353,8 @@ fn coerce_to_pubsub_message(value: Dynamic) -> pubsub.Message
 /// Track a presence in a topic
 ///
 /// Returns a reference string (the pid) that can be used to untrack later.
+///
+/// Panics if the presence actor is unavailable or does not reply within 5 seconds.
 pub fn track(
   presence: Presence,
   topic: String,
@@ -366,6 +368,8 @@ pub fn track(
 }
 
 /// Untrack a specific presence by topic, key, and pid
+///
+/// Panics if the presence actor is unavailable or does not reply within 5 seconds.
 pub fn untrack(
   presence: Presence,
   topic: String,
@@ -378,16 +382,22 @@ pub fn untrack(
 }
 
 /// Untrack all presences for a pid (e.g., when a socket disconnects)
+///
+/// Panics if the presence actor is unavailable or does not reply within 5 seconds.
 pub fn untrack_all(presence: Presence, pid: String) -> Nil {
   process.call(presence.subject, 5000, fn(reply) { UntrackAll(pid, reply) })
 }
 
 /// List all presences for a topic
+///
+/// Panics if the presence actor is unavailable or does not reply within 5 seconds.
 pub fn list(presence: Presence, topic: String) -> List(PresenceEntry) {
   process.call(presence.subject, 5000, fn(reply) { List(topic, reply) })
 }
 
 /// Get presences for a specific key within a topic
+///
+/// Panics if the presence actor is unavailable or does not reply within 5 seconds.
 pub fn get_by_key(
   presence: Presence,
   topic: String,

--- a/src/beryl/pubsub.gleam
+++ b/src/beryl/pubsub.gleam
@@ -85,6 +85,11 @@ pub fn default_config() -> PubSubConfig {
 }
 
 /// Create a PubSub configuration with a custom scope name
+///
+/// The scope name is converted to an Erlang atom via `binary_to_atom`.
+/// Atoms are never garbage-collected, so the scope name must be a static,
+/// bounded value — never derive it from user input, or a malicious or
+/// high-cardinality source could exhaust the atom table and crash the VM.
 pub fn config_with_scope(name: String) -> PubSubConfig {
   PubSubConfig(scope: binary_to_atom(name))
 }

--- a/src/beryl/rate_limit.gleam
+++ b/src/beryl/rate_limit.gleam
@@ -363,6 +363,7 @@ pub fn stop(limiter: RateLimiter) -> Nil {
   )
 }
 
+/// Stop the rate limiter if one is present; a no-op when `None`.
 pub fn stop_optional(limiter: Option(RateLimiter)) -> Nil {
   case limiter {
     Some(limiter) -> stop(limiter)

--- a/src/beryl/socket.gleam
+++ b/src/beryl/socket.gleam
@@ -23,6 +23,13 @@ import gleam/dict.{type Dict}
 import gleam/dynamic.{type Dynamic}
 
 /// Transport abstraction for sending messages
+///
+/// Wraps the underlying connection (e.g. a Mist WebSocket) with functions to
+/// send text/binary frames and close the connection.
+///
+/// Note: as constructed by the built-in Mist transport, `close` is a no-op
+/// that returns `Ok(Nil)`. Closing is driven by the transport's own
+/// connection lifecycle rather than by calling this function.
 pub type Transport {
   Transport(
     send_text: fn(String) -> Result(Nil, TransportError),
@@ -31,8 +38,11 @@ pub type Transport {
   )
 }
 
+/// Errors returned by transport send/close operations.
 pub type TransportError {
+  /// The underlying connection is already closed and cannot be used.
   ConnectionClosed
+  /// Sending failed; the wrapped `String` describes the reason.
   SendFailed(String)
 }
 

--- a/src/beryl/topic.gleam
+++ b/src/beryl/topic.gleam
@@ -311,7 +311,11 @@ fn has_control_characters(value: String) -> Bool {
   })
 }
 
+/// Errors returned when validating a topic or topic pattern.
 pub type TopicError {
+  /// The topic or pattern was an empty string.
   EmptyTopic
+  /// The topic, pattern, or event was malformed; the wrapped `String`
+  /// describes the problem (e.g. leading/trailing `:` or control characters).
   InvalidFormat(String)
 }

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -120,6 +120,14 @@ type SendRequest {
 ///   }
 /// }
 /// ```
+///
+/// ## Path matching
+///
+/// The request path is normalised by re-joining its segments as
+/// `"/" <> string.join(segments, "/")` and compared for exact equality with
+/// `config.path`. Because the normalised path never has a trailing slash, a
+/// config path written with a trailing slash (e.g. `"/socket/"`) will never
+/// match. Configure the path without a trailing slash (e.g. `"/socket"`).
 pub fn upgrade(
   request: Request(Connection),
   channels: Channels,

--- a/src/beryl/wire/codec.gleam
+++ b/src/beryl/wire/codec.gleam
@@ -19,15 +19,21 @@ import gleam/option.{type Option}
 
 /// Encoded WebSocket frame returned by a codec.
 pub type Frame {
+  /// A UTF-8 text frame.
   TextFrame(String)
+  /// A binary frame.
   BinaryFrame(BitArray)
 }
 
 /// Structural inbound message kind used for protocol dispatch.
 pub type InboundKind {
+  /// A client joining a topic.
   Join
+  /// A client leaving a topic.
   Leave
+  /// A heartbeat/keep-alive message.
   Heartbeat
+  /// A user-defined event; the wrapped `String` is the event name.
   Event(String)
 }
 
@@ -53,14 +59,20 @@ pub type Inbound {
 
 /// Errors a codec may emit when decoding inbound bytes.
 pub type DecodeError {
+  /// The bytes were not valid JSON; `reason` describes the parse error.
   InvalidJson(reason: String)
+  /// The message was valid JSON but did not match the expected framing;
+  /// `reason` describes the mismatch.
   InvalidFormat(reason: String)
+  /// A required field was absent; `name` is the missing field.
   MissingField(name: String)
 }
 
 /// Status of a reply produced by a channel handler.
 pub type ReplyStatus {
+  /// The handler succeeded (`"ok"` in Phoenix framing).
   StatusOk
+  /// The handler failed (`"error"` in Phoenix framing).
   StatusError
 }
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -106,6 +106,14 @@ export default defineConfig({
 							label: "WebSocket Transport",
 							slug: "guides/websocket",
 						},
+						{
+							label: "Authentication",
+							slug: "guides/authentication",
+						},
+						{
+							label: "Backend Integration",
+							slug: "guides/backend-integration",
+						},
 					],
 				},
 				{

--- a/website/src/content/docs/guides/authentication.md
+++ b/website/src/content/docs/guides/authentication.md
@@ -1,0 +1,140 @@
+---
+title: Authentication
+description: Verify real tokens in on_connect, decode claims into assigns, and authorize joins.
+---
+
+beryl authenticates a connection **once**, at the transport's `on_connect` hook,
+before any channel join. This guide shows a realistic token flow: read a token
+from the handshake, verify it into typed **claims**, seed those claims as the
+socket's initial assigns, and then authorize individual topic joins.
+
+For the mechanics of `with_on_connect` and rejection behavior, see the
+[WebSocket Transport guide](/guides/websocket#authentication). This page focuses
+on wiring *real* auth end to end.
+
+## 1. Model your claims
+
+Decode the token into a typed record so channels never touch raw token strings:
+
+```gleam
+pub type Claims {
+  Claims(user_id: String, username: String, roles: List(String))
+}
+```
+
+`Claims` becomes the socket's `assigns` type, so give your channels the same
+`assigns` type parameter (commonly a record shared across every authenticated
+topic).
+
+## 2. Read the token from the handshake
+
+Browsers cannot set custom headers on a WebSocket handshake, so the two common
+transports for a token are a **query parameter** (browser clients) or the
+**`Authorization` header** (server-to-server clients). Support whichever you
+need:
+
+```gleam
+import gleam/http/request.{type Request}
+import gleam/list
+import gleam/result
+import gleam/string
+import mist
+
+/// Prefer the Authorization: Bearer header, fall back to a ?token= query param.
+fn extract_token(req: Request(mist.Connection)) -> Result(String, Nil) {
+  case bearer_header(req) {
+    Ok(token) -> Ok(token)
+    Error(_) -> query_param(req, "token")
+  }
+}
+
+fn bearer_header(req: Request(mist.Connection)) -> Result(String, Nil) {
+  use header <- result.try(request.get_header(req, "authorization"))
+  case string.split(header, " ") {
+    ["Bearer", token] -> Ok(token)
+    _ -> Error(Nil)
+  }
+}
+
+fn query_param(req: Request(mist.Connection), name: String) -> Result(String, Nil) {
+  use params <- result.try(request.get_query(req))
+  list.find(params, fn(pair) { pair.0 == name })
+  |> result.map(fn(pair) { pair.1 })
+}
+```
+
+## 3. Verify the token in `on_connect`
+
+`verify_token` is where you plug in your token library — for example a JWT
+verifier such as [`vestibule`](https://hex.pm/) or a call to
+[`gleam_crypto`](https://hexdocs.pm/gleam_crypto/) to check an HMAC signature.
+It must validate the signature and expiry and return typed `Claims`:
+
+```gleam
+import beryl/transport/mist as mist_transport
+
+// let verify_token: fn(String) -> Result(Claims, Nil)
+
+let ws_config =
+  mist_transport.default_config("/socket/websocket")
+  // Reject cross-site handshakes when auth relies on ambient credentials.
+  |> mist_transport.with_allowed_origins(["https://app.example.com"])
+  |> mist_transport.with_on_connect(fn(req) {
+    case extract_token(req) {
+      Ok(token) ->
+        case verify_token(token) {
+          // Seed the verified claims as the socket's initial assigns.
+          Ok(claims) -> Ok(claims)
+          Error(_) -> Error(mist_transport.ConnectRejected)
+        }
+      Error(_) -> Error(mist_transport.ConnectRejected)
+    }
+  })
+```
+
+Returning `Error(mist_transport.ConnectRejected)` sends HTTP 403 before the
+upgrade, so an unauthenticated client never reaches a channel.
+
+## 4. Read claims at join and authorize the topic
+
+Because the claims are already in the socket's assigns, channels authenticate
+for free and only need to decide **authorization** — is this user allowed on
+*this* topic?
+
+```gleam
+import beryl/channel
+import beryl/socket.{type Socket}
+import gleam/option.{None}
+
+fn join(topic: String, _payload, socket: Socket(Claims)) {
+  let claims = socket.get_assigns(socket)
+  case authorized_for_topic(claims, topic) {
+    True -> channel.JoinOk(reply: None, socket:)
+    False -> channel.JoinError(reason: channel.error("forbidden"))
+  }
+}
+
+/// Example policy: "room:<user_id>:*" is private to that user.
+fn authorized_for_topic(claims: Claims, topic: String) -> Bool {
+  case string.split(topic, ":") {
+    ["room", owner, ..] -> owner == claims.user_id || has_role(claims, "admin")
+    _ -> True
+  }
+}
+
+fn has_role(claims: Claims, role: String) -> Bool {
+  list.contains(claims.roles, role)
+}
+```
+
+## Notes
+
+- **Verify once, trust everywhere.** Do the expensive signature/expiry check in
+  `on_connect`; channel `join` should only apply cheap authorization rules
+  against the already-verified claims.
+- **Cookie sessions need origin checks.** If you authenticate from a cookie
+  instead of a token, always pair it with `with_allowed_origins` to prevent
+  Cross-Site WebSocket Hijacking. See
+  [Origin validation and CSWSH](/guides/websocket#origin-validation-and-cswsh).
+- **Rejection shape.** For the client-visible error when a join or connection is
+  refused, see [Error Handling](/guides/error-handling#connection-level-authentication-rejection).

--- a/website/src/content/docs/guides/backend-integration.md
+++ b/website/src/content/docs/guides/backend-integration.md
@@ -1,0 +1,164 @@
+---
+title: Backend Integration
+description: Use beryl alongside an existing backend that owns auth and persistence and publishes over an internal endpoint.
+---
+
+beryl does not have to own your application. A common setup keeps an existing
+backend — a Phoenix, Rails, or another Gleam service — as the source of truth
+for **authentication and persistence**, and uses beryl purely as the realtime
+fan-out layer. The backend tells beryl *what* to push; beryl handles delivery to
+connected sockets.
+
+This guide wires up that split:
+
+1. The existing backend authenticates users and issues a token.
+2. beryl verifies that token at connect (see [Authentication](/guides/authentication)).
+3. When domain data changes, the backend calls an **internal publish endpoint**
+   on the beryl service, which forwards the change with `beryl.broadcast`.
+
+```
+Browser ──WebSocket──► beryl ◄──HTTP POST /internal/publish── Backend
+                         │                                      │
+                         └── broadcasts to topic subscribers     └── owns auth + DB
+```
+
+## The internal publish endpoint
+
+Run the endpoint on the same Mist listener as the WebSocket transport. Guard it
+with a shared secret so only your backend — never a browser — can publish:
+
+```gleam
+import beryl
+import beryl/transport/mist as mist_transport
+import gleam/bytes_tree
+import gleam/dynamic/decode
+import gleam/http.{Post}
+import gleam/http/request.{type Request}
+import gleam/http/response.{type Response}
+import gleam/json
+import gleam/result
+import mist
+
+fn handle_request(
+  req: Request(mist.Connection),
+  channels: beryl.Channels,
+  ws_config,
+) -> Response(mist.ResponseData) {
+  // WebSocket upgrades go to beryl; everything else is normal HTTP routing.
+  use <- mist_transport.upgrade(req, channels, ws_config)
+
+  case request.path_segments(req), req.method {
+    ["internal", "publish"], Post -> publish(req, channels)
+    _, _ -> not_found()
+  }
+}
+```
+
+The handler decodes the backend's request into a typed event and forwards it:
+
+```gleam
+/// The contract your backend POSTs to /internal/publish.
+type PublishRequest {
+  PublishRequest(topic: String, order_id: String, status: String)
+}
+
+fn publish(
+  req: Request(mist.Connection),
+  channels: beryl.Channels,
+) -> Response(mist.ResponseData) {
+  // Only the trusted backend knows this secret.
+  case authorized_internal(req) {
+    False -> forbidden()
+    True ->
+      case read_publish_request(req) {
+        Ok(msg) -> {
+          // Fan out to every socket subscribed to the topic.
+          beryl.broadcast(
+            channels,
+            msg.topic,
+            "order_updated",
+            json.object([
+              #("order_id", json.string(msg.order_id)),
+              #("status", json.string(msg.status)),
+            ]),
+          )
+          accepted()
+        }
+        Error(_) -> bad_request()
+      }
+  }
+}
+
+fn read_publish_request(
+  req: Request(mist.Connection),
+) -> Result(PublishRequest, Nil) {
+  use req <- result.try(
+    mist.read_body(req, 1_000_000) |> result.replace_error(Nil),
+  )
+  let decoder = {
+    use topic <- decode.field("topic", decode.string)
+    use order_id <- decode.field("order_id", decode.string)
+    use status <- decode.field("status", decode.string)
+    decode.success(PublishRequest(topic:, order_id:, status:))
+  }
+  json.parse_bits(req.body, decoder) |> result.replace_error(Nil)
+}
+```
+
+## Guarding the endpoint
+
+`authorized_internal` compares a shared secret from an internal-only header. Keep
+the endpoint on a private network or behind your ingress so it is never exposed
+to browsers:
+
+```gleam
+import gleam/crypto
+
+fn authorized_internal(req: Request(mist.Connection)) -> Bool {
+  case request.get_header(req, "x-internal-secret") {
+    Ok(provided) ->
+      // Constant-time comparison avoids leaking the secret via timing.
+      crypto.secure_compare(
+        <<provided:utf8>>,
+        <<internal_secret():utf8>>,
+      )
+    Error(_) -> False
+  }
+}
+```
+
+## Response helpers
+
+The backend only needs an acknowledgement — beryl returns `202 Accepted` once the
+broadcast is queued:
+
+```gleam
+fn accepted() -> Response(mist.ResponseData) {
+  response.new(202) |> response.set_body(mist.Bytes(bytes_tree.new()))
+}
+
+fn bad_request() -> Response(mist.ResponseData) {
+  response.new(400) |> response.set_body(mist.Bytes(bytes_tree.new()))
+}
+
+fn forbidden() -> Response(mist.ResponseData) {
+  response.new(403) |> response.set_body(mist.Bytes(bytes_tree.new()))
+}
+
+fn not_found() -> Response(mist.ResponseData) {
+  response.new(404) |> response.set_body(mist.Bytes(bytes_tree.new()))
+}
+```
+
+## Why this split works
+
+- **One source of truth.** Your backend keeps owning auth and the database; beryl
+  never persists domain state, it only relays it.
+- **Push from anywhere.** Any backend process — an HTTP handler, a background job,
+  a webhook consumer — can publish by POSTing to the internal endpoint.
+- **Distributed fan-out for free.** If beryl runs as a cluster, use the
+  [PubSub layer](/guides/pubsub) so a broadcast on one node reaches subscribers on
+  every node.
+
+For the connect-time verification of the tokens your backend issues, see the
+[Authentication guide](/guides/authentication).

--- a/website/src/content/docs/installation.md
+++ b/website/src/content/docs/installation.md
@@ -16,7 +16,7 @@ This adds beryl to your `gleam.toml` dependencies. beryl targets the **Erlang (B
 
 ## Requirements
 
-- **Gleam** >= 1.3.0
+- **Gleam** >= 1.13.0
 - **Erlang/OTP** >= 26 (recommended: 27+)
 - **Target**: Erlang only
 

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -32,6 +32,7 @@ type holds per-socket state — anything you want to remember about this connect
 import beryl
 import beryl/channel.{type Channel, type HandleResult, type JoinResult}
 import beryl/socket.{type Socket}
+import gleam/dynamic.{type Dynamic}
 import gleam/dynamic/decode
 import gleam/json
 import gleam/option.{None, Some}
@@ -53,12 +54,13 @@ pub fn new(channels: beryl.Channels) -> Channel(RoomAssigns, info) {
 fn join(
   channels: beryl.Channels,
   topic: String,
-  payload: json.Json,
+  payload: Dynamic,
   socket: Socket(RoomAssigns),
 ) -> JoinResult(RoomAssigns) {
+  // Payloads arrive as `Dynamic`; decode the fields you need.
   // Extract username from the join payload, default to "Anonymous".
   let username = case
-    json.parse(json.to_string(payload), {
+    channel.decode_payload(payload, {
       use u <- decode.field("username", decode.string)
       decode.success(u)
     })
@@ -80,15 +82,33 @@ fn join(
 /// Called for every push the client sends after joining.
 fn handle_in(
   event: String,
-  payload: json.Json,
+  payload: Dynamic,
   socket: Socket(RoomAssigns),
 ) -> HandleResult(RoomAssigns) {
   let assigns = socket.get_assigns(socket)
 
   case event {
     "new_msg" -> {
-      // Broadcast to every socket joined to this topic (including the sender).
-      beryl.broadcast(assigns.channels, assigns.topic, "new_msg", payload)
+      // Decode the incoming text, then broadcast it as JSON to every socket
+      // joined to this topic (including the sender).
+      let text = case
+        channel.decode_payload(payload, {
+          use t <- decode.field("text", decode.string)
+          decode.success(t)
+        })
+      {
+        Ok(t) -> t
+        Error(_) -> ""
+      }
+      beryl.broadcast(
+        assigns.channels,
+        assigns.topic,
+        "new_msg",
+        json.object([
+          #("username", json.string(assigns.username)),
+          #("text", json.string(text)),
+        ]),
+      )
       // Return NoReply — phx_reply is NOT sent for broadcasts.
       channel.NoReply(socket)
     }
@@ -225,7 +245,12 @@ to the original message ref:
 ```gleam
 // Server side — acknowledge message delivery
 "new_msg" -> {
-  beryl.broadcast(assigns.channels, assigns.topic, "new_msg", payload)
+  beryl.broadcast(
+    assigns.channels,
+    assigns.topic,
+    "new_msg",
+    json.object([#("username", json.string(assigns.username))]),
+  )
   channel.Reply(
     event: "msg_ack",  // event is ignored in the wire protocol; only payload matters
     payload: json.object([#("status", json.string("ok"))]),

--- a/website/src/content/docs/reference/api/beryl-error.md
+++ b/website/src/content/docs/reference/api/beryl-error.md
@@ -27,3 +27,11 @@ Convert a startup failure to a human-readable diagnostic string.
 ```gleam
 pub fn describe_start_failure(StartFailure) -> String
 ```
+
+### `from_actor_start_error`
+
+Convert a `gleam/otp/actor.StartError` into beryl's `StartFailure`.
+
+```gleam
+pub fn from_actor_start_error(actor.StartError) -> StartFailure
+```

--- a/website/src/content/docs/reference/api/beryl-group.md
+++ b/website/src/content/docs/reference/api/beryl-group.md
@@ -83,6 +83,8 @@ pub type Message
 
 Add a topic to a group
 
+ Panics if the groups actor is unavailable or does not reply within 5 seconds.
+
 ```gleam
 pub fn add(
   Groups,
@@ -112,6 +114,8 @@ pub fn broadcast(
 
 Create a new named group
 
+ Panics if the groups actor is unavailable or does not reply within 5 seconds.
+
 ```gleam
 pub fn create(
   Groups,
@@ -122,6 +126,8 @@ pub fn create(
 ### `delete`
 
 Delete a group
+
+ Panics if the groups actor is unavailable or does not reply within 5 seconds.
 
 ```gleam
 pub fn delete(
@@ -134,6 +140,8 @@ pub fn delete(
 
 List all group names
 
+ Panics if the groups actor is unavailable or does not reply within 5 seconds.
+
 ```gleam
 pub fn list_groups(Groups) -> List(String)
 ```
@@ -141,6 +149,8 @@ pub fn list_groups(Groups) -> List(String)
 ### `remove`
 
 Remove a topic from a group
+
+ Panics if the groups actor is unavailable or does not reply within 5 seconds.
 
 ```gleam
 pub fn remove(
@@ -158,9 +168,19 @@ Start the groups actor
 pub fn start() -> Result(Groups, GroupStartError)
 ```
 
+### `start_named`
+
+Start the groups actor with a registered name (for supervision)
+
+```gleam
+pub fn start_named(process.Name(Message)) -> Result(actor.Started(process.Subject(Message)), actor.StartError)
+```
+
 ### `topics`
 
 Get all topics in a group
+
+ Panics if the groups actor is unavailable or does not reply within 5 seconds.
 
 ```gleam
 pub fn topics(

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -158,6 +158,8 @@ pub fn diff_topics(Diff) -> List(String)
 
 Get presences for a specific key within a topic
 
+ Panics if the presence actor is unavailable or does not reply within 5 seconds.
+
 ```gleam
 pub fn get_by_key(
   Presence,
@@ -169,6 +171,8 @@ pub fn get_by_key(
 ### `list`
 
 List all presences for a topic
+
+ Panics if the presence actor is unavailable or does not reply within 5 seconds.
 
 ```gleam
 pub fn list(
@@ -185,11 +189,24 @@ Start the presence actor
 pub fn start(Config) -> Result(Presence, PresenceError)
 ```
 
+### `start_named`
+
+Start the presence actor with a registered name (for supervision)
+
+```gleam
+pub fn start_named(
+  Config,
+  process.Name(Message)
+) -> Result(actor.Started(process.Subject(Message)), actor.StartError)
+```
+
 ### `track`
 
 Track a presence in a topic
 
  Returns a reference string (the pid) that can be used to untrack later.
+
+ Panics if the presence actor is unavailable or does not reply within 5 seconds.
 
 ```gleam
 pub fn track(
@@ -205,6 +222,8 @@ pub fn track(
 
 Untrack a specific presence by topic, key, and pid
 
+ Panics if the presence actor is unavailable or does not reply within 5 seconds.
+
 ```gleam
 pub fn untrack(
   Presence,
@@ -217,6 +236,8 @@ pub fn untrack(
 ### `untrack_all`
 
 Untrack all presences for a pid (e.g., when a socket disconnects)
+
+ Panics if the presence actor is unavailable or does not reply within 5 seconds.
 
 ```gleam
 pub fn untrack_all(

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -140,6 +140,11 @@ pub fn broadcast_from_socket(
 
 Create a PubSub configuration with a custom scope name
 
+ The scope name is converted to an Erlang atom via `binary_to_atom`.
+ Atoms are never garbage-collected, so the scope name must be a static,
+ bounded value — never derive it from user input, or a malicious or
+ high-cardinality source could exhaust the atom table and crash the VM.
+
 ```gleam
 pub fn config_with_scope(String) -> PubSubConfig
 ```

--- a/website/src/content/docs/reference/api/beryl-socket.md
+++ b/website/src/content/docs/reference/api/beryl-socket.md
@@ -42,6 +42,13 @@ pub type Socket(a)
 
 Transport abstraction for sending messages
 
+ Wraps the underlying connection (e.g. a Mist WebSocket) with functions to
+ send text/binary frames and close the connection.
+
+ Note: as constructed by the built-in Mist transport, `close` is a no-op
+ that returns `Ok(Nil)`. Closing is driven by the transport's own
+ connection lifecycle rather than by calling this function.
+
 ```gleam
 pub type Transport {
   Transport(
@@ -54,12 +61,24 @@ pub type Transport {
 
 ### `TransportError`
 
+Errors returned by transport send/close operations.
+
 ```gleam
 pub type TransportError {
   ConnectionClosed
   SendFailed(String)
 }
 ```
+
+#### Constructors
+
+##### `ConnectionClosed`
+
+The underlying connection is already closed and cannot be used.
+
+##### `SendFailed(String)`
+
+Sending failed; the wrapped `String` describes the reason.
 
 ## Functions
 

--- a/website/src/content/docs/reference/api/beryl-topic.md
+++ b/website/src/content/docs/reference/api/beryl-topic.md
@@ -45,12 +45,25 @@ The topic does not match the pattern.
 
 ### `TopicError`
 
+Errors returned when validating a topic or topic pattern.
+
 ```gleam
 pub type TopicError {
   EmptyTopic
   InvalidFormat(String)
 }
 ```
+
+#### Constructors
+
+##### `EmptyTopic`
+
+The topic or pattern was an empty string.
+
+##### `InvalidFormat(String)`
+
+The topic, pattern, or event was malformed; the wrapped `String`
+ describes the problem (e.g. leading/trailing `:` or control characters).
 
 ### `TopicPattern`
 
@@ -192,6 +205,18 @@ Parse a pattern string into TopicPattern
 pub fn parse_pattern(String) -> TopicPattern
 ```
 
+### `sanitize_for_log`
+
+Escape control characters in a string for safe use in log metadata.
+
+ Replaces codepoints in the range 0–31 and 127 with `?` so that
+ client-supplied strings cannot inject additional fields into structured
+ log output.
+
+```gleam
+pub fn sanitize_for_log(String) -> String
+```
+
 ### `segments`
 
 Parse a topic into segments by splitting on ":"
@@ -213,9 +238,36 @@ Validate a topic string
 
  Topics must:
  - Not be empty
- - Not contain control characters
+ - Not contain control characters (codepoints 0–31 or 127)
  - Not start or end with ":"
 
 ```gleam
 pub fn validate(String) -> Result(String, TopicError)
+```
+
+### `validate_event`
+
+Validate an event name string
+
+ Event names must:
+ - Not be empty
+ - Not contain control characters (codepoints 0–31 or 127)
+
+```gleam
+pub fn validate_event(String) -> Result(String, TopicError)
+```
+
+### `validate_pattern`
+
+Validate a topic pattern string
+
+ Patterns must:
+ - Not be empty
+ - Not contain control characters (codepoints 0–31 or 127)
+
+ The bare pattern `"*"` is valid: it parses to a catch-all wildcard that
+ matches every topic.
+
+```gleam
+pub fn validate_pattern(String) -> Result(String, TopicError)
 ```

--- a/website/src/content/docs/reference/api/beryl-transport-mist.md
+++ b/website/src/content/docs/reference/api/beryl-transport-mist.md
@@ -95,6 +95,14 @@ Upgrade a request to WebSocket if it matches the configured path
  }
  ```
 
+ ## Path matching
+
+ The request path is normalised by re-joining its segments as
+ `"/" <> string.join(segments, "/")` and compared for exact equality with
+ `config.path`. Because the normalised path never has a trailing slash, a
+ config path written with a trailing slash (e.g. `"/socket/"`) will never
+ match. Configure the path without a trailing slash (e.g. `"/socket"`).
+
 ```gleam
 pub fn upgrade(
   request.Request(http.Connection),
@@ -120,6 +128,22 @@ pub fn upgrade_connection(
 ) -> response.Response(mist.ResponseData)
 ```
 
+### `with_allowed_origins`
+
+Restrict WebSocket upgrades to requests with an allowed `Origin` header.
+
+ Values are matched exactly against the full Origin header value, including
+ scheme and host (and port when present), such as
+ `"https://app.example.com"`. When configured, missing or non-matching
+ origins are rejected with `403 Forbidden` before the WebSocket handshake.
+
+```gleam
+pub fn with_allowed_origins(
+  TransportConfig(a),
+  List(String)
+) -> TransportConfig(a)
+```
+
 ### `with_on_connect`
 
 Set a socket-level connect/authentication callback on the transport config.
@@ -135,20 +159,4 @@ pub fn with_on_connect(
   TransportConfig(a),
   fn(request.Request(http.Connection)) -> Result(b, ConnectError)
 ) -> TransportConfig(b)
-```
-
-### `with_allowed_origins`
-
-Restrict WebSocket upgrades to requests with an allowed `Origin` header.
-
- Values are matched exactly against the full Origin header value, including
- scheme and host (and port when present), such as
- `"https://app.example.com"`. When configured, missing or non-matching
- origins are rejected with `403 Forbidden` before the WebSocket handshake.
-
-```gleam
-pub fn with_allowed_origins(
-  TransportConfig(a),
-  List(String)
-) -> TransportConfig(a)
 ```

--- a/website/src/content/docs/reference/api/beryl-wire-codec.md
+++ b/website/src/content/docs/reference/api/beryl-wire-codec.md
@@ -48,6 +48,21 @@ pub type DecodeError {
 }
 ```
 
+#### Constructors
+
+##### `InvalidJson(reason: String)`
+
+The bytes were not valid JSON; `reason` describes the parse error.
+
+##### `InvalidFormat(reason: String)`
+
+The message was valid JSON but did not match the expected framing;
+ `reason` describes the mismatch.
+
+##### `MissingField(name: String)`
+
+A required field was absent; `name` is the missing field.
+
 ### `Frame`
 
 Encoded WebSocket frame returned by a codec.
@@ -58,6 +73,16 @@ pub type Frame {
   BinaryFrame(BitArray)
 }
 ```
+
+#### Constructors
+
+##### `TextFrame(String)`
+
+A UTF-8 text frame.
+
+##### `BinaryFrame(BitArray)`
+
+A binary frame.
 
 ### `Inbound`
 
@@ -97,6 +122,24 @@ pub type InboundKind {
 }
 ```
 
+#### Constructors
+
+##### `Join`
+
+A client joining a topic.
+
+##### `Leave`
+
+A client leaving a topic.
+
+##### `Heartbeat`
+
+A heartbeat/keep-alive message.
+
+##### `Event(String)`
+
+A user-defined event; the wrapped `String` is the event name.
+
 ### `ReplyStatus`
 
 Status of a reply produced by a channel handler.
@@ -107,6 +150,16 @@ pub type ReplyStatus {
   StatusError
 }
 ```
+
+#### Constructors
+
+##### `StatusOk`
+
+The handler succeeded (`"ok"` in Phoenix framing).
+
+##### `StatusError`
+
+The handler failed (`"error"` in Phoenix framing).
 
 ## Functions
 

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -155,7 +155,8 @@ A handler is already registered for this exact topic pattern.
 
 ##### `InvalidPattern(String)`
 
-The topic pattern is invalid.
+The topic pattern is invalid. Patterns must be non-empty and must not
+ contain control characters (codepoints 0–31 or 127).
 
 ### `StartError`
 
@@ -179,6 +180,17 @@ The coordinator actor failed to start.
 heartbeat_timeout_ms must be > 0 (it is used to derive the check interval)
 
 ## Functions
+
+### `acquire_connection_slot`
+
+Try to acquire a configured per-IP connection slot for transports.
+
+```gleam
+pub fn acquire_connection_slot(
+  Channels,
+  String
+) -> Result(option.Option(connection_limit.Permit), Nil)
+```
 
 ### `broadcast`
 
@@ -310,6 +322,14 @@ pub fn logging_config(
 ) -> LoggingConfig
 ```
 
+### `max_inbound_frame_bytes`
+
+Return the configured inbound frame size cap for transports.
+
+```gleam
+pub fn max_inbound_frame_bytes(Channels) -> Int
+```
+
 ### `register`
 
 Register a channel handler for a topic pattern
@@ -317,6 +337,14 @@ Register a channel handler for a topic pattern
  Patterns can be exact matches like "room:lobby", legacy prefix wildcards
  like "room:*" which match any topic starting with "room:", or segment
  wildcards like "document:*:ops" where "*" matches one complete segment.
+ The bare pattern "*" is a catch-all that matches every topic.
+
+ Patterns are validated at registration: they must be non-empty and must
+ not contain control characters (codepoints 0–31 or 127). Invalid patterns
+ are rejected with `InvalidPattern`.
+
+ Panics if the coordinator actor is unavailable or does not reply within
+ 5 seconds (e.g. during a supervisor restart window after a crash).
 
  ## Example
 
@@ -347,6 +375,14 @@ pub fn register(
   String,
   channel.Channel(a, b)
 ) -> Result(RegisteredChannel(a, b), RegisterError)
+```
+
+### `release_connection_slot`
+
+Release a per-IP connection slot acquired by a transport.
+
+```gleam
+pub fn release_connection_slot(option.Option(connection_limit.Permit)) -> Nil
 ```
 
 ### `send_info`
@@ -394,15 +430,46 @@ Start the channels system
 pub fn start(Config) -> Result(Channels, StartError)
 ```
 
+### `stop`
+
+Stop an unsupervised channels system.
+
+ This shuts down the coordinator actor started by `start` and any auxiliary
+ limiter actors owned by the `Channels` handle. Joined channel handlers
+ receive `channel.Shutdown` in their `terminate` callback before the
+ coordinator exits. After this call the `Channels` handle should no longer be
+ used.
+
+```gleam
+pub fn stop(Channels) -> Nil
+```
+
 ### `with_channel_rate`
 
-Configure per-channel message rate limiting
+Configure per-channel message rate limiting.
+
+ The limiter applies only after a socket has joined a topic. Active
+ per-socket channel buckets are capped by default; use
+ `with_channel_rate_max_keys_per_socket` to adjust the cap.
 
 ```gleam
 pub fn with_channel_rate(
   Config,
   per_second: Int,
   burst: Int
+) -> Config
+```
+
+### `with_channel_rate_max_keys_per_socket`
+
+Configure the maximum active per-channel rate-limit buckets per socket.
+
+ Values <= 0 disable the cap. The default is 1000.
+
+```gleam
+pub fn with_channel_rate_max_keys_per_socket(
+  Config,
+  max_keys: Int
 ) -> Config
 ```
 
@@ -418,9 +485,38 @@ pub fn with_join_rate(
 ) -> Config
 ```
 
+### `with_logging`
+
+Configure Beryl's internal logging.
+
+```gleam
+pub fn with_logging(
+  Config,
+  LoggingConfig
+) -> Config
+```
+
+### `with_max_event_length`
+
+Configure the maximum allowed byte length for client-supplied event name
+ strings.
+
+ Event names longer than `max_length` bytes are dropped before reaching a
+ channel handler. The default is 64.
+
+```gleam
+pub fn with_max_event_length(
+  Config,
+  max_length: Int
+) -> Config
+```
+
 ### `with_max_inbound_frame_bytes`
 
 Configure the maximum allowed inbound WebSocket frame size in bytes.
+
+ Frames larger than `max_bytes` are closed before decoding. Values <= 0
+ disable the cap. The default is 1 MiB.
 
 ```gleam
 pub fn with_max_inbound_frame_bytes(
@@ -433,6 +529,8 @@ pub fn with_max_inbound_frame_bytes(
 
 Configure the maximum number of topics a socket may join at once.
 
+ Values <= 0 disable the cap. The default is 1000.
+
 ```gleam
 pub fn with_max_joined_topics_per_socket(
   Config,
@@ -440,14 +538,19 @@ pub fn with_max_joined_topics_per_socket(
 ) -> Config
 ```
 
-### `with_logging`
+### `with_max_topic_length`
 
-Configure Beryl's internal logging.
+Configure the maximum allowed byte length for client-supplied topic
+ strings.
+
+ Topics longer than `max_length` bytes are rejected with a `phx_reply`
+ error before reaching a channel handler, bounding the size of keys stored
+ in the coordinator's topic registry. The default is 256.
 
 ```gleam
-pub fn with_logging(
+pub fn with_max_topic_length(
   Config,
-  LoggingConfig
+  max_length: Int
 ) -> Config
 ```
 


### PR DESCRIPTION
Addresses all open documentation issues ahead of 1.0.

## Changes

### Doc-comment sweep (#165)
- Documented `socket.TransportError`, `topic.TopicError`, and codec `Frame` / `InboundKind` / `ReplyStatus` / `DecodeError` variants.
- Documented three under-documented behaviors: Mist `upgrade` exact path matching (trailing slash never matches), `pubsub.config_with_scope` atom lifetime (scope names must be static), and the built-in transport's no-op `close`.
- Filled remaining undocumented public functions (`from_actor_start_error`, `stop_optional`).

### Undocumented panics (#158)
- Added "Panics if the underlying actor is unavailable or does not reply within 5 seconds" to `beryl.register`, all `group.*`, and all `presence.*` call-based functions.

### Refresh docs/examples for current API (#124)
- Rewrote the README bridge recipe to compile against the current API (`Channel(assigns, info)`, `channel:` + `RegisteredChannel`, typed `handle_info`).
- Fixed the Quick Start to use `Dynamic` payloads with `channel.decode_payload` and to broadcast `json.Json`.
- Regenerated the website API reference from current Gleam docs metadata.

### Release readiness (#125)
- Aligned documented Gleam version (`>= 1.13`) with `gleam.toml` in README and installation docs.
- Pointed the README changelog link at the GitHub Releases page (the generated `CHANGELOG.md` does not exist pre-release).
- Added a 1.0 release checklist to `DEV.md` (removing the "not yet 1.0" callout, verifying versions and tarball).
- Added a CI step that validates the generated reference docs stay in sync with the API.

### New guides
- **Authentication** (#149): real token verification in `on_connect`, decoding claims into assigns, authorizing joins.
- **Backend Integration** (#150): an existing backend owning auth/persistence and publishing changes through an internal endpoint that calls `beryl.broadcast`.

## Validation
- `gleam check`, `gleam format --check`, and `gleam test` (232 passed) all pass.
- `just site-reference-test` passes; regenerated reference docs are committed.
- `astro check` passes (0 errors) with the new guide pages and sidebar entries.

Closes #165
Closes #158
Closes #124
Closes #125
Closes #149
Closes #150