### PR TITLE
refactor(presence)!: rename PresenceEntry.pid to session_id

### DIFF
--- a/.changes/unreleased/Changed-20260707-000000.yaml
+++ b/.changes/unreleased/Changed-20260707-000000.yaml
@@ -1,0 +1,8 @@
+kind: Changed
+body: |-
+  Rename the `PresenceEntry.pid` field to `session_id` (#161).
+
+  The field holds a caller-supplied session/socket identifier, not an Erlang
+  `Pid`. This is a breaking rename of a transparent record field; update any
+  `entry.pid` reads and `PresenceEntry(pid: ...)` constructions to `session_id`.
+time: 2026-07-07T00:00:00.000000000-07:00

--- a/examples/chatrooms/src/chatrooms/chat_channel.gleam
+++ b/examples/chatrooms/src/chatrooms/chat_channel.gleam
@@ -111,7 +111,9 @@ fn join(
           // Broadcast updated presence list
           let users = presence.list(presence, topic)
           let users_json =
-            json.object(list.map(users, fn(entry) { #(entry.pid, entry.meta) }))
+            json.object(
+              list.map(users, fn(entry) { #(entry.session_id, entry.meta) }),
+            )
           beryl.broadcast(channels, topic, "presence_list", users_json)
 
           channel.JoinOk(
@@ -268,7 +270,7 @@ fn terminate(_reason: channel.StopReason, socket: Socket(ChatAssigns)) -> Nil {
   // Broadcast updated presence list
   let users = presence.list(assigns.presence, assigns.topic)
   let users_json =
-    json.object(list.map(users, fn(entry) { #(entry.pid, entry.meta) }))
+    json.object(list.map(users, fn(entry) { #(entry.session_id, entry.meta) }))
   beryl.broadcast(assigns.channels, assigns.topic, "presence_list", users_json)
 }
 

--- a/examples/cursors/src/cursors/cursor_channel.gleam
+++ b/examples/cursors/src/cursors/cursor_channel.gleam
@@ -60,7 +60,7 @@ fn join(
   // Push the current presence list to the joining client
   let users = presence.list(presence, topic)
   let users_json =
-    json.object(list.map(users, fn(entry) { #(entry.pid, entry.meta) }))
+    json.object(list.map(users, fn(entry) { #(entry.session_id, entry.meta) }))
 
   // Broadcast updated presence to all clients on this topic
   beryl.broadcast(channels, topic, "presence_list", users_json)
@@ -121,7 +121,7 @@ fn terminate(
   // Broadcast updated presence list
   let users = presence.list(assigns.presence, assigns.topic)
   let users_json =
-    json.object(list.map(users, fn(entry) { #(entry.pid, entry.meta) }))
+    json.object(list.map(users, fn(entry) { #(entry.session_id, entry.meta) }))
   beryl.broadcast(assigns.channels, assigns.topic, "presence_list", users_json)
 }
 

--- a/src/beryl/presence.gleam
+++ b/src/beryl/presence.gleam
@@ -72,7 +72,7 @@ pub opaque type Diff {
 /// This type is intentionally transparent so callers can inspect query results
 /// and construct entries for `diff`.
 pub type PresenceEntry {
-  PresenceEntry(pid: String, key: String, meta: json.Json)
+  PresenceEntry(session_id: String, key: String, meta: json.Json)
 }
 
 /// Build a presence diff from topic-grouped joins and leaves.
@@ -133,7 +133,7 @@ fn state_entries_to_presence_entries(
       topic,
       list.map(topic_entries, fn(topic_entry) {
         let #(key, pid, meta) = topic_entry
-        PresenceEntry(pid: pid, key: key, meta: meta)
+        PresenceEntry(session_id: pid, key: key, meta: meta)
       }),
     )
   })
@@ -455,7 +455,9 @@ fn handle_message(
     List(topic, reply) -> {
       let entries =
         state.get_by_topic(actor_state.crdt, topic)
-        |> list.map(fn(t) { PresenceEntry(pid: t.0, key: t.1, meta: t.2) })
+        |> list.map(fn(t) {
+          PresenceEntry(session_id: t.0, key: t.1, meta: t.2)
+        })
       process.send(reply, entries)
       actor.continue(actor_state)
     }
@@ -502,7 +504,7 @@ fn single_join_diff(
   Diff(
     joins: dict.from_list([
       #(topic, [
-        PresenceEntry(pid: pid, key: key, meta: meta),
+        PresenceEntry(session_id: pid, key: key, meta: meta),
       ]),
     ]),
     leaves: dict.new(),
@@ -519,7 +521,7 @@ fn leave_diff(
     state.get_by_key(crdt, topic, key)
     |> list.filter(fn(entry) { entry.0 == pid })
     |> list.map(fn(entry) {
-      PresenceEntry(pid: entry.0, key: key, meta: entry.1)
+      PresenceEntry(session_id: entry.0, key: key, meta: entry.1)
     })
 
   Diff(joins: dict.new(), leaves: topic_entries(topic, leaves))
@@ -535,7 +537,7 @@ fn leave_all_diff(crdt: State, pid: String) -> Diff {
         dict.get(grouped, topic)
         |> result.unwrap([])
       dict.insert(grouped, topic, [
-        PresenceEntry(pid: pid, key: key, meta: meta),
+        PresenceEntry(session_id: pid, key: key, meta: meta),
         ..existing
       ])
     })

--- a/test/broadcast_test.gleam
+++ b/test/broadcast_test.gleam
@@ -96,7 +96,7 @@ fn presence_diff() -> presence.Diff {
     joins: [
       #("room:lobby", [
         presence.PresenceEntry(
-          pid: "socket-1",
+          session_id: "socket-1",
           key: "user:1",
           meta: json.object([#("status", json.string("online"))]),
         ),

--- a/test/presence_test.gleam
+++ b/test/presence_test.gleam
@@ -28,7 +28,7 @@ pub fn presence_track_and_list_test() {
   list.length(entries) |> should.equal(1)
 
   let assert [entry] = entries
-  entry.pid |> should.equal("socket-1")
+  entry.session_id |> should.equal("socket-1")
   entry.key |> should.equal("user:1")
 }
 
@@ -135,7 +135,7 @@ pub fn on_diff_callback_receives_local_track_diff_test() {
   presence.diff_joins(diff, "room:lobby")
   |> should.equal([
     presence.PresenceEntry(
-      pid: "socket-1",
+      session_id: "socket-1",
       key: "user:1",
       meta: json.object([#("status", json.string("online"))]),
     ),
@@ -170,7 +170,7 @@ pub fn on_diff_callback_receives_local_untrack_diff_test() {
   presence.diff_leaves(diff, "room:lobby")
   |> should.equal([
     presence.PresenceEntry(
-      pid: "socket-1",
+      session_id: "socket-1",
       key: "user:1",
       meta: json.object([#("status", json.string("online"))]),
     ),
@@ -208,7 +208,7 @@ pub fn diff_accessors_return_empty_lists_for_unmentioned_topics_test() {
       joins: [
         #("room:lobby", [
           presence.PresenceEntry(
-            pid: "socket-1",
+            session_id: "socket-1",
             key: "user:1",
             meta: json.null(),
           ),

--- a/test/presence_wire_test.gleam
+++ b/test/presence_wire_test.gleam
@@ -16,17 +16,17 @@ fn sample_diff() -> presence.Diff {
     joins: [
       #("room:lobby", [
         presence.PresenceEntry(
-          pid: "socket-1",
+          session_id: "socket-1",
           key: "user:1",
           meta: json.object([#("status", json.string("online"))]),
         ),
         presence.PresenceEntry(
-          pid: "socket-2",
+          session_id: "socket-2",
           key: "user:1",
           meta: json.object([#("status", json.string("away"))]),
         ),
         presence.PresenceEntry(
-          pid: "socket-3",
+          session_id: "socket-3",
           key: "user:2",
           meta: json.object([#("device", json.string("mobile"))]),
         ),
@@ -35,14 +35,14 @@ fn sample_diff() -> presence.Diff {
     leaves: [
       #("room:lobby", [
         presence.PresenceEntry(
-          pid: "socket-4",
+          session_id: "socket-4",
           key: "user:3",
           meta: json.object([#("status", json.string("offline"))]),
         ),
       ]),
       #("room:other", [
         presence.PresenceEntry(
-          pid: "socket-5",
+          session_id: "socket-5",
           key: "ignored",
           meta: json.object([#("status", json.string("away"))]),
         ),

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -68,7 +68,7 @@ presence.untrack_all(p, socket_id)
 ```gleam
 // Get all presences in a topic
 let entries = presence.list(p, "room:lobby")
-// Returns: [PresenceEntry(pid: "socket_1", key: "user:alice", meta: ...)]
+// Returns: [PresenceEntry(session_id: "socket_1", key: "user:alice", meta: ...)]
 
 // Get presences for a specific key
 let alice_sessions = presence.get_by_key(p, "room:lobby", "user:alice")

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -77,7 +77,7 @@ A presence entry returned from queries and diff accessors.
 ```gleam
 pub type PresenceEntry {
   PresenceEntry(
-    pid: String,
+    session_id: String,
     key: String,
     meta: json.Json
   )


### PR DESCRIPTION
## Summary

Renames the `presence.PresenceEntry` record field `pid` to `session_id`.

`PresenceEntry` is a transparent record whose field names are public API. Its `pid: String` field is **not** an Erlang `Pid` — it is a caller-supplied session/socket identifier. The old name was misleading; `session_id` reflects what the value actually is.

This is a **breaking change** to a public record field name (pre-1.0).

## Changes

- `src/beryl/presence.gleam`: renamed the `PresenceEntry` field and updated all internal construction sites (`state_entries_to_presence_entries`, `List` handler, `single_join_diff`, `leave_diff`, `leave_all_diff`).
- `test/`: updated `entry.pid` read and all `PresenceEntry(pid: ...)` constructions in `presence_test`, `presence_wire_test`, `broadcast_test`.
- `examples/cursors` and `examples/chatrooms`: updated `entry.pid` reads (purely a field relabel — emitted JSON is unchanged).
- Docs: updated `website/.../beryl-presence.md` and `guides/presence.md`.
- Added a `Changed` changelog entry.

Scope was limited to the `PresenceEntry` record field and its read sites. The `track`/`untrack`/`untrack_all` write API and actor `Msg` `pid` parameters were intentionally left untouched (owned by #162).

## Testing

`gleam format --check`, `gleam check`, `gleam test` (232 passed), and `gleam build --warnings-as-errors` all pass. Example projects compile. (The `examples-test` Playwright e2e step fails only in this sandbox due to a port collision with an unrelated local service; it is unaffected by this field relabel.)

Closes #161