### PR TITLE
perf: optimize internal hot paths

### DIFF
--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -628,18 +628,9 @@ fn handle_socket_disconnected(
 }
 
 fn remove_socket_rate_limits(state: State, socket_id: String) -> Nil {
-  rate_limit.remove_by_prefix_optional(
-    state.config.message_limiter,
-    "msg:" <> socket_id,
-  )
-  rate_limit.remove_by_prefix_optional(
-    state.config.join_limiter,
-    "join:" <> socket_id,
-  )
-  rate_limit.remove_by_prefix_optional(
-    state.config.channel_limiter,
-    "ch:" <> socket_id <> ":",
-  )
+  rate_limit.remove_group_optional(state.config.message_limiter, socket_id)
+  rate_limit.remove_group_optional(state.config.join_limiter, socket_id)
+  rate_limit.remove_group_optional(state.config.channel_limiter, socket_id)
 }
 
 fn handle_join(
@@ -651,9 +642,7 @@ fn handle_join(
   ref: Option(String),
 ) -> actor.Next(State, Message) {
   // Check join rate limit
-  case
-    rate_limit.check_optional(state.config.join_limiter, "join:" <> socket_id)
-  {
+  case rate_limit.check_optional(state.config.join_limiter, socket_id, "join") {
     Error(Nil) -> {
       let logger = coordinator_logger(state)
       logger
@@ -841,7 +830,11 @@ fn handle_in(
 ) -> actor.Next(State, Message) {
   // Check per-socket message rate limit
   case
-    rate_limit.check_optional(state.config.message_limiter, "msg:" <> socket_id)
+    rate_limit.check_optional(
+      state.config.message_limiter,
+      socket_id,
+      "message",
+    )
   {
     Error(Nil) -> {
       let logger = coordinator_logger(state)
@@ -918,8 +911,8 @@ fn handle_in_rate_limited(
   case
     rate_limit.check_capped_optional(
       state.config.channel_limiter,
-      "ch:" <> socket_id <> ":" <> topic_name,
-      "ch:" <> socket_id <> ":",
+      socket_id,
+      topic_name,
       state.config.channel_limiter_max_keys_per_socket,
     )
   {
@@ -1015,7 +1008,11 @@ fn handle_raw_binary_with_rate_limit(
   data: BitArray,
 ) -> actor.Next(State, Message) {
   case
-    rate_limit.check_optional(state.config.message_limiter, "msg:" <> socket_id)
+    rate_limit.check_optional(
+      state.config.message_limiter,
+      socket_id,
+      "message",
+    )
   {
     Error(Nil) -> {
       let logger = coordinator_logger(state)
@@ -1067,14 +1064,7 @@ fn handle_raw_binary_in_inner(
     Ok(socket_info) -> {
       let state =
         set.fold(socket_info.subscribed_topics, state, fn(st, topic_name) {
-          route_binary_to_handler(
-            state,
-            st,
-            socket_info,
-            socket_id,
-            topic_name,
-            data,
-          )
+          route_binary_to_handler(st, socket_info, socket_id, topic_name, data)
         })
       actor.continue(state)
     }
@@ -1794,7 +1784,6 @@ fn dispatch_handle_info(
 }
 
 fn dispatch_handle_binary(
-  _state: State,
   st: State,
   socket_info: SocketInfo,
   handler: ChannelHandler,
@@ -1912,7 +1901,8 @@ fn do_terminate_channel(
 
   rate_limit.remove_optional(
     state.config.channel_limiter,
-    "ch:" <> socket_id <> ":" <> topic_name,
+    socket_id,
+    topic_name,
   )
 
   let new_subscribed = set.delete(socket_info.subscribed_topics, topic_name)
@@ -2045,7 +2035,6 @@ fn find_joined_handler(
 }
 
 fn route_binary_to_handler(
-  state: State,
   st: State,
   socket_info: SocketInfo,
   socket_id: String,
@@ -2065,7 +2054,6 @@ fn route_binary_to_handler(
     }
     Some(handler) ->
       dispatch_handle_binary(
-        state,
         st,
         socket_info,
         handler,

--- a/src/beryl/presence.gleam
+++ b/src/beryl/presence.gleam
@@ -37,6 +37,7 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/otp/actor
 import gleam/result
+import gleam/set.{type Set}
 import gleam/string
 import lattice_presence/presence_state as state
 import lattice_presence/state_json
@@ -91,7 +92,7 @@ pub fn diff(
 /// List topics touched by this diff.
 pub fn diff_topics(diff: Diff) -> List(String) {
   list.append(dict.keys(diff.joins), dict.keys(diff.leaves))
-  |> unique_strings([])
+  |> unique_strings(set.new(), [])
 }
 
 /// Get presence joins for a topic in this diff.
@@ -106,13 +107,18 @@ pub fn diff_leaves(diff: Diff, topic: String) -> List(PresenceEntry) {
   |> result.unwrap([])
 }
 
-fn unique_strings(values: List(String), seen: List(String)) -> List(String) {
+fn unique_strings(
+  values: List(String),
+  seen: Set(String),
+  unique: List(String),
+) -> List(String) {
   case values {
-    [] -> list.reverse(seen)
+    [] -> list.reverse(unique)
     [value, ..rest] ->
-      case list.contains(seen, value) {
-        True -> unique_strings(rest, seen)
-        False -> unique_strings(rest, [value, ..seen])
+      case set.contains(seen, value) {
+        True -> unique_strings(rest, seen, unique)
+        False ->
+          unique_strings(rest, set.insert(seen, value), [value, ..unique])
       }
   }
 }

--- a/src/beryl/rate_limit.gleam
+++ b/src/beryl/rate_limit.gleam
@@ -7,7 +7,6 @@ import gleam/bool
 import gleam/dict.{type Dict}
 import gleam/erlang/process.{type Subject}
 import gleam/int
-import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/otp/actor
 import gleam/result
@@ -93,21 +92,25 @@ pub opaque type RateLimiter {
 }
 
 type RegistryState {
-  RegistryState(config: RateLimitConfig, buckets: Dict(String, BucketState))
+  RegistryState(
+    config: RateLimitConfig,
+    groups: Dict(String, Dict(String, BucketState)),
+    bucket_count: Int,
+  )
 }
 
 type RegistryMsg {
-  Check(key: String, reply: Subject(Result(Nil, Nil)))
+  Check(group: String, key: String, reply: Subject(Result(Nil, Nil)))
   CheckCapped(
+    group: String,
     key: String,
-    prefix: String,
     max_keys: Int,
     reply: Subject(Result(Nil, Nil)),
   )
   Count(reply: Subject(Int))
-  CountByPrefix(prefix: String, reply: Subject(Int))
-  RemoveKey(key: String)
-  RemoveByPrefix(prefix: String)
+  CountGroup(group: String, reply: Subject(Int))
+  RemoveKey(group: String, key: String)
+  RemoveGroup(group: String)
   RegistryStop(reply: Subject(Nil))
 }
 
@@ -121,54 +124,55 @@ fn handle_registry_msg(
       actor.stop()
     }
 
-    Check(key, reply) -> actor.continue(check_key(state, key, reply))
+    Check(group, key, reply) ->
+      actor.continue(check_key(state, group, key, reply))
 
-    CheckCapped(key, prefix, max_keys, reply) ->
-      actor.continue(check_key_capped(state, key, prefix, max_keys, reply))
+    CheckCapped(group, key, max_keys, reply) ->
+      actor.continue(check_key_capped(state, group, key, max_keys, reply))
 
     Count(reply) -> {
-      process.send(reply, list.length(dict.to_list(state.buckets)))
+      process.send(reply, state.bucket_count)
       actor.continue(state)
     }
 
-    CountByPrefix(prefix, reply) -> {
-      process.send(reply, count_by_prefix(state.buckets, prefix))
+    CountGroup(group, reply) -> {
+      process.send(reply, group_size(state, group))
       actor.continue(state)
     }
 
-    RemoveKey(key) -> {
-      actor.continue(
-        RegistryState(..state, buckets: dict.delete(state.buckets, key)),
-      )
-    }
+    RemoveKey(group, key) -> actor.continue(remove_key(state, group, key))
 
-    RemoveByPrefix(prefix) -> {
-      let to_keep =
-        dict.to_list(state.buckets)
-        |> list.filter(fn(entry) { !string_starts_with(entry.0, prefix) })
-      actor.continue(RegistryState(..state, buckets: dict.from_list(to_keep)))
-    }
+    RemoveGroup(group) -> actor.continue(remove_group_state(state, group))
   }
 }
 
-fn count_by_prefix(buckets: Dict(String, BucketState), prefix: String) -> Int {
-  dict.to_list(buckets)
-  |> list.filter(fn(entry) { string_starts_with(entry.0, prefix) })
-  |> list.length
+fn group_size(state: RegistryState, group: String) -> Int {
+  dict.get(state.groups, group)
+  |> result.map(dict.size)
+  |> result.unwrap(0)
 }
 
 fn check_key(
   state: RegistryState,
+  group: String,
   key: String,
   reply: Subject(Result(Nil, Nil)),
 ) -> RegistryState {
-  case dict.get(state.buckets, key) {
+  let buckets =
+    dict.get(state.groups, group)
+    |> result.unwrap(dict.new())
+
+  case dict.get(buckets, key) {
     Ok(bucket) -> {
       let #(updated_bucket, check_result) = take_token(bucket)
       process.send(reply, check_result)
       RegistryState(
         ..state,
-        buckets: dict.insert(state.buckets, key, updated_bucket),
+        groups: dict.insert(
+          state.groups,
+          group,
+          dict.insert(buckets, key, updated_bucket),
+        ),
       )
     }
     Error(Nil) -> {
@@ -177,7 +181,12 @@ fn check_key(
       process.send(reply, check_result)
       RegistryState(
         ..state,
-        buckets: dict.insert(state.buckets, key, new_bucket),
+        groups: dict.insert(
+          state.groups,
+          group,
+          dict.insert(buckets, key, new_bucket),
+        ),
+        bucket_count: state.bucket_count + 1,
       )
     }
   }
@@ -185,27 +194,66 @@ fn check_key(
 
 fn check_key_capped(
   state: RegistryState,
+  group: String,
   key: String,
-  prefix: String,
   max_keys: Int,
   reply: Subject(Result(Nil, Nil)),
 ) -> RegistryState {
-  case dict.get(state.buckets, key) {
-    Ok(_) -> check_key(state, key, reply)
+  let buckets =
+    dict.get(state.groups, group)
+    |> result.unwrap(dict.new())
+
+  case dict.get(buckets, key) {
+    Ok(_) -> check_key(state, group, key, reply)
     Error(Nil) -> {
-      case max_keys > 0 && count_by_prefix(state.buckets, prefix) >= max_keys {
+      case max_keys > 0 && dict.size(buckets) >= max_keys {
         True -> {
           process.send(reply, Error(Nil))
           state
         }
-        False -> check_key(state, key, reply)
+        False -> check_key(state, group, key, reply)
       }
     }
   }
 }
 
-@external(erlang, "beryl_ffi", "string_starts_with")
-fn string_starts_with(string: String, prefix: String) -> Bool
+fn remove_key(
+  state: RegistryState,
+  group: String,
+  key: String,
+) -> RegistryState {
+  case dict.get(state.groups, group) {
+    Error(Nil) -> state
+    Ok(buckets) ->
+      case dict.get(buckets, key) {
+        Error(Nil) -> state
+        Ok(_) -> {
+          let remaining = dict.delete(buckets, key)
+          let groups = case dict.is_empty(remaining) {
+            True -> dict.delete(state.groups, group)
+            False -> dict.insert(state.groups, group, remaining)
+          }
+          RegistryState(
+            ..state,
+            groups: groups,
+            bucket_count: state.bucket_count - 1,
+          )
+        }
+      }
+  }
+}
+
+fn remove_group_state(state: RegistryState, group: String) -> RegistryState {
+  case dict.get(state.groups, group) {
+    Error(Nil) -> state
+    Ok(buckets) ->
+      RegistryState(
+        ..state,
+        groups: dict.delete(state.groups, group),
+        bucket_count: state.bucket_count - dict.size(buckets),
+      )
+  }
+}
 
 // Send a registry request without letting timeouts or dead subjects exit the
 // caller. If the limiter is unavailable, return the provided fallback so rate
@@ -234,7 +282,7 @@ fn request(
 /// Start a new rate limiter registry with the given config.
 /// All keys managed by this registry share the same rate/burst settings.
 pub fn start(cfg: RateLimitConfig) -> Result(RateLimiter, Nil) {
-  let state = RegistryState(config: cfg, buckets: dict.new())
+  let state = RegistryState(config: cfg, groups: dict.new(), bucket_count: 0)
   actor.new(state)
   |> actor.on_message(handle_registry_msg)
   |> actor.start
@@ -242,29 +290,33 @@ pub fn start(cfg: RateLimitConfig) -> Result(RateLimiter, Nil) {
   |> result.replace_error(Nil)
 }
 
-/// Check if a request for the given key is allowed.
+/// Check if a request for the given group and key is allowed.
 /// Returns Ok(Nil) if allowed, Error(Nil) if rate limited.
-pub fn check(limiter: RateLimiter, key: String) -> Result(Nil, Nil) {
+pub fn check(
+  limiter: RateLimiter,
+  group: String,
+  key: String,
+) -> Result(Nil, Nil) {
   request(
     limiter.subject,
     registry_call_timeout_ms,
-    fn(reply) { Check(key, reply) },
+    fn(reply) { Check(group, key, reply) },
     Ok(Nil),
   )
 }
 
-/// Check if a request is allowed, rejecting new keys after a per-prefix cap.
+/// Check if a request is allowed, rejecting new keys after a per-group cap.
 pub fn check_capped(
   limiter: RateLimiter,
+  group: String,
   key: String,
-  prefix: String,
   max_keys: Int,
 ) -> Result(Nil, Nil) {
   request(
     limiter.subject,
     registry_call_timeout_ms,
     fn(reply) {
-      CheckCapped(key: key, prefix: prefix, max_keys: max_keys, reply: reply)
+      CheckCapped(group: group, key: key, max_keys: max_keys, reply: reply)
     },
     Ok(Nil),
   )
@@ -273,24 +325,25 @@ pub fn check_capped(
 /// Check an optional rate limiter. If None, always allows.
 pub fn check_optional(
   limiter: Option(RateLimiter),
+  group: String,
   key: String,
 ) -> Result(Nil, Nil) {
   case limiter {
     None -> Ok(Nil)
-    Some(l) -> check(l, key)
+    Some(l) -> check(l, group, key)
   }
 }
 
-/// Check an optional rate limiter with a per-prefix key cap.
+/// Check an optional rate limiter with a per-group key cap.
 pub fn check_capped_optional(
   limiter: Option(RateLimiter),
+  group: String,
   key: String,
-  prefix: String,
   max_keys: Int,
 ) -> Result(Nil, Nil) {
   case limiter {
     None -> Ok(Nil)
-    Some(l) -> check_capped(l, key, prefix, max_keys)
+    Some(l) -> check_capped(l, group, key, max_keys)
   }
 }
 
@@ -304,43 +357,47 @@ pub fn bucket_count(limiter: RateLimiter) -> Int {
   )
 }
 
-/// Return the number of active token buckets matching a key prefix.
-pub fn bucket_count_by_prefix(limiter: RateLimiter, prefix: String) -> Int {
+/// Return the number of active token buckets in a group.
+pub fn bucket_count_by_group(limiter: RateLimiter, group: String) -> Int {
   request(
     limiter.subject,
     registry_call_timeout_ms,
-    fn(reply) { CountByPrefix(prefix: prefix, reply: reply) },
+    fn(reply) { CountGroup(group: group, reply: reply) },
     0,
   )
 }
 
-/// Remove rate limit state for an exact key.
-fn remove(limiter: RateLimiter, key: String) -> Nil {
-  process.send(limiter.subject, RemoveKey(key))
+/// Remove rate limit state for an exact group and key.
+fn remove(limiter: RateLimiter, group: String, key: String) -> Nil {
+  process.send(limiter.subject, RemoveKey(group, key))
 }
 
-/// Remove rate limit state for an exact key (optional limiter).
-pub fn remove_optional(limiter: Option(RateLimiter), key: String) -> Nil {
-  case limiter {
-    None -> Nil
-    Some(l) -> remove(l, key)
-  }
-}
-
-/// Remove all rate limit state for keys matching a prefix.
-/// Call this when a socket disconnects to clean up its buckets.
-pub fn remove_by_prefix(limiter: RateLimiter, prefix: String) -> Nil {
-  process.send(limiter.subject, RemoveByPrefix(prefix))
-}
-
-/// Remove rate limit state for keys matching a prefix (optional limiter).
-pub fn remove_by_prefix_optional(
+/// Remove rate limit state for an exact group and key (optional limiter).
+pub fn remove_optional(
   limiter: Option(RateLimiter),
-  prefix: String,
+  group: String,
+  key: String,
 ) -> Nil {
   case limiter {
     None -> Nil
-    Some(l) -> remove_by_prefix(l, prefix)
+    Some(l) -> remove(l, group, key)
+  }
+}
+
+/// Remove all rate limit state for a group.
+/// Call this when a socket disconnects to clean up its buckets.
+pub fn remove_group(limiter: RateLimiter, group: String) -> Nil {
+  process.send(limiter.subject, RemoveGroup(group))
+}
+
+/// Remove all rate limit state for a group (optional limiter).
+pub fn remove_group_optional(
+  limiter: Option(RateLimiter),
+  group: String,
+) -> Nil {
+  case limiter {
+    None -> Nil
+    Some(l) -> remove_group(l, group)
   }
 }
 

--- a/src/beryl_ffi.erl
+++ b/src/beryl_ffi.erl
@@ -1,6 +1,6 @@
 -module(beryl_ffi).
 -export([identity/1, monotonic_time_ms/0, monotonic_time_ns/0,
-         string_starts_with/2, stop_supervisor/1]).
+         stop_supervisor/1]).
 
 %% Identity function for type erasure
 identity(X) -> X.
@@ -10,14 +10,6 @@ monotonic_time_ms() -> erlang:monotonic_time(millisecond).
 
 %% Return Erlang monotonic time in nanoseconds
 monotonic_time_ns() -> erlang:monotonic_time(nanosecond).
-
-%% Check if a string starts with a prefix
-string_starts_with(String, Prefix) ->
-    PrefixLen = byte_size(Prefix),
-    case String of
-        <<Prefix:PrefixLen/binary, _/binary>> -> true;
-        _ -> false
-    end.
 
 %% Stop a supervisor process cleanly.
 %% Unlinks first so the calling process is not affected, then sends

--- a/test/channel_rate_limit_security_test.gleam
+++ b/test/channel_rate_limit_security_test.gleam
@@ -73,6 +73,38 @@ pub fn joined_topics_cannot_exceed_channel_bucket_cap_test() {
   rate_limit.stop(limiter)
 }
 
+pub fn channel_bucket_cap_is_isolated_per_socket_test() {
+  let assert Ok(limiter) =
+    rate_limit.start(rate_limit.config(per_second: 1000, burst: 1000))
+  let assert Ok(coord) =
+    coordinator.start_with_config(
+      coordinator.CoordinatorConfig(
+        ..coordinator.config(wire.phoenix_codec()),
+        channel_limiter: option.Some(limiter),
+        channel_limiter_max_keys_per_socket: 1,
+      ),
+    )
+  let sent = process.new_subject()
+  let assert Ok(_) = register_test_channel(coord, sent)
+
+  connect(coord, sent, "socket-one")
+  connect(coord, sent, "socket-two")
+  join(coord, "socket-one", "room:one")
+  join(coord, "socket-two", "room:two")
+  process.sleep(20)
+  drain(sent)
+
+  event(coord, "socket-one", "room:one", "ref-one")
+  event(coord, "socket-two", "room:two", "ref-two")
+
+  let assert Ok("handled") = process.receive(sent, 100)
+  let assert Ok("handled") = process.receive(sent, 100)
+  rate_limit.bucket_count(limiter) |> should.equal(2)
+  rate_limit.bucket_count_by_group(limiter, "socket-one") |> should.equal(1)
+  rate_limit.bucket_count_by_group(limiter, "socket-two") |> should.equal(1)
+  rate_limit.stop(limiter)
+}
+
 pub fn heartbeat_eviction_removes_channel_buckets_test() {
   let assert Ok(limiter) =
     rate_limit.start(rate_limit.config(per_second: 1000, burst: 1000))

--- a/test/presence_test.gleam
+++ b/test/presence_test.gleam
@@ -173,6 +173,14 @@ pub fn presence_default_config_test() {
   |> should.equal(1)
 }
 
+pub fn diff_topics_deduplicates_topics_in_joins_and_leaves_test() {
+  let diff =
+    presence.diff(joins: [#("room:lobby", [])], leaves: [#("room:lobby", [])])
+
+  presence.diff_topics(diff)
+  |> should.equal(["room:lobby"])
+}
+
 // ── on_diff callback tests ──────────────────────────────────────────────────
 
 pub fn on_diff_callback_receives_local_track_diff_test() {

--- a/test/rate_limit_test.gleam
+++ b/test/rate_limit_test.gleam
@@ -10,11 +10,11 @@ pub fn rate_limiter_allows_within_limit_test() {
     rate_limit.start(rate_limit.config(per_second: 100, burst: 10))
 
   // First 10 requests should be allowed (burst capacity)
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
 
   rate_limit.stop(limiter)
 }
@@ -24,12 +24,12 @@ pub fn rate_limiter_rejects_over_limit_test() {
     rate_limit.start(rate_limit.config(per_second: 100, burst: 3))
 
   // Exhaust the burst
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
 
   // Should be rate limited now
-  should.be_error(rate_limit.check(limiter, "key1"))
+  should.be_error(rate_limit.check(limiter, "group1", "key1"))
 
   rate_limit.stop(limiter)
 }
@@ -39,13 +39,16 @@ pub fn rate_limiter_per_key_isolation_test() {
     rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
 
   // Exhaust key1's bucket
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_error(rate_limit.check(limiter, "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_error(rate_limit.check(limiter, "group1", "key1"))
 
   // key2 should still have full bucket
-  should.be_ok(rate_limit.check(limiter, "key2"))
-  should.be_ok(rate_limit.check(limiter, "key2"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key2"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key2"))
+
+  // The same key in another group has an independent bucket.
+  should.be_ok(rate_limit.check(limiter, "group2", "key1"))
 
   rate_limit.stop(limiter)
 }
@@ -55,15 +58,15 @@ pub fn rate_limiter_refills_over_time_test() {
     rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
 
   // Exhaust the bucket
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_error(rate_limit.check(limiter, "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_error(rate_limit.check(limiter, "group1", "key1"))
 
   // Wait for tokens to refill (at 100/sec, 1 token every 10ms)
   process.sleep(25)
 
   // Should have tokens again
-  should.be_ok(rate_limit.check(limiter, "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
 
   rate_limit.stop(limiter)
 }
@@ -72,54 +75,58 @@ pub fn rate_limiter_refills_over_time_test() {
 
 pub fn check_optional_none_always_allows_test() {
   // None limiter should always allow
-  should.be_ok(rate_limit.check_optional(option.None, "any_key"))
+  should.be_ok(rate_limit.check_optional(option.None, "group", "any_key"))
 }
 
 pub fn check_optional_some_applies_limit_test() {
   let assert Ok(limiter) =
     rate_limit.start(rate_limit.config(per_second: 100, burst: 1))
 
-  should.be_ok(rate_limit.check_optional(option.Some(limiter), "key1"))
-  should.be_error(rate_limit.check_optional(option.Some(limiter), "key1"))
+  should.be_ok(rate_limit.check_optional(option.Some(limiter), "group1", "key1"))
+  should.be_error(rate_limit.check_optional(
+    option.Some(limiter),
+    "group1",
+    "key1",
+  ))
 
   rate_limit.stop(limiter)
 }
 
 // ── Cleanup ─────────────────────────────────────────────────────────────────
 
-pub fn remove_by_prefix_cleans_up_test() {
+pub fn remove_group_cleans_up_test() {
   let assert Ok(limiter) =
     rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
 
   // Create some buckets
-  should.be_ok(rate_limit.check(limiter, "ch:socket1:room:lobby"))
-  should.be_ok(rate_limit.check(limiter, "ch:socket1:room:lobby"))
-  should.be_error(rate_limit.check(limiter, "ch:socket1:room:lobby"))
+  should.be_ok(rate_limit.check(limiter, "socket1", "room:lobby"))
+  should.be_ok(rate_limit.check(limiter, "socket1", "room:lobby"))
+  should.be_error(rate_limit.check(limiter, "socket1", "room:lobby"))
 
-  // Remove by prefix for socket1
-  rate_limit.remove_by_prefix(limiter, "ch:socket1:")
+  // Remove all buckets for socket1.
+  rate_limit.remove_group(limiter, "socket1")
 
   // After cleanup, a new bucket is created — should be allowed again
-  should.be_ok(rate_limit.check(limiter, "ch:socket1:room:lobby"))
+  should.be_ok(rate_limit.check(limiter, "socket1", "room:lobby"))
 
   rate_limit.stop(limiter)
 }
 
-pub fn remove_by_prefix_preserves_other_keys_test() {
+pub fn remove_group_preserves_other_groups_test() {
   let assert Ok(limiter) =
     rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
 
   // Create buckets for two sockets
-  should.be_ok(rate_limit.check(limiter, "ch:socket1:topic"))
-  should.be_ok(rate_limit.check(limiter, "ch:socket1:topic"))
-  should.be_ok(rate_limit.check(limiter, "ch:socket2:topic"))
-  should.be_ok(rate_limit.check(limiter, "ch:socket2:topic"))
+  should.be_ok(rate_limit.check(limiter, "socket1", "topic"))
+  should.be_ok(rate_limit.check(limiter, "socket1", "topic"))
+  should.be_ok(rate_limit.check(limiter, "socket2", "topic"))
+  should.be_ok(rate_limit.check(limiter, "socket2", "topic"))
 
   // Remove socket1 only
-  rate_limit.remove_by_prefix(limiter, "ch:socket1:")
+  rate_limit.remove_group(limiter, "socket1")
 
   // socket2's state should be preserved (still limited)
-  should.be_error(rate_limit.check(limiter, "ch:socket2:topic"))
+  should.be_error(rate_limit.check(limiter, "socket2", "topic"))
 
   rate_limit.stop(limiter)
 }
@@ -131,21 +138,21 @@ pub fn burst_defaults_to_per_second_test() {
     rate_limit.start(rate_limit.config(per_second: 5, burst: 0))
 
   // With burst=0, it defaults to per_second (5)
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_error(rate_limit.check(limiter, "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_error(rate_limit.check(limiter, "group1", "key1"))
 
   rate_limit.stop(limiter)
 }
 
-// ── Remove by prefix optional ───────────────────────────────────────────────
+// ── Remove group optional ──────────────────────────────────────────────────
 
-pub fn remove_by_prefix_optional_none_is_noop_test() {
+pub fn remove_group_optional_none_is_noop_test() {
   // Should not crash
-  rate_limit.remove_by_prefix_optional(option.None, "anything")
+  rate_limit.remove_group_optional(option.None, "anything")
 }
 
 pub fn bucket_count_reports_active_keys_test() {
@@ -153,11 +160,11 @@ pub fn bucket_count_reports_active_keys_test() {
     rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
 
   rate_limit.bucket_count(limiter) |> should.equal(0)
-  should.be_ok(rate_limit.check(limiter, "socket:one"))
-  should.be_ok(rate_limit.check(limiter, "socket:two"))
+  should.be_ok(rate_limit.check(limiter, "socket", "one"))
+  should.be_ok(rate_limit.check(limiter, "socket", "two"))
   rate_limit.bucket_count(limiter) |> should.equal(2)
 
-  rate_limit.remove_by_prefix(limiter, "socket:")
+  rate_limit.remove_group(limiter, "socket")
   process.sleep(10)
   rate_limit.bucket_count(limiter) |> should.equal(0)
 
@@ -168,16 +175,16 @@ pub fn check_capped_rejects_new_keys_after_cap_test() {
   let assert Ok(limiter) =
     rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
 
-  should.be_ok(rate_limit.check_capped(limiter, "socket:one", "socket:", 2))
-  should.be_ok(rate_limit.check_capped(limiter, "socket:two", "socket:", 2))
-  should.be_error(rate_limit.check_capped(limiter, "socket:three", "socket:", 2))
+  should.be_ok(rate_limit.check_capped(limiter, "socket", "one", 2))
+  should.be_ok(rate_limit.check_capped(limiter, "socket", "two", 2))
+  should.be_error(rate_limit.check_capped(limiter, "socket", "three", 2))
   rate_limit.bucket_count(limiter) |> should.equal(2)
 
-  should.be_ok(rate_limit.check_capped(limiter, "other:one", "other:", 2))
+  should.be_ok(rate_limit.check_capped(limiter, "other", "one", 2))
   rate_limit.bucket_count(limiter) |> should.equal(3)
-  rate_limit.bucket_count_by_prefix(limiter, "socket:") |> should.equal(2)
+  rate_limit.bucket_count_by_group(limiter, "socket") |> should.equal(2)
 
-  should.be_ok(rate_limit.check_capped(limiter, "socket:one", "socket:", 2))
+  should.be_ok(rate_limit.check_capped(limiter, "socket", "one", 2))
 
   rate_limit.stop(limiter)
 }
@@ -186,12 +193,27 @@ pub fn stopped_limiter_checks_fail_open_test() {
   let assert Ok(limiter) =
     rate_limit.start(rate_limit.config(per_second: 100, burst: 1))
 
-  should.be_ok(rate_limit.check(limiter, "key1"))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
   rate_limit.bucket_count(limiter) |> should.equal(1)
 
   rate_limit.stop(limiter)
 
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check_capped(limiter, "key1", "key:", 1))
+  should.be_ok(rate_limit.check(limiter, "group1", "key1"))
+  should.be_ok(rate_limit.check_capped(limiter, "group1", "key1", 1))
   rate_limit.bucket_count(limiter) |> should.equal(0)
+}
+
+pub fn remove_exact_key_drops_empty_group_test() {
+  let assert Ok(limiter) =
+    rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
+
+  should.be_ok(rate_limit.check(limiter, "socket1", "room:lobby"))
+  rate_limit.bucket_count_by_group(limiter, "socket1") |> should.equal(1)
+
+  rate_limit.remove_optional(option.Some(limiter), "socket1", "room:lobby")
+  process.sleep(10)
+
+  rate_limit.bucket_count(limiter) |> should.equal(0)
+  rate_limit.bucket_count_by_group(limiter, "socket1") |> should.equal(0)
+  rate_limit.stop(limiter)
 }


### PR DESCRIPTION
## Summary

- group rate-limit buckets by socket to eliminate registry-wide prefix scans
- remove duplicate coordinator state threading from raw binary routing
- use set-backed presence topic deduplication while preserving output order
- add regression coverage for group cleanup, per-socket isolation, and duplicate topics

Closes #169
