### PR TITLE
docs: update guides for opaque config and presence APIs

### DIFF
--- a/website/src/content/docs/guides/groups.md
+++ b/website/src/content/docs/guides/groups.md
@@ -132,24 +132,23 @@ let assert Ok(Nil) = group.delete(groups, "team:eng")
 
 ## Using groups with the supervisor
 
-When using `beryl/supervisor`, set `groups: True` in `SupervisedConfig` and access the groups handle from the returned `SupervisedChannels`:
+When using `beryl/supervisor`, enable groups with `supervisor.with_groups` and access the groups handle from the returned `SupervisedChannels` via `supervisor.groups`:
 
 ```gleam
 import beryl
 import beryl/supervisor
 import beryl/wire
-import gleam/option.{None}
+import gleam/option.{None, Some}
 
-let config = supervisor.SupervisedConfig(
-  channels: beryl.config(wire.phoenix_codec()),
-  presence: None,
-  groups: True,
-)
+let config =
+  supervisor.config(beryl.config(wire.phoenix_codec()))
+  |> supervisor.with_groups()
 let assert Ok(supervised) = supervisor.start(config)
 
-// supervised.groups is Option(group.Groups)
-case supervised.groups {
-  Some(g) -> group.broadcast(g, supervised.channels, "team:eng", "alert", payload)
+// supervisor.groups(supervised) is Option(group.Groups)
+case supervisor.groups(supervised) {
+  Some(g) ->
+    group.broadcast(g, supervisor.channels(supervised), "team:eng", "alert", payload)
   None -> Nil
 }
 ```

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -56,12 +56,17 @@ The **key** groups multiple connections from the same user. The **pid** uniquely
 ## Untracking
 
 ```gleam
-// Remove a specific presence
-presence.untrack(p, "room:lobby", "user:alice", socket_id)
+// Remove a specific presence, using the ref returned by `track`
+presence.untrack(p, ref)
 
-// Remove all presences for a socket (e.g., on disconnect)
+// Remove all presences for a session id / socket (e.g., on disconnect)
 presence.untrack_all(p, socket_id)
 ```
+
+`track` returns a server-generated ref that identifies exactly the presence it
+created. Hold onto that ref if you need to remove one specific presence later
+with `untrack`. To clear every presence for a disconnecting socket, use
+`untrack_all` with the session id instead.
 
 ## Listing presences
 
@@ -116,13 +121,13 @@ let config =
 `broadcast_presence_diff` broadcasts to a single topic. The `diff` passed to `on_diff` may span multiple topics; if you track presence across several topics, iterate over the affected topics:
 
 ```gleam
-on_diff: option.Some(fn(diff) {
+|> presence.with_on_diff(fn(diff) {
   diff
   |> presence.diff_topics
   |> list.each(fn(topic) {
     beryl.broadcast_presence_diff(channels, topic, diff)
   })
-}),
+})
 ```
 
 Passing the full diff on each iteration is safe: `broadcast_presence_diff` encodes only the named topic's entries from the diff, so unrelated topics are never included in a broadcast.

--- a/website/src/content/docs/guides/supervision.md
+++ b/website/src/content/docs/guides/supervision.md
@@ -23,54 +23,50 @@ import beryl
 import beryl/supervisor
 import beryl/presence
 import beryl/wire
-import gleam/option.{None, Some}
 
 pub fn main() {
-  let config = supervisor.SupervisedConfig(
-    channels: beryl.config(wire.phoenix_codec()),
-    presence: Some(presence.default_config("node1")),
-    groups: True,
-  )
+  let config =
+    supervisor.config(beryl.config(wire.phoenix_codec()))
+    |> supervisor.with_presence(presence.default_config("node1"))
+    |> supervisor.with_groups()
 
   let assert Ok(supervised) = supervisor.start(config)
 
-  // Use the handles
-  // supervised.channels  → beryl.Channels
-  // supervised.presence  → option.Option(presence.Presence)
-  // supervised.groups    → option.Option(group.Groups)
+  // Read the handles with the accessor functions
+  // supervisor.channels(supervised)  → beryl.Channels
+  // supervisor.presence(supervised)  → option.Option(presence.Presence)
+  // supervisor.groups(supervised)    → option.Option(group.Groups)
 }
 ```
 
 ## SupervisedConfig
 
+`SupervisedConfig` is an opaque type. Build it with `supervisor.config` and refine
+it with the `with_*` functions:
+
 ```gleam
-pub type SupervisedConfig {
-  SupervisedConfig(
-    channels: beryl.Config,         // always started
-    presence: Option(presence.Config), // Some → start presence, None → skip
-    groups: Bool,                   // True → start groups actor
-  )
-}
+supervisor.config(beryl.config(wire.phoenix_codec())) // coordinator only
+|> supervisor.with_presence(presence.default_config("node1")) // enable presence
+|> supervisor.with_groups()                                   // enable groups
 ```
 
-Pass `None` for presence and `False` for groups if your application does not use them. The coordinator is always started.
+The coordinator (channels) is always started. Omit `with_presence` to skip
+presence and `with_groups` to skip the groups actor.
 
 ## SupervisedChannels
 
-`supervisor.start` returns `SupervisedChannels`:
+`supervisor.start` returns an opaque `SupervisedChannels` handle. Read its
+subsystems with the accessor functions:
 
 ```gleam
