### PR TITLE
feat(supervisor)!: make SupervisedConfig/SupervisedChannels opaque

### DIFF
--- a/.changes/unreleased/Changed-20260707-143551.yaml
+++ b/.changes/unreleased/Changed-20260707-143551.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'Make `supervisor.SupervisedConfig` an opaque type built via `supervisor.config(channels) |> with_presence(..) |> with_groups()`, and make `SupervisedChannels` opaque with `channels`, `presence`, `groups`, and `supervisor_pid` accessor functions. BREAKING: replace direct `SupervisedConfig(..)` construction and field access with the builder and accessors (#160).'
+time: 2026-07-07T14:35:51.300301269-07:00

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -15,15 +15,14 @@
 //// import beryl/supervisor
 //// import beryl/presence
 //// import beryl/wire
-//// import gleam/option.{None, Some}
 ////
-//// let config = supervisor.SupervisedConfig(
-////   channels: beryl.config(wire.phoenix_codec()),
-////   presence: Some(presence.default_config("node1")),
-////   groups: True,
-//// )
+//// let config =
+////   supervisor.config(beryl.config(wire.phoenix_codec()))
+////   |> supervisor.with_presence(presence.default_config("node1"))
+////   |> supervisor.with_groups()
 //// let assert Ok(supervised) = supervisor.start(config)
-//// // supervised.channels, supervised.presence, supervised.groups
+//// // supervisor.channels(supervised), supervisor.presence(supervised),
+//// // supervisor.groups(supervised)
 //// ```
 
 import beryl
@@ -41,30 +40,74 @@ import gleam/otp/static_supervisor
 import gleam/otp/supervision
 import gleam/result
 
