### PR TITLE
refactor(codec): make Codec and Transport opaque

### DIFF
--- a/.changes/unreleased/Changed-20260707-140000.yaml
+++ b/.changes/unreleased/Changed-20260707-140000.yaml
@@ -1,0 +1,11 @@
+kind: Changed
+body: |-
+  Make `codec.Codec` and `socket.Transport` opaque types before 1.0 (#157).
+
+  BREAKING: both records are now constructed through builders rather than their
+  constructors. Build a codec with `codec.new(decode_text:, encode_reply:,
+  encode_push:, encode_heartbeat_reply:)` and attach an optional binary decoder
+  with `codec.with_binary_decoder`. Build a transport with
+  `socket.new_transport(send_text:, send_binary:, close:)`. Making these opaque
+  lets new fields be added post-1.0 without a breaking change. Closes #157.
+time: 2026-07-07T14:00:00.000000000-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -903,7 +903,7 @@ fn typed_handle_info(
 }
 
 fn transport_from_context(ctx: coordinator.SocketContext) -> socket.Transport {
-  socket.Transport(
+  socket.new_transport(
     send_text: fn(text) {
       ctx.send(text)
       |> result_to_transport_result()

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -665,7 +665,7 @@ fn handle_join(
       case dict.get(state.sockets, socket_id) {
         Ok(socket_info) -> {
           let reply =
-            socket_info.codec.encode_reply(
+            codec.encode_reply(socket_info.codec)(
               join_ref,
               ref,
               topic_name,
@@ -747,7 +747,7 @@ fn reject_join_cap(
     #("topic", topic_name),
   ])
   let reply =
-    socket_info.codec.encode_reply(
+    codec.encode_reply(socket_info.codec)(
       join_ref,
       ref,
       topic_name,
@@ -778,7 +778,7 @@ fn handle_join_with_handler(
         #("join_ref", optional_string(join_ref)),
       ])
       let reply =
-        socket_info.codec.encode_reply(
+        codec.encode_reply(socket_info.codec)(
           join_ref,
           ref,
           topic_name,
@@ -814,7 +814,7 @@ fn handle_leave(
   case ref, dict.get(state.sockets, socket_id) {
     Some(r), Ok(socket_info) -> {
       let reply =
-        socket_info.codec.encode_reply(
+        codec.encode_reply(socket_info.codec)(
           None,
           Some(r),
           topic_name,
@@ -1002,7 +1002,7 @@ fn handle_binary_in(
     Ok(socket_info) -> socket_info.codec
     Error(Nil) -> state.config.codec
   }
-  case active_codec.decode_binary {
+  case codec.decode_binary(active_codec) {
     Some(decode_binary) ->
       handle_route_binary_frame(state, socket_id, data, decode_binary)
     None -> handle_raw_binary_with_rate_limit(state, socket_id, data)
@@ -1093,7 +1093,7 @@ fn handle_heartbeat(
         SocketInfo(..socket_info, last_heartbeat: monotonic_time_ms())
       let new_sockets = dict.insert(state.sockets, socket_id, updated_socket)
 
-      let reply = socket_info.codec.encode_heartbeat_reply(ref)
+      let reply = codec.encode_heartbeat_reply(socket_info.codec)(ref)
       let _send_result =
         send_frame_logged(state, socket_info, "__heartbeat__", reply)
       let logger = coordinator_logger(state)
@@ -1213,7 +1213,8 @@ fn handle_broadcast(
       Ok(socket_info) -> {
         // Encode per recipient so connections negotiating different
         // serializers each receive a frame in their own wire format.
-        let msg = socket_info.codec.encode_push(topic_name, event, payload)
+        let msg =
+          codec.encode_push(socket_info.codec)(topic_name, event, payload)
         let _send_result =
           send_frame_logged(state, socket_info, topic_name, msg)
         Nil
@@ -1328,7 +1329,7 @@ fn handle_route_text(
     Error(Nil) -> state.config.codec
   }
   let logging = internal_logging(state.config.logging)
-  case active_codec.decode_text(raw_text) {
+  case codec.decode_text(active_codec)(raw_text) {
     Error(err) -> {
       let logger = coordinator_logger(state)
       logger
@@ -1483,7 +1484,7 @@ fn reject_invalid_join(
     Error(Nil) -> actor.continue(state)
     Ok(socket_info) -> {
       let reply =
-        socket_info.codec.encode_reply(
+        codec.encode_reply(socket_info.codec)(
           msg.join_ref,
           msg.ref,
           msg.topic,
@@ -1547,7 +1548,7 @@ fn dispatch_join(
         #("join_ref", optional_string(join_ref)),
       ])
       let reply =
-        socket_info.codec.encode_reply(
+        codec.encode_reply(socket_info.codec)(
           join_ref,
           ref,
           topic_name,
@@ -1599,7 +1600,7 @@ fn dispatch_join(
         Some(p) -> p
       }
       let reply =
-        socket_info.codec.encode_reply(
+        codec.encode_reply(socket_info.codec)(
           join_ref,
           ref,
           topic_name,
@@ -1668,7 +1669,7 @@ fn dispatch_handle_in(
       case ref {
         Some(r) -> {
           let reply =
-            socket_info.codec.encode_reply(
+            codec.encode_reply(socket_info.codec)(
               None,
               Some(r),
               topic_name,
@@ -1694,7 +1695,11 @@ fn dispatch_handle_in(
         #("push_event", push_event),
       ])
       let msg =
-        socket_info.codec.encode_push(topic_name, push_event, push_payload)
+        codec.encode_push(socket_info.codec)(
+          topic_name,
+          push_event,
+          push_payload,
+        )
       let _send_result = send_frame_logged(state, socket_info, topic_name, msg)
       let state = update_assigns(state, socket_id, topic_name, new_assigns)
       actor.continue(state)
@@ -1764,7 +1769,11 @@ fn dispatch_handle_info(
       // No ref correlation in handle_info, so reply and push are
       // wire-identical: both become a server-initiated push.
       let msg =
-        socket_info.codec.encode_push(topic_name, reply_event, reply_payload)
+        codec.encode_push(socket_info.codec)(
+          topic_name,
+          reply_event,
+          reply_payload,
+        )
       let _send_result = send_frame_logged(state, socket_info, topic_name, msg)
       let state = update_assigns(state, socket_id, topic_name, new_assigns)
       actor.continue(state)
@@ -1830,7 +1839,11 @@ fn dispatch_handle_binary(
         #("callback", "handle_binary"),
       ])
       let msg =
-        socket_info.codec.encode_push(topic_name, "binary_reply", reply_payload)
+        codec.encode_push(socket_info.codec)(
+          topic_name,
+          "binary_reply",
+          reply_payload,
+        )
       let _send_result = send_frame_logged(st, socket_info, topic_name, msg)
       update_assigns(st, socket_id, topic_name, new_assigns)
     }
@@ -1843,7 +1856,11 @@ fn dispatch_handle_binary(
         #("push_event", push_event),
       ])
       let msg =
-        socket_info.codec.encode_push(topic_name, push_event, push_payload)
+        codec.encode_push(socket_info.codec)(
+          topic_name,
+          push_event,
+          push_payload,
+        )
       let _send_result = send_frame_logged(st, socket_info, topic_name, msg)
       update_assigns(st, socket_id, topic_name, new_assigns)
     }

--- a/src/beryl/socket.gleam
+++ b/src/beryl/socket.gleam
@@ -30,12 +30,49 @@ import gleam/dynamic.{type Dynamic}
 /// Note: as constructed by the built-in Mist transport, `close` is a no-op
 /// that returns `Ok(Nil)`. Closing is driven by the transport's own
 /// connection lifecycle rather than by calling this function.
-pub type Transport {
+/// `Transport` is opaque; build one with `new_transport`. Its behaviour is
+/// read through the `@internal` accessors below.
+pub opaque type Transport {
   Transport(
     send_text: fn(String) -> Result(Nil, TransportError),
     send_binary: fn(BitArray) -> Result(Nil, TransportError),
     close: fn() -> Result(Nil, TransportError),
   )
+}
+
+/// Build a transport from its send/close functions.
+///
+/// - `send_text`: send a UTF-8 text frame to the client.
+/// - `send_binary`: send a binary frame to the client.
+/// - `close`: close the underlying connection.
+pub fn new_transport(
+  send_text send_text: fn(String) -> Result(Nil, TransportError),
+  send_binary send_binary: fn(BitArray) -> Result(Nil, TransportError),
+  close close: fn() -> Result(Nil, TransportError),
+) -> Transport {
+  Transport(send_text:, send_binary:, close:)
+}
+
+/// Accessor for the transport's text sender.
+@internal
+pub fn send_text(
+  transport: Transport,
+) -> fn(String) -> Result(Nil, TransportError) {
+  transport.send_text
+}
+
+/// Accessor for the transport's binary sender.
+@internal
+pub fn send_binary(
+  transport: Transport,
+) -> fn(BitArray) -> Result(Nil, TransportError) {
+  transport.send_binary
+}
+
+/// Accessor for the transport's close function.
+@internal
+pub fn close(transport: Transport) -> fn() -> Result(Nil, TransportError) {
+  transport.close
 }
 
 /// Errors returned by transport send/close operations.

--- a/src/beryl/wire.gleam
+++ b/src/beryl/wire.gleam
@@ -13,8 +13,8 @@
 
 import beryl/wire/codec.{
   type Codec, type DecodeError, type Frame, type Inbound, type InboundKind,
-  type ReplyStatus, Codec, Event, Heartbeat, Inbound, InvalidFormat, InvalidJson,
-  Join, Leave, StatusError, StatusOk, TextFrame,
+  type ReplyStatus, Event, Heartbeat, Inbound, InvalidFormat, InvalidJson, Join,
+  Leave, StatusError, StatusOk, TextFrame,
 }
 import gleam/bool
 import gleam/dict
@@ -31,9 +31,8 @@ const max_json_nesting_depth = 64
 
 /// The canonical Phoenix wire codec. Pass to `beryl.config/1`.
 pub fn phoenix_codec() -> Codec {
-  Codec(
+  codec.new(
     decode_text: decode_message,
-    decode_binary: None,
     encode_reply: reply_json,
     encode_push: push,
     encode_heartbeat_reply: heartbeat_reply,

--- a/src/beryl/wire/codec.gleam
+++ b/src/beryl/wire/codec.gleam
@@ -15,7 +15,7 @@
 
 import gleam/dynamic.{type Dynamic}
 import gleam/json
-import gleam/option.{type Option}
+import gleam/option.{type Option, None, Some}
 
 /// Encoded WebSocket frame returned by a codec.
 pub type Frame {
@@ -87,16 +87,14 @@ pub fn format_decode_error(error: DecodeError) -> String {
 }
 
 /// A wire codec.
-pub type Codec {
+///
+/// `Codec` is opaque; build one with `new` (and, for binary support,
+/// `with_binary_decoder`). The coordinator reads the codec's behaviour
+/// through the `@internal` accessors below.
+pub opaque type Codec {
   Codec(
-    /// Decode raw inbound text into a normalised `Inbound`.
     decode_text: fn(String) -> Result(Inbound, DecodeError),
-    /// Decode raw inbound binary into a normalised `Inbound`.
-    ///
-    /// When `None`, binary WebSocket frames are routed to `channel.handle_binary`
-    /// as raw data for backwards compatibility.
     decode_binary: Option(fn(BitArray) -> Result(Inbound, DecodeError)),
-    /// Encode a reply to a client message: `(join_ref, ref, topic, status, response_payload)`.
     encode_reply: fn(
       Option(String),
       Option(String),
@@ -104,9 +102,85 @@ pub type Codec {
       ReplyStatus,
       json.Json,
     ) -> Frame,
-    /// Encode a server-initiated push: `(topic, event, payload)`.
     encode_push: fn(String, String, json.Json) -> Frame,
-    /// Encode a heartbeat reply for a given client `ref`.
     encode_heartbeat_reply: fn(Option(String)) -> Frame,
   )
+}
+
+/// Build a text-only wire codec.
+///
+/// - `decode_text`: decode raw inbound text into a normalised `Inbound`.
+/// - `encode_reply`: encode a reply to a client message:
+///   `(join_ref, ref, topic, status, response_payload)`.
+/// - `encode_push`: encode a server-initiated push: `(topic, event, payload)`.
+/// - `encode_heartbeat_reply`: encode a heartbeat reply for a given client `ref`.
+///
+/// The resulting codec has no binary decoder; binary WebSocket frames are
+/// routed to `channel.handle_binary` as raw data. Add a binary decoder with
+/// `with_binary_decoder`.
+pub fn new(
+  decode_text decode_text: fn(String) -> Result(Inbound, DecodeError),
+  encode_reply encode_reply: fn(
+    Option(String),
+    Option(String),
+    String,
+    ReplyStatus,
+    json.Json,
+  ) -> Frame,
+  encode_push encode_push: fn(String, String, json.Json) -> Frame,
+  encode_heartbeat_reply encode_heartbeat_reply: fn(Option(String)) -> Frame,
+) -> Codec {
+  Codec(
+    decode_text:,
+    decode_binary: None,
+    encode_reply:,
+    encode_push:,
+    encode_heartbeat_reply:,
+  )
+}
+
+/// Attach a binary decoder to a codec.
+///
+/// When set, binary WebSocket frames are decoded into a normalised `Inbound`
+/// via `decode_binary` instead of being routed to `channel.handle_binary` as
+/// raw data.
+pub fn with_binary_decoder(
+  codec: Codec,
+  decode_binary: fn(BitArray) -> Result(Inbound, DecodeError),
+) -> Codec {
+  Codec(..codec, decode_binary: Some(decode_binary))
+}
+
+/// Accessor for the codec's text decoder.
+@internal
+pub fn decode_text(codec: Codec) -> fn(String) -> Result(Inbound, DecodeError) {
+  codec.decode_text
+}
+
+/// Accessor for the codec's optional binary decoder.
+@internal
+pub fn decode_binary(
+  codec: Codec,
+) -> Option(fn(BitArray) -> Result(Inbound, DecodeError)) {
+  codec.decode_binary
+}
+
+/// Accessor for the codec's reply encoder.
+@internal
+pub fn encode_reply(
+  codec: Codec,
+) -> fn(Option(String), Option(String), String, ReplyStatus, json.Json) -> Frame {
+  codec.encode_reply
+}
+
+/// Accessor for the codec's push encoder.
+@internal
+pub fn encode_push(codec: Codec) -> fn(String, String, json.Json) -> Frame {
+  codec.encode_push
+}
+
+/// Accessor for the codec's heartbeat-reply encoder.
+@internal
+pub fn encode_heartbeat_reply(codec: Codec) -> fn(Option(String)) -> Frame {
+  codec.encode_heartbeat_reply
 }

--- a/test/beryl_test.gleam
+++ b/test/beryl_test.gleam
@@ -18,7 +18,7 @@ import gleeunit/should
 
 // Test helper: create a mock transport
 fn mock_transport() -> socket.Transport {
-  socket.Transport(
+  socket.new_transport(
     send_text: fn(_) { Ok(Nil) },
     send_binary: fn(_) { Ok(Nil) },
     close: fn() { Ok(Nil) },

--- a/test/binary_codec_test.gleam
+++ b/test/binary_codec_test.gleam
@@ -17,13 +17,13 @@ pub fn main() {
 }
 
 fn binary_test_codec() -> codec.Codec {
-  codec.Codec(
+  codec.new(
     decode_text: fn(_) { Error(codec.InvalidFormat("text unsupported")) },
-    decode_binary: Some(decode_binary_frame),
     encode_reply: encode_reply,
     encode_push: encode_push,
     encode_heartbeat_reply: encode_heartbeat_reply,
   )
+  |> codec.with_binary_decoder(decode_binary_frame)
 }
 
 fn decode_binary_frame(

--- a/test/wire_codec_test.gleam
+++ b/test/wire_codec_test.gleam
@@ -19,8 +19,8 @@ const phoenix_codec_env = "BERYL_PHOENIX_CODEC"
 pub fn phoenix_codec_round_trip_test() {
   let phoenix = wire.phoenix_codec()
   let encoded =
-    text_frame(phoenix.encode_push("room:1", "msg", json.string("hi")))
-  let assert Ok(inbound) = phoenix.decode_text(encoded)
+    text_frame(codec.encode_push(phoenix)("room:1", "msg", json.string("hi")))
+  let assert Ok(inbound) = codec.decode_text(phoenix)(encoded)
   inbound.topic |> should.equal("room:1")
   inbound.kind |> should.equal(codec.Event("msg"))
 }
@@ -29,19 +29,19 @@ pub fn phoenix_codec_decodes_system_events_to_kinds_test() {
   let phoenix = wire.phoenix_codec()
 
   let assert Ok(join) =
-    phoenix.decode_text("[\"j\",\"r\",\"room:1\",\"phx_join\",{}]")
+    codec.decode_text(phoenix)("[\"j\",\"r\",\"room:1\",\"phx_join\",{}]")
   join.kind |> should.equal(codec.Join)
 
   let assert Ok(leave) =
-    phoenix.decode_text("[null,\"r\",\"room:1\",\"phx_leave\",{}]")
+    codec.decode_text(phoenix)("[null,\"r\",\"room:1\",\"phx_leave\",{}]")
   leave.kind |> should.equal(codec.Leave)
 
   let assert Ok(heartbeat) =
-    phoenix.decode_text("[null,\"r\",\"phoenix\",\"heartbeat\",{}]")
+    codec.decode_text(phoenix)("[null,\"r\",\"phoenix\",\"heartbeat\",{}]")
   heartbeat.kind |> should.equal(codec.Heartbeat)
 
   let assert Ok(event) =
-    phoenix.decode_text("[null,\"r\",\"room:1\",\"new_msg\",{}]")
+    codec.decode_text(phoenix)("[null,\"r\",\"room:1\",\"new_msg\",{}]")
   event.kind |> should.equal(codec.Event("new_msg"))
 }
 
@@ -49,7 +49,13 @@ pub fn phoenix_codec_reply_accepts_missing_ref_test() {
   let phoenix = wire.phoenix_codec()
 
   let frame =
-    phoenix.encode_reply(None, None, "room:1", codec.StatusOk, json.object([]))
+    codec.encode_reply(phoenix)(
+      None,
+      None,
+      "room:1",
+      codec.StatusOk,
+      json.object([]),
+    )
 
   let assert codec.TextFrame(encoded) = frame
   encoded
@@ -63,7 +69,7 @@ pub fn phoenix_codec_defaults_to_native_implementation_test() {
     let phoenix = wire.phoenix_codec()
 
     let assert Error(codec.InvalidFormat(reason)) =
-      phoenix.decode_text("[null,\"1\",123,\"event\",{}]")
+      codec.decode_text(phoenix)("[null,\"1\",123,\"event\",{}]")
 
     reason
     |> should.equal(
@@ -77,7 +83,7 @@ pub fn phoenix_codec_uses_native_when_env_is_unknown_test() {
     let phoenix = wire.phoenix_codec()
 
     let assert Error(codec.InvalidFormat(reason)) =
-      phoenix.decode_text("[null,\"1\",123,\"event\",{}]")
+      codec.decode_text(phoenix)("[null,\"1\",123,\"event\",{}]")
 
     reason
     |> should.equal(
@@ -89,7 +95,7 @@ pub fn phoenix_codec_uses_native_when_env_is_unknown_test() {
 pub fn phoenix_codec_preserves_missing_ref_reply_shape_test() {
   let phoenix = wire.phoenix_codec()
 
-  phoenix.encode_reply(
+  codec.encode_reply(phoenix)(
     Some("join-ref"),
     None,
     "room:1",
@@ -135,7 +141,7 @@ pub fn inbound_supports_optional_refs_test() {
 pub fn reply_status_round_trips_through_phoenix_codec_test() {
   let phoenix = wire.phoenix_codec()
   let s =
-    phoenix.encode_reply(
+    codec.encode_reply(phoenix)(
       Some("j"),
       Some("r"),
       "topic:1",
@@ -152,7 +158,7 @@ pub fn phoenix_codec_decodes_shared_inbound_fixtures_test() {
   let phoenix = wire.phoenix_codec()
   fixtures.inbound_common()
   |> list.each(fn(case_) {
-    let assert Ok(inbound) = phoenix.decode_text(case_.encoded)
+    let assert Ok(inbound) = codec.decode_text(phoenix)(case_.encoded)
     inbound.join_ref |> should.equal(case_.join_ref)
     inbound.ref |> should.equal(case_.ref)
     inbound.topic |> should.equal(case_.topic)
@@ -173,7 +179,7 @@ pub fn phoenix_codec_encodes_shared_server_push_fixtures_test() {
         && event != fixtures.error_event
         && event != fixtures.close_event
       ->
-        phoenix.encode_push(case_.topic, event, case_.payload)
+        codec.encode_push(phoenix)(case_.topic, event, case_.payload)
         |> text_frame()
         |> should.equal(case_.encoded)
       _, _, _ -> Nil
@@ -189,7 +195,7 @@ pub fn phoenix_codec_encodes_shared_reply_fixtures_test() {
       fixtures.StatusOk -> codec.StatusOk
       fixtures.StatusError -> codec.StatusError
     }
-    phoenix.encode_reply(
+    codec.encode_reply(phoenix)(
       case_.join_ref,
       Some(case_.ref),
       case_.topic,
@@ -208,12 +214,12 @@ pub fn phoenix_codec_rejects_shared_invalid_fixtures_test() {
     case case_.reason {
       fixtures.InvalidJson -> {
         let assert Error(codec.InvalidJson(_)) =
-          phoenix.decode_text(case_.encoded)
+          codec.decode_text(phoenix)(case_.encoded)
         Nil
       }
       fixtures.InvalidFormat -> {
         let assert Error(codec.InvalidFormat(_)) =
-          phoenix.decode_text(case_.encoded)
+          codec.decode_text(phoenix)(case_.encoded)
         Nil
       }
     }
@@ -226,7 +232,7 @@ pub fn phoenix_codec_rejects_excessively_nested_payload_test() {
     string.repeat("[", 70) <> "null" <> string.repeat("]", 70)
 
   let assert Error(codec.InvalidFormat(reason)) =
-    phoenix.decode_text(
+    codec.decode_text(phoenix)(
       "[null,\"r\",\"room:1\",\"event\"," <> nested_payload <> "]",
     )
 

--- a/website/src/content/docs/reference/api/beryl-socket.md
+++ b/website/src/content/docs/reference/api/beryl-socket.md
@@ -48,15 +48,11 @@ Transport abstraction for sending messages
  Note: as constructed by the built-in Mist transport, `close` is a no-op
  that returns `Ok(Nil)`. Closing is driven by the transport's own
  connection lifecycle rather than by calling this function.
+ `Transport` is opaque; build one with `new_transport`. Its behaviour is
+ read through the `@internal` accessors below.
 
 ```gleam
-pub type Transport {
-  Transport(
-    send_text: fn(String) -> Result(Nil, TransportError),
-    send_binary: fn(BitArray) -> Result(Nil, TransportError),
-    close: fn() -> Result(Nil, TransportError)
-  )
-}
+pub type Transport
 ```
 
 ### `TransportError`
@@ -129,6 +125,22 @@ pub fn new(
   a,
   Transport
 ) -> Socket(a)
+```
+
+### `new_transport`
+
+Build a transport from its send/close functions.
+
+ - `send_text`: send a UTF-8 text frame to the client.
+ - `send_binary`: send a binary frame to the client.
+ - `close`: close the underlying connection.
+
+```gleam
+pub fn new_transport(
+  send_text: fn(String) -> Result(Nil, TransportError),
+  send_binary: fn(BitArray) -> Result(Nil, TransportError),
+  close: fn() -> Result(Nil, TransportError)
+) -> Transport
 ```
 
 ### `set_assigns`

--- a/website/src/content/docs/reference/api/beryl-wire-codec.md
+++ b/website/src/content/docs/reference/api/beryl-wire-codec.md
@@ -24,16 +24,12 @@ Pluggable wire codec for beryl.
 
 A wire codec.
 
+ `Codec` is opaque; build one with `new` (and, for binary support,
+ `with_binary_decoder`). The coordinator reads the codec's behaviour
+ through the `@internal` accessors below.
+
 ```gleam
-pub type Codec {
-  Codec(
-    decode_text: fn(String) -> Result(Inbound, DecodeError),
-    decode_binary: option.Option(fn(BitArray) -> Result(Inbound, DecodeError)),
-    encode_reply: fn(option.Option(String), option.Option(String), String, ReplyStatus, json.Json) -> Frame,
-    encode_push: fn(String, String, json.Json) -> Frame,
-    encode_heartbeat_reply: fn(option.Option(String)) -> Frame
-  )
-}
+pub type Codec
 ```
 
 ### `DecodeError`
@@ -170,4 +166,42 @@ Format a `DecodeError` as a human-readable string. Used by the
 
 ```gleam
 pub fn format_decode_error(DecodeError) -> String
+```
+
+### `new`
+
+Build a text-only wire codec.
+
+ - `decode_text`: decode raw inbound text into a normalised `Inbound`.
+ - `encode_reply`: encode a reply to a client message:
+   `(join_ref, ref, topic, status, response_payload)`.
+ - `encode_push`: encode a server-initiated push: `(topic, event, payload)`.
+ - `encode_heartbeat_reply`: encode a heartbeat reply for a given client `ref`.
+
+ The resulting codec has no binary decoder; binary WebSocket frames are
+ routed to `channel.handle_binary` as raw data. Add a binary decoder with
+ `with_binary_decoder`.
+
+```gleam
+pub fn new(
+  decode_text: fn(String) -> Result(Inbound, DecodeError),
+  encode_reply: fn(option.Option(String), option.Option(String), String, ReplyStatus, json.Json) -> Frame,
+  encode_push: fn(String, String, json.Json) -> Frame,
+  encode_heartbeat_reply: fn(option.Option(String)) -> Frame
+) -> Codec
+```
+
+### `with_binary_decoder`
+
+Attach a binary decoder to a codec.
+
+ When set, binary WebSocket frames are decoded into a normalised `Inbound`
+ via `decode_binary` instead of being routed to `channel.handle_binary` as
+ raw data.
+
+```gleam
+pub fn with_binary_decoder(
+  Codec,
+  fn(BitArray) -> Result(Inbound, DecodeError)
+) -> Codec
 ```


### PR DESCRIPTION
## Summary

Converts `codec.Codec` (`src/beryl/wire/codec.gleam`) and `socket.Transport` (`src/beryl/socket.gleam`) to `pub opaque type`s ahead of 1.0, so new fields can be added later without a breaking change.

## Changes

- **`codec.Codec` is now opaque.** New builders:
  - `codec.new(decode_text:, encode_reply:, encode_push:, encode_heartbeat_reply:) -> Codec` (text-only; no binary decoder)
  - `codec.with_binary_decoder(codec, decode_binary) -> Codec` (optional binary hook)
  - `@internal` accessors: `decode_text`, `decode_binary`, `encode_reply`, `encode_push`, `encode_heartbeat_reply`
- **`socket.Transport` is now opaque.** New builder:
  - `socket.new_transport(send_text:, send_binary:, close:) -> Transport`
  - `@internal` accessors: `send_text`, `send_binary`, `close`
- `wire.phoenix_codec()` builds via `codec.new(...)`; `beryl.gleam` builds via `socket.new_transport(...)`.
- The coordinator's ~15 codec call sites now go through accessors (e.g. `codec.encode_reply(socket_info.codec)(...)`, `codec.decode_text(active_codec)(...)`).
- Tests updated to the builder/accessor API; regenerated website reference docs.

## Testing

- `just format-check`, `just check`, `just build-strict` pass
- `just test` — 234 passed, no failures
- Docs reference gate clean (`beryl-wire-codec.md`, `beryl-socket.md` regenerated)

Closes #157