-pub type SupervisedChannels {
-  SupervisedChannels(
-    channels: beryl.Channels,
-    presence: Option(presence.Presence),
-    groups: Option(group.Groups),
-    supervisor_pid: process.Pid,
-  )
-}
+supervisor.channels(supervised)       // beryl.Channels (always present)
+supervisor.presence(supervised)       // Option(presence.Presence)
+supervisor.groups(supervised)         // Option(group.Groups)
+supervisor.supervisor_pid(supervised) // process.Pid
 ```
 
-The optional fields reflect your configuration — if you passed `groups: False`, `supervised.groups` is `None`.
+The optional accessors reflect your configuration — if you did not call
+`with_groups`, `supervisor.groups(supervised)` is `None`.
 
 ## Restart strategy
 
@@ -89,7 +85,7 @@ Under rest-for-one, if a child crashes, that child and all children started *aft
 The default restart tolerance is **3 restarts in 5 seconds** before the supervisor itself shuts down.
 
 :::note[PubSub is not supervised]
-`beryl/pubsub` is backed by Erlang's `pg` module, which has its own lifecycle managed by the BEAM runtime. Start PubSub separately and pass it to `beryl.Config` via `beryl.with_pubsub`.
+`beryl/pubsub` is backed by Erlang's `pg` module, which has its own lifecycle managed by the BEAM runtime. Start PubSub separately and add it to the channels config via `beryl.with_pubsub`.
 :::
 
 ## Stopping the supervisor
@@ -111,11 +107,9 @@ import beryl/supervisor
 import beryl/wire
 import gleam/otp/static_supervisor
 
-let beryl_config = supervisor.SupervisedConfig(
-  channels: beryl.config(wire.phoenix_codec()),
-  presence: None,
-  groups: True,
-)
+let beryl_config =
+  supervisor.config(beryl.config(wire.phoenix_codec()))
+  |> supervisor.with_groups()
 
 static_supervisor.new(static_supervisor.OneForOne)
 |> static_supervisor.add(supervisor.child_spec(beryl_config))

--- a/website/src/content/docs/guides/websocket.md
+++ b/website/src/content/docs/guides/websocket.md
@@ -212,11 +212,12 @@ Clients should send periodic heartbeat messages to stay connected:
 Configure heartbeat timing in the beryl config:
 
 ```gleam
-let config = beryl.Config(
-  ..beryl.config(wire.phoenix_codec()),
-  heartbeat_interval_ms: 30_000,  // Client sends every 30s
-  heartbeat_timeout_ms: 60_000,   // Server evicts after 60s silence
-)
+let config =
+  beryl.config(wire.phoenix_codec())
+  |> beryl.with_heartbeat(
+    interval_ms: 30_000,  // Client-advisory ping cadence (server does not read it)
+    timeout_ms: 60_000,   // Server evicts after 60s silence (must be >= 2)
+  )
 ```
 
 ## Rate limiting


### PR DESCRIPTION
Updates hand-written documentation so code examples match the public API after the batch of pre-1.0 opaque-type changes.

## Files updated
- **website/src/content/docs/guides/websocket.md** — heartbeat example used `beryl.Config(..)` record spread; now uses `beryl.config() |> beryl.with_heartbeat(interval_ms:, timeout_ms:)`, with notes that `interval_ms` is client-advisory only and `timeout_ms` must be `>= 2`. (Left the new Per-IP connection limits section intact.)
- **website/src/content/docs/guides/supervision.md** — replaced `SupervisedConfig(..)` / `SupervisedChannels(..)` record construction and field access with the builder (`supervisor.config |> with_presence |> with_groups`) and accessors (`supervisor.channels/presence/groups/supervisor_pid`); updated the type-description blocks, the `child_spec` example, and a PubSub prose mention. Dropped the now-unused `gleam/option` import.
- **website/src/content/docs/guides/groups.md** — supervisor usage example switched from `supervisor.SupervisedConfig(..)` + `supervised.groups`/`supervised.channels` field access to `supervisor.with_groups()` + `supervisor.groups(..)`/`supervisor.channels(..)` accessors.
- **website/src/content/docs/guides/presence.md** — replaced the old 4-arg `untrack(p, topic, key, pid)` with the new 2-arg `untrack(p, ref)` (ref captured from `track`), clarified `untrack_all(p, session_id)` for disconnects, and converted the multi-topic diff example from the `on_diff:` record-field fragment to the `with_on_diff` builder.

## Scope / notes
- No changes under `reference/api/` (generated), `src/`, or `test/`.
- `PRD.md` already referenced `topic.extract_id` (the `extract_topic_id` removal was handled); example READMEs are clean.
- Final grep sweep for `beryl.Config(`, `SupervisedConfig(`, `SupervisedChannels(`, `Codec(`, `socket.Transport(`, `extract_topic_id`, 4-arg `untrack`, and `supervised.` field access comes back clean across hand-written docs.
- No changie entry added: `docs:`-type commits are not flagged as needing one by the changie-check workflow (it only comments, never fails).