-/// Configuration for starting all beryl subsystems under a supervisor
-pub type SupervisedConfig {
+/// Configuration for starting all beryl subsystems under a supervisor.
+///
+/// Opaque: build it with [`config`](#config) and refine it with the
+/// `with_*` functions. This keeps the configuration extensible — new
+/// subsystem options can be added post-1.0 without breaking callers.
+pub opaque type SupervisedConfig {
   SupervisedConfig(
-    /// Configuration for the channels system (coordinator is always started)
     channels: beryl.Config,
-    /// Optional presence configuration. When Some, presence is started.
     presence: Option(presence.Config),
-    /// Whether to start the groups subsystem
     groups: Bool,
   )
 }
 
-/// Handle to all supervised beryl subsystems
-pub type SupervisedChannels {
+/// Handle to all supervised beryl subsystems.
+///
+/// Opaque: read its fields with the accessor functions
+/// ([`channels`](#channels), [`presence`](#presence), [`groups`](#groups),
+/// [`supervisor_pid`](#supervisor_pid)). This lets the handle grow new
+/// fields post-1.0 without breaking readers.
+pub opaque type SupervisedChannels {
   SupervisedChannels(
-    /// The channels system handle (always present)
     channels: beryl.Channels,
-    /// Presence handle (if configured)
     presence: Option(presence.Presence),
-    /// Groups handle (if configured)
     groups: Option(group.Groups),
-    /// The supervisor process PID (for lifecycle management)
     supervisor_pid: process.Pid,
   )
+}
+
+/// Start building a supervised configuration.
+///
+/// Requires the channels configuration (the coordinator is always started).
+/// Presence and groups are opt-in via [`with_presence`](#with_presence) and
+/// [`with_groups`](#with_groups); by default neither is started.
+pub fn config(channels: beryl.Config) -> SupervisedConfig {
+  SupervisedConfig(channels: channels, presence: None, groups: False)
+}
+
+/// Enable presence tracking with the given configuration.
+pub fn with_presence(
+  config: SupervisedConfig,
+  presence: presence.Config,
+) -> SupervisedConfig {
+  SupervisedConfig(..config, presence: Some(presence))
+}
+
+/// Enable the named channel groups subsystem.
+pub fn with_groups(config: SupervisedConfig) -> SupervisedConfig {
+  SupervisedConfig(..config, groups: True)
+}
+
+/// The channels system handle (always present).
+pub fn channels(supervised: SupervisedChannels) -> beryl.Channels {
+  supervised.channels
+}
+
+/// The presence handle, if presence was configured.
+pub fn presence(supervised: SupervisedChannels) -> Option(presence.Presence) {
+  supervised.presence
+}
+
+/// The groups handle, if groups were configured.
+pub fn groups(supervised: SupervisedChannels) -> Option(group.Groups) {
+  supervised.groups
+}
+
+/// The supervisor process PID (for lifecycle management).
+pub fn supervisor_pid(supervised: SupervisedChannels) -> process.Pid {
+  supervised.supervisor_pid
 }
 
 /// Errors when starting the supervised system
@@ -245,11 +288,9 @@ pub fn stop(supervised: SupervisedChannels) -> Nil {
 /// import beryl/supervisor
 /// import gleam/otp/static_supervisor
 ///
-/// let beryl_config = supervisor.SupervisedConfig(
-///   channels: beryl.config(wire.phoenix_codec()),
-///   presence: None,
-///   groups: True,
-/// )
+/// let beryl_config =
+///   supervisor.config(beryl.config(wire.phoenix_codec()))
+///   |> supervisor.with_groups()
 ///
 /// static_supervisor.new(static_supervisor.OneForOne)
 /// |> static_supervisor.add(supervisor.child_spec(beryl_config))

--- a/test/supervisor_test.gleam
+++ b/test/supervisor_test.gleam
@@ -13,72 +13,54 @@ import test_helpers
 // ── Supervised startup tests ────────────────────────────────────────────────
 
 pub fn start_supervised_coordinator_only_test() {
-  let config =
-    supervisor.SupervisedConfig(
-      channels: beryl.config(wire.phoenix_codec()),
-      presence: None,
-      groups: False,
-    )
+  let config = supervisor.config(beryl.config(wire.phoenix_codec()))
 
   let result = supervisor.start(config)
   result |> should.be_ok
 
   let assert Ok(supervised) = result
-  supervised.presence |> should.be_none
-  supervised.groups |> should.be_none
+  supervisor.presence(supervised) |> should.be_none
+  supervisor.groups(supervised) |> should.be_none
 }
 
 pub fn start_supervised_all_subsystems_test() {
   let config =
-    supervisor.SupervisedConfig(
-      channels: beryl.config(wire.phoenix_codec()),
-      presence: Some(presence.default_config("test-node")),
-      groups: True,
-    )
+    supervisor.config(beryl.config(wire.phoenix_codec()))
+    |> supervisor.with_presence(presence.default_config("test-node"))
+    |> supervisor.with_groups()
 
   let result = supervisor.start(config)
   result |> should.be_ok
 
   let assert Ok(supervised) = result
-  supervised.presence |> should.be_some
-  supervised.groups |> should.be_some
+  supervisor.presence(supervised) |> should.be_some
+  supervisor.groups(supervised) |> should.be_some
 }
 
 pub fn start_supervised_with_presence_only_test() {
   let config =
-    supervisor.SupervisedConfig(
-      channels: beryl.config(wire.phoenix_codec()),
-      presence: Some(presence.default_config("test-node-2")),
-      groups: False,
-    )
+    supervisor.config(beryl.config(wire.phoenix_codec()))
+    |> supervisor.with_presence(presence.default_config("test-node-2"))
 
   let assert Ok(supervised) = supervisor.start(config)
-  supervised.presence |> should.be_some
-  supervised.groups |> should.be_none
+  supervisor.presence(supervised) |> should.be_some
+  supervisor.groups(supervised) |> should.be_none
 }
 
 pub fn start_supervised_with_groups_only_test() {
   let config =
-    supervisor.SupervisedConfig(
-      channels: beryl.config(wire.phoenix_codec()),
-      presence: None,
-      groups: True,
-    )
+    supervisor.config(beryl.config(wire.phoenix_codec()))
+    |> supervisor.with_groups()
 
   let assert Ok(supervised) = supervisor.start(config)
-  supervised.presence |> should.be_none
-  supervised.groups |> should.be_some
+  supervisor.presence(supervised) |> should.be_none
+  supervisor.groups(supervised) |> should.be_some
 }
 
 // ── Subsystem accessibility tests ───────────────────────────────────────────
 
 pub fn supervised_coordinator_accepts_register_test() {
-  let config =
-    supervisor.SupervisedConfig(
-      channels: beryl.config(wire.phoenix_codec()),
-      presence: None,
-      groups: False,
-    )
+  let config = supervisor.config(beryl.config(wire.phoenix_codec()))
 
   let assert Ok(supervised) = supervisor.start(config)
 
@@ -88,20 +70,18 @@ pub fn supervised_coordinator_accepts_register_test() {
       channel.JoinOk(reply: None, socket: socket)
     })
 
-  let result = beryl.register(supervised.channels, "test:*", handler)
+  let result =
+    beryl.register(supervisor.channels(supervised), "test:*", handler)
   result |> should.be_ok
 }
 
 pub fn supervised_presence_tracks_test() {
   let config =
-    supervisor.SupervisedConfig(
-      channels: beryl.config(wire.phoenix_codec()),
-      presence: Some(presence.default_config("test-track")),
-      groups: False,
-    )
+    supervisor.config(beryl.config(wire.phoenix_codec()))
+    |> supervisor.with_presence(presence.default_config("test-track"))
 
   let assert Ok(supervised) = supervisor.start(config)
-  let assert Some(pres) = supervised.presence
+  let assert Some(pres) = supervisor.presence(supervised)
 
   // Track a presence and verify it's queryable
   let _ref =
@@ -113,14 +93,11 @@ pub fn supervised_presence_tracks_test() {
 
 pub fn supervised_groups_work_test() {
   let config =
-    supervisor.SupervisedConfig(
-      channels: beryl.config(wire.phoenix_codec()),
-      presence: None,
-      groups: True,
-    )
+    supervisor.config(beryl.config(wire.phoenix_codec()))
+    |> supervisor.with_groups()
 
   let assert Ok(supervised) = supervisor.start(config)
-  let assert Some(grps) = supervised.groups
+  let assert Some(grps) = supervisor.groups(supervised)
 
   // Create a group and verify it's queryable
   let assert Ok(Nil) = group.create(grps, "team:eng")
@@ -132,15 +109,13 @@ pub fn supervised_groups_work_test() {
 
 pub fn stop_shuts_down_supervisor_and_children_test() {
   let config =
-    supervisor.SupervisedConfig(
-      channels: beryl.config(wire.phoenix_codec()),
-      presence: Some(presence.default_config("test-stop")),
-      groups: True,
-    )
+    supervisor.config(beryl.config(wire.phoenix_codec()))
+    |> supervisor.with_presence(presence.default_config("test-stop"))
+    |> supervisor.with_groups()
 
   let assert Ok(supervised) = supervisor.start(config)
-  let assert Some(pres) = supervised.presence
-  let assert Some(grps) = supervised.groups
+  let assert Some(pres) = supervisor.presence(supervised)
+  let assert Some(grps) = supervisor.groups(supervised)
 
   // Verify everything is running
   let _ref =
@@ -148,9 +123,9 @@ pub fn stop_shuts_down_supervisor_and_children_test() {
   let assert Ok(Nil) = group.create(grps, "team:stop")
 
   // Get PIDs before stopping
-  let sup_pid = supervised.supervisor_pid
+  let sup_pid = supervisor.supervisor_pid(supervised)
   let assert Ok(coord_pid) =
-    get_subject_pid(beryl.coordinator_subject(supervised.channels))
+    get_subject_pid(beryl.coordinator_subject(supervisor.channels(supervised)))
 
   // Stop the supervisor
   supervisor.stop(supervised)
@@ -163,12 +138,7 @@ pub fn stop_shuts_down_supervisor_and_children_test() {
 }
 
 pub fn stop_coordinator_only_test() {
-  let config =
-    supervisor.SupervisedConfig(
-      channels: beryl.config(wire.phoenix_codec()),
-      presence: None,
-      groups: False,
-    )
+  let config = supervisor.config(beryl.config(wire.phoenix_codec()))
 
   let assert Ok(supervised) = supervisor.start(config)
 
@@ -177,9 +147,10 @@ pub fn stop_coordinator_only_test() {
     channel.new(fn(_topic, _payload, socket) {
       channel.JoinOk(reply: None, socket: socket)
     })
-  let assert Ok(_) = beryl.register(supervised.channels, "pre-stop:*", handler)
+  let assert Ok(_) =
+    beryl.register(supervisor.channels(supervised), "pre-stop:*", handler)
 
-  let sup_pid = supervised.supervisor_pid
+  let sup_pid = supervisor.supervisor_pid(supervised)
   supervisor.stop(supervised)
 
   process.is_alive(sup_pid) |> should.be_false
@@ -188,12 +159,7 @@ pub fn stop_coordinator_only_test() {
 // ── Restart behavior test ───────────────────────────────────────────────────
 
 pub fn supervised_coordinator_restarts_on_crash_test() {
-  let config =
-    supervisor.SupervisedConfig(
-      channels: beryl.config(wire.phoenix_codec()),
-      presence: None,
-      groups: False,
-    )
+  let config = supervisor.config(beryl.config(wire.phoenix_codec()))
 
   let assert Ok(supervised) = supervisor.start(config)
 
@@ -202,11 +168,14 @@ pub fn supervised_coordinator_restarts_on_crash_test() {
     channel.new(fn(_topic, _payload, socket) {
       channel.JoinOk(reply: None, socket: socket)
     })
-  let assert Ok(_) = beryl.register(supervised.channels, "pre-crash:*", handler)
+  let assert Ok(_) =
+    beryl.register(supervisor.channels(supervised), "pre-crash:*", handler)
 
   // Kill the coordinator process
   let assert Ok(name) =
-    process.subject_name(beryl.coordinator_subject(supervised.channels))
+    process.subject_name(
+      beryl.coordinator_subject(supervisor.channels(supervised)),
+    )
   let coord_subject = process.named_subject(name)
 
   // Send an exit signal to crash the coordinator
@@ -230,7 +199,8 @@ pub fn supervised_coordinator_restarts_on_crash_test() {
     channel.new(fn(_topic, _payload, socket) {
       channel.JoinOk(reply: None, socket: socket)
     })
-  let result = beryl.register(supervised.channels, "post-crash:*", handler2)
+  let result =
+    beryl.register(supervisor.channels(supervised), "post-crash:*", handler2)
   result |> should.be_ok
 }
 
@@ -241,14 +211,13 @@ pub fn supervised_coordinator_restarts_on_crash_test() {
 
 pub fn coordinator_crash_resets_presence_state_test() {
   let config =
-    supervisor.SupervisedConfig(
-      channels: beryl.config(wire.phoenix_codec()),
-      presence: Some(presence.default_config("test-rest-for-one-pres")),
-      groups: False,
-    )
+    supervisor.config(beryl.config(wire.phoenix_codec()))
+    |> supervisor.with_presence(presence.default_config(
+      "test-rest-for-one-pres",
+    ))
 
   let assert Ok(supervised) = supervisor.start(config)
-  let assert Some(pres) = supervised.presence
+  let assert Some(pres) = supervisor.presence(supervised)
 
   // Track a presence entry and verify it exists
   let _ref =
@@ -257,7 +226,9 @@ pub fn coordinator_crash_resets_presence_state_test() {
 
   // Get coordinator PID and kill it
   let assert Ok(name) =
-    process.subject_name(beryl.coordinator_subject(supervised.channels))
+    process.subject_name(
+      beryl.coordinator_subject(supervisor.channels(supervised)),
+    )
   let coord_subject = process.named_subject(name)
   let assert Ok(old_coord_pid) = get_subject_pid(coord_subject)
 
@@ -298,14 +269,11 @@ pub fn coordinator_crash_resets_presence_state_test() {
 
 pub fn coordinator_crash_resets_groups_state_test() {
   let config =
-    supervisor.SupervisedConfig(
-      channels: beryl.config(wire.phoenix_codec()),
-      presence: None,
-      groups: True,
-    )
+    supervisor.config(beryl.config(wire.phoenix_codec()))
+    |> supervisor.with_groups()
 
   let assert Ok(supervised) = supervisor.start(config)
-  let assert Some(grps) = supervised.groups
+  let assert Some(grps) = supervisor.groups(supervised)
 
   // Create a group and verify it exists
   let assert Ok(Nil) = group.create(grps, "team:cascade")
@@ -313,7 +281,9 @@ pub fn coordinator_crash_resets_groups_state_test() {
 
   // Get coordinator PID and kill it
   let assert Ok(name) =
-    process.subject_name(beryl.coordinator_subject(supervised.channels))
+    process.subject_name(
+      beryl.coordinator_subject(supervisor.channels(supervised)),
+    )
   let coord_subject = process.named_subject(name)
   let assert Ok(old_coord_pid) = get_subject_pid(coord_subject)
 
@@ -353,14 +323,11 @@ pub fn coordinator_crash_resets_groups_state_test() {
 
 pub fn independent_presence_crash_does_not_affect_coordinator_test() {
   let config =
-    supervisor.SupervisedConfig(
-      channels: beryl.config(wire.phoenix_codec()),
-      presence: Some(presence.default_config("test-indep-pres")),
-      groups: False,
-    )
+    supervisor.config(beryl.config(wire.phoenix_codec()))
+    |> supervisor.with_presence(presence.default_config("test-indep-pres"))
 
   let assert Ok(supervised) = supervisor.start(config)
-  let assert Some(pres) = supervised.presence
+  let assert Some(pres) = supervisor.presence(supervised)
 
   // Register a channel handler on the coordinator
   let handler =
@@ -368,11 +335,11 @@ pub fn independent_presence_crash_does_not_affect_coordinator_test() {
       channel.JoinOk(reply: None, socket: socket)
     })
   let assert Ok(_) =
-    beryl.register(supervised.channels, "indep-pres:*", handler)
+    beryl.register(supervisor.channels(supervised), "indep-pres:*", handler)
 
   // Get coordinator PID before
   let assert Ok(coord_pid_before) =
-    get_subject_pid(beryl.coordinator_subject(supervised.channels))
+    get_subject_pid(beryl.coordinator_subject(supervisor.channels(supervised)))
 
   // Kill the presence process directly
   let assert Ok(old_pres_pid) = get_subject_pid(presence.subject(pres))
@@ -392,7 +359,7 @@ pub fn independent_presence_crash_does_not_affect_coordinator_test() {
 
   // Coordinator should still be the same process (not restarted)
   let assert Ok(coord_pid_after) =
-    get_subject_pid(beryl.coordinator_subject(supervised.channels))
+    get_subject_pid(beryl.coordinator_subject(supervisor.channels(supervised)))
   coord_pid_after |> should.equal(coord_pid_before)
 
   // Coordinator should still be functional with its existing state
@@ -401,20 +368,21 @@ pub fn independent_presence_crash_does_not_affect_coordinator_test() {
       channel.JoinOk(reply: None, socket: socket)
     })
   let result =
-    beryl.register(supervised.channels, "indep-pres-after:*", handler2)
+    beryl.register(
+      supervisor.channels(supervised),
+      "indep-pres-after:*",
+      handler2,
+    )
   result |> should.be_ok
 }
 
 pub fn independent_groups_crash_does_not_affect_coordinator_test() {
   let config =
-    supervisor.SupervisedConfig(
-      channels: beryl.config(wire.phoenix_codec()),
-      presence: None,
-      groups: True,
-    )
+    supervisor.config(beryl.config(wire.phoenix_codec()))
+    |> supervisor.with_groups()
 
   let assert Ok(supervised) = supervisor.start(config)
-  let assert Some(grps) = supervised.groups
+  let assert Some(grps) = supervisor.groups(supervised)
 
   // Register a channel handler on the coordinator
   let handler =
@@ -422,11 +390,11 @@ pub fn independent_groups_crash_does_not_affect_coordinator_test() {
       channel.JoinOk(reply: None, socket: socket)
     })
   let assert Ok(_) =
-    beryl.register(supervised.channels, "indep-grps:*", handler)
+    beryl.register(supervisor.channels(supervised), "indep-grps:*", handler)
 
   // Get coordinator PID before
   let assert Ok(coord_pid_before) =
-    get_subject_pid(beryl.coordinator_subject(supervised.channels))
+    get_subject_pid(beryl.coordinator_subject(supervisor.channels(supervised)))
 
   // Kill the groups process directly
   let assert Ok(old_grps_pid) = get_subject_pid(group.subject(grps))
@@ -446,7 +414,7 @@ pub fn independent_groups_crash_does_not_affect_coordinator_test() {
 
   // Coordinator should still be the same process (not restarted)
   let assert Ok(coord_pid_after) =
-    get_subject_pid(beryl.coordinator_subject(supervised.channels))
+    get_subject_pid(beryl.coordinator_subject(supervisor.channels(supervised)))
   coord_pid_after |> should.equal(coord_pid_before)
 
   // Coordinator should still be functional
@@ -455,7 +423,11 @@ pub fn independent_groups_crash_does_not_affect_coordinator_test() {
       channel.JoinOk(reply: None, socket: socket)
     })
   let result =
-    beryl.register(supervised.channels, "indep-grps-after:*", handler2)
+    beryl.register(
+      supervisor.channels(supervised),
+      "indep-grps-after:*",
+      handler2,
+    )
   result |> should.be_ok
 }
 

--- a/website/src/content/docs/reference/api/beryl-supervisor.md
+++ b/website/src/content/docs/reference/api/beryl-supervisor.md
@@ -20,15 +20,14 @@ Supervisor - OTP supervision tree for beryl subsystems
  import beryl/supervisor
  import beryl/presence
  import beryl/wire
- import gleam/option.{None, Some}
 
- let config = supervisor.SupervisedConfig(
-   channels: beryl.config(wire.phoenix_codec()),
-   presence: Some(presence.default_config("node1")),
-   groups: True,
- )
+ let config =
+   supervisor.config(beryl.config(wire.phoenix_codec()))
+   |> supervisor.with_presence(presence.default_config("node1"))
+   |> supervisor.with_groups()
  let assert Ok(supervised) = supervisor.start(config)
- // supervised.channels, supervised.presence, supervised.groups
+ // supervisor.channels(supervised), supervisor.presence(supervised),
+ // supervisor.groups(supervised)
  ```
 
 ## Types
@@ -56,34 +55,38 @@ heartbeat_timeout_ms must be > 0
 
 ### `SupervisedChannels`
 
-Handle to all supervised beryl subsystems
+Handle to all supervised beryl subsystems.
+
+ Opaque: read its fields with the accessor functions
+ ([`channels`](#channels), [`presence`](#presence), [`groups`](#groups),
+ [`supervisor_pid`](#supervisor_pid)). This lets the handle grow new
+ fields post-1.0 without breaking readers.
 
 ```gleam
-pub type SupervisedChannels {
-  SupervisedChannels(
-    channels: beryl.Channels,
-    presence: option.Option(presence.Presence),
-    groups: option.Option(group.Groups),
-    supervisor_pid: process.Pid
-  )
-}
+pub type SupervisedChannels
 ```
 
 ### `SupervisedConfig`
 
-Configuration for starting all beryl subsystems under a supervisor
+Configuration for starting all beryl subsystems under a supervisor.
+
+ Opaque: build it with [`config`](#config) and refine it with the
+ `with_*` functions. This keeps the configuration extensible — new
+ subsystem options can be added post-1.0 without breaking callers.
 
 ```gleam
-pub type SupervisedConfig {
-  SupervisedConfig(
-    channels: beryl.Config,
-    presence: option.Option(presence.Config),
-    groups: Bool
-  )
-}
+pub type SupervisedConfig
 ```
 
 ## Functions
+
+### `channels`
+
+The channels system handle (always present).
+
+```gleam
+pub fn channels(SupervisedChannels) -> beryl.Channels
+```
 
 ### `child_spec`
 
@@ -99,11 +102,9 @@ Create a child specification for composing beryl into a larger supervision tree
  import beryl/supervisor
  import gleam/otp/static_supervisor
 
- let beryl_config = supervisor.SupervisedConfig(
-   channels: beryl.config(wire.phoenix_codec()),
-   presence: None,
-   groups: True,
- )
+ let beryl_config =
+   supervisor.config(beryl.config(wire.phoenix_codec()))
+   |> supervisor.with_groups()
 
  static_supervisor.new(static_supervisor.OneForOne)
  |> static_supervisor.add(supervisor.child_spec(beryl_config))
@@ -112,6 +113,34 @@ Create a child specification for composing beryl into a larger supervision tree
 
 ```gleam
 pub fn child_spec(SupervisedConfig) -> supervision.ChildSpecification(SupervisedChannels)
+```
+
+### `config`
+
+Start building a supervised configuration.
+
+ Requires the channels configuration (the coordinator is always started).
+ Presence and groups are opt-in via [`with_presence`](#with_presence) and
+ [`with_groups`](#with_groups); by default neither is started.
+
+```gleam
+pub fn config(beryl.Config) -> SupervisedConfig
+```
+
+### `groups`
+
+The groups handle, if groups were configured.
+
+```gleam
+pub fn groups(SupervisedChannels) -> option.Option(group.Groups)
+```
+
+### `presence`
+
+The presence handle, if presence was configured.
+
+```gleam
+pub fn presence(SupervisedChannels) -> option.Option(presence.Presence)
 ```
 
 ### `start`
@@ -139,4 +168,31 @@ Stop the supervisor and all its children
 
 ```gleam
 pub fn stop(SupervisedChannels) -> Nil
+```
+
+### `supervisor_pid`
+
+The supervisor process PID (for lifecycle management).
+
+```gleam
+pub fn supervisor_pid(SupervisedChannels) -> process.Pid
+```
+
+### `with_groups`
+
+Enable the named channel groups subsystem.
+
+```gleam
+pub fn with_groups(SupervisedConfig) -> SupervisedConfig
+```
+
+### `with_presence`
+
+Enable presence tracking with the given configuration.
+
+```gleam
+pub fn with_presence(
+  SupervisedConfig,
+  presence.Config
+) -> SupervisedConfig
 ```


### PR DESCRIPTION
## Summary

Makes the `beryl/supervisor` public API opaque and future-proof, matching the opaque-builder pattern `beryl.Config` uses.

- `SupervisedConfig` is now a `pub opaque type` built via a builder:
  - `supervisor.config(channels_config)` — entry point (channels required)
  - `|> supervisor.with_presence(p)` — opt in to presence
  - `|> supervisor.with_groups()` — opt in to groups
- `SupervisedChannels` is now a `pub opaque type` with accessor functions so its fields can evolve post-1.0 without breaking readers:
  - `supervisor.channels(supervised) -> beryl.Channels`
  - `supervisor.presence(supervised) -> Option(presence.Presence)`
  - `supervisor.groups(supervised) -> Option(group.Groups)`
  - `supervisor.supervisor_pid(supervised) -> process.Pid`

Defaults and behavior are unchanged (channels required; presence and groups optional/off by default).

## Changes
- `src/beryl/supervisor.gleam` — opaque types, builder, accessors, updated `///` doc examples
- `test/supervisor_test.gleam` — migrated all constructions to the builder + accessors
- `website/src/content/docs/reference/api/beryl-supervisor.md` — regenerated (not hand-edited)
- Changie `Changed` entry (breaking API change)

## Breaking change
Direct `SupervisedConfig(channels:, presence:, groups:)` construction and field access on the config/handle are replaced by the builder and accessors.

## Notes
- The four Gleam CI steps pass locally: `just format-check`, `just check`, `just test` (234 passed), `just build-strict`.
- Reference docs regenerated via `just site-reference`; `git diff` for `reference/api` is clean.
- Hand-written website guides (`guides/supervision.md`, `guides/groups.md`, `architecture/coordinator.md`) still reference the old API but are outside this change's scope.

Closes #160