### PR TITLE
fix(beryl): reject heartbeat_timeout_ms below 2 at start

### DIFF
--- a/.changes/unreleased/Fixed-20260707-143500.yaml
+++ b/.changes/unreleased/Fixed-20260707-143500.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: |-
+    `beryl.start` now rejects `heartbeat_timeout_ms < 2` with `InvalidHeartbeatTimeout` instead of silently disabling heartbeat eviction.
+
+    The server derives its staleness check interval as `heartbeat_timeout_ms / 2`, so a timeout of 1 rounded down to a check interval of 0, which the scheduler treated as "disabled". Configs with a timeout below 2 now fail loudly at `start`. Also re-documented `heartbeat_interval_ms` as client-advisory only — the server never reads it. (#154)
+time: 2026-07-07T14:35:00.000000-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -125,9 +125,13 @@ pub opaque type Config {
     /// Wire codec used to decode inbound text and encode replies/pushes.
     /// Use `wire.phoenix_codec()` for the historical Phoenix array format.
     codec: codec.Codec,
-    /// Heartbeat interval in milliseconds (default: 30000)
+    /// Client-advisory heartbeat interval in milliseconds (default: 30000).
+    /// The server does not read this value; it is the interval clients should
+    /// use for their own pings. See `with_heartbeat`.
     heartbeat_interval_ms: Int,
-    /// Heartbeat timeout - disconnect if no response (default: 60000)
+    /// Server-side heartbeat staleness window in milliseconds (default: 60000).
+    /// Sockets that send no heartbeat within this window are evicted. Must be
+    /// at least 2 (see `with_heartbeat`).
     heartbeat_timeout_ms: Int,
     /// Max connections per IP (0 = unlimited)
     max_connections_per_ip: Int,
@@ -216,10 +220,17 @@ pub fn with_pubsub(config: Config, ps: PubSub) -> Config {
 
 /// Configure heartbeat timing.
 ///
-/// `interval_ms` is the client-facing heartbeat interval (informational: how
-/// often clients should send heartbeats). `timeout_ms` is the server-side
-/// staleness window — a socket that sends no heartbeat within this window is
-/// evicted. The defaults are 30000 ms and 60000 ms respectively.
+/// `interval_ms` is **client-advisory only**: it is the interval clients should
+/// use for their own outbound pings. The server never reads it and does not use
+/// it to schedule anything — it exists purely to communicate a suggested ping
+/// cadence to clients.
+///
+/// `timeout_ms` is the server-side staleness window — a socket that sends no
+/// heartbeat within this window is evicted. The server derives its internal
+/// check interval as `timeout_ms / 2` (integer division), so `timeout_ms` must
+/// be at least 2; smaller values are rejected by `start` with
+/// `InvalidHeartbeatTimeout` because a check interval of 0 would disable
+/// eviction. The defaults are 30000 ms and 60000 ms respectively.
 pub fn with_heartbeat(
   config: Config,
   interval_ms interval_ms: Int,
@@ -525,7 +536,11 @@ pub fn max_inbound_frame_bytes(channels: Channels) -> Int {
 pub type StartError {
   /// The coordinator actor failed to start.
   CoordinatorStartFailed(beryl_error.StartFailure)
-  /// heartbeat_timeout_ms must be > 0 (it is used to derive the check interval)
+  /// `heartbeat_timeout_ms` must be at least 2. The server derives its staleness
+  /// check interval as `heartbeat_timeout_ms / 2` (integer division), so a
+  /// timeout of 1 would round down to a check interval of 0 — which disables
+  /// heartbeat eviction entirely. `start` rejects such a config loudly rather
+  /// than silently turning eviction off.
   InvalidHeartbeatTimeout
 }
 
@@ -534,10 +549,14 @@ pub type StartError {
 /// Call once at application startup. Returns a handle that can be passed
 /// to the WebSocket transport and used for broadcasting.
 ///
-/// Heartbeat timeout enforcement is configured via `heartbeat_interval_ms`
-/// and `heartbeat_timeout_ms` in the Config. The coordinator checks for
-/// stale sockets at `heartbeat_interval_ms` and evicts any socket that
-/// hasn't sent a heartbeat within `heartbeat_timeout_ms`.
+/// Heartbeat eviction is configured via `heartbeat_timeout_ms` in the Config.
+/// The coordinator evicts any socket that has not sent a heartbeat within that
+/// window, checking for stale sockets at a server-derived interval of
+/// `heartbeat_timeout_ms / 2`. `heartbeat_interval_ms` is client-advisory only
+/// (see `with_heartbeat`) and does not schedule anything on the server.
+///
+/// Returns `Error(InvalidHeartbeatTimeout)` if `heartbeat_timeout_ms` is less
+/// than 2.
 ///
 /// ## Example
 ///
@@ -549,7 +568,7 @@ pub type StartError {
 /// ```
 pub fn start(config: Config) -> Result(Channels, StartError) {
   use <- bool.guard(
-    when: config.heartbeat_timeout_ms <= 0,
+    when: config.heartbeat_timeout_ms < 2,
     return: internal.result_error(InvalidHeartbeatTimeout),
   )
   let coord_config = to_coordinator_config(config)

--- a/test/heartbeat_test.gleam
+++ b/test/heartbeat_test.gleam
@@ -1,3 +1,4 @@
+import beryl
 import beryl/channel
 import beryl/coordinator
 import beryl/topic
@@ -272,6 +273,60 @@ pub fn positive_timeout_with_checking_enabled_is_ok_test() {
     )
   coordinator.start_with_config(config)
   |> should.be_ok
+}
+
+// --- Public API config validation (issue #154) ---------------------------
+//
+// `heartbeat_timeout_ms` drives the server's staleness check interval, which
+// is derived as `timeout_ms / 2`. A timeout of 1 integer-divides to a check
+// interval of 0, which the scheduler treats as "disabled" — silently turning
+// off heartbeat eviction. `beryl.start` must reject any timeout below 2 loudly
+// rather than accepting a config that disables eviction.
+
+pub fn beryl_start_rejects_timeout_of_one_test() {
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_heartbeat(interval_ms: 30_000, timeout_ms: 1)
+
+  beryl.start(config)
+  |> should.be_error
+  |> should.equal(beryl.InvalidHeartbeatTimeout)
+}
+
+pub fn beryl_start_rejects_zero_timeout_test() {
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_heartbeat(interval_ms: 30_000, timeout_ms: 0)
+
+  beryl.start(config)
+  |> should.be_error
+  |> should.equal(beryl.InvalidHeartbeatTimeout)
+}
+
+pub fn beryl_start_rejects_negative_timeout_test() {
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_heartbeat(interval_ms: 30_000, timeout_ms: -5)
+
+  beryl.start(config)
+  |> should.be_error
+  |> should.equal(beryl.InvalidHeartbeatTimeout)
+}
+
+pub fn beryl_start_accepts_timeout_of_two_test() {
+  // 2 is the smallest timeout that still yields a non-zero derived check
+  // interval (2 / 2 = 1), so eviction stays enabled.
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_heartbeat(interval_ms: 30_000, timeout_ms: 2)
+
+  let assert Ok(channels) = beryl.start(config)
+  beryl.stop(channels)
+}
+
+pub fn beryl_start_accepts_default_timeout_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  beryl.stop(channels)
 }
 
 pub fn start_named_validates_heartbeat_timeout_test() {

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -161,7 +161,11 @@ The coordinator actor failed to start.
 
 ##### `InvalidHeartbeatTimeout`
 
-heartbeat_timeout_ms must be > 0 (it is used to derive the check interval)
+`heartbeat_timeout_ms` must be at least 2. The server derives its staleness
+ check interval as `heartbeat_timeout_ms / 2` (integer division), so a
+ timeout of 1 would round down to a check interval of 0 — which disables
+ heartbeat eviction entirely. `start` rejects such a config loudly rather
+ than silently turning eviction off.
 
 ## Functions
 
@@ -396,10 +400,14 @@ Start the channels system
  Call once at application startup. Returns a handle that can be passed
  to the WebSocket transport and used for broadcasting.
 
- Heartbeat timeout enforcement is configured via `heartbeat_interval_ms`
- and `heartbeat_timeout_ms` in the Config. The coordinator checks for
- stale sockets at `heartbeat_interval_ms` and evicts any socket that
- hasn't sent a heartbeat within `heartbeat_timeout_ms`.
+ Heartbeat eviction is configured via `heartbeat_timeout_ms` in the Config.
+ The coordinator evicts any socket that has not sent a heartbeat within that
+ window, checking for stale sockets at a server-derived interval of
+ `heartbeat_timeout_ms / 2`. `heartbeat_interval_ms` is client-advisory only
+ (see `with_heartbeat`) and does not schedule anything on the server.
+
+ Returns `Error(InvalidHeartbeatTimeout)` if `heartbeat_timeout_ms` is less
+ than 2.
 
  ## Example
 
@@ -461,10 +469,17 @@ pub fn with_channel_rate_max_keys_per_socket(
 
 Configure heartbeat timing.
 
- `interval_ms` is the client-facing heartbeat interval (informational: how
- often clients should send heartbeats). `timeout_ms` is the server-side
- staleness window — a socket that sends no heartbeat within this window is
- evicted. The defaults are 30000 ms and 60000 ms respectively.
+ `interval_ms` is **client-advisory only**: it is the interval clients should
+ use for their own outbound pings. The server never reads it and does not use
+ it to schedule anything — it exists purely to communicate a suggested ping
+ cadence to clients.
+
+ `timeout_ms` is the server-side staleness window — a socket that sends no
+ heartbeat within this window is evicted. The server derives its internal
+ check interval as `timeout_ms / 2` (integer division), so `timeout_ms` must
+ be at least 2; smaller values are rejected by `start` with
+ `InvalidHeartbeatTimeout` because a check interval of 0 would disable
+ eviction. The defaults are 30000 ms and 60000 ms respectively.
 
 ```gleam
 pub fn with_heartbeat(


### PR DESCRIPTION
## Summary

Fixes issue #154 (two parts).

### 1. Validate `heartbeat_timeout_ms >= 2` at config construction

The coordinator derives its staleness check interval as `heartbeat_timeout_ms / 2` (integer division). A timeout of `1` divided down to a check interval of `0`, which the scheduler treats as "disabled" — **silently turning off heartbeat eviction entirely**. Previously the `> 0` guard in `beryl.start` let this through.

`beryl.start` now rejects any `heartbeat_timeout_ms < 2` with `Error(InvalidHeartbeatTimeout)`, failing loudly at construction rather than clamping the derived interval. `2` is the smallest accepted value (yields a check interval of `1`).

### 2. Re-document `heartbeat_interval_ms` as client-advisory

The server never reads `heartbeat_interval_ms`. Updated the field doc, the `with_heartbeat` builder doc, the `start` doc, and the `InvalidHeartbeatTimeout` variant doc to state that this value is advisory — the ping cadence clients should use — and that the server schedules nothing from it.

## How the error surfaces

Validation lives in the existing `beryl.start` path (the config builders return an opaque `Config` and are non-fallible). `start` returns `Result(Channels, StartError)`; a timeout below 2 yields `Error(InvalidHeartbeatTimeout)`.

## Tests (TDD)

Added to `test/heartbeat_test.gleam`, exercising the public `beryl.start` API:
- `beryl_start_rejects_timeout_of_one_test` — the regression case (was silently accepted)
- `beryl_start_rejects_zero_timeout_test`, `beryl_start_rejects_negative_timeout_test`
- `beryl_start_accepts_timeout_of_two_test` — smallest valid value
- `beryl_start_accepts_default_timeout_test`

All 239 tests pass. Regenerated `website/src/content/docs/reference/api/beryl.md` via `just site-reference` and added a changie `Fixed` entry.

Closes #154