### PR TITLE
feat(config): make Config opaque with full builder coverage

### DIFF
--- a/.changes/unreleased/Changed-20260707-133617.yaml
+++ b/.changes/unreleased/Changed-20260707-133617.yaml
@@ -1,0 +1,10 @@
+kind: Changed
+body: |-
+  Make `beryl.Config` an opaque type and add the missing builders.
+
+  `Config` is now constructed via `beryl.config` and adjusted with `with_*`
+  builders, so new options can be added post-1.0 without a breaking change.
+  Added `with_heartbeat(interval_ms:, timeout_ms:)` and
+  `with_max_connections_per_ip(max_connections:)` so every user-settable field
+  is reachable through a builder. Closes #152.
+time: 2026-07-07T13:36:17-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -115,8 +115,12 @@ pub type LoggingConfig {
   )
 }
 
-/// Configuration for the channels system
-pub type Config {
+/// Configuration for the channels system.
+///
+/// This type is opaque: construct it with `config` and adjust it with the
+/// `with_*` builder functions. Keeping it opaque lets Beryl add configuration
+/// options in the future without a breaking change.
+pub opaque type Config {
   Config(
     /// Wire codec used to decode inbound text and encode replies/pushes.
     /// Use `wire.phoenix_codec()` for the historical Phoenix array format.
@@ -208,6 +212,35 @@ pub fn config(codec: codec.Codec) -> Config {
 /// Add PubSub to a configuration for distributed broadcasts
 pub fn with_pubsub(config: Config, ps: PubSub) -> Config {
   Config(..config, pubsub: Some(ps))
+}
+
+/// Configure heartbeat timing.
+///
+/// `interval_ms` is the client-facing heartbeat interval (informational: how
+/// often clients should send heartbeats). `timeout_ms` is the server-side
+/// staleness window — a socket that sends no heartbeat within this window is
+/// evicted. The defaults are 30000 ms and 60000 ms respectively.
+pub fn with_heartbeat(
+  config: Config,
+  interval_ms interval_ms: Int,
+  timeout_ms timeout_ms: Int,
+) -> Config {
+  Config(
+    ..config,
+    heartbeat_interval_ms: interval_ms,
+    heartbeat_timeout_ms: timeout_ms,
+  )
+}
+
+/// Configure the maximum number of concurrent connections allowed per client
+/// IP address.
+///
+/// A value of 0 (the default) means unlimited.
+pub fn with_max_connections_per_ip(
+  config: Config,
+  max_connections max_connections: Int,
+) -> Config {
+  Config(..config, max_connections_per_ip: max_connections)
 }
 
 /// Configure Beryl's internal logging.
@@ -327,6 +360,107 @@ pub fn with_max_joined_topics_per_socket(
   Config(..config, max_joined_topics_per_socket: max_topics)
 }
 
+// nolint: unused_exports -- package-internal accessors for supervisor/tests; hidden from public docs with @internal
+@internal
+pub fn config_heartbeat_interval_ms(config: Config) -> Int {
+  config.heartbeat_interval_ms
+}
+
+@internal
+pub fn config_heartbeat_timeout_ms(config: Config) -> Int {
+  config.heartbeat_timeout_ms
+}
+
+@internal
+pub fn config_max_connections_per_ip(config: Config) -> Int {
+  config.max_connections_per_ip
+}
+
+@internal
+pub fn config_pubsub(config: Config) -> Option(PubSub) {
+  config.pubsub
+}
+
+@internal
+pub fn config_logging(config: Config) -> LoggingConfig {
+  config.logging
+}
+
+@internal
+pub fn config_join_rate(config: Config) -> Int {
+  config.join_rate
+}
+
+@internal
+pub fn config_join_burst(config: Config) -> Int {
+  config.join_burst
+}
+
+@internal
+pub fn config_channel_rate(config: Config) -> Int {
+  config.channel_rate
+}
+
+@internal
+pub fn config_channel_burst(config: Config) -> Int {
+  config.channel_burst
+}
+
+@internal
+pub fn config_channel_rate_max_keys_per_socket(config: Config) -> Int {
+  config.channel_rate_max_keys_per_socket
+}
+
+@internal
+pub fn config_max_topic_length(config: Config) -> Int {
+  config.max_topic_length
+}
+
+@internal
+pub fn config_max_event_length(config: Config) -> Int {
+  config.max_event_length
+}
+
+@internal
+pub fn config_max_inbound_frame_bytes(config: Config) -> Int {
+  config.max_inbound_frame_bytes
+}
+
+@internal
+pub fn config_max_joined_topics_per_socket(config: Config) -> Int {
+  config.max_joined_topics_per_socket
+}
+
+/// Build a coordinator config (starting rate-limiter actors) from a `Config`.
+/// Shared by `start` and the supervisor so the mapping lives in one place.
+@internal
+pub fn to_coordinator_config(config: Config) -> coordinator.CoordinatorConfig {
+  // Server checks at half the timeout interval to detect stale sockets
+  // promptly. The client heartbeat_interval_ms is informational only.
+  let check_interval = config.heartbeat_timeout_ms / 2
+
+  let message_limiter =
+    rate_limit.start_optional(config.message_rate, config.message_burst)
+  let join_limiter =
+    rate_limit.start_optional(config.join_rate, config.join_burst)
+  let channel_limiter =
+    rate_limit.start_optional(config.channel_rate, config.channel_burst)
+
+  coordinator.CoordinatorConfig(
+    codec: config.codec,
+    heartbeat_check_interval_ms: check_interval,
+    heartbeat_timeout_ms: config.heartbeat_timeout_ms,
+    message_limiter: message_limiter,
+    join_limiter: join_limiter,
+    channel_limiter: channel_limiter,
+    channel_limiter_max_keys_per_socket: config.channel_rate_max_keys_per_socket,
+    max_topic_length: config.max_topic_length,
+    max_event_length: config.max_event_length,
+    max_joined_topics_per_socket: config.max_joined_topics_per_socket,
+    logging: coordinator_logging(config.logging),
+  )
+}
+
 /// Channels system handle.
 ///
 /// This opaque handle is returned by `start` and passed to registration,
@@ -418,32 +552,7 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
     when: config.heartbeat_timeout_ms <= 0,
     return: internal.result_error(InvalidHeartbeatTimeout),
   )
-  // Server checks at half the timeout interval to detect stale sockets
-  // promptly. The client heartbeat_interval_ms is informational only
-  // (used by clients to know how often to send heartbeats).
-  let check_interval = config.heartbeat_timeout_ms / 2
-
-  let message_limiter =
-    rate_limit.start_optional(config.message_rate, config.message_burst)
-  let join_limiter =
-    rate_limit.start_optional(config.join_rate, config.join_burst)
-  let channel_limiter =
-    rate_limit.start_optional(config.channel_rate, config.channel_burst)
-
-  let coord_config =
-    coordinator.CoordinatorConfig(
-      codec: config.codec,
-      heartbeat_check_interval_ms: check_interval,
-      heartbeat_timeout_ms: config.heartbeat_timeout_ms,
-      message_limiter: message_limiter,
-      join_limiter: join_limiter,
-      channel_limiter: channel_limiter,
-      channel_limiter_max_keys_per_socket: config.channel_rate_max_keys_per_socket,
-      max_topic_length: config.max_topic_length,
-      max_event_length: config.max_event_length,
-      max_joined_topics_per_socket: config.max_joined_topics_per_socket,
-      logging: coordinator_logging(config.logging),
-    )
+  let coord_config = to_coordinator_config(config)
 
   let coordinator_result = case config.pubsub {
     Some(ps) -> coordinator.start_with_config_and_pubsub(coord_config, ps)

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -33,7 +33,6 @@ import beryl/group
 import beryl/internal
 import beryl/log
 import beryl/presence
-import beryl/rate_limit
 import gleam/bool
 import gleam/erlang/process
 import gleam/option.{type Option, None, Some}
@@ -89,7 +88,7 @@ pub fn start(
 ) -> Result(SupervisedChannels, StartError) {
   // Validate heartbeat_timeout_ms before deriving check_interval
   use <- bool.guard(
-    when: config.channels.heartbeat_timeout_ms <= 0,
+    when: beryl.config_heartbeat_timeout_ms(config.channels) <= 0,
     return: Error(InvalidHeartbeatTimeout),
   )
   start_supervised(config)
@@ -115,38 +114,9 @@ fn start_supervised(
     False -> None
   }
 
-  // Build coordinator config from channels config.
-  // Server checks at half the timeout interval (same as beryl.start).
-  let check_interval = config.channels.heartbeat_timeout_ms / 2
-  let message_limiter =
-    rate_limit.start_optional(
-      config.channels.message_rate,
-      config.channels.message_burst,
-    )
-  let join_limiter =
-    rate_limit.start_optional(
-      config.channels.join_rate,
-      config.channels.join_burst,
-    )
-  let channel_limiter =
-    rate_limit.start_optional(
-      config.channels.channel_rate,
-      config.channels.channel_burst,
-    )
-  let coord_config =
-    coordinator.CoordinatorConfig(
-      codec: config.channels.codec,
-      heartbeat_check_interval_ms: check_interval,
-      heartbeat_timeout_ms: config.channels.heartbeat_timeout_ms,
-      message_limiter: message_limiter,
-      join_limiter: join_limiter,
-      channel_limiter: channel_limiter,
-      channel_limiter_max_keys_per_socket: config.channels.channel_rate_max_keys_per_socket,
-      max_topic_length: config.channels.max_topic_length,
-      max_event_length: config.channels.max_event_length,
-      max_joined_topics_per_socket: config.channels.max_joined_topics_per_socket,
-      logging: coordinator_logging(config.channels.logging),
-    )
+  // Build coordinator config from channels config (same mapping and
+  // half-timeout check interval as beryl.start).
+  let coord_config = beryl.to_coordinator_config(config.channels)
 
   // Build the supervisor with rest-for-one strategy.
   // If the coordinator crashes, presence and groups restart too to maintain
@@ -160,7 +130,7 @@ fn start_supervised(
     builder
     |> static_supervisor.add(
       supervision.worker(fn() {
-        let started = case config.channels.pubsub {
+        let started = case beryl.config_pubsub(config.channels) {
           Some(ps) ->
             coordinator.start_named_with_pubsub(
               coord_config,
@@ -250,25 +220,6 @@ fn start_supervised(
       ))
     }
   }
-}
-
-fn coordinator_log_level(level: beryl.LogLevel) -> coordinator.LogLevel {
-  case level {
-    beryl.Debug -> coordinator.Debug
-    beryl.Info -> coordinator.Info
-    beryl.Warn -> coordinator.Warn
-    beryl.Error -> coordinator.Err
-  }
-}
-
-fn coordinator_logging(
-  logging: beryl.LoggingConfig,
-) -> coordinator.LoggingConfig {
-  coordinator.LoggingConfig(
-    level: coordinator_log_level(logging.level),
-    include_payloads: logging.include_payloads,
-    payload_preview_bytes: logging.payload_preview_bytes,
-  )
 }
 
 /// Stop the supervisor and all its children

--- a/test/beryl_test.gleam
+++ b/test/beryl_test.gleam
@@ -617,11 +617,35 @@ pub fn segment_wildcard_registered_channel_rejects_wrong_segment_test() {
 pub fn default_config_test() {
   let config = beryl.config(wire.phoenix_codec())
 
-  config.heartbeat_interval_ms
+  beryl.config_heartbeat_interval_ms(config)
   |> should.equal(30_000)
 
-  config.heartbeat_timeout_ms
+  beryl.config_heartbeat_timeout_ms(config)
   |> should.equal(60_000)
+
+  beryl.config_max_connections_per_ip(config)
+  |> should.equal(0)
+}
+
+pub fn with_heartbeat_sets_interval_and_timeout_test() {
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_heartbeat(interval_ms: 5000, timeout_ms: 10_000)
+
+  beryl.config_heartbeat_interval_ms(config)
+  |> should.equal(5000)
+
+  beryl.config_heartbeat_timeout_ms(config)
+  |> should.equal(10_000)
+}
+
+pub fn with_max_connections_per_ip_sets_limit_test() {
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_max_connections_per_ip(max_connections: 5)
+
+  beryl.config_max_connections_per_ip(config)
+  |> should.equal(5)
 }
 
 pub fn send_info_routes_message_to_joined_channel_test() {
@@ -1034,8 +1058,8 @@ pub fn with_join_rate_sets_fields_test() {
     beryl.config(wire.phoenix_codec())
     |> beryl.with_join_rate(per_second: 5, burst: 10)
 
-  cfg.join_rate |> should.equal(5)
-  cfg.join_burst |> should.equal(10)
+  beryl.config_join_rate(cfg) |> should.equal(5)
+  beryl.config_join_burst(cfg) |> should.equal(10)
 }
 
 pub fn with_channel_rate_sets_fields_test() {
@@ -1043,14 +1067,14 @@ pub fn with_channel_rate_sets_fields_test() {
     beryl.config(wire.phoenix_codec())
     |> beryl.with_channel_rate(per_second: 7, burst: 14)
 
-  cfg.channel_rate |> should.equal(7)
-  cfg.channel_burst |> should.equal(14)
+  beryl.config_channel_rate(cfg) |> should.equal(7)
+  beryl.config_channel_burst(cfg) |> should.equal(14)
 }
 
 pub fn channel_rate_max_keys_defaults_to_1000_test() {
   let cfg = beryl.config(wire.phoenix_codec())
 
-  cfg.channel_rate_max_keys_per_socket |> should.equal(1000)
+  beryl.config_channel_rate_max_keys_per_socket(cfg) |> should.equal(1000)
 }
 
 pub fn with_channel_rate_max_keys_per_socket_sets_field_test() {
@@ -1058,13 +1082,13 @@ pub fn with_channel_rate_max_keys_per_socket_sets_field_test() {
     beryl.config(wire.phoenix_codec())
     |> beryl.with_channel_rate_max_keys_per_socket(max_keys: 42)
 
-  cfg.channel_rate_max_keys_per_socket |> should.equal(42)
+  beryl.config_channel_rate_max_keys_per_socket(cfg) |> should.equal(42)
 }
 
 pub fn default_max_topic_length_is_256_test() {
   let cfg = beryl.config(wire.phoenix_codec())
 
-  cfg.max_topic_length |> should.equal(256)
+  beryl.config_max_topic_length(cfg) |> should.equal(256)
 }
 
 pub fn with_max_topic_length_sets_field_test() {
@@ -1072,13 +1096,13 @@ pub fn with_max_topic_length_sets_field_test() {
     beryl.config(wire.phoenix_codec())
     |> beryl.with_max_topic_length(max_length: 128)
 
-  cfg.max_topic_length |> should.equal(128)
+  beryl.config_max_topic_length(cfg) |> should.equal(128)
 }
 
 pub fn default_max_event_length_is_64_test() {
   let cfg = beryl.config(wire.phoenix_codec())
 
-  cfg.max_event_length |> should.equal(64)
+  beryl.config_max_event_length(cfg) |> should.equal(64)
 }
 
 pub fn with_max_event_length_sets_field_test() {
@@ -1086,13 +1110,13 @@ pub fn with_max_event_length_sets_field_test() {
     beryl.config(wire.phoenix_codec())
     |> beryl.with_max_event_length(max_length: 32)
 
-  cfg.max_event_length |> should.equal(32)
+  beryl.config_max_event_length(cfg) |> should.equal(32)
 }
 
 pub fn default_max_inbound_frame_bytes_is_1mb_test() {
   let cfg = beryl.config(wire.phoenix_codec())
 
-  cfg.max_inbound_frame_bytes |> should.equal(1_048_576)
+  beryl.config_max_inbound_frame_bytes(cfg) |> should.equal(1_048_576)
 }
 
 pub fn with_max_inbound_frame_bytes_sets_field_test() {
@@ -1100,13 +1124,13 @@ pub fn with_max_inbound_frame_bytes_sets_field_test() {
     beryl.config(wire.phoenix_codec())
     |> beryl.with_max_inbound_frame_bytes(max_bytes: 4096)
 
-  cfg.max_inbound_frame_bytes |> should.equal(4096)
+  beryl.config_max_inbound_frame_bytes(cfg) |> should.equal(4096)
 }
 
 pub fn default_max_joined_topics_per_socket_is_1000_test() {
   let cfg = beryl.config(wire.phoenix_codec())
 
-  cfg.max_joined_topics_per_socket |> should.equal(1000)
+  beryl.config_max_joined_topics_per_socket(cfg) |> should.equal(1000)
 }
 
 pub fn with_max_joined_topics_per_socket_sets_field_test() {
@@ -1114,7 +1138,7 @@ pub fn with_max_joined_topics_per_socket_sets_field_test() {
     beryl.config(wire.phoenix_codec())
     |> beryl.with_max_joined_topics_per_socket(max_topics: 12)
 
-  cfg.max_joined_topics_per_socket |> should.equal(12)
+  beryl.config_max_joined_topics_per_socket(cfg) |> should.equal(12)
 }
 
 pub fn extract_topic_id_test() {
@@ -1144,10 +1168,8 @@ pub fn channels_handle_remains_usable_after_start_test() {
 
 pub fn stop_shuts_down_unsupervised_coordinator_test() {
   let config =
-    beryl.Config(
-      ..beryl.config(wire.phoenix_codec()),
-      max_connections_per_ip: 1,
-    )
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_max_connections_per_ip(max_connections: 1)
     |> beryl.with_message_rate(per_second: 10, burst: 10)
     |> beryl.with_join_rate(per_second: 10, burst: 10)
     |> beryl.with_channel_rate(per_second: 10, burst: 10)

--- a/test/logging_test.gleam
+++ b/test/logging_test.gleam
@@ -70,11 +70,12 @@ fn drain(selector: process.Selector(CapturedLog)) -> Nil {
 pub fn default_logging_preserves_info_without_payloads_test() {
   let config = beryl.config(wire.phoenix_codec())
 
-  config.logging.level
+  let logging = beryl.config_logging(config)
+  logging.level
   |> should.equal(beryl.Info)
-  config.logging.include_payloads
+  logging.include_payloads
   |> should.be_false
-  config.logging.payload_preview_bytes
+  logging.payload_preview_bytes
   |> should.equal(200)
 }
 
@@ -87,11 +88,12 @@ pub fn with_logging_replaces_logging_config_test() {
     beryl.config(wire.phoenix_codec())
     |> beryl.with_logging(logging)
 
-  config.logging.level
+  let logging = beryl.config_logging(config)
+  logging.level
   |> should.equal(beryl.Error)
-  config.logging.include_payloads
+  logging.include_payloads
   |> should.be_true
-  config.logging.payload_preview_bytes
+  logging.payload_preview_bytes
   |> should.equal(64)
 }
 

--- a/test/mist_handler_test.gleam
+++ b/test/mist_handler_test.gleam
@@ -84,10 +84,8 @@ fn start_server_with_config(
 fn start_limited_server() -> #(Int, process.Pid) {
   let assert Ok(channels) =
     beryl.start(
-      beryl.Config(
-        ..beryl.config(wire.phoenix_codec()),
-        max_connections_per_ip: 1,
-      ),
+      beryl.config(wire.phoenix_codec())
+      |> beryl.with_max_connections_per_ip(max_connections: 1),
     )
   start_server(channels)
 }

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -71,30 +71,14 @@ pub type Channels
 
 ### `Config`
 
-Configuration for the channels system
+Configuration for the channels system.
+
+ This type is opaque: construct it with `config` and adjust it with the
+ `with_*` builder functions. Keeping it opaque lets Beryl add configuration
+ options in the future without a breaking change.
 
 ```gleam
-pub type Config {
-  Config(
-    codec: codec.Codec,
-    heartbeat_interval_ms: Int,
-    heartbeat_timeout_ms: Int,
-    max_connections_per_ip: Int,
-    pubsub: option.Option(pubsub.PubSub),
-    message_rate: Int,
-    message_burst: Int,
-    join_rate: Int,
-    join_burst: Int,
-    channel_rate: Int,
-    channel_burst: Int,
-    channel_rate_max_keys_per_socket: Int,
-    max_topic_length: Int,
-    max_event_length: Int,
-    max_inbound_frame_bytes: Int,
-    max_joined_topics_per_socket: Int,
-    logging: LoggingConfig
-  )
-}
+pub type Config
 ```
 
 ### `LoggingConfig`
@@ -473,6 +457,23 @@ pub fn with_channel_rate_max_keys_per_socket(
 ) -> Config
 ```
 
+### `with_heartbeat`
+
+Configure heartbeat timing.
+
+ `interval_ms` is the client-facing heartbeat interval (informational: how
+ often clients should send heartbeats). `timeout_ms` is the server-side
+ staleness window — a socket that sends no heartbeat within this window is
+ evicted. The defaults are 30000 ms and 60000 ms respectively.
+
+```gleam
+pub fn with_heartbeat(
+  Config,
+  interval_ms: Int,
+  timeout_ms: Int
+) -> Config
+```
+
 ### `with_join_rate`
 
 Configure per-socket join rate limiting
@@ -493,6 +494,20 @@ Configure Beryl's internal logging.
 pub fn with_logging(
   Config,
   LoggingConfig
+) -> Config
+```
+
+### `with_max_connections_per_ip`
+
+Configure the maximum number of concurrent connections allowed per client
+ IP address.
+
+ A value of 0 (the default) means unlimited.
+
+```gleam
+pub fn with_max_connections_per_ip(
+  Config,
+  max_connections: Int
 ) -> Config
 ```
 


### PR DESCRIPTION
## Summary

Makes `beryl.Config` a `pub opaque type` so the channels configuration can gain fields after 1.0 without a breaking change (a transparent public record cannot). Every user-settable field is now reachable through a `with_*` builder.

## Changes

- **`Config` is now opaque.** Construct it with `beryl.config(codec)` and adjust it with `with_*` builders.
- **New builders** (the only fields that previously had no builder):
  - `with_heartbeat(interval_ms:, timeout_ms:)`
  - `with_max_connections_per_ip(max_connections:)`
- **`@internal` accessors** added for the fields read outside the `beryl` module (by `supervisor` and tests), plus a shared `@internal to_coordinator_config` helper now used by both `beryl.start` and `supervisor.start` (removing duplicated coordinator-config construction).
- **Migrated all construction/record-update sites** off `beryl.Config(...)` to the builder API: `test/beryl_test.gleam`, `test/mist_handler_test.gleam`, `test/logging_test.gleam`.

Scope note: heartbeat `>= 2` validation (#154) and per-IP enforcement (#153) are intentionally untouched — those fields behave exactly as before, only now set via builders.

## Testing

- `just format-check`, `just check`, `just build-strict` pass.
- `just test`: **234 passed, no failures**.
- All examples build (`just examples-build`). The Playwright `examples-test` step is environment-gated (browsers/servers) and unaffected by this change.

Closes #152