### PR TITLE
feat(transport): enforce and document per-IP connection limits

### DIFF
--- a/.changes/unreleased/Security-20260707-171500.yaml
+++ b/.changes/unreleased/Security-20260707-171500.yaml
@@ -1,0 +1,6 @@
+kind: Security
+body: |-
+    Document that per-IP connection limits (with_max_connections_per_ip) enforce on the real socket peer IP and that X-Forwarded-For is not trusted or parsed, so clients cannot spoof their address to bypass the limit.
+
+    Adds guidance for deployments behind a trusted reverse proxy, where all connections share the proxy IP and per-IP limits must be enforced at the proxy layer. Also adds tests covering admission under the limit, rejection over it, slot release on disconnect, per-IP isolation, and 0 meaning unlimited. Closes #153 and #176.
+time: 2026-07-07T17:15:00.000000000-07:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -246,7 +246,24 @@ pub fn with_heartbeat(
 /// Configure the maximum number of concurrent connections allowed per client
 /// IP address.
 ///
-/// A value of 0 (the default) means unlimited.
+/// A value of 0 (the default) means unlimited. When a limit is set, a transport
+/// admits a new connection only while the peer is below the limit and rejects
+/// it otherwise; the slot is freed when the connection closes.
+///
+/// ## Which IP is used
+///
+/// The limit is enforced on the **real socket peer IP** as reported by the
+/// transport (for the Mist transport, the address of the TCP connection).
+/// Beryl deliberately does **not** trust or parse forwarded headers such as
+/// `X-Forwarded-For`, because a client can set them freely and would otherwise
+/// be able to spoof its address and bypass this limit.
+///
+/// If Beryl runs behind a trusted reverse proxy or load balancer, every
+/// connection shares the proxy's address, so a per-IP limit throttles all
+/// clients as a single IP. In that topology you must resolve the real client
+/// IP yourself at the proxy layer (for example, by enforcing limits there). A
+/// built-in trusted-proxy opt-in may be added in a future release. See the
+/// WebSocket transport guide for deployment guidance.
 pub fn with_max_connections_per_ip(
   config: Config,
   max_connections max_connections: Int,
@@ -515,6 +532,13 @@ pub fn configured_codec(channels: Channels) -> codec.Codec {
 }
 
 /// Try to acquire a configured per-IP connection slot for transports.
+///
+/// Transports call this before admitting a connection, passing the **real
+/// socket peer IP**. Do not pass a client-supplied address (e.g. from
+/// `X-Forwarded-For`): a spoofed value would defeat the per-IP limit. Returns
+/// `Ok(Some(permit))` when admitted (release the permit with
+/// `release_connection_slot` on close), `Ok(None)` when no limit is configured
+/// (unlimited), or `Error(Nil)` when the peer is already at its limit.
 pub fn acquire_connection_slot(
   channels: Channels,
   ip: String,

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -128,6 +128,17 @@ type SendRequest {
 /// `config.path`. Because the normalised path never has a trailing slash, a
 /// config path written with a trailing slash (e.g. `"/socket/"`) will never
 /// match. Configure the path without a trailing slash (e.g. `"/socket"`).
+///
+/// ## Per-IP connection limits
+///
+/// When `beryl.with_max_connections_per_ip` is configured, this transport
+/// enforces the limit before completing the handshake and returns `429 Too
+/// Many Requests` once the peer is at its limit. Enforcement uses the **real
+/// socket peer IP** from the TCP connection; forwarded headers such as
+/// `X-Forwarded-For` are **not** trusted or parsed, because clients can set
+/// them and would otherwise spoof their address to bypass the limit. Behind a
+/// trusted reverse proxy, all connections share the proxy's IP — resolve the
+/// real client IP at the proxy layer. See the WebSocket transport guide.
 pub fn upgrade(
   request: Request(Connection),
   channels: Channels,

--- a/test/connection_limit_test.gleam
+++ b/test/connection_limit_test.gleam
@@ -1,0 +1,109 @@
+//// Per-IP connection limit enforcement tests.
+////
+//// These exercise the public transport-facing API
+//// (`beryl.acquire_connection_slot` / `beryl.release_connection_slot`) which
+//// the Mist transport uses to admit or reject WebSocket upgrades based on the
+//// real socket peer IP.
+
+import beryl
+import beryl/wire
+import gleam/option.{None, Some}
+import gleeunit/should
+
+fn start_with_limit(max_connections: Int) -> beryl.Channels {
+  let assert Ok(channels) =
+    beryl.start(
+      beryl.config(wire.phoenix_codec())
+      |> beryl.with_max_connections_per_ip(max_connections: max_connections),
+    )
+  channels
+}
+
+// A limit of 0 means unlimited: every acquire from the same IP succeeds and no
+// permit is handed back (there is nothing to release).
+pub fn zero_means_unlimited_test() {
+  let channels = start_with_limit(0)
+
+  beryl.acquire_connection_slot(channels, "1.2.3.4")
+  |> should.equal(Ok(None))
+  beryl.acquire_connection_slot(channels, "1.2.3.4")
+  |> should.equal(Ok(None))
+  beryl.acquire_connection_slot(channels, "1.2.3.4")
+  |> should.equal(Ok(None))
+
+  beryl.stop(channels)
+}
+
+// Connections at or below the configured limit are admitted.
+pub fn admits_connections_under_limit_test() {
+  let channels = start_with_limit(2)
+
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.1"))
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.1"))
+
+  beryl.stop(channels)
+}
+
+// The connection that would exceed the limit is rejected.
+pub fn rejects_connection_over_limit_test() {
+  let channels = start_with_limit(1)
+
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.2"))
+  beryl.acquire_connection_slot(channels, "10.0.0.2")
+  |> should.equal(Error(Nil))
+
+  beryl.stop(channels)
+}
+
+// Releasing a slot frees capacity so a subsequent connection from that IP
+// succeeds. This guards against slot leaks that would permanently exhaust an IP.
+pub fn releasing_slot_frees_capacity_test() {
+  let channels = start_with_limit(1)
+
+  let assert Ok(permit) = beryl.acquire_connection_slot(channels, "10.0.0.3")
+  // At the limit now.
+  beryl.acquire_connection_slot(channels, "10.0.0.3")
+  |> should.equal(Error(Nil))
+
+  // Freeing the slot admits the next connection from the same IP.
+  beryl.release_connection_slot(permit)
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.3"))
+
+  beryl.stop(channels)
+}
+
+// The limit is tracked independently per IP.
+pub fn limit_is_per_ip_test() {
+  let channels = start_with_limit(1)
+
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.4"))
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.5"))
+
+  // Each IP is independently at its limit now.
+  beryl.acquire_connection_slot(channels, "10.0.0.4")
+  |> should.equal(Error(Nil))
+  beryl.acquire_connection_slot(channels, "10.0.0.5")
+  |> should.equal(Error(Nil))
+
+  beryl.stop(channels)
+}
+
+// Releasing an unlimited (`None`) permit is a harmless no-op.
+pub fn releasing_none_permit_is_noop_test() {
+  beryl.release_connection_slot(None)
+  |> should.equal(Nil)
+}
+
+// A permit obtained under a limit can be released explicitly.
+pub fn some_permit_can_be_released_test() {
+  let channels = start_with_limit(1)
+
+  let assert Ok(permit) = beryl.acquire_connection_slot(channels, "10.0.0.6")
+  case permit {
+    Some(_) -> Nil
+    None -> should.fail()
+  }
+  beryl.release_connection_slot(permit)
+
+  beryl.stop(channels)
+}

--- a/test/mist_handler_test.gleam
+++ b/test/mist_handler_test.gleam
@@ -185,6 +185,22 @@ pub fn handler_rejects_connections_over_per_ip_limit_test() {
   stop_supervisor(server_pid)
 }
 
+pub fn handler_allows_unlimited_connections_when_limit_is_zero_test() {
+  // The default config leaves `max_connections_per_ip` at 0 (unlimited), so
+  // multiple concurrent connections from the same peer IP are all admitted.
+  let channels = start_channels()
+  let #(port, server_pid) = start_server(channels)
+
+  let assert Ok(first) = connect_websocket(port, "/socket")
+  let assert Ok(second) = connect_websocket(port, "/socket")
+  let assert Ok(third) = connect_websocket(port, "/socket")
+
+  close(first)
+  close(second)
+  close(third)
+  stop_supervisor(server_pid)
+}
+
 pub fn handler_closes_socket_on_oversized_text_frame_test() {
   let #(port, server_pid) = start_frame_limited_server()
   let assert Ok(client) = connect_websocket(port, "/socket")

--- a/website/src/content/docs/guides/websocket.md
+++ b/website/src/content/docs/guides/websocket.md
@@ -237,6 +237,42 @@ let config =
 | `join_rate` | Per socket | Join attempts per second |
 | `channel_rate` | Per socket+topic | Messages per second on a single topic |
 
+## Per-IP connection limits
+
+Cap the number of concurrent connections a single client IP may hold with
+`with_max_connections_per_ip`. A value of `0` (the default) means unlimited.
+
+```gleam
+let config =
+  beryl.config(wire.phoenix_codec())
+  |> beryl.with_max_connections_per_ip(max_connections: 5)
+```
+
+When a peer is already at its limit, the Mist transport rejects the new upgrade
+with `429 Too Many Requests` before the WebSocket handshake completes. The slot
+is released automatically when a connection closes, so disconnecting frees
+capacity for that IP.
+
+### Reverse proxies and `X-Forwarded-For`
+
+The limit is enforced on the **real socket peer IP** — the address of the TCP
+connection Mist accepts. beryl deliberately does **not** trust or parse
+forwarded headers such as `X-Forwarded-For`, because any client can set them and
+would otherwise be able to spoof its address and bypass the limit.
+
+This has an important consequence when beryl runs **behind a reverse proxy or
+load balancer** (nginx, HAProxy, a cloud LB, etc.): every connection arrives
+from the proxy's IP, so a per-IP limit sees all clients as one address and
+throttles them collectively. In that topology:
+
+- Enforce per-IP limits at the proxy layer, where the real client IP is known, or
+- Terminate connections directly (no intermediary) if you want beryl's built-in
+  per-IP limit to apply to individual clients.
+
+A built-in trusted-proxy opt-in (to derive the client IP from a forwarded header
+only when the immediate peer is a configured trusted proxy) may be added in a
+future release. Until then, treat `X-Forwarded-For` as untrusted input.
+
 ## Next steps
 
 - [Error Handling guide](/guides/error-handling/) — rejected joins, malformed frames, and client-visible error shapes

--- a/website/src/content/docs/reference/api/beryl-transport-mist.md
+++ b/website/src/content/docs/reference/api/beryl-transport-mist.md
@@ -103,6 +103,17 @@ Upgrade a request to WebSocket if it matches the configured path
  config path written with a trailing slash (e.g. `"/socket/"`) will never
  match. Configure the path without a trailing slash (e.g. `"/socket"`).
 
+ ## Per-IP connection limits
+
+ When `beryl.with_max_connections_per_ip` is configured, this transport
+ enforces the limit before completing the handshake and returns `429 Too
+ Many Requests` once the peer is at its limit. Enforcement uses the **real
+ socket peer IP** from the TCP connection; forwarded headers such as
+ `X-Forwarded-For` are **not** trusted or parsed, because clients can set
+ them and would otherwise spoof their address to bypass the limit. Behind a
+ trusted reverse proxy, all connections share the proxy's IP — resolve the
+ real client IP at the proxy layer. See the WebSocket transport guide.
+
 ```gleam
 pub fn upgrade(
   request.Request(http.Connection),

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -173,6 +173,13 @@ The coordinator actor failed to start.
 
 Try to acquire a configured per-IP connection slot for transports.
 
+ Transports call this before admitting a connection, passing the **real
+ socket peer IP**. Do not pass a client-supplied address (e.g. from
+ `X-Forwarded-For`): a spoofed value would defeat the per-IP limit. Returns
+ `Ok(Some(permit))` when admitted (release the permit with
+ `release_connection_slot` on close), `Ok(None)` when no limit is configured
+ (unlimited), or `Error(Nil)` when the peer is already at its limit.
+
 ```gleam
 pub fn acquire_connection_slot(
   Channels,
@@ -496,7 +503,24 @@ pub fn with_logging(
 Configure the maximum number of concurrent connections allowed per client
  IP address.
 
- A value of 0 (the default) means unlimited.
+ A value of 0 (the default) means unlimited. When a limit is set, a transport
+ admits a new connection only while the peer is below the limit and rejects
+ it otherwise; the slot is freed when the connection closes.
+
+ ## Which IP is used
+
+ The limit is enforced on the **real socket peer IP** as reported by the
+ transport (for the Mist transport, the address of the TCP connection).
+ Beryl deliberately does **not** trust or parse forwarded headers such as
+ `X-Forwarded-For`, because a client can set them freely and would otherwise
+ be able to spoof its address and bypass this limit.
+
+ If Beryl runs behind a trusted reverse proxy or load balancer, every
+ connection shares the proxy's address, so a per-IP limit throttles all
+ clients as a single IP. In that topology you must resolve the real client
+ IP yourself at the proxy layer (for example, by enforcing limits there). A
+ built-in trusted-proxy opt-in may be added in a future release. See the
+ WebSocket transport guide for deployment guidance.
 
 ```gleam
 pub fn with_max_connections_per_ip(


### PR DESCRIPTION
## Summary

Addresses the per-IP connection limit control (`with_max_connections_per_ip`) for v1: confirms end-to-end enforcement, documents the `X-Forwarded-For` posture, and adds test coverage.

### Investigation
The core enforcement was already wired end-to-end by #145:
- The Mist transport reads the **real socket peer IP** via `mist.get_connection_info` (`request_ip`), not a client header.
- `beryl.acquire_connection_slot` consults the per-IP limiter and returns `Error` at the limit; the transport rejects the upgrade with `429`.
- The permit lifecycle is correct: acquired before upgrade, released on `on_close`, and also released when an `on_connect` callback rejects the connection.
- `max_connections_per_ip = 0` disables the limiter entirely (`connection_limit.start_optional`).

So no enforcement logic was missing. This PR hardens the guarantees with docs and tests.

### #153 — Per-IP connection limiting
- New `test/connection_limit_test.gleam`: admission under the limit, rejection over the limit, slot release freeing capacity, per-IP isolation, and `0 = unlimited` — exercised through the public `beryl.acquire_connection_slot` / `release_connection_slot` API.
- New Mist handler integration test: multiple concurrent connections from one IP all admitted when the limit is `0` (complements the existing over-limit `429` + slot-release test).

### #176 — `X-Forwarded-For`
Documented (not parsed). Enforcement stays on the real socket peer IP because trusting `X-Forwarded-For` would let clients spoof their address and defeat the limit. Documented on:
- `with_max_connections_per_ip` and `acquire_connection_slot` doc comments
- the Mist transport `upgrade` entry point
- a new **Per-IP connection limits** section in `website/src/content/docs/guides/websocket.md`, including reverse-proxy deployment guidance and a note that a trusted-proxy opt-in may come later.

Regenerated `reference/api/*.md` via `just site-reference` (docs gate clean).

### Verification
- `just format-check`, `just check`, `just test` (251 passed), `just build-strict` — all green.
- `just examples-build` — all example apps compile against these changes.

Closes #153
Closes #176