### PR TITLE
feat(presence): return server-generated tracking ref from track

### DIFF
--- a/.changes/unreleased/Changed-20260707-143709.yaml
+++ b/.changes/unreleased/Changed-20260707-143709.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: |-
+    Presence track now returns a server-generated tracking ref, and untrack takes that ref.
+
+    BREAKING: presence.track previously echoed back the caller-supplied pid; it now returns an opaque, unique ref minted by the presence actor. presence.untrack changes from untrack(presence, topic, key, pid) to untrack(presence, ref). The actor maps each ref to its topic/key/session_id so the correct entry is removed, and untrack_all drops any refs pointing at the removed session. Closes #162.
+time: 2026-07-07T14:00:00.000000000-07:00

--- a/examples/chatrooms/src/chatrooms/chat_channel.gleam
+++ b/examples/chatrooms/src/chatrooms/chat_channel.gleam
@@ -255,8 +255,8 @@ fn terminate(_reason: channel.StopReason, socket: Socket(ChatAssigns)) -> Nil {
   let assigns = socket.get_assigns(socket)
   let socket_id = socket.id(socket)
 
-  // Untrack from presence
-  presence.untrack(assigns.presence, assigns.topic, assigns.username, socket_id)
+  // Untrack all presences for this disconnecting socket
+  presence.untrack_all(assigns.presence, socket_id)
 
   // Broadcast system leave message
   let sys_payload =

--- a/examples/cursors/src/cursors/cursor_channel.gleam
+++ b/examples/cursors/src/cursors/cursor_channel.gleam
@@ -115,8 +115,8 @@ fn terminate(
   let assigns = socket.get_assigns(socket)
   let socket_id = socket.id(socket)
 
-  // Untrack from presence
-  presence.untrack(assigns.presence, assigns.topic, assigns.username, socket_id)
+  // Untrack all presences for this disconnecting socket
+  presence.untrack_all(assigns.presence, socket_id)
 
   // Broadcast updated presence list
   let users = presence.list(assigns.presence, assigns.topic)

--- a/src/beryl/presence.gleam
+++ b/src/beryl/presence.gleam
@@ -23,7 +23,9 @@ import beryl/error as beryl_error
 import beryl/internal
 import beryl/log
 import beryl/pubsub.{type PubSub}
+import gleam/bit_array
 import gleam/bool
+import gleam/crypto
 import gleam/dict.{type Dict}
 import gleam/dynamic.{type Dynamic}
 import gleam/dynamic/decode as gdecode
@@ -173,7 +175,7 @@ pub opaque type Message {
     meta: json.Json,
     reply: Subject(String),
   )
-  Untrack(topic: String, key: String, pid: String, reply: Subject(Nil))
+  Untrack(ref: String, reply: Subject(Nil))
   UntrackAll(pid: String, reply: Subject(Nil))
   List(topic: String, reply: Subject(List(PresenceEntry)))
   GetByKey(
@@ -186,6 +188,11 @@ pub opaque type Message {
   RemoteSync(pubsub_msg: pubsub.Message)
 }
 
+/// A tracked presence's location within the CRDT, keyed by tracking ref.
+type TrackedPresence {
+  TrackedPresence(topic: String, key: String, session_id: String)
+}
+
 /// Internal actor state
 type ActorState {
   ActorState(
@@ -196,6 +203,10 @@ type ActorState {
     /// Set whenever the local CRDT mutates; cleared after a broadcast tick.
     /// Skips the encode+broadcast when there is nothing new to gossip.
     dirty: Bool,
+    /// Maps each server-generated tracking ref to the presence it created, so
+    /// `untrack` can locate the correct CRDT entry to leave. Populated on
+    /// `Track` and pruned on `Untrack`/`UntrackAll`.
+    refs: Dict(String, TrackedPresence),
   )
 }
 
@@ -270,6 +281,7 @@ fn build_presence(
         config: config,
         self_subject: Some(subject),
         dirty: False,
+        refs: dict.new(),
       )
 
     case config.pubsub {
@@ -311,6 +323,7 @@ fn build_presence(
             config: config,
             self_subject: None,
             dirty: False,
+            refs: dict.new(),
           )
         actor.initialised(no_pubsub_initial)
         |> actor.returning(subject)
@@ -350,9 +363,21 @@ fn schedule_broadcast_tick(subject: Subject(Message), interval_ms: Int) -> Nil {
 @external(erlang, "beryl_ffi", "identity")
 fn coerce_to_pubsub_message(value: Dynamic) -> pubsub.Message
 
-/// Track a presence in a topic
+/// Generate a unique, opaque tracking ref for a presence.
 ///
-/// Returns a reference string (the pid) that can be used to untrack later.
+/// Uses 16 bytes of cryptographically strong randomness (base16-encoded), which
+/// makes collisions between refs negligibly unlikely and keeps them unguessable.
+fn generate_ref() -> String {
+  crypto.strong_random_bytes(16)
+  |> bit_array.base16_encode()
+}
+
+/// Track a presence in a topic.
+///
+/// Returns a server-generated tracking ref: an opaque, unique handle for this
+/// specific presence. Pass it to `untrack` to remove exactly this entry later.
+/// The ref is not the `pid`/session id — it is minted by the presence actor and
+/// is only meaningful to that actor.
 ///
 /// Panics if the presence actor is unavailable or does not reply within 5 seconds.
 pub fn track(
@@ -367,18 +392,13 @@ pub fn track(
   })
 }
 
-/// Untrack a specific presence by topic, key, and pid
+/// Untrack a specific presence using the ref returned by `track`.
+///
+/// Removing an unknown or already-removed ref is a harmless no-op.
 ///
 /// Panics if the presence actor is unavailable or does not reply within 5 seconds.
-pub fn untrack(
-  presence: Presence,
-  topic: String,
-  key: String,
-  pid: String,
-) -> Nil {
-  process.call(presence.subject, 5000, fn(reply) {
-    Untrack(topic, key, pid, reply)
-  })
+pub fn untrack(presence: Presence, ref: String) -> Nil {
+  process.call(presence.subject, 5000, fn(reply) { Untrack(ref, reply) })
 }
 
 /// Untrack all presences for a pid (e.g., when a socket disconnects)
@@ -415,6 +435,7 @@ fn handle_message(
   let logger = internal.logger("beryl.presence")
   case message {
     Track(topic, key, pid, meta, reply) -> {
+      let ref = generate_ref()
       let new_crdt = state.join(actor_state.crdt, pid, topic, key, meta)
       maybe_invoke_on_diff(
         actor_state.config,
@@ -425,31 +446,65 @@ fn handle_message(
         #("topic", topic),
         #("key", key),
         #("pid", pid),
+        #("ref", ref),
       ])
-      process.send(reply, pid)
-      actor.continue(ActorState(..actor_state, crdt: new_crdt, dirty: True))
+      let new_refs =
+        dict.insert(
+          actor_state.refs,
+          ref,
+          TrackedPresence(topic: topic, key: key, session_id: pid),
+        )
+      process.send(reply, ref)
+      actor.continue(
+        ActorState(..actor_state, crdt: new_crdt, dirty: True, refs: new_refs),
+      )
     }
 
-    Untrack(topic, key, pid, reply) -> {
-      let diff = leave_diff(actor_state.crdt, topic, key, pid)
-      let new_crdt = state.leave(actor_state.crdt, pid, topic, key)
-      maybe_invoke_on_diff(actor_state.config, diff)
-      logger
-      |> log.debug("Presence untracked", [
-        #("topic", topic),
-        #("key", key),
-        #("pid", pid),
-      ])
-      process.send(reply, Nil)
-      actor.continue(ActorState(..actor_state, crdt: new_crdt, dirty: True))
+    Untrack(ref, reply) -> {
+      case dict.get(actor_state.refs, ref) {
+        Error(_) -> {
+          // Unknown or already-removed ref: nothing to do.
+          process.send(reply, Nil)
+          actor.continue(actor_state)
+        }
+        Ok(TrackedPresence(topic, key, session_id)) -> {
+          let diff = leave_diff(actor_state.crdt, topic, key, session_id)
+          let new_crdt = state.leave(actor_state.crdt, session_id, topic, key)
+          maybe_invoke_on_diff(actor_state.config, diff)
+          logger
+          |> log.debug("Presence untracked", [
+            #("topic", topic),
+            #("key", key),
+            #("pid", session_id),
+            #("ref", ref),
+          ])
+          process.send(reply, Nil)
+          actor.continue(
+            ActorState(
+              ..actor_state,
+              crdt: new_crdt,
+              dirty: True,
+              refs: dict.delete(actor_state.refs, ref),
+            ),
+          )
+        }
+      }
     }
 
     UntrackAll(pid, reply) -> {
       let diff = leave_all_diff(actor_state.crdt, pid)
       let new_crdt = state.leave_by_pid(actor_state.crdt, pid)
       maybe_invoke_on_diff(actor_state.config, diff)
+      // Drop any refs that pointed at the removed session so they cannot leak
+      // or later leave presences they no longer own.
+      let new_refs =
+        dict.filter(actor_state.refs, fn(_ref, tracked) {
+          tracked.session_id != pid
+        })
       process.send(reply, Nil)
-      actor.continue(ActorState(..actor_state, crdt: new_crdt, dirty: True))
+      actor.continue(
+        ActorState(..actor_state, crdt: new_crdt, dirty: True, refs: new_refs),
+      )
     }
 
     List(topic, reply) -> {

--- a/test/presence_replication_test.gleam
+++ b/test/presence_replication_test.gleam
@@ -221,7 +221,7 @@ pub fn untrack_propagates_via_pubsub_test() {
   let assert Ok(p2) = presence.start(config2)
 
   // Track on node1
-  let _ = presence.track(p1, "room:lobby", "user:1", "socket-1", json.null())
+  let ref = presence.track(p1, "room:lobby", "user:1", "socket-1", json.null())
 
   // Wait for convergence -- both should see the entry
   test_helpers.wait_until(
@@ -231,7 +231,7 @@ pub fn untrack_propagates_via_pubsub_test() {
   )
 
   // Untrack on node1
-  presence.untrack(p1, "room:lobby", "user:1", "socket-1")
+  presence.untrack(p1, ref)
 
   // Wait for the untrack to propagate via next broadcast tick
   test_helpers.wait_until(

--- a/test/presence_test.gleam
+++ b/test/presence_test.gleam
@@ -47,11 +47,54 @@ pub fn presence_track_multiple_test() {
 pub fn presence_untrack_test() {
   let assert Ok(p) = presence.start(test_config("node1"))
 
-  let _ = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
-  presence.untrack(p, "room:lobby", "user:1", "socket-1")
+  let ref = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
+  presence.untrack(p, ref)
 
   let entries = presence.list(p, "room:lobby")
   list.length(entries) |> should.equal(0)
+}
+
+pub fn presence_track_returns_ref_distinct_from_pid_test() {
+  let assert Ok(p) = presence.start(test_config("node1"))
+
+  let ref = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
+
+  // The returned ref must be a server-generated handle, not the passed pid.
+  ref |> should.not_equal("socket-1")
+}
+
+pub fn presence_track_yields_distinct_refs_test() {
+  let assert Ok(p) = presence.start(test_config("node1"))
+
+  let ref1 = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
+  let ref2 = presence.track(p, "room:lobby", "user:2", "socket-2", json.null())
+
+  ref1 |> should.not_equal(ref2)
+}
+
+pub fn presence_untrack_removes_only_that_ref_test() {
+  let assert Ok(p) = presence.start(test_config("node1"))
+
+  let ref1 = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
+  let _ref2 = presence.track(p, "room:lobby", "user:2", "socket-2", json.null())
+
+  // Untracking ref1 removes exactly that presence, leaving ref2's intact.
+  presence.untrack(p, ref1)
+
+  let entries = presence.list(p, "room:lobby")
+  list.length(entries) |> should.equal(1)
+  let assert [entry] = entries
+  entry.session_id |> should.equal("socket-2")
+}
+
+pub fn presence_untrack_unknown_ref_is_noop_test() {
+  let assert Ok(p) = presence.start(test_config("node1"))
+
+  let _ = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
+  // An unknown/stale ref is a harmless no-op.
+  presence.untrack(p, "does-not-exist")
+
+  list.length(presence.list(p, "room:lobby")) |> should.equal(1)
 }
 
 pub fn presence_untrack_all_test() {
@@ -69,6 +112,27 @@ pub fn presence_untrack_all_test() {
 
   list.length(presence.list(p, "room:lobby")) |> should.equal(0)
   list.length(presence.list(p, "room:general")) |> should.equal(0)
+}
+
+pub fn presence_untrack_all_leaves_no_dangling_refs_test() {
+  let assert Ok(p) = presence.start(test_config("node1"))
+
+  let ref1 = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
+  let _ref2 =
+    presence.track(p, "room:general", "user:1", "socket-1", json.null())
+
+  presence.untrack_all(p, "socket-1")
+
+  // A fresh track re-populates state.
+  let _ = presence.track(p, "room:lobby", "user:2", "socket-2", json.null())
+  list.length(presence.list(p, "room:lobby")) |> should.equal(1)
+
+  // Replaying a ref that untrack_all should have dropped must be a no-op and
+  // must not disturb the surviving presence.
+  presence.untrack(p, ref1)
+  list.length(presence.list(p, "room:lobby")) |> should.equal(1)
+  let assert [entry] = presence.list(p, "room:lobby")
+  entry.session_id |> should.equal("socket-2")
 }
 
 pub fn presence_get_by_key_test() {
@@ -151,7 +215,7 @@ pub fn on_diff_callback_receives_local_untrack_diff_test() {
     |> presence.with_on_diff(fn(diff) { process.send(diff_subject, diff) })
 
   let assert Ok(p) = presence.start(config)
-  let _ =
+  let ref =
     presence.track(
       p,
       "room:lobby",
@@ -161,7 +225,7 @@ pub fn on_diff_callback_receives_local_untrack_diff_test() {
     )
   let assert Ok(_) = process.receive(diff_subject, 1000)
 
-  presence.untrack(p, "room:lobby", "user:1", "socket-1")
+  presence.untrack(p, ref)
 
   let assert Ok(diff) = process.receive(diff_subject, 1000)
   presence.diff_topics(diff)

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -202,9 +202,12 @@ pub fn start_named(
 
 ### `track`
 
-Track a presence in a topic
+Track a presence in a topic.
 
- Returns a reference string (the pid) that can be used to untrack later.
+ Returns a server-generated tracking ref: an opaque, unique handle for this
+ specific presence. Pass it to `untrack` to remove exactly this entry later.
+ The ref is not the `pid`/session id — it is minted by the presence actor and
+ is only meaningful to that actor.
 
  Panics if the presence actor is unavailable or does not reply within 5 seconds.
 
@@ -220,15 +223,15 @@ pub fn track(
 
 ### `untrack`
 
-Untrack a specific presence by topic, key, and pid
+Untrack a specific presence using the ref returned by `track`.
+
+ Removing an unknown or already-removed ref is a harmless no-op.
 
  Panics if the presence actor is unavailable or does not reply within 5 seconds.
 
 ```gleam
 pub fn untrack(
   Presence,
-  String,
-  String,
   String
 ) -> Nil
 ```


### PR DESCRIPTION
## Summary

Fixes #162. `presence.track` previously returned the caller's `pid` argument verbatim — a meaningless echo. It now returns a **server-generated tracking ref**: a unique, opaque handle minted by the presence actor. `untrack` accepts that ref to remove exactly the presence that `track` created.

## Changes

- `track(presence, topic, key, pid, meta) -> String` now generates a ref via `crypto.strong_random_bytes(16) |> bit_array.base16_encode()` and returns it instead of `pid`.
- `untrack(presence, ref) -> Nil` replaces the old `untrack(presence, topic, key, pid)`. Unknown/stale refs are a harmless no-op.
- The actor keeps a `Dict(String, TrackedPresence)` mapping ref -> `{topic, key, session_id}`, populated on `track`, pruned on `untrack`, and filtered on `untrack_all` so no dangling refs survive a cleared session.
- `untrack_all(presence, pid)` unchanged in signature; still clears all presences for a session and now also drops their refs.
- Updated `///` docs to describe the ref as a server-generated handle.
- Regenerated `website/src/content/docs/reference/api/beryl-presence.md`.
- Changie `Changed` entry (breaking) added.

## Tests (TDD)

New presence tests prove: track returns a ref distinct from the pid; two tracks yield distinct refs; `untrack(ref)` removes only that presence; unknown ref is a no-op; `untrack_all` clears a session and leaves no dangling refs (replaying a stale ref does not disturb survivors). Existing untrack callers updated to the ref API. All 239 tests pass.

Closes #162