### PR TITLE
refactor: remove beryl.extract_topic_id

### DIFF
--- a/.changes/unreleased/Removed-20260707-143527.yaml
+++ b/.changes/unreleased/Removed-20260707-143527.yaml
@@ -1,0 +1,6 @@
+kind: Removed
+body: |-
+    Remove beryl.extract_topic_id (#163).
+
+    This was a one-line delegation to topic.extract_id with identical signature and semantics, so both names shipping at 1.0 would mean two permanent APIs for one function. Callers should use topic.extract_id directly.
+time: 2026-07-07T14:35:27.286035878-07:00

--- a/PRD.md
+++ b/PRD.md
@@ -88,7 +88,7 @@ Channels are registered with topic patterns:
 - **Exact**: `"room:lobby"` — matches only that topic.
 - **Wildcard**: `"room:*"` — matches any topic starting with `"room:"`.
 
-The coordinator matches incoming join requests to the first registered pattern. `extract_topic_id` extracts the wildcard portion (e.g. `"room:123"` → `"123"`).
+The coordinator matches incoming join requests to the first registered pattern. `topic.extract_id` extracts the wildcard portion (e.g. `"room:123"` → `"123"`).
 
 #### FR-1.3: Socket Lifecycle
 

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -804,24 +804,6 @@ pub fn send_info(
   )
 }
 
-/// Get the topic ID from a topic using wildcard extraction
-///
-/// For pattern "room:*" and topic "room:lobby", returns Ok("lobby").
-/// For segment wildcard patterns with one wildcard segment, returns that
-/// segment. Use `topic.extract_wildcards` when extracting multiple segments.
-///
-/// ## Example
-///
-/// ```gleam
-/// let assert Ok("lobby") = topic.extract_id(topic.Wildcard("room:"), "room:lobby")
-/// ```
-pub fn extract_topic_id(
-  pattern: topic.TopicPattern,
-  topic_name: String,
-) -> Result(String, topic.ExtractError) {
-  topic.extract_id(pattern, topic_name)
-}
-
 // ─────────────────────────────────────────────────────────────────────────────
 // Type erasure - Convert typed Channel to ChannelHandler
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/beryl_test.gleam
+++ b/test/beryl_test.gleam
@@ -1141,14 +1141,6 @@ pub fn with_max_joined_topics_per_socket_sets_field_test() {
   beryl.config_max_joined_topics_per_socket(cfg) |> should.equal(12)
 }
 
-pub fn extract_topic_id_test() {
-  beryl.extract_topic_id(topic.Wildcard("room:"), "room:lobby")
-  |> should.equal(Ok("lobby"))
-
-  beryl.extract_topic_id(topic.Exact("room:lobby"), "room:lobby")
-  |> should.equal(Error(topic.NoWildcard))
-}
-
 pub fn start_failure_description_is_public_test() {
   let describe = beryl_error.describe_start_failure
   should.be_true(True)

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -270,27 +270,6 @@ Build a configuration with sensible defaults.
 pub fn config(codec.Codec) -> Config
 ```
 
-### `extract_topic_id`
-
-Get the topic ID from a topic using wildcard extraction
-
- For pattern "room:*" and topic "room:lobby", returns Ok("lobby").
- For segment wildcard patterns with one wildcard segment, returns that
- segment. Use `topic.extract_wildcards` when extracting multiple segments.
-
- ## Example
-
- ```gleam
- let assert Ok("lobby") = topic.extract_id(topic.Wildcard("room:"), "room:lobby")
- ```
-
-```gleam
-pub fn extract_topic_id(
-  topic.TopicPattern,
-  String
-) -> Result(String, topic.ExtractError)
-```
-
 ### `logging_config`
 
 Build a logging configuration.


### PR DESCRIPTION
## Summary

- `beryl.extract_topic_id` was a one-line delegation to `beryl/topic.extract_id` with an identical signature and semantics. Shipping both names permanently at 1.0 would mean two public APIs for one function, so the wrapper is removed. Use `topic.extract_id` directly.
- Removed the doc comment along with the function definition in `src/beryl.gleam`.
- Removed the redundant `extract_topic_id_test` from `test/beryl_test.gleam` — the same wildcard-extraction cases are already covered by `extract_id_test` in the same file, which calls `topic.extract_id` directly.
- Updated `PRD.md`'s reference to the old name.
- Regenerated `website/src/content/docs/reference/api/beryl.md` via `just site-reference` (generated file, not hand-edited).
- Added a `Removed` changie entry noting the breaking removal.

Closes #163