### PR TITLE
build(just): fold website reference regen into `just docs`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,6 @@ jobs:
       - name: Install Gleam dependencies
         run: gleam deps download
 
-      - name: Build documentation
-        run: just docs
-
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
         with:
@@ -76,6 +73,9 @@ jobs:
 
       - name: Install website dependencies
         run: pnpm -C website install --frozen-lockfile
+
+      - name: Build documentation (Gleam docs + website reference)
+        run: just docs
 
       - name: Test reference docs generator
         run: just site-reference-test

--- a/justfile
+++ b/justfile
@@ -59,9 +59,13 @@ lint:
 
 # === DOCUMENTATION ===
 
-# Build documentation
-docs:
+# Build Gleam API documentation (HTML + docs metadata)
+gleam-docs:
     gleam docs build
+
+# Build documentation: Gleam docs + regenerated website reference pages
+docs: gleam-docs
+    pnpm -C website generate:reference
 
 # Render the architecture deck to HTML
 deck:
@@ -91,9 +95,8 @@ site-dev:
 site-deps:
     pnpm -C website install
 
-# Generate website reference docs from Gleam docs metadata
+# Regenerate website reference docs (delegates to `docs`, which regenerates them)
 site-reference: docs
-    pnpm -C website generate:reference
 
 # Test the website reference docs generator
 site-reference-test:


### PR DESCRIPTION
## What

- `just docs` now runs `gleam docs build` **and** `pnpm -C website generate:reference`, so regenerating docs always refreshes the website reference API pages.
- Added a low-level `gleam-docs` recipe (Gleam-only) that `docs` depends on.
- `site-reference` now delegates to `docs` (kept for discoverability / CI use).
- Reordered the CI `docs` job so Node/pnpm/website deps install **before** `just docs` (which now needs the pnpm generator).

## Why

The CI `docs` job hard-fails any PR whose regenerated `website/src/content/docs/reference/api/*.md` isn't committed. Folding the generator into `just docs` means anyone (or any agent) who runs `just docs` after an API change picks up the regenerated reference automatically, instead of forgetting the separate `just site-reference` step.

## Verification

- `just --list` / `just --show docs` parse correctly.
- `just docs` runs clean end-to-end and produces no diff against current `main`.