### PR TITLE
fix(deps): raise dependency lower bounds to match used APIs

### DIFF
--- a/.changes/unreleased/Fixed-20260707-133430.yaml
+++ b/.changes/unreleased/Fixed-20260707-133430.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: |-
+    Raise dependency lower bounds in gleam.toml to match the APIs actually used, so a resolver cannot legally pick versions that fail to compile.
+    gleam_stdlib >= 1.0, gleam_erlang >= 1.3, gleam_otp >= 1.2, gleam_json >= 3.1, gleam_crypto >= 1.6, and envoy >= 1.2 now reflect the minimum versions the code is compiled and tested against. Upper bounds are unchanged. (#156)
+time: 2026-07-07T13:34:30.370659484-07:00

--- a/gleam.toml
+++ b/gleam.toml
@@ -14,13 +14,13 @@ internal_modules = [
 ]
 
 [dependencies]
-envoy = ">= 1.0.0 and < 2.0.0"
+envoy = ">= 1.2.0 and < 2.0.0"
 palabres = ">= 1.0.4 and < 2.0.0"
-gleam_stdlib = ">= 0.44.0 and < 2.0.0"
-gleam_erlang = ">= 0.29.0 and < 2.0.0"
-gleam_otp = ">= 0.12.0 and < 2.0.0"
-gleam_json = ">= 3.0.0 and < 4.0.0"
-gleam_crypto = ">= 1.5.1 and < 2.0.0"
+gleam_stdlib = ">= 1.0.0 and < 2.0.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
+gleam_otp = ">= 1.2.0 and < 2.0.0"
+gleam_json = ">= 3.1.0 and < 4.0.0"
+gleam_crypto = ">= 1.6.0 and < 2.0.0"
 gleam_http = ">= 4.3.0 and < 5.0.0"
 lattice_presence = ">= 1.0.0 and < 2.0.0"
 mist = ">= 6.0.0 and < 7.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -41,13 +41,13 @@ packages = [
 
 [requirements]
 aquamarine = { git = "https://github.com/tylerbutler/aquamarine.git", ref = "main" }
-envoy = { version = ">= 1.0.0 and < 2.0.0" }
-gleam_crypto = { version = ">= 1.5.1 and < 2.0.0" }
-gleam_erlang = { version = ">= 0.29.0 and < 2.0.0" }
+envoy = { version = ">= 1.2.0 and < 2.0.0" }
+gleam_crypto = { version = ">= 1.6.0 and < 2.0.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
-gleam_json = { version = ">= 3.0.0 and < 4.0.0" }
-gleam_otp = { version = ">= 0.12.0 and < 2.0.0" }
-gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
+gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
+gleam_otp = { version = ">= 1.2.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glinter = { version = ">= 2.19.0 and < 3.0.0" }
 gluegun = { git = "https://github.com/tylerbutler/gluegun.git", ref = "532af1ac0308ff93c8a957467dbb638859593c93" }


### PR DESCRIPTION
## Summary

The lower bounds in `gleam.toml` were far below the versions the code is actually compiled and tested against, so a version resolver could legally pick older releases that fail to compile.

Raised each lower bound to match the resolved/locked minor (`manifest.toml`), leaving all upper bounds unchanged. `manifest.toml`'s `[requirements]` section was regenerated to match; the resolved `packages` list is unchanged.

## Before / After bounds

| Dependency | Before | After | Locked | Reason |
|---|---|---|---|---|
| `gleam_stdlib` | `>= 0.44.0` | `>= 1.0.0` | 1.0.0 | matches locked minor |
| `gleam_erlang` | `>= 0.29.0` | `>= 1.3.0` | 1.3.0 | uses `process.new_name`, `process.select_record`, `process.spawn_unlinked` |
| `gleam_otp` | `>= 0.12.0` | `>= 1.2.0` | 1.2.0 | uses `actor.new`, `actor.new_with_initialiser`, `static_supervisor` |
| `gleam_json` | `>= 3.0.0` | `>= 3.1.0` | 3.1.0 | matches locked minor |
| `gleam_crypto` | `>= 1.5.1` | `>= 1.6.0` | 1.6.0 | matches locked minor |
| `envoy` | `>= 1.0.0` | `>= 1.2.0` | 1.2.0 | matches locked minor |
| `gleam_http` | `>= 4.3.0` | `>= 4.3.0` | 4.3.0 | already correct |
| `mist` | `>= 6.0.0` | `>= 6.0.0` | 6.0.3 | `>= 6.0.0` matches the used API surface |
| `palabres` | `>= 1.0.4` | `>= 1.0.4` | 1.0.4 | already correct |
| `lattice_presence` | `>= 1.0.0` | `>= 1.0.0` | 1.0.0 | already correct |

## Verification

- `gleam deps download` re-resolves cleanly; the locked `packages` list is unchanged.
- `just format-check`, `just check`, `just test` (232 passed), and `just build-strict` all pass.

Closes #156