### PR TITLE
feat: phoenix v2 binary protocol and production hardening

### DIFF
--- a/.changes/unreleased/Added-20260708-173000.yaml
+++ b/.changes/unreleased/Added-20260708-173000.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: |-
+    Negotiate the wire protocol version at the WebSocket handshake.
+    The Mist transport now reads the ?vsn= query parameter Phoenix clients send: vsn=2.x is accepted, a missing vsn is accepted for non-Phoenix clients, and unsupported versions (e.g. the V1 object framing) are rejected with 403 at the handshake instead of connecting successfully and silently dropping every frame.
+time: 2026-07-08T17:30:00.000000-00:00

--- a/.changes/unreleased/Added-20260708-173600.yaml
+++ b/.changes/unreleased/Added-20260708-173600.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: |-
+    Add channel.ReplyError for error-status replies from handle_in.
+    Channels can now answer a client message with a Phoenix "status": "error" reply (delivered to the JS client's push.receive("error", ...) hook), the equivalent of Phoenix's {:reply, {:error, payload}, socket}. Previously error-ness had to be smuggled inside an ok reply payload.
+time: 2026-07-08T17:36:00.000000-00:00

--- a/.changes/unreleased/Added-20260709-093000.yaml
+++ b/.changes/unreleased/Added-20260709-093000.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: |-
+    Warn at startup when no abuse controls are configured, and add a production hardening guide.
+    Rate and connection limits stay opt-in, but beryl.start and supervisor.start now log a prominent warning when every control is disabled, and the website gains a Production Hardening guide with recommended limits and deployment caveats (reverse proxies, NAT, reconnect semantics).
+time: 2026-07-09T09:30:00.000000-00:00

--- a/.changes/unreleased/Added-20260709-100000.yaml
+++ b/.changes/unreleased/Added-20260709-100000.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: |-
+    Implement the Phoenix V2 binary subprotocol.
+    The Phoenix codec now decodes client binary push frames (the framing the JS client uses for ArrayBuffer payloads) into normal channel dispatch: correct topic/event routing, ref/join_ref correlation, rate limits, and join checks all apply, and the payload reaches handle_in as a BitArray. Previously binary frames were fanned out raw to every joined topic's handle_binary regardless of the topic inside the frame. wire also gains binary_push/binary_reply/binary_broadcast encoders for the server-to-client shapes. Raw handle_binary fan-out now applies only to custom codecs without a binary decoder.
+time: 2026-07-09T10:00:00.000000-00:00

--- a/.changes/unreleased/Changed-20260708-175000.yaml
+++ b/.changes/unreleased/Changed-20260708-175000.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: |-
+    Lock down the public API ahead of 1.0 (breaking).
+    LoggingConfig and codec.Inbound are now opaque (use logging_config/codec.inbound and the inbound_* accessors); connection permits are an opaque beryl.ConnectionPermit instead of leaking the internal connection_limit module; LogLevel variants are now DebugLevel/InfoLevel/WarnLevel/ErrorLevel and channel.StopReason's Error is now Errored, so neither shadows the prelude's Error; group/presence start_named and topic.sanitize_for_log are package-internal; supervisor.start now validates heartbeat_timeout_ms with the same bound as beryl.start and reports invalid configs as InitFailed instead of InitTimeout; presence.track/untrack_all name their session parameter session_id.
+time: 2026-07-08T17:50:00.000000-00:00

--- a/.changes/unreleased/Changed-20260709-090000.yaml
+++ b/.changes/unreleased/Changed-20260709-090000.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: |-
+    Wire-contract cleanups ahead of the 1.0 freeze.
+    Empty-topic event routing is now an explicit codec capability (codec.with_topicless_events); the Phoenix codec drops empty-topic frames instead of guessing. Replies from handle_binary use the handler's own event name instead of the undocumented "binary_reply". Malformed pg-delivered broadcasts are dropped with a log instead of crashing the coordinator, and pubsub.Message is documented as a frozen v1 inter-node wire contract. presence.default_config now defaults the broadcast interval to 1500 ms so with_pubsub replicates out of the box (0 still disables). Bridge docs no longer overpromise automatic cleanup: bridge.stop in terminate is required.
+time: 2026-07-09T09:00:00.000000-00:00

--- a/.changes/unreleased/Fixed-20260708-171200.yaml
+++ b/.changes/unreleased/Fixed-20260708-171200.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: |-
+    Isolate channel callback crashes from the shared coordinator.
+    A panicking join, handle_in, handle_info, handle_binary, or terminate callback now terminates only the offending channel (the client receives a "join crashed" error reply for join crashes) instead of crashing the coordinator and destroying every connected socket's state.
+time: 2026-07-08T17:12:00.000000-00:00

--- a/.changes/unreleased/Fixed-20260708-172000.yaml
+++ b/.changes/unreleased/Fixed-20260708-172000.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: |-
+    Send phx_close/phx_error frames when a channel terminates.
+    Phoenix clients rely on these terminal events to leave the joined state and schedule rejoins; previously a server-side channel termination left clients believing they were still joined, with every subsequent push timing out. Custom codecs can opt in via codec.with_close_encoder and codec.with_error_encoder.
+time: 2026-07-08T17:20:00.000000-00:00

--- a/.changes/unreleased/Fixed-20260708-172500.yaml
+++ b/.changes/unreleased/Fixed-20260708-172500.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: |-
+    Inject phx_ref into tracked presence metas and add a presence_state encoder.
+    Phoenix client Presence helpers identify individual metas by phx_ref when applying diffs; without it a single leave removed every meta stored under the same key, corrupting multi-device presence. presence.track now merges the tracking ref into object metas as phx_ref, and presence/wire.encode_state encodes the Phoenix presence_state payload clients expect after joining.
+time: 2026-07-08T17:25:00.000000-00:00

--- a/.changes/unreleased/Fixed-20260708-173300.yaml
+++ b/.changes/unreleased/Fixed-20260708-173300.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: |-
+    Reserve the heartbeat event only on the "phoenix" topic.
+    Previously any event named "heartbeat" on any topic was hijacked as a protocol heartbeat, so applications could not define their own heartbeat channel event and such frames incorrectly refreshed the socket's liveness timer. Matching Phoenix, only topic "phoenix" is special; elsewhere "heartbeat" now reaches handle_in as an ordinary event.
+time: 2026-07-08T17:33:00.000000-00:00

--- a/.changes/unreleased/Fixed-20260708-173900.yaml
+++ b/.changes/unreleased/Fixed-20260708-173900.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: |-
+    Reply with an "unmatched topic" error for events on unjoined topics.
+    Matching Phoenix, an event pushed to a topic the socket has not joined now receives a phx_reply with status "error" and reason "unmatched topic" (when the message carries a ref), so client pushes error immediately instead of silently timing out.
+time: 2026-07-08T17:39:00.000000-00:00

--- a/.changes/unreleased/Fixed-20260708-180500.yaml
+++ b/.changes/unreleased/Fixed-20260708-180500.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: |-
+    Close the WebSocket on heartbeat eviction and stop leaking per-IP connection slots.
+    Evicted sockets previously stayed open as zombies: the client believed it was connected while every frame (including rejoins) was dropped, and the per-IP slot stayed held. The coordinator now actively closes evicted connections, socket.Transport.close is wired to the real transport, failed WebSocket handshakes release their acquired slot, and the connection limiter monitors bound holder processes (beryl.bind_connection_slot) so slots are reclaimed even when a connection process dies without running its close path.
+time: 2026-07-08T18:05:00.000000-00:00

--- a/.changes/unreleased/Fixed-20260708-181500.yaml
+++ b/.changes/unreleased/Fixed-20260708-181500.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: |-
+    Track join_ref per channel and adopt Phoenix duplicate-join semantics.
+    A phx_join for an already-joined topic now terminates the previous channel instance (running its terminate callback and emitting phx_close) before dispatching the new join, so cleanup like presence untracking is never skipped by a rejoin. Messages and leaves carrying a stale join_ref from a previous instance are dropped, and replies plus terminal frames now echo the channel's join_ref.
+time: 2026-07-08T18:15:00.000000-00:00

--- a/.changes/unreleased/Fixed-20260709-120000.yaml
+++ b/.changes/unreleased/Fixed-20260709-120000.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: |-
+    Channel registrations now survive coordinator restarts.
+    Registrations live in a crash-survivable registry that starts before the coordinator in the supervised tree; a restarted coordinator re-seeds its handler table from it, so a coordinator crash no longer leaves the node unable to serve joins until the whole application restarts. beryl.register is unchanged for callers.
+time: 2026-07-09T12:00:00.000000-00:00

--- a/.changes/unreleased/Fixed-20260709-140000.yaml
+++ b/.changes/unreleased/Fixed-20260709-140000.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: |-
+    Presence survives node restarts without losing joins or leaking ghosts.
+    Each presence actor start now derives a unique incarnation name from the configured replica base, so a restarted node never reuses its previous incarnation's CRDT clocks (which silently hid its new presences from peers). On every inbound sync, state left behind by dead incarnations of the sender's base — or of the node's own base, echoed back by peers — is pruned with leave diffs, so pre-crash ghost entries converge away within about one broadcast interval. The configured replica base must identify at most one live node.
+time: 2026-07-09T14:00:00.000000-00:00

--- a/.changes/unreleased/Performance-20260709-110000.yaml
+++ b/.changes/unreleased/Performance-20260709-110000.yaml
@@ -1,0 +1,5 @@
+kind: Performance
+body: |-
+    Shed hostile traffic at the transport edge and make rate limiting pure.
+    The Mist transport now decodes frames and enforces the per-socket message rate in each connection's own process, so floods and malformed input are dropped before they can fill the shared coordinator's mailbox or consume its CPU. Token buckets are now plain data held in coordinator/connection state instead of separate limiter actors, eliminating the 100 ms blocking check per frame, a coordinator mailbox leak under limiter backlog, O(n) bucket scans on new topics, and limiter-actor leaks on supervisor restarts.
+time: 2026-07-09T11:00:00.000000-00:00

--- a/.changes/unreleased/Security-20260708-182500.yaml
+++ b/.changes/unreleased/Security-20260708-182500.yaml
@@ -1,0 +1,5 @@
+kind: Security
+body: |-
+    Harden the protocol surface against hostile clients.
+    Heartbeat and leave frames now count against the per-socket message rate limit (flooding them previously bypassed with_message_rate entirely, with each heartbeat generating an amplified reply); client joins to reserved beryl:* topics are rejected, closing a path where a catch-all handler would forward internal presence replication traffic to a client; and client-sent phx_* reserved events are dropped before reaching channel handlers.
+time: 2026-07-08T18:25:00.000000-00:00

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -54,6 +54,7 @@ import beryl/connection_limit
 import beryl/coordinator
 import beryl/error as beryl_error
 import beryl/internal
+import beryl/log
 import beryl/presence.{type Diff}
 import beryl/presence/wire as presence_wire
 import beryl/pubsub.{type PubSub}
@@ -482,6 +483,34 @@ pub fn config_max_joined_topics_per_socket(config: Config) -> Int {
   config.max_joined_topics_per_socket
 }
 
+/// Warn when a channels system starts with every abuse control disabled.
+///
+/// Beryl ships with rate and connection limits off (like Phoenix) because
+/// no default is right for every deployment — but running that way in
+/// production leaves the server open to trivial floods, so the choice
+/// should be a visible one. Called by both `start` and `supervisor.start`.
+// nolint: unused_exports -- package-internal helper shared with beryl/supervisor; hidden from public docs with @internal
+
+@internal
+pub fn warn_if_unprotected(config: Config) -> Nil {
+  let unprotected =
+    config.max_connections_per_ip <= 0
+    && config.message_rate <= 0
+    && config.join_rate <= 0
+    && config.channel_rate <= 0
+  use <- bool.guard(when: !unprotected, return: Nil)
+  internal.logger("beryl")
+  |> log.warn("No abuse controls configured", [
+    #(
+      "hint",
+      "rate and connection limits are all disabled; fine for development, "
+        <> "but for production configure with_message_rate, with_join_rate, "
+        <> "and with_max_connections_per_ip (see the production hardening "
+        <> "guide)",
+    ),
+  ])
+}
+
 /// Build a coordinator config (starting rate-limiter actors) from a `Config`.
 /// Shared by `start` and the supervisor so the mapping lives in one place.
 @internal
@@ -645,6 +674,7 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
     when: config.heartbeat_timeout_ms < 2,
     return: internal.result_error(InvalidHeartbeatTimeout),
   )
+  warn_if_unprotected(config)
   let coord_config = to_coordinator_config(config)
 
   let coordinator_result = case config.pubsub {

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -582,7 +582,21 @@ pub fn acquire_connection_slot(
   |> result.map(ConnectionPermit)
 }
 
+/// Bind an acquired connection slot to the calling process.
+///
+/// Call this from the long-lived connection process (e.g. the WebSocket
+/// handler's init) after `acquire_connection_slot`. The limiter monitors the
+/// caller so the slot is reclaimed even if the connection process dies
+/// without running its close path — otherwise crashed connections would
+/// permanently exhaust their IP's slots.
+pub fn bind_connection_slot(permit: ConnectionPermit) -> Nil {
+  connection_limit.bind_optional(permit.inner)
+}
+
 /// Release a per-IP connection slot acquired by a transport.
+///
+/// Call from the process the permit was bound to (or from an unbound
+/// process when releasing before the connection was established).
 pub fn release_connection_slot(permit: ConnectionPermit) -> Nil {
   connection_limit.release_optional(permit.inner)
 }
@@ -973,7 +987,10 @@ fn transport_from_context(ctx: coordinator.SocketContext) -> socket.Transport {
       ctx.send_binary(data)
       |> result_to_transport_result()
     },
-    close: fn() { Ok(Nil) },
+    close: fn() {
+      ctx.close()
+      Ok(Nil)
+    },
   )
 }
 

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -971,6 +971,11 @@ fn erase_handle_result(
         payload: payload,
         assigns: unsafe_coerce_to_dynamic(socket.get_assigns(new_socket)),
       )
+    channel.ReplyError(payload, new_socket) ->
+      coordinator.ReplyErrorErased(
+        payload: payload,
+        assigns: unsafe_coerce_to_dynamic(socket.get_assigns(new_socket)),
+      )
     channel.Push(event, payload, new_socket) ->
       coordinator.PushErased(
         event: event,

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -552,6 +552,7 @@ pub fn to_coordinator_config(config: Config) -> coordinator.CoordinatorConfig {
     max_event_length: config.max_event_length,
     max_joined_topics_per_socket: config.max_joined_topics_per_socket,
     logging: coordinator_logging(config.logging),
+    registry: None,
   )
 }
 
@@ -567,6 +568,10 @@ pub opaque type Channels {
     config: Config,
     pubsub: Option(PubSub),
     connection_limiter: Option(connection_limit.ConnectionLimiter),
+    /// Crash-survivable handler registry. When present, `register` writes
+    /// here and syncs the coordinator, so registrations survive coordinator
+    /// restarts.
+    registry: Option(coordinator.Registry),
   )
 }
 
@@ -575,6 +580,7 @@ pub opaque type Channels {
 pub fn channels_from_coordinator(
   coordinator coordinator: Subject(coordinator.Message),
   config config: Config,
+  registry registry: Option(coordinator.Registry),
 ) -> Channels {
   Channels(
     coordinator: coordinator,
@@ -583,6 +589,7 @@ pub fn channels_from_coordinator(
     connection_limiter: connection_limit.start_optional(
       config.max_connections_per_ip,
     ),
+    registry: registry,
   )
 }
 
@@ -689,7 +696,20 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
     return: internal.result_error(InvalidHeartbeatTimeout),
   )
   warn_if_unprotected(config)
-  let coord_config = to_coordinator_config(config)
+  // Registrations live in a registry that outlives the coordinator, so a
+  // supervised restart (or manual coordinator replacement) can re-seed
+  // them.
+  use registry <- result.try(
+    coordinator.start_registry()
+    |> result.map_error(fn(error) {
+      CoordinatorStartFailed(beryl_error.from_actor_start_error(error))
+    }),
+  )
+  let coord_config =
+    coordinator.CoordinatorConfig(
+      ..to_coordinator_config(config),
+      registry: Some(registry),
+    )
 
   let coordinator_result = case config.pubsub {
     Some(ps) -> coordinator.start_with_config_and_pubsub(coord_config, ps)
@@ -698,7 +718,11 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
 
   case coordinator_result {
     Ok(coord) ->
-      Ok(channels_from_coordinator(coordinator: coord, config: config))
+      Ok(channels_from_coordinator(
+        coordinator: coord,
+        config: config,
+        registry: Some(registry),
+      ))
     error_result -> {
       case
         result.unwrap_error(
@@ -727,6 +751,10 @@ pub fn start(config: Config) -> Result(Channels, StartError) {
 pub fn stop(channels: Channels) -> Nil {
   stop_coordinator(channels.coordinator)
   connection_limit.stop_optional(channels.connection_limiter)
+  case channels.registry {
+    Some(registry) -> coordinator.stop_registry(registry)
+    None -> Nil
+  }
 }
 
 fn stop_coordinator(coordinator: Subject(coordinator.Message)) -> Nil {
@@ -787,10 +815,29 @@ pub fn register(
   // Convert typed Channel to type-erased ChannelHandler
   let erased_handler = erase_channel_types(pattern, handler)
 
-  // Register with coordinator
-  process.call(channels.coordinator, 5000, fn(reply) {
-    coordinator.RegisterChannel(pattern, erased_handler, reply)
-  })
+  let registration = case channels.registry {
+    // Write to the crash-survivable registry, then sync the live
+    // coordinator so the handler is visible before this call returns.
+    Some(registry) -> {
+      use id <- result.try(coordinator.registry_put(
+        registry,
+        pattern,
+        erased_handler,
+      ))
+      let #(handlers, next_id) = coordinator.registry_snapshot(registry)
+      process.call(channels.coordinator, 5000, fn(reply) {
+        coordinator.SyncHandlers(handlers, next_id, reply)
+      })
+      Ok(id)
+    }
+    // No registry configured: register with the coordinator directly.
+    None ->
+      process.call(channels.coordinator, 5000, fn(reply) {
+        coordinator.RegisterChannel(pattern, erased_handler, reply)
+      })
+  }
+
+  registration
   |> result.map(fn(id) {
     RegisteredChannel(
       coordinator: channels.coordinator,

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -489,8 +489,6 @@ pub fn config_max_joined_topics_per_socket(config: Config) -> Int {
 /// no default is right for every deployment — but running that way in
 /// production leaves the server open to trivial floods, so the choice
 /// should be a visible one. Called by both `start` and `supervisor.start`.
-// nolint: unused_exports -- package-internal helper shared with beryl/supervisor; hidden from public docs with @internal
-
 @internal
 pub fn warn_if_unprotected(config: Config) -> Nil {
   let unprotected =
@@ -511,7 +509,30 @@ pub fn warn_if_unprotected(config: Config) -> Nil {
   ])
 }
 
-/// Build a coordinator config (starting rate-limiter actors) from a `Config`.
+/// Rate-limit settings as a pure config, `None` when the rate is unlimited.
+fn optional_limits(
+  rate: Int,
+  burst: Int,
+) -> Option(rate_limit.RateLimitConfig) {
+  use <- bool.guard(when: rate <= 0, return: None)
+  Some(rate_limit.config(per_second: rate, burst: burst))
+}
+
+/// Per-socket message rate limits for transports, `None` when unlimited.
+///
+/// Transports enforce this with a local token bucket per connection so
+/// flooded sockets are shed at the edge, before frames are decoded or
+/// enqueued on the coordinator.
+// nolint: unused_exports -- package-internal accessor for transports; hidden from public docs with @internal
+
+@internal
+pub fn message_limits(
+  channels: Channels,
+) -> Option(rate_limit.RateLimitConfig) {
+  optional_limits(channels.config.message_rate, channels.config.message_burst)
+}
+
+/// Build a coordinator config from a `Config`.
 /// Shared by `start` and the supervisor so the mapping lives in one place.
 @internal
 pub fn to_coordinator_config(config: Config) -> coordinator.CoordinatorConfig {
@@ -519,20 +540,13 @@ pub fn to_coordinator_config(config: Config) -> coordinator.CoordinatorConfig {
   // promptly. The client heartbeat_interval_ms is informational only.
   let check_interval = config.heartbeat_timeout_ms / 2
 
-  let message_limiter =
-    rate_limit.start_optional(config.message_rate, config.message_burst)
-  let join_limiter =
-    rate_limit.start_optional(config.join_rate, config.join_burst)
-  let channel_limiter =
-    rate_limit.start_optional(config.channel_rate, config.channel_burst)
-
   coordinator.CoordinatorConfig(
     codec: config.codec,
     heartbeat_check_interval_ms: check_interval,
     heartbeat_timeout_ms: config.heartbeat_timeout_ms,
-    message_limiter: message_limiter,
-    join_limiter: join_limiter,
-    channel_limiter: channel_limiter,
+    message_limits: optional_limits(config.message_rate, config.message_burst),
+    join_limits: optional_limits(config.join_rate, config.join_burst),
+    channel_limits: optional_limits(config.channel_rate, config.channel_burst),
     channel_limiter_max_keys_per_socket: config.channel_rate_max_keys_per_socket,
     max_topic_length: config.max_topic_length,
     max_event_length: config.max_event_length,

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -518,13 +518,12 @@ fn optional_limits(
   Some(rate_limit.config(per_second: rate, burst: burst))
 }
 
+// nolint: unused_exports -- package-internal accessor for transports; hidden from public docs with @internal
 /// Per-socket message rate limits for transports, `None` when unlimited.
 ///
 /// Transports enforce this with a local token bucket per connection so
 /// flooded sockets are shed at the edge, before frames are decoded or
 /// enqueued on the coordinator.
-// nolint: unused_exports -- package-internal accessor for transports; hidden from public docs with @internal
-
 @internal
 pub fn message_limits(
   channels: Channels,

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -96,15 +96,22 @@ pub type RegisterError {
 }
 
 /// Logging verbosity for Beryl's internal loggers.
+///
+/// The variants carry a `Level` suffix so `ErrorLevel` does not shadow the
+/// prelude's `Result` `Error` constructor when imported unqualified.
 pub type LogLevel {
-  Debug
-  Info
-  Warn
-  Error
+  DebugLevel
+  InfoLevel
+  WarnLevel
+  ErrorLevel
 }
 
 /// Logging configuration for Beryl diagnostics.
-pub type LoggingConfig {
+///
+/// This type is opaque: construct it with `logging_config` and adjust it with
+/// the `with_*` builder functions so Beryl can add logging options without a
+/// breaking change.
+pub opaque type LoggingConfig {
   LoggingConfig(
     /// Minimum level emitted by Beryl's namespaced loggers.
     level: LogLevel,
@@ -113,6 +120,22 @@ pub type LoggingConfig {
     /// Maximum number of bytes/characters included in payload previews.
     payload_preview_bytes: Int,
   )
+}
+
+// nolint: unused_exports -- package-internal accessors for tests; hidden from public docs with @internal
+@internal
+pub fn logging_level(logging: LoggingConfig) -> LogLevel {
+  logging.level
+}
+
+@internal
+pub fn logging_include_payloads(logging: LoggingConfig) -> Bool {
+  logging.include_payloads
+}
+
+@internal
+pub fn logging_payload_preview_bytes(logging: LoggingConfig) -> Int {
+  logging.payload_preview_bytes
 }
 
 /// Configuration for the channels system.
@@ -209,7 +232,7 @@ pub fn config(codec: codec.Codec) -> Config {
     max_event_length: 64,
     max_inbound_frame_bytes: 1_048_576,
     max_joined_topics_per_socket: 1000,
-    logging: logging_config(level: Info, include_payloads: False),
+    logging: logging_config(level: InfoLevel, include_payloads: False),
   )
 }
 
@@ -286,10 +309,10 @@ pub fn with_payload_preview_bytes(
 
 fn coordinator_log_level(level: LogLevel) -> coordinator.LogLevel {
   case level {
-    Debug -> coordinator.Debug
-    Info -> coordinator.Info
-    Warn -> coordinator.Warn
-    Error -> coordinator.Err
+    DebugLevel -> coordinator.Debug
+    InfoLevel -> coordinator.Info
+    WarnLevel -> coordinator.Warn
+    ErrorLevel -> coordinator.Err
   }
 }
 
@@ -531,24 +554,37 @@ pub fn configured_codec(channels: Channels) -> codec.Codec {
   channels.config.codec
 }
 
+/// A held per-IP connection slot returned by `acquire_connection_slot`.
+///
+/// Opaque so Beryl can restructure the connection limiter without breaking
+/// transport authors. Hold it for the lifetime of the connection and pass it
+/// to `release_connection_slot` when the connection closes. When no per-IP
+/// limit is configured the permit is an admit-everything placeholder and
+/// releasing it is a no-op.
+pub opaque type ConnectionPermit {
+  ConnectionPermit(inner: Option(connection_limit.Permit))
+}
+
 /// Try to acquire a configured per-IP connection slot for transports.
 ///
 /// Transports call this before admitting a connection, passing the **real
 /// socket peer IP**. Do not pass a client-supplied address (e.g. from
 /// `X-Forwarded-For`): a spoofed value would defeat the per-IP limit. Returns
-/// `Ok(Some(permit))` when admitted (release the permit with
-/// `release_connection_slot` on close), `Ok(None)` when no limit is configured
-/// (unlimited), or `Error(Nil)` when the peer is already at its limit.
+/// `Ok(permit)` when admitted (release the permit with
+/// `release_connection_slot` on close; when no limit is configured every
+/// connection is admitted), or `Error(Nil)` when the peer is already at its
+/// limit.
 pub fn acquire_connection_slot(
   channels: Channels,
   ip: String,
-) -> Result(Option(connection_limit.Permit), Nil) {
+) -> Result(ConnectionPermit, Nil) {
   connection_limit.acquire_optional(channels.connection_limiter, ip)
+  |> result.map(ConnectionPermit)
 }
 
 /// Release a per-IP connection slot acquired by a transport.
-pub fn release_connection_slot(permit: Option(connection_limit.Permit)) -> Nil {
-  connection_limit.release_optional(permit)
+pub fn release_connection_slot(permit: ConnectionPermit) -> Nil {
+  connection_limit.release_optional(permit.inner)
 }
 
 /// Return the configured inbound frame size cap for transports.

--- a/src/beryl/bridge.gleam
+++ b/src/beryl/bridge.gleam
@@ -10,8 +10,12 @@
 //// `bridge` packages that plumbing into a single helper. Start a bridge inside
 //// a channel `join`, store the handle in the socket assigns, subscribe the
 //// returned `Subject` to your domain actor, and stop the bridge in `terminate`.
-//// The forwarder also monitors the owning channel process, so it is cleaned up
-//// automatically if that process dies — no leaked processes.
+////
+//// Calling `stop` from `terminate` is **required** for cleanup: channels are
+//// dispatched by a shared coordinator rather than one process per channel, so
+//// the process the forwarder monitors is the coordinator itself — the monitor
+//// is a backstop for coordinator death, not a per-channel lifecycle. A bridge
+//// whose `stop` is never called keeps running until the coordinator exits.
 ////
 //// ## Example
 ////
@@ -90,9 +94,11 @@ type Event(message) {
 /// `handle_info` expects. If no translation is needed, pass the identity
 /// function `fn(value) { value }`.
 ///
-/// The forwarder monitors the calling (channel) process and exits if it dies,
-/// so a missed `stop` will not leak a process. Always call `stop` from your
-/// channel's `terminate` for prompt, deterministic cleanup.
+/// Always call `stop` from your channel's `terminate` — that is the only
+/// per-channel cleanup. The forwarder also monitors the calling process, but
+/// because channel callbacks run inside the shared coordinator, that monitor
+/// fires only if the coordinator itself dies; it does not detect an
+/// individual channel ending.
 pub fn start(
   channel channel: RegisteredChannel(assigns, info),
   socket_id socket_id: String,

--- a/src/beryl/channel.gleam
+++ b/src/beryl/channel.gleam
@@ -47,6 +47,14 @@ pub type HandleResult(assigns) {
   /// coordinator. When returned from `handle_info` (where no client ref
   /// exists), it is sent as a push using `event` as the event name.
   Reply(event: String, payload: Json, socket: Socket(assigns))
+  /// Send an error reply to the client in response to their message
+  /// (`"status": "error"` in Phoenix framing, delivered to the client's
+  /// `push.receive("error", ...)` hook).
+  ///
+  /// Only meaningful from `handle_in` for messages carrying a client ref;
+  /// from `handle_info`/`handle_binary` (where no ref exists) the reply is
+  /// dropped with a warning.
+  ReplyError(payload: Json, socket: Socket(assigns))
   /// Push a message to the client (server-initiated)
   Push(event: String, payload: Json, socket: Socket(assigns))
   /// Stop the channel with a reason

--- a/src/beryl/channel.gleam
+++ b/src/beryl/channel.gleam
@@ -61,7 +61,10 @@ pub type HandleResult(assigns) {
   Stop(reason: StopReason)
 }
 
-/// Why a channel is stopping
+/// Why a channel is stopping.
+///
+/// Delivered to every channel's `terminate` callback. Match with a catch-all
+/// (`_`) arm: new stop reasons may be added in minor releases.
 pub type StopReason {
   /// Normal shutdown (client left or disconnected cleanly)
   Normal
@@ -69,8 +72,10 @@ pub type StopReason {
   Shutdown
   /// Client failed to send heartbeat within the configured timeout
   HeartbeatTimeout
-  /// Error occurred
-  Error(String)
+  /// The channel stopped because of an error (named `Errored` so importing
+  /// it unqualified does not shadow the prelude's `Result` `Error`
+  /// constructor)
+  Errored(String)
 }
 
 /// Channel behavior definition

--- a/src/beryl/connection_limit.gleam
+++ b/src/beryl/connection_limit.gleam
@@ -2,7 +2,7 @@
 
 import gleam/bool
 import gleam/dict.{type Dict}
-import gleam/erlang/process.{type Subject}
+import gleam/erlang/process.{type Monitor, type Pid, type Subject}
 import gleam/option.{type Option, None, Some}
 import gleam/otp/actor
 import gleam/result
@@ -20,7 +20,16 @@ pub opaque type Permit {
 }
 
 type State {
-  State(max_per_ip: Int, counts: Dict(String, Int))
+  State(
+    max_per_ip: Int,
+    counts: Dict(String, Int),
+    /// Monitors on bound permit-holder processes, so slots self-release when
+    /// the holder dies without running its close path (crash, brutal kill).
+    monitors: Dict(Monitor, #(Pid, String)),
+    /// Reverse index from holder pid to its monitor, so an explicit release
+    /// can drop the monitor and never double-decrement.
+    holders: Dict(Pid, Monitor),
+  )
 }
 
 type Message {
@@ -29,7 +38,9 @@ type Message {
     limiter: ConnectionLimiter,
     reply: Subject(Result(Permit, Nil)),
   )
-  Release(ip: String)
+  Bind(ip: String, owner: Pid)
+  Release(ip: String, owner: Pid)
+  HolderDown(down: process.Down)
   Stop(reply: Subject(Nil))
 }
 
@@ -56,10 +67,60 @@ fn handle_message(
         }
       }
     }
-    Release(ip) -> actor.continue(release_ip(state, ip))
+    Bind(ip, owner) -> actor.continue(bind_holder(state, ip, owner))
+    Release(ip, owner) -> {
+      // Drop the holder's monitor (when bound) before decrementing, so a
+      // later exit of the same process cannot decrement this IP twice.
+      let state = case dict.get(state.holders, owner) {
+        Ok(monitor) -> {
+          process.demonitor_process(monitor)
+          State(
+            ..state,
+            monitors: dict.delete(state.monitors, monitor),
+            holders: dict.delete(state.holders, owner),
+          )
+        }
+        Error(Nil) -> state
+      }
+      actor.continue(release_ip(state, ip))
+    }
+    HolderDown(down) ->
+      case down {
+        process.ProcessDown(monitor, pid, _reason) ->
+          case dict.get(state.monitors, monitor) {
+            Ok(#(_owner, ip)) -> {
+              let state =
+                State(
+                  ..state,
+                  monitors: dict.delete(state.monitors, monitor),
+                  holders: dict.delete(state.holders, pid),
+                )
+              actor.continue(release_ip(state, ip))
+            }
+            // Already explicitly released (or an unrelated monitor).
+            Error(Nil) -> actor.continue(state)
+          }
+        process.PortDown(_, _, _) -> actor.continue(state)
+      }
     Stop(reply) -> {
       process.send(reply, Nil)
       actor.stop()
+    }
+  }
+}
+
+/// Monitor a permit holder so its slot is reclaimed if the process dies
+/// without releasing. Rebinding the same pid is a no-op.
+fn bind_holder(state: State, ip: String, owner: Pid) -> State {
+  case dict.has_key(state.holders, owner) {
+    True -> state
+    False -> {
+      let monitor = process.monitor(owner)
+      State(
+        ..state,
+        monitors: dict.insert(state.monitors, monitor, #(owner, ip)),
+        holders: dict.insert(state.holders, owner, monitor),
+      )
     }
   }
 }
@@ -91,8 +152,23 @@ fn request(
 
 /// Start a connection limiter with a maximum active connection count per IP.
 fn start(max_per_ip: Int) -> Result(ConnectionLimiter, actor.StartError) {
-  let state = State(max_per_ip: max_per_ip, counts: dict.new())
-  actor.new(state)
+  let state =
+    State(
+      max_per_ip: max_per_ip,
+      counts: dict.new(),
+      monitors: dict.new(),
+      holders: dict.new(),
+    )
+  actor.new_with_initialiser(1000, fn(subject) {
+    let selector =
+      process.new_selector()
+      |> process.select(subject)
+      |> process.select_monitors(HolderDown)
+    actor.initialised(state)
+    |> actor.selecting(selector)
+    |> actor.returning(subject)
+    |> Ok
+  })
   |> actor.on_message(handle_message)
   |> actor.start
   |> result.map(fn(started) { ConnectionLimiter(subject: started.data) })
@@ -123,9 +199,26 @@ pub fn acquire_optional(
   }
 }
 
+/// Bind a permit to the calling process (the long-lived connection process),
+/// so its slot is reclaimed if that process dies without releasing.
+fn bind(permit: Permit) -> Nil {
+  process.send(permit.limiter.subject, Bind(permit.ip, process.self()))
+}
+
+/// Bind a slot to the calling process if one was acquired.
+pub fn bind_optional(permit: Option(Permit)) -> Nil {
+  case permit {
+    Some(permit) -> bind(permit)
+    None -> Nil
+  }
+}
+
 /// Release a previously acquired slot.
+///
+/// Call from the process the permit was bound to (or from an unbound
+/// process, e.g. when the handshake fails before binding).
 fn release(permit: Permit) -> Nil {
-  process.send(permit.limiter.subject, Release(permit.ip))
+  process.send(permit.limiter.subject, Release(permit.ip, process.self()))
 }
 
 /// Release a slot if one was acquired.

--- a/src/beryl/connection_limit.gleam
+++ b/src/beryl/connection_limit.gleam
@@ -112,17 +112,13 @@ fn handle_message(
 /// Monitor a permit holder so its slot is reclaimed if the process dies
 /// without releasing. Rebinding the same pid is a no-op.
 fn bind_holder(state: State, ip: String, owner: Pid) -> State {
-  case dict.has_key(state.holders, owner) {
-    True -> state
-    False -> {
-      let monitor = process.monitor(owner)
-      State(
-        ..state,
-        monitors: dict.insert(state.monitors, monitor, #(owner, ip)),
-        holders: dict.insert(state.holders, owner, monitor),
-      )
-    }
-  }
+  use <- bool.guard(when: dict.has_key(state.holders, owner), return: state)
+  let monitor = process.monitor(owner)
+  State(
+    ..state,
+    monitors: dict.insert(state.monitors, monitor, #(owner, ip)),
+    holders: dict.insert(state.holders, owner, monitor),
+  )
 }
 
 fn release_ip(state: State, ip: String) -> State {

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -133,6 +133,10 @@ pub type CoordinatorConfig {
     max_joined_topics_per_socket: Int,
     /// Logging configuration for coordinator diagnostics.
     logging: LoggingConfig,
+    /// Optional crash-survivable handler registry. When set, the
+    /// coordinator seeds its handler table from the registry at init, so a
+    /// supervised restart recovers every registration.
+    registry: Option(Registry),
   )
 }
 
@@ -156,6 +160,7 @@ pub fn config(codec: Codec) -> CoordinatorConfig {
       include_payloads: False,
       payload_preview_bytes: 200,
     ),
+    registry: None,
   )
 }
 
@@ -320,6 +325,16 @@ pub type Message {
     handler: ChannelHandler,
     reply: Subject(Result(Int, RegisterError)),
   )
+  /// Replace the handler table with a registry snapshot. Sent by
+  /// `beryl.register` after a registry write so the new registration
+  /// reaches the live coordinator; the reply confirms visibility. Do not
+  /// mix with direct `RegisterChannel` on the same coordinator — the
+  /// snapshot replaces the whole table.
+  SyncHandlers(
+    handlers: List(ChannelHandler),
+    next_handler_id: Int,
+    reply: Subject(Nil),
+  )
   // Socket lifecycle
   SocketConnected(
     socket_id: String,
@@ -377,6 +392,130 @@ fn coerce_to_pubsub_message(value: Dynamic) -> pubsub.Message
 /// so a faulty channel cannot take down the shared coordinator actor.
 @external(erlang, "beryl_ffi", "rescue")
 fn rescue(callback: fn() -> value) -> Result(value, String)
+
+// ── Handler registry ────────────────────────────────────────────────────────
+
+/// A crash-survivable store for channel registrations.
+///
+/// Registrations live outside the coordinator so a coordinator restart can
+/// re-seed its handler table instead of coming back empty — which would
+/// fail every join with `no_channel_handler` until the application itself
+/// restarted. In the supervised tree the registry starts before the
+/// coordinator, so a rest-for-one coordinator restart leaves it untouched.
+pub opaque type Registry {
+  Registry(subject: Subject(RegistryMsg))
+}
+
+/// Messages the registry actor handles. Opaque: use `registry_put` and the
+/// coordinator's seeding; the type is public only so names can be created
+/// for supervised registries.
+pub opaque type RegistryMsg {
+  RegistryPut(
+    pattern: String,
+    handler: ChannelHandler,
+    reply: Subject(Result(Int, RegisterError)),
+  )
+  RegistrySnapshot(reply: Subject(#(List(ChannelHandler), Int)))
+  RegistryStop(reply: Subject(Nil))
+}
+
+type RegistryState {
+  RegistryState(handlers: List(ChannelHandler), next_id: Int)
+}
+
+fn handle_registry_msg(
+  state: RegistryState,
+  msg: RegistryMsg,
+) -> actor.Next(RegistryState, RegistryMsg) {
+  case msg {
+    RegistryPut(pattern, handler, reply) ->
+      case add_handler(state.handlers, state.next_id, pattern, handler) {
+        Error(error) -> {
+          process.send(reply, Error(error))
+          actor.continue(state)
+        }
+        Ok(#(handlers, next_id, handler_id)) -> {
+          process.send(reply, Ok(handler_id))
+          actor.continue(RegistryState(handlers: handlers, next_id: next_id))
+        }
+      }
+    RegistrySnapshot(reply) -> {
+      process.send(reply, #(state.handlers, state.next_id))
+      actor.continue(state)
+    }
+    RegistryStop(reply) -> {
+      process.send(reply, Nil)
+      actor.stop()
+    }
+  }
+}
+
+/// Start an unsupervised handler registry.
+pub fn start_registry() -> Result(Registry, actor.StartError) {
+  actor.new(RegistryState(handlers: [], next_id: 0))
+  |> actor.on_message(handle_registry_msg)
+  |> actor.start
+  |> result.map(fn(started) { Registry(subject: started.data) })
+}
+
+/// Start a handler registry with a registered name (for supervision).
+pub fn start_registry_named(
+  name: process.Name(RegistryMsg),
+) -> Result(actor.Started(Subject(RegistryMsg)), actor.StartError) {
+  actor.new(RegistryState(handlers: [], next_id: 0))
+  |> actor.on_message(handle_registry_msg)
+  |> actor.named(name)
+  |> actor.start
+}
+
+/// Build a registry handle from a registered name.
+pub fn registry_from_name(name: process.Name(RegistryMsg)) -> Registry {
+  Registry(subject: process.named_subject(name))
+}
+
+/// Validate and store a registration, returning its assigned handler id.
+///
+/// Panics if the registry is unavailable or does not reply within 5
+/// seconds, matching `beryl.register`'s contract.
+pub fn registry_put(
+  registry: Registry,
+  pattern: String,
+  handler: ChannelHandler,
+) -> Result(Int, RegisterError) {
+  process.call(registry.subject, 5000, fn(reply) {
+    RegistryPut(pattern, handler, reply)
+  })
+}
+
+/// Read the registry's full handler table and next id. Falls back to an
+/// empty table when the registry is unavailable, so a coordinator can still
+/// start (with a logged snapshot of nothing) rather than crash-loop.
+pub fn registry_snapshot(registry: Registry) -> #(List(ChannelHandler), Int) {
+  case process.subject_owner(registry.subject) {
+    Error(Nil) -> #([], 0)
+    Ok(_) -> {
+      let reply_subject = process.new_subject()
+      process.send(registry.subject, RegistrySnapshot(reply_subject))
+      case process.receive(reply_subject, 1000) {
+        Ok(snapshot) -> snapshot
+        Error(Nil) -> #([], 0)
+      }
+    }
+  }
+}
+
+/// Stop an unsupervised registry.
+pub fn stop_registry(registry: Registry) -> Nil {
+  let should_send = case process.subject_owner(registry.subject) {
+    Ok(pid) -> process.is_alive(pid)
+    Error(Nil) -> False
+  }
+  use <- bool.guard(when: !should_send, return: Nil)
+  let reply = process.new_subject()
+  process.send(registry.subject, RegistryStop(reply))
+  let _stop_result = process.receive(reply, 1000)
+  Nil
+}
 
 /// Start the coordinator actor with default heartbeat settings (no checking),
 /// using the supplied wire codec.
@@ -447,10 +586,16 @@ fn build_coordinator(
 ) -> actor.Builder(State, Message, Subject(Message)) {
   let logging = internal_logging(config.logging)
   internal.configure(logging)
+  // Seed the handler table from the registry (empty when none is
+  // configured), so a supervised restart recovers every registration.
+  let #(seeded_handlers, seeded_next_id) = case config.registry {
+    Some(registry) -> registry_snapshot(registry)
+    None -> #([], 0)
+  }
   let initial_state =
     State(
-      handlers: [],
-      next_handler_id: 0,
+      handlers: seeded_handlers,
+      next_handler_id: seeded_next_id,
       sockets: dict.new(),
       topics: dict.new(),
       config: config,
@@ -516,6 +661,13 @@ fn handle_message(
   case message {
     RegisterChannel(pattern, handler, reply) ->
       handle_register_channel(state, pattern, handler, reply)
+
+    SyncHandlers(handlers, next_handler_id, reply) -> {
+      process.send(reply, Nil)
+      actor.continue(
+        State(..state, handlers: handlers, next_handler_id: next_handler_id),
+      )
+    }
 
     SocketConnected(socket_id, send, send_binary, codec, connect_assigns) ->
       handle_socket_connected(
@@ -599,33 +751,50 @@ fn handle_register_channel(
       actor.continue(state)
     },
   )
-  let pattern = topic.parse_pattern(pattern_str)
-  let already_registered =
-    list.any(state.handlers, fn(h) { h.pattern == pattern })
-
-  case already_registered {
-    True -> {
-      process.send(reply, Error(PatternAlreadyRegistered(pattern_str)))
+  case
+    add_handler(state.handlers, state.next_handler_id, pattern_str, handler)
+  {
+    Error(error) -> {
+      process.send(reply, Error(error))
       actor.continue(state)
     }
-    False -> {
-      let handler_id = state.next_handler_id
-      let registered_handler =
-        ChannelHandler(
-          id: handler_id,
-          pattern: pattern,
-          join: handler.join,
-          handle_in: handler.handle_in,
-          handle_binary: handler.handle_binary,
-          terminate: handler.terminate,
-        )
-      let new_handlers = list.append(state.handlers, [registered_handler])
+    Ok(#(new_handlers, next_id, handler_id)) -> {
       process.send(reply, Ok(handler_id))
       actor.continue(
-        State(..state, handlers: new_handlers, next_handler_id: handler_id + 1),
+        State(..state, handlers: new_handlers, next_handler_id: next_id),
       )
     }
   }
+}
+
+/// Validate and append a handler to a handler table, assigning the next id.
+/// Shared by the coordinator's direct registration path and the registry.
+fn add_handler(
+  handlers: List(ChannelHandler),
+  next_id: Int,
+  pattern_str: String,
+  handler: ChannelHandler,
+) -> Result(#(List(ChannelHandler), Int, Int), RegisterError) {
+  use <- bool.guard(
+    when: result.is_error(topic.validate_pattern(pattern_str)),
+    return: Error(InvalidPattern(pattern_str)),
+  )
+  let pattern = topic.parse_pattern(pattern_str)
+  let already_registered = list.any(handlers, fn(h) { h.pattern == pattern })
+  use <- bool.guard(
+    when: already_registered,
+    return: Error(PatternAlreadyRegistered(pattern_str)),
+  )
+  let registered_handler =
+    ChannelHandler(
+      id: next_id,
+      pattern: pattern,
+      join: handler.join,
+      handle_in: handler.handle_in,
+      handle_binary: handler.handle_binary,
+      terminate: handler.terminate,
+    )
+  Ok(#(list.append(handlers, [registered_handler]), next_id + 1, next_id))
 }
 
 fn handle_socket_connected(

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -11,7 +11,7 @@ import beryl/channel.{type StopReason}
 import beryl/internal
 import beryl/log.{type Logger}
 import beryl/pubsub.{type PubSub}
-import beryl/rate_limit.{type RateLimiter}
+import beryl/rate_limit.{type RateLimitConfig}
 import beryl/topic.{type TopicPattern}
 import beryl/wire/codec.{type Codec}
 import gleam/bool
@@ -115,13 +115,13 @@ pub type CoordinatorConfig {
     heartbeat_check_interval_ms: Int,
     /// Disconnect sockets that haven't sent a heartbeat within this duration
     heartbeat_timeout_ms: Int,
-    /// Per-socket message rate limiter (None = unlimited)
-    message_limiter: Option(RateLimiter),
-    /// Per-socket join rate limiter (None = unlimited)
-    join_limiter: Option(RateLimiter),
-    /// Per-channel message rate limiter (None = unlimited)
-    channel_limiter: Option(RateLimiter),
-    /// Maximum active channel-limiter keys per socket. Values <= 0 disable the cap.
+    /// Per-socket message rate limits (None = unlimited)
+    message_limits: Option(RateLimitConfig),
+    /// Per-socket join rate limits (None = unlimited)
+    join_limits: Option(RateLimitConfig),
+    /// Per-channel message rate limits (None = unlimited)
+    channel_limits: Option(RateLimitConfig),
+    /// Maximum active channel-limiter buckets per socket. Values <= 0 disable the cap.
     channel_limiter_max_keys_per_socket: Int,
     /// Maximum byte length for client-supplied topic strings (default: 256).
     /// Topics exceeding this limit are rejected before reaching a channel handler.
@@ -144,9 +144,9 @@ pub fn config(codec: Codec) -> CoordinatorConfig {
     codec: codec,
     heartbeat_check_interval_ms: 0,
     heartbeat_timeout_ms: 60_000,
-    message_limiter: None,
-    join_limiter: None,
-    channel_limiter: None,
+    message_limits: None,
+    join_limits: None,
+    channel_limits: None,
     channel_limiter_max_keys_per_socket: 1000,
     max_topic_length: 256,
     max_event_length: 64,
@@ -227,6 +227,14 @@ type State {
     logger: Logger,
     /// The coordinator's own subject, used for scheduling timers
     self_subject: Option(Subject(Message)),
+    /// Per-socket message-rate token buckets (socket_id -> bucket).
+    message_buckets: Dict(String, rate_limit.Bucket),
+    /// Per-socket join-rate token buckets (socket_id -> bucket).
+    join_buckets: Dict(String, rate_limit.Bucket),
+    /// Per-channel token buckets (socket_id -> topic -> bucket). Keyed by
+    /// socket first so the per-socket cap and disconnect cleanup are O(1)
+    /// lookups instead of prefix scans.
+    channel_buckets: Dict(String, Dict(String, rate_limit.Bucket)),
   )
 }
 
@@ -449,6 +457,9 @@ fn build_coordinator(
       pubsub: ps,
       logger: internal.logger_with_config("beryl.coordinator", logging),
       self_subject: None,
+      message_buckets: dict.new(),
+      join_buckets: dict.new(),
+      channel_buckets: dict.new(),
     )
 
   actor.new_with_initialiser(5000, fn(subject) {
@@ -571,9 +582,6 @@ fn handle_stop(
     disconnect_socket(st, socket_id, channel.Shutdown)
   })
 
-  rate_limit.stop_optional(state.config.message_limiter)
-  rate_limit.stop_optional(state.config.join_limiter)
-  rate_limit.stop_optional(state.config.channel_limiter)
   process.send(reply, Nil)
   actor.stop()
 }
@@ -685,19 +693,122 @@ fn handle_socket_disconnected(
   actor.continue(disconnect_socket(state, socket_id, channel.Normal))
 }
 
-fn remove_socket_rate_limits(state: State, socket_id: String) -> Nil {
-  rate_limit.remove_by_prefix_optional(
-    state.config.message_limiter,
-    "msg:" <> socket_id,
+fn remove_socket_rate_limits(state: State, socket_id: String) -> State {
+  State(
+    ..state,
+    message_buckets: dict.delete(state.message_buckets, socket_id),
+    join_buckets: dict.delete(state.join_buckets, socket_id),
+    channel_buckets: dict.delete(state.channel_buckets, socket_id),
   )
-  rate_limit.remove_by_prefix_optional(
-    state.config.join_limiter,
-    "join:" <> socket_id,
+}
+
+/// Take a token from the socket's message-rate bucket. Always allowed when
+/// no message limits are configured.
+fn check_message_rate(state: State, socket_id: String) -> #(State, Bool) {
+  case state.config.message_limits {
+    None -> #(state, True)
+    Some(limits) -> {
+      let bucket =
+        dict.get(state.message_buckets, socket_id)
+        |> result.lazy_unwrap(fn() { rate_limit.new_bucket(limits) })
+      let #(bucket, taken) = rate_limit.take(bucket)
+      #(
+        State(
+          ..state,
+          message_buckets: dict.insert(state.message_buckets, socket_id, bucket),
+        ),
+        result.is_ok(taken),
+      )
+    }
+  }
+}
+
+/// Take a token from the socket's join-rate bucket. Always allowed when no
+/// join limits are configured.
+fn check_join_rate(state: State, socket_id: String) -> #(State, Bool) {
+  case state.config.join_limits {
+    None -> #(state, True)
+    Some(limits) -> {
+      let bucket =
+        dict.get(state.join_buckets, socket_id)
+        |> result.lazy_unwrap(fn() { rate_limit.new_bucket(limits) })
+      let #(bucket, taken) = rate_limit.take(bucket)
+      #(
+        State(
+          ..state,
+          join_buckets: dict.insert(state.join_buckets, socket_id, bucket),
+        ),
+        result.is_ok(taken),
+      )
+    }
+  }
+}
+
+/// Take a token from the socket's per-topic channel bucket, refusing to
+/// create a new bucket beyond the per-socket cap. Always allowed when no
+/// channel limits are configured.
+fn check_channel_rate(
+  state: State,
+  socket_id: String,
+  topic_name: String,
+) -> #(State, Bool) {
+  case state.config.channel_limits {
+    None -> #(state, True)
+    Some(limits) -> take_channel_token(state, socket_id, topic_name, limits)
+  }
+}
+
+fn take_channel_token(
+  state: State,
+  socket_id: String,
+  topic_name: String,
+  limits: RateLimitConfig,
+) -> #(State, Bool) {
+  let socket_buckets =
+    dict.get(state.channel_buckets, socket_id)
+    |> result.unwrap(dict.new())
+  let cap = state.config.channel_limiter_max_keys_per_socket
+  let over_cap = case dict.has_key(socket_buckets, topic_name) {
+    True -> False
+    False -> cap > 0 && dict.size(socket_buckets) >= cap
+  }
+  use <- bool.guard(when: over_cap, return: #(state, False))
+  let bucket =
+    dict.get(socket_buckets, topic_name)
+    |> result.lazy_unwrap(fn() { rate_limit.new_bucket(limits) })
+  let #(bucket, taken) = rate_limit.take(bucket)
+  let socket_buckets = dict.insert(socket_buckets, topic_name, bucket)
+  #(
+    State(
+      ..state,
+      channel_buckets: dict.insert(
+        state.channel_buckets,
+        socket_id,
+        socket_buckets,
+      ),
+    ),
+    result.is_ok(taken),
   )
-  rate_limit.remove_by_prefix_optional(
-    state.config.channel_limiter,
-    "ch:" <> socket_id <> ":",
-  )
+}
+
+/// Drop the channel bucket for a terminated socket/topic pair.
+fn remove_channel_bucket(
+  state: State,
+  socket_id: String,
+  topic_name: String,
+) -> State {
+  case dict.get(state.channel_buckets, socket_id) {
+    Error(Nil) -> state
+    Ok(socket_buckets) ->
+      State(
+        ..state,
+        channel_buckets: dict.insert(
+          state.channel_buckets,
+          socket_id,
+          dict.delete(socket_buckets, topic_name),
+        ),
+      )
+  }
 }
 
 fn handle_join(
@@ -709,10 +820,9 @@ fn handle_join(
   ref: Option(String),
 ) -> actor.Next(State, Message) {
   // Check join rate limit
-  case
-    rate_limit.check_optional(state.config.join_limiter, "join:" <> socket_id)
-  {
-    Error(Nil) -> {
+  let #(state, join_allowed) = check_join_rate(state, socket_id)
+  case join_allowed {
+    False -> {
       let logger = coordinator_logger(state)
       logger
       |> log.warn("Join rate limited", [
@@ -738,7 +848,7 @@ fn handle_join(
       }
       actor.continue(state)
     }
-    Ok(_) ->
+    True ->
       handle_join_inner(state, socket_id, topic_name, payload, join_ref, ref)
   }
 }
@@ -958,10 +1068,9 @@ fn handle_in(
   ref: Option(String),
 ) -> actor.Next(State, Message) {
   // Check per-socket message rate limit
-  case
-    rate_limit.check_optional(state.config.message_limiter, "msg:" <> socket_id)
-  {
-    Error(Nil) -> {
+  let #(state, allowed) = check_message_rate(state, socket_id)
+  case allowed {
+    False -> {
       let logger = coordinator_logger(state)
       logger
       |> log.warn("Message rate limited", [
@@ -970,7 +1079,7 @@ fn handle_in(
       ])
       actor.continue(state)
     }
-    Ok(_) -> {
+    True -> {
       handle_in_subscribed(
         state,
         socket_id,
@@ -1114,15 +1223,9 @@ fn handle_in_rate_limited(
   payload: Dynamic,
   ref: Option(String),
 ) -> actor.Next(State, Message) {
-  case
-    rate_limit.check_capped_optional(
-      state.config.channel_limiter,
-      "ch:" <> socket_id <> ":" <> topic_name,
-      "ch:" <> socket_id <> ":",
-      state.config.channel_limiter_max_keys_per_socket,
-    )
-  {
-    Error(Nil) -> {
+  let #(state, allowed) = check_channel_rate(state, socket_id, topic_name)
+  case allowed {
+    False -> {
       let logger = coordinator_logger(state)
       logger
       |> log.warn("Channel rate limited", [
@@ -1131,7 +1234,7 @@ fn handle_in_rate_limited(
       ])
       actor.continue(state)
     }
-    Ok(_) ->
+    True ->
       route_in_to_handler(
         state,
         socket_info,
@@ -1213,18 +1316,15 @@ fn handle_raw_binary_with_rate_limit(
   socket_id: String,
   data: BitArray,
 ) -> actor.Next(State, Message) {
-  case
-    rate_limit.check_optional(state.config.message_limiter, "msg:" <> socket_id)
-  {
-    Error(Nil) -> {
+  let #(state, allowed) = check_message_rate(state, socket_id)
+  case allowed {
+    False -> {
       let logger = coordinator_logger(state)
       logger
-      |> log.warn("Binary message rate limited", [
-        #("socket_id", socket_id),
-      ])
+      |> log.warn("Binary message rate limited", [#("socket_id", socket_id)])
       actor.continue(state)
     }
-    Ok(_) -> handle_raw_binary_in_inner(state, socket_id, data)
+    True -> handle_raw_binary_in_inner(state, socket_id, data)
   }
 }
 
@@ -1352,7 +1452,7 @@ fn disconnect_socket(
   case dict.get(state.sockets, socket_id) {
     Error(Nil) -> state
     Ok(socket_info) -> {
-      remove_socket_rate_limits(state, socket_id)
+      let state = remove_socket_rate_limits(state, socket_id)
       let logger = coordinator_logger(state)
       logger
       |> log.debug(
@@ -1516,7 +1616,6 @@ pub fn route_message(
   process.send(coord, RouteText(socket_id, raw_text))
 }
 
-// nolint: unused_exports -- public transport API for callers that decode frames before routing
 /// Route a transport-decoded inbound message to the coordinator.
 pub fn route_decoded(
   coord: Subject(Message),
@@ -1600,7 +1699,7 @@ fn dispatch_inbound(
         False -> reject_invalid_join(state, socket_id, msg)
       }
     codec.Leave -> {
-      use <- with_message_rate_limit(state, socket_id, "leave")
+      use state <- with_message_rate_limit(state, socket_id, "leave")
       case is_valid_topic(msg_topic, state.config) {
         False -> {
           let safe_topic = topic.sanitize_for_log(msg_topic)
@@ -1622,7 +1721,7 @@ fn dispatch_inbound(
       }
     }
     codec.Heartbeat -> {
-      use <- with_message_rate_limit(state, socket_id, "heartbeat")
+      use state <- with_message_rate_limit(state, socket_id, "heartbeat")
       handle_heartbeat(state, socket_id, msg_ref)
     }
     codec.Event(event) -> {
@@ -1726,12 +1825,11 @@ fn with_message_rate_limit(
   state: State,
   socket_id: String,
   kind: String,
-  next: fn() -> actor.Next(State, Message),
+  next: fn(State) -> actor.Next(State, Message),
 ) -> actor.Next(State, Message) {
-  case
-    rate_limit.check_optional(state.config.message_limiter, "msg:" <> socket_id)
-  {
-    Error(Nil) -> {
+  let #(state, allowed) = check_message_rate(state, socket_id)
+  case allowed {
+    False -> {
       coordinator_logger(state)
       |> log.warn("Message rate limited", [
         #("socket_id", socket_id),
@@ -1739,7 +1837,7 @@ fn with_message_rate_limit(
       ])
       actor.continue(state)
     }
-    Ok(_) -> next()
+    True -> next(state)
   }
 }
 
@@ -2361,10 +2459,7 @@ fn do_terminate_channel(
 
   send_terminal_frame(state, socket_info, topic_name, reason)
 
-  rate_limit.remove_optional(
-    state.config.channel_limiter,
-    "ch:" <> socket_id <> ":" <> topic_name,
-  )
+  let state = remove_channel_bucket(state, socket_id, topic_name)
 
   let new_subscribed = set.delete(socket_info.subscribed_topics, topic_name)
   let new_assigns = dict.delete(socket_info.channel_assigns, topic_name)

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -1572,7 +1572,9 @@ fn dispatch_inbound(
   let msg_ref = codec.inbound_ref(msg)
   case codec.inbound_kind(msg) {
     codec.Join ->
-      case is_valid_topic(msg_topic, state.config) {
+      case
+        is_valid_topic(msg_topic, state.config) && !is_reserved_topic(msg_topic)
+      {
         True ->
           handle_join(
             state,
@@ -1584,7 +1586,8 @@ fn dispatch_inbound(
           )
         False -> reject_invalid_join(state, socket_id, msg)
       }
-    codec.Leave ->
+    codec.Leave -> {
+      use <- with_message_rate_limit(state, socket_id, "leave")
       case is_valid_topic(msg_topic, state.config) {
         False -> {
           let safe_topic = topic.sanitize_for_log(msg_topic)
@@ -1604,7 +1607,11 @@ fn dispatch_inbound(
             msg_ref,
           )
       }
-    codec.Heartbeat -> handle_heartbeat(state, socket_id, msg_ref)
+    }
+    codec.Heartbeat -> {
+      use <- with_message_rate_limit(state, socket_id, "heartbeat")
+      handle_heartbeat(state, socket_id, msg_ref)
+    }
     codec.Event(event) -> {
       let resolved = resolve_event_topic(state, socket_id, msg_topic)
       case
@@ -1676,9 +1683,47 @@ fn is_valid_topic(topic_name: String, config: CoordinatorConfig) -> Bool {
   && result.is_ok(topic.validate(topic_name))
 }
 
+/// Topics under the `beryl:` prefix are reserved for internal machinery
+/// (e.g. the presence replication sync topic). Clients must not join them:
+/// with a catch-all handler registered, a client join would subscribe the
+/// coordinator to the internal topic and forward its traffic — including
+/// other users' presence state — to that client.
+fn is_reserved_topic(topic_name: String) -> Bool {
+  string.starts_with(topic_name, "beryl:")
+}
+
+/// Event names under the `phx_` prefix are reserved by the protocol.
+/// Client-supplied `phx_*` events (e.g. a forged `phx_reply`) must never
+/// reach channel handlers, where a naive echo channel could re-broadcast
+/// frames that confuse other clients.
 fn is_valid_event(event_name: String, config: CoordinatorConfig) -> Bool {
   string.byte_size(event_name) <= config.max_event_length
+  && !string.starts_with(event_name, "phx_")
   && result.is_ok(topic.validate_event(event_name))
+}
+
+/// Apply the per-socket message limiter to protocol frames (heartbeat,
+/// leave) so flooding them cannot bypass `with_message_rate` — each
+/// heartbeat otherwise generates an amplified reply exempt from limits.
+fn with_message_rate_limit(
+  state: State,
+  socket_id: String,
+  kind: String,
+  next: fn() -> actor.Next(State, Message),
+) -> actor.Next(State, Message) {
+  case
+    rate_limit.check_optional(state.config.message_limiter, "msg:" <> socket_id)
+  {
+    Error(Nil) -> {
+      coordinator_logger(state)
+      |> log.warn("Message rate limited", [
+        #("socket_id", socket_id),
+        #("kind", kind),
+      ])
+      actor.continue(state)
+    }
+    Ok(_) -> next()
+  }
 }
 
 /// Send a `phx_reply` error for a join with an invalid topic and drop the message.

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -194,7 +194,7 @@ fn stop_reason(reason: channel.StopReason) -> String {
     channel.Normal -> "normal"
     channel.Shutdown -> "shutdown"
     channel.HeartbeatTimeout -> "heartbeat_timeout"
-    channel.Error(message) -> message
+    channel.Errored(message) -> message
   }
 }
 
@@ -350,6 +350,7 @@ fn monotonic_time_ms() -> Int
 @external(erlang, "beryl_ffi", "identity")
 fn coerce_to_pubsub_message(value: Dynamic) -> pubsub.Message
 
+// nolint: stringly_typed_error -- the error is the formatted BEAM crash description; it is wrapped in channel.Errored at use sites
 /// Run a user-supplied channel callback, converting any crash into an error
 /// so a faulty channel cannot take down the shared coordinator actor.
 @external(erlang, "beryl_ffi", "rescue")
@@ -1396,10 +1397,13 @@ fn handle_route_text(
         list.append(
           [
             #("socket_id", socket_id),
-            #("topic", topic.sanitize_for_log(msg.topic)),
-            #("event", topic.sanitize_for_log(inbound_kind(msg.kind))),
-            #("ref", optional_string(msg.ref)),
-            #("join_ref", optional_string(msg.join_ref)),
+            #("topic", topic.sanitize_for_log(codec.inbound_topic(msg))),
+            #(
+              "event",
+              topic.sanitize_for_log(inbound_kind(codec.inbound_kind(msg))),
+            ),
+            #("ref", optional_string(codec.inbound_ref(msg))),
+            #("join_ref", optional_string(codec.inbound_join_ref(msg))),
           ],
           internal.preview_metadata("frame_preview", raw_text, logging),
         ),
@@ -1414,24 +1418,26 @@ fn dispatch_inbound(
   socket_id: String,
   msg: codec.Inbound,
 ) -> actor.Next(State, Message) {
-  case msg.kind {
+  let msg_topic = codec.inbound_topic(msg)
+  let msg_ref = codec.inbound_ref(msg)
+  case codec.inbound_kind(msg) {
     codec.Join ->
-      case is_valid_topic(msg.topic, state.config) {
+      case is_valid_topic(msg_topic, state.config) {
         True ->
           handle_join(
             state,
             socket_id,
-            msg.topic,
-            msg.payload,
-            msg.join_ref,
-            msg.ref,
+            msg_topic,
+            codec.inbound_payload(msg),
+            codec.inbound_join_ref(msg),
+            msg_ref,
           )
         False -> reject_invalid_join(state, socket_id, msg)
       }
     codec.Leave ->
-      case is_valid_topic(msg.topic, state.config) {
+      case is_valid_topic(msg_topic, state.config) {
         False -> {
-          let safe_topic = topic.sanitize_for_log(msg.topic)
+          let safe_topic = topic.sanitize_for_log(msg_topic)
           coordinator_logger(state)
           |> log.warn("Leave dropped: invalid topic", [
             #("socket_id", socket_id),
@@ -1439,19 +1445,26 @@ fn dispatch_inbound(
           ])
           actor.continue(state)
         }
-        True -> handle_leave(state, socket_id, msg.topic, msg.ref)
+        True -> handle_leave(state, socket_id, msg_topic, msg_ref)
       }
-    codec.Heartbeat -> handle_heartbeat(state, socket_id, msg.ref)
+    codec.Heartbeat -> handle_heartbeat(state, socket_id, msg_ref)
     codec.Event(event) -> {
-      let resolved = resolve_event_topic(state, socket_id, msg.topic)
+      let resolved = resolve_event_topic(state, socket_id, msg_topic)
       case
         is_valid_topic(resolved, state.config),
         is_valid_event(event, state.config)
       {
         True, True ->
-          handle_in(state, socket_id, resolved, event, msg.payload, msg.ref)
+          handle_in(
+            state,
+            socket_id,
+            resolved,
+            event,
+            codec.inbound_payload(msg),
+            msg_ref,
+          )
         False, _ -> {
-          let safe_topic = topic.sanitize_for_log(msg.topic)
+          let safe_topic = topic.sanitize_for_log(msg_topic)
           let safe_event = topic.sanitize_for_log(event)
           coordinator_logger(state)
           |> log.warn("Event dropped: invalid topic", [
@@ -1466,7 +1479,7 @@ fn dispatch_inbound(
           coordinator_logger(state)
           |> log.warn("Event dropped: invalid event", [
             #("socket_id", socket_id),
-            #("topic", msg.topic),
+            #("topic", msg_topic),
             #("event", safe_event),
           ])
           actor.continue(state)
@@ -1517,7 +1530,7 @@ fn reject_invalid_join(
   msg: codec.Inbound,
 ) -> actor.Next(State, Message) {
   let logger = coordinator_logger(state)
-  let safe_topic = topic.sanitize_for_log(msg.topic)
+  let safe_topic = topic.sanitize_for_log(codec.inbound_topic(msg))
   logger
   |> log.warn("Join rejected: invalid topic", [
     #("socket_id", socket_id),
@@ -1528,9 +1541,9 @@ fn reject_invalid_join(
     Ok(socket_info) -> {
       let reply =
         codec.encode_reply(socket_info.codec)(
-          msg.join_ref,
-          msg.ref,
-          msg.topic,
+          codec.inbound_join_ref(msg),
+          codec.inbound_ref(msg),
+          codec.inbound_topic(msg),
           codec.StatusError,
           json.object([#("reason", json.string("invalid_topic"))]),
         )
@@ -1705,7 +1718,7 @@ fn handle_callback_crash(
     #("callback", callback_name),
     #("crash", crash),
   ])
-  terminate_channel(state, socket_id, topic_name, channel.Error(crash))
+  terminate_channel(state, socket_id, topic_name, channel.Errored(crash))
 }
 
 fn dispatch_handle_in(
@@ -2048,7 +2061,7 @@ fn send_terminal_frame(
   reason: StopReason,
 ) -> Nil {
   let encoder = case reason {
-    channel.Error(_) -> codec.encode_error(socket_info.codec)
+    channel.Errored(_) -> codec.encode_error(socket_info.codec)
     channel.Normal | channel.Shutdown | channel.HeartbeatTimeout ->
       codec.encode_close(socket_info.codec)
   }

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -887,17 +887,15 @@ fn handle_in_subscribed(
     }
     Ok(socket_info) -> {
       case set.contains(socket_info.subscribed_topics, topic_name) {
-        False -> {
-          let logger = coordinator_logger(state)
-          logger
-          |> log.debug("Inbound message ignored", [
-            #("socket_id", socket_id),
-            #("topic", topic_name),
-            #("event", event),
-            #("reason", "topic_not_joined"),
-          ])
-          actor.continue(state)
-        }
+        False ->
+          reject_unjoined_event(
+            state,
+            socket_info,
+            socket_id,
+            topic_name,
+            event,
+            ref,
+          )
         True ->
           handle_in_rate_limited(
             state,
@@ -911,6 +909,44 @@ fn handle_in_subscribed(
       }
     }
   }
+}
+
+/// Reject an event pushed to a topic the socket has not joined. Phoenix
+/// replies with `{"status":"error","response":{"reason":"unmatched topic"}}`
+/// so the client's push errors immediately instead of timing out; messages
+/// without a ref have nothing to correlate a reply with and are dropped.
+fn reject_unjoined_event(
+  state: State,
+  socket_info: SocketInfo,
+  socket_id: String,
+  topic_name: String,
+  event: String,
+  ref: Option(String),
+) -> actor.Next(State, Message) {
+  coordinator_logger(state)
+  |> log.debug("Inbound message rejected", [
+    #("socket_id", socket_id),
+    #("topic", topic_name),
+    #("event", event),
+    #("reason", "topic_not_joined"),
+  ])
+  case ref {
+    Some(r) -> {
+      let reply =
+        codec.encode_reply(socket_info.codec)(
+          None,
+          Some(r),
+          topic_name,
+          codec.StatusError,
+          json.object([#("reason", json.string("unmatched topic"))]),
+        )
+      let _send_result =
+        send_frame_logged(state, socket_info, topic_name, reply)
+      Nil
+    }
+    None -> Nil
+  }
+  actor.continue(state)
 }
 
 fn handle_in_rate_limited(

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -65,6 +65,7 @@ pub type JoinResultErased {
 pub type HandleResultErased {
   NoReplyErased(assigns: Dynamic)
   ReplyErased(event: String, payload: json.Json, assigns: Dynamic)
+  ReplyErrorErased(payload: json.Json, assigns: Dynamic)
   PushErased(event: String, payload: json.Json, assigns: Dynamic)
   StopErased(reason: StopReason)
 }
@@ -1750,6 +1751,34 @@ fn dispatch_handle_in(
       actor.continue(state)
     }
 
+    Ok(ReplyErrorErased(reply_payload, new_assigns)) -> {
+      logger
+      |> log.debug("Channel callback returned error reply", [
+        #("socket_id", socket_id),
+        #("topic", topic_name),
+        #("event", event),
+        #("ref", optional_string(ref)),
+      ])
+      case ref {
+        Some(r) -> {
+          let reply =
+            codec.encode_reply(socket_info.codec)(
+              None,
+              Some(r),
+              topic_name,
+              codec.StatusError,
+              reply_payload,
+            )
+          let _send_result =
+            send_frame_logged(state, socket_info, topic_name, reply)
+          Nil
+        }
+        None -> Nil
+      }
+      let state = update_assigns(state, socket_id, topic_name, new_assigns)
+      actor.continue(state)
+    }
+
     Ok(PushErased(push_event, push_payload, new_assigns)) -> {
       logger
       |> log.debug("Channel callback returned push", [
@@ -1851,6 +1880,18 @@ fn dispatch_handle_info(
       actor.continue(state)
     }
 
+    Ok(ReplyErrorErased(_payload, new_assigns)) -> {
+      // Error replies require a client ref for correlation; handle_info is
+      // server-originated so there is nothing to attach the error to.
+      logger
+      |> log.warn("Error reply dropped: no client ref in handle_info", [
+        #("socket_id", socket_id),
+        #("topic", topic_name),
+      ])
+      let state = update_assigns(state, socket_id, topic_name, new_assigns)
+      actor.continue(state)
+    }
+
     Ok(StopErased(reason)) -> {
       logger
       |> log.debug("Channel callback stopped channel", [
@@ -1919,6 +1960,15 @@ fn dispatch_handle_binary(
           reply_payload,
         )
       let _send_result = send_frame_logged(st, socket_info, topic_name, msg)
+      update_assigns(st, socket_id, topic_name, new_assigns)
+    }
+    Ok(ReplyErrorErased(_payload, new_assigns)) -> {
+      // Raw binary frames carry no ref to correlate an error reply with.
+      logger
+      |> log.warn("Error reply dropped: no client ref in handle_binary", [
+        #("socket_id", socket_id),
+        #("topic", topic_name),
+      ])
       update_assigns(st, socket_id, topic_name, new_assigns)
     }
     Ok(PushErased(push_event, push_payload, new_assigns)) -> {

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -251,6 +251,10 @@ type SocketInfo {
     channel_assigns: Dict(String, Dynamic),
     /// Per-topic registered channel id (topic -> handler id)
     channel_ids: Dict(String, Int),
+    /// Per-topic join_ref from the accepted `phx_join` (topic -> join_ref).
+    /// Used to echo the channel's join_ref in replies/terminal frames and to
+    /// drop messages from a stale channel instance after a rejoin.
+    join_refs: Dict(String, Option(String)),
     /// Socket-level assigns seeded by the transport connect hook (type-erased).
     /// Used as the initial assigns visible to a channel at join time.
     connect_assigns: Dynamic,
@@ -621,6 +625,7 @@ fn handle_socket_connected(
       subscribed_topics: set.new(),
       channel_assigns: dict.new(),
       channel_ids: dict.new(),
+      join_refs: dict.new(),
       connect_assigns: connect_assigns,
       last_heartbeat: monotonic_time_ms(),
     )
@@ -748,9 +753,8 @@ fn handle_join_inner(
       case can_join_topic(socket_info, topic_name, state.config) {
         False -> reject_join_cap(state, socket_info, topic_name, join_ref, ref)
         True ->
-          handle_join_with_handler(
+          replace_existing_then_join(
             state,
-            socket_info,
             socket_id,
             topic_name,
             payload,
@@ -759,6 +763,35 @@ fn handle_join_inner(
           )
       }
     }
+  }
+}
+
+/// Phoenix duplicate-join semantics: a `phx_join` for an already-joined
+/// topic replaces the previous channel instance. Terminate the old instance
+/// first (running its `terminate` callback and emitting `phx_close`) so
+/// cleanup keyed off termination — presence untracking, bridge shutdown —
+/// is never silently skipped by a rejoin.
+fn replace_existing_then_join(
+  state: State,
+  socket_id: String,
+  topic_name: String,
+  payload: Dynamic,
+  join_ref: Option(String),
+  ref: Option(String),
+) -> actor.Next(State, Message) {
+  let state = terminate_channel(state, socket_id, topic_name, channel.Normal)
+  case dict.get(state.sockets, socket_id) {
+    Error(Nil) -> actor.continue(state)
+    Ok(socket_info) ->
+      handle_join_with_handler(
+        state,
+        socket_info,
+        socket_id,
+        topic_name,
+        payload,
+        join_ref,
+        ref,
+      )
   }
 }
 
@@ -847,8 +880,24 @@ fn handle_leave(
   state: State,
   socket_id: String,
   topic_name: String,
+  msg_join_ref: Option(String),
   ref: Option(String),
 ) -> actor.Next(State, Message) {
+  // A leave carrying a join_ref from a previous channel instance (the
+  // client rejoined since sending it) must not close the new instance.
+  let stale = case dict.get(state.sockets, socket_id) {
+    Ok(socket_info) -> is_stale_join_ref(socket_info, topic_name, msg_join_ref)
+    Error(Nil) -> False
+  }
+  use <- bool.lazy_guard(when: stale, return: fn() {
+    coordinator_logger(state)
+    |> log.debug("Leave dropped: stale join_ref", [
+      #("socket_id", socket_id),
+      #("topic", topic_name),
+    ])
+    actor.continue(state)
+  })
+
   // Acknowledge the leave before terminating, so the client sees the reply
   // to its own ref first and the `phx_close` emitted by termination second —
   // matching the frame order Phoenix produces.
@@ -856,7 +905,7 @@ fn handle_leave(
     Some(r), Ok(socket_info) -> {
       let reply =
         codec.encode_reply(socket_info.codec)(
-          None,
+          joined_ref(socket_info, topic_name),
           Some(r),
           topic_name,
           codec.StatusOk,
@@ -872,12 +921,27 @@ fn handle_leave(
   actor.continue(terminate_channel(state, socket_id, topic_name, channel.Normal))
 }
 
+/// A message is stale when it carries a join_ref from a previous channel
+/// instance on this topic (the client rejoined since sending it). Messages
+/// without a join_ref are never treated as stale.
+fn is_stale_join_ref(
+  socket_info: SocketInfo,
+  topic_name: String,
+  msg_join_ref: Option(String),
+) -> Bool {
+  case msg_join_ref, joined_ref(socket_info, topic_name) {
+    Some(sent), Some(current) -> sent != current
+    _, _ -> False
+  }
+}
+
 fn handle_in(
   state: State,
   socket_id: String,
   topic_name: String,
   event: String,
   payload: Dynamic,
+  msg_join_ref: Option(String),
   ref: Option(String),
 ) -> actor.Next(State, Message) {
   // Check per-socket message rate limit
@@ -894,7 +958,15 @@ fn handle_in(
       actor.continue(state)
     }
     Ok(_) -> {
-      handle_in_subscribed(state, socket_id, topic_name, event, payload, ref)
+      handle_in_subscribed(
+        state,
+        socket_id,
+        topic_name,
+        event,
+        payload,
+        msg_join_ref,
+        ref,
+      )
     }
   }
 }
@@ -905,6 +977,7 @@ fn handle_in_subscribed(
   topic_name: String,
   event: String,
   payload: Dynamic,
+  msg_join_ref: Option(String),
   ref: Option(String),
 ) -> actor.Next(State, Message) {
   case dict.get(state.sockets, socket_id) {
@@ -931,17 +1004,53 @@ fn handle_in_subscribed(
             ref,
           )
         True ->
-          handle_in_rate_limited(
+          handle_in_current_instance(
             state,
             socket_info,
             socket_id,
             topic_name,
             event,
             payload,
+            msg_join_ref,
             ref,
           )
       }
     }
+  }
+}
+
+/// Drop messages sent to a previous channel instance (stale join_ref after a
+/// rejoin), matching Phoenix; otherwise continue to per-channel rate limits.
+fn handle_in_current_instance(
+  state: State,
+  socket_info: SocketInfo,
+  socket_id: String,
+  topic_name: String,
+  event: String,
+  payload: Dynamic,
+  msg_join_ref: Option(String),
+  ref: Option(String),
+) -> actor.Next(State, Message) {
+  case is_stale_join_ref(socket_info, topic_name, msg_join_ref) {
+    True -> {
+      coordinator_logger(state)
+      |> log.debug("Inbound message dropped: stale join_ref", [
+        #("socket_id", socket_id),
+        #("topic", topic_name),
+        #("event", event),
+      ])
+      actor.continue(state)
+    }
+    False ->
+      handle_in_rate_limited(
+        state,
+        socket_info,
+        socket_id,
+        topic_name,
+        event,
+        payload,
+        ref,
+      )
   }
 }
 
@@ -1486,7 +1595,14 @@ fn dispatch_inbound(
           ])
           actor.continue(state)
         }
-        True -> handle_leave(state, socket_id, msg_topic, msg_ref)
+        True ->
+          handle_leave(
+            state,
+            socket_id,
+            msg_topic,
+            codec.inbound_join_ref(msg),
+            msg_ref,
+          )
       }
     codec.Heartbeat -> handle_heartbeat(state, socket_id, msg_ref)
     codec.Event(event) -> {
@@ -1502,6 +1618,7 @@ fn dispatch_inbound(
             resolved,
             event,
             codec.inbound_payload(msg),
+            codec.inbound_join_ref(msg),
             msg_ref,
           )
         False, _ -> {
@@ -1672,12 +1789,15 @@ fn dispatch_join(
         dict.insert(socket_info.channel_assigns, topic_name, assigns)
       let new_channel_ids =
         dict.insert(socket_info.channel_ids, topic_name, handler.id)
+      let new_join_refs =
+        dict.insert(socket_info.join_refs, topic_name, join_ref)
       let new_socket_info =
         SocketInfo(
           ..socket_info,
           subscribed_topics: new_subscribed,
           channel_assigns: new_assigns,
           channel_ids: new_channel_ids,
+          join_refs: new_join_refs,
         )
 
       let existing_topic_subscribers =
@@ -1827,7 +1947,7 @@ fn dispatch_handle_in(
         Some(r) -> {
           let reply =
             codec.encode_reply(socket_info.codec)(
-              None,
+              joined_ref(socket_info, topic_name),
               Some(r),
               topic_name,
               codec.StatusOk,
@@ -1855,7 +1975,7 @@ fn dispatch_handle_in(
         Some(r) -> {
           let reply =
             codec.encode_reply(socket_info.codec)(
-              None,
+              joined_ref(socket_info, topic_name),
               Some(r),
               topic_name,
               codec.StatusError,
@@ -2117,12 +2237,18 @@ fn send_terminal_frame(
           state,
           socket_info,
           topic_name,
-          encode(None, topic_name),
+          encode(joined_ref(socket_info, topic_name), topic_name),
         )
       Nil
     }
     None -> Nil
   }
+}
+
+/// The join_ref of the socket's current channel instance on a topic, if any.
+fn joined_ref(socket_info: SocketInfo, topic_name: String) -> Option(String) {
+  dict.get(socket_info.join_refs, topic_name)
+  |> result.unwrap(None)
 }
 
 fn do_terminate_channel(
@@ -2178,12 +2304,14 @@ fn do_terminate_channel(
   let new_subscribed = set.delete(socket_info.subscribed_topics, topic_name)
   let new_assigns = dict.delete(socket_info.channel_assigns, topic_name)
   let new_channel_ids = dict.delete(socket_info.channel_ids, topic_name)
+  let new_join_refs = dict.delete(socket_info.join_refs, topic_name)
   let new_socket_info =
     SocketInfo(
       ..socket_info,
       subscribed_topics: new_subscribed,
       channel_assigns: new_assigns,
       channel_ids: new_channel_ids,
+      join_refs: new_join_refs,
     )
 
   let topic_subscribers =

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -349,6 +349,11 @@ fn monotonic_time_ms() -> Int
 @external(erlang, "beryl_ffi", "identity")
 fn coerce_to_pubsub_message(value: Dynamic) -> pubsub.Message
 
+/// Run a user-supplied channel callback, converting any crash into an error
+/// so a faulty channel cannot take down the shared coordinator actor.
+@external(erlang, "beryl_ffi", "rescue")
+fn rescue(callback: fn() -> value) -> Result(value, String)
+
 /// Start the coordinator actor with default heartbeat settings (no checking),
 /// using the supplied wire codec.
 pub fn start(codec: Codec) -> Result(Subject(Message), StartError) {
@@ -1538,8 +1543,10 @@ fn dispatch_join(
       send_binary: socket_info.send_binary,
     )
 
-  case handler.join(topic_name, payload, ctx) {
-    JoinErrorErased(reason) -> {
+  case rescue(fn() { handler.join(topic_name, payload, ctx) }) {
+    Error(crash) ->
+      reject_crashed_join(state, socket_info, topic_name, join_ref, ref, crash)
+    Ok(JoinErrorErased(reason)) -> {
       logger
       |> log.debug("Join rejected", [
         #("socket_id", socket_id),
@@ -1559,7 +1566,7 @@ fn dispatch_join(
         send_frame_logged(state, socket_info, topic_name, reply)
       actor.continue(state)
     }
-    JoinOkErased(reply_payload, assigns) -> {
+    Ok(JoinOkErased(reply_payload, assigns)) -> {
       logger
       |> log.debug("Join accepted", [
         #("socket_id", socket_id),
@@ -1615,6 +1622,54 @@ fn dispatch_join(
   }
 }
 
+/// Reject a join whose channel callback crashed. No subscription state has
+/// been created yet, so the socket keeps working; the client receives an
+/// error reply mirroring Phoenix's "join crashed" response.
+fn reject_crashed_join(
+  state: State,
+  socket_info: SocketInfo,
+  topic_name: String,
+  join_ref: Option(String),
+  ref: Option(String),
+  crash: String,
+) -> actor.Next(State, Message) {
+  coordinator_logger(state)
+  |> log.error("Channel join crashed", [
+    #("socket_id", socket_info.id),
+    #("topic", topic_name),
+    #("crash", crash),
+  ])
+  let reply =
+    codec.encode_reply(socket_info.codec)(
+      join_ref,
+      ref,
+      topic_name,
+      codec.StatusError,
+      json.object([#("reason", json.string("join crashed"))]),
+    )
+  let _send_result = send_frame_logged(state, socket_info, topic_name, reply)
+  actor.continue(state)
+}
+
+/// Tear down a channel whose callback crashed, leaving the socket and the
+/// coordinator's other channels untouched.
+fn handle_callback_crash(
+  state: State,
+  socket_id: String,
+  topic_name: String,
+  callback_name: String,
+  crash: String,
+) -> State {
+  coordinator_logger(state)
+  |> log.error("Channel callback crashed", [
+    #("socket_id", socket_id),
+    #("topic", topic_name),
+    #("callback", callback_name),
+    #("crash", crash),
+  ])
+  terminate_channel(state, socket_id, topic_name, channel.Error(crash))
+}
+
 fn dispatch_handle_in(
   state: State,
   socket_info: SocketInfo,
@@ -1646,8 +1701,16 @@ fn dispatch_handle_in(
       send_binary: socket_info.send_binary,
     )
 
-  case handler.handle_in(event, payload, ctx) {
-    NoReplyErased(new_assigns) -> {
+  case rescue(fn() { handler.handle_in(event, payload, ctx) }) {
+    Error(crash) ->
+      actor.continue(handle_callback_crash(
+        state,
+        socket_id,
+        topic_name,
+        "handle_in",
+        crash,
+      ))
+    Ok(NoReplyErased(new_assigns)) -> {
       logger
       |> log.debug("Channel callback returned no reply", [
         #("socket_id", socket_id),
@@ -1658,7 +1721,7 @@ fn dispatch_handle_in(
       actor.continue(state)
     }
 
-    ReplyErased(_reply_event, reply_payload, new_assigns) -> {
+    Ok(ReplyErased(_reply_event, reply_payload, new_assigns)) -> {
       logger
       |> log.debug("Channel callback returned reply", [
         #("socket_id", socket_id),
@@ -1686,7 +1749,7 @@ fn dispatch_handle_in(
       actor.continue(state)
     }
 
-    PushErased(push_event, push_payload, new_assigns) -> {
+    Ok(PushErased(push_event, push_payload, new_assigns)) -> {
       logger
       |> log.debug("Channel callback returned push", [
         #("socket_id", socket_id),
@@ -1705,7 +1768,7 @@ fn dispatch_handle_in(
       actor.continue(state)
     }
 
-    StopErased(reason) -> {
+    Ok(StopErased(reason)) -> {
       logger
       |> log.debug("Channel callback stopped channel", [
         #("socket_id", socket_id),
@@ -1745,8 +1808,16 @@ fn dispatch_handle_info(
       send_binary: socket_info.send_binary,
     )
 
-  case callback(ctx) {
-    NoReplyErased(new_assigns) -> {
+  case rescue(fn() { callback(ctx) }) {
+    Error(crash) ->
+      actor.continue(handle_callback_crash(
+        state,
+        socket_id,
+        topic_name,
+        "handle_info",
+        crash,
+      ))
+    Ok(NoReplyErased(new_assigns)) -> {
       logger
       |> log.debug("Channel callback returned no reply", [
         #("socket_id", socket_id),
@@ -1757,8 +1828,8 @@ fn dispatch_handle_info(
       actor.continue(state)
     }
 
-    ReplyErased(reply_event, reply_payload, new_assigns)
-    | PushErased(reply_event, reply_payload, new_assigns) -> {
+    Ok(ReplyErased(reply_event, reply_payload, new_assigns))
+    | Ok(PushErased(reply_event, reply_payload, new_assigns)) -> {
       logger
       |> log.debug("Channel callback returned push", [
         #("socket_id", socket_id),
@@ -1779,7 +1850,7 @@ fn dispatch_handle_info(
       actor.continue(state)
     }
 
-    StopErased(reason) -> {
+    Ok(StopErased(reason)) -> {
       logger
       |> log.debug("Channel callback stopped channel", [
         #("socket_id", socket_id),
@@ -1821,8 +1892,10 @@ fn dispatch_handle_binary(
       send_binary: socket_info.send_binary,
     )
 
-  case handler.handle_binary(data, ctx) {
-    NoReplyErased(new_assigns) -> {
+  case rescue(fn() { handler.handle_binary(data, ctx) }) {
+    Error(crash) ->
+      handle_callback_crash(st, socket_id, topic_name, "handle_binary", crash)
+    Ok(NoReplyErased(new_assigns)) -> {
       logger
       |> log.debug("Channel callback returned no reply", [
         #("socket_id", socket_id),
@@ -1831,7 +1904,7 @@ fn dispatch_handle_binary(
       ])
       update_assigns(st, socket_id, topic_name, new_assigns)
     }
-    ReplyErased(_event, reply_payload, new_assigns) -> {
+    Ok(ReplyErased(_event, reply_payload, new_assigns)) -> {
       logger
       |> log.debug("Channel callback returned reply", [
         #("socket_id", socket_id),
@@ -1847,7 +1920,7 @@ fn dispatch_handle_binary(
       let _send_result = send_frame_logged(st, socket_info, topic_name, msg)
       update_assigns(st, socket_id, topic_name, new_assigns)
     }
-    PushErased(push_event, push_payload, new_assigns) -> {
+    Ok(PushErased(push_event, push_payload, new_assigns)) -> {
       logger
       |> log.debug("Channel callback returned push", [
         #("socket_id", socket_id),
@@ -1864,7 +1937,7 @@ fn dispatch_handle_binary(
       let _send_result = send_frame_logged(st, socket_info, topic_name, msg)
       update_assigns(st, socket_id, topic_name, new_assigns)
     }
-    StopErased(reason) -> {
+    Ok(StopErased(reason)) -> {
       logger
       |> log.debug("Channel callback stopped channel", [
         #("socket_id", socket_id),
@@ -1905,7 +1978,16 @@ fn do_terminate_channel(
           send: socket_info.send,
           send_binary: socket_info.send_binary,
         )
-      handler.terminate(reason, ctx)
+      case rescue(fn() { handler.terminate(reason, ctx) }) {
+        Ok(Nil) -> Nil
+        Error(crash) ->
+          logger
+          |> log.error("Channel terminate crashed", [
+            #("socket_id", socket_id),
+            #("topic", topic_name),
+            #("crash", crash),
+          ])
+      }
     }
     None -> Nil
   }

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -535,7 +535,20 @@ fn handle_message(
     Broadcast(topic_name, event, payload, except) ->
       handle_broadcast(state, topic_name, event, payload, except)
 
-    RemoteBroadcast(pubsub_msg) -> handle_remote_broadcast(state, pubsub_msg)
+    RemoteBroadcast(pubsub_msg) ->
+      // The pg-delivered record is coerced without validation, so a
+      // malformed message (mixed-version cluster, stray tuple sent to the
+      // coordinator's pid) must not crash the coordinator.
+      case rescue(fn() { handle_remote_broadcast(state, pubsub_msg) }) {
+        Ok(next) -> next
+        Error(crash) -> {
+          coordinator_logger(state)
+          |> log.error("Remote broadcast dropped: malformed message", [
+            #("crash", crash),
+          ])
+          actor.continue(state)
+        }
+      }
 
     CheckHeartbeats -> handle_check_heartbeats(state)
 
@@ -1654,11 +1667,12 @@ fn dispatch_inbound(
   }
 }
 
-/// Resolve the topic for an inbound Event. Some codecs (e.g. Socket.IO/Fluid)
-/// omit a per-frame topic; in that case route to the socket's single joined
-/// topic. With zero or multiple joined topics the original (empty) topic is
-/// returned so existing validation drops it. Topic-carrying codecs (Phoenix)
-/// are unaffected.
+/// Resolve the topic for an inbound Event. Codecs that opt in via
+/// `codec.with_topicless_events` (e.g. Socket.IO-style framings) omit a
+/// per-frame topic; for those, an empty topic routes to the socket's single
+/// joined topic. With zero or multiple joined topics — or for
+/// topic-carrying codecs like Phoenix, where an empty topic is a protocol
+/// violation — the original (empty) topic is returned so validation drops it.
 fn resolve_event_topic(
   state: State,
   socket_id: String,
@@ -1668,9 +1682,12 @@ fn resolve_event_topic(
     "" ->
       case dict.get(state.sockets, socket_id) {
         Ok(info) ->
-          case set.to_list(info.subscribed_topics) {
-            [only] -> only
-            _ -> requested
+          case
+            codec.topicless_events(info.codec),
+            set.to_list(info.subscribed_topics)
+          {
+            True, [only] -> only
+            _, _ -> requested
           }
         Error(Nil) -> requested
       }
@@ -2205,17 +2222,20 @@ fn dispatch_handle_binary(
       ])
       update_assigns(st, socket_id, topic_name, new_assigns)
     }
-    Ok(ReplyErased(_event, reply_payload, new_assigns)) -> {
+    Ok(ReplyErased(reply_event, reply_payload, new_assigns)) -> {
       logger
       |> log.debug("Channel callback returned reply", [
         #("socket_id", socket_id),
         #("topic", topic_name),
         #("callback", "handle_binary"),
       ])
+      // Raw binary frames carry no ref to correlate a reply with, so the
+      // reply is delivered as a push under the handler's own event name
+      // (mirroring handle_info).
       let msg =
         codec.encode_push(socket_info.codec)(
           topic_name,
-          "binary_reply",
+          reply_event,
           reply_payload,
         )
       let _send_result = send_frame_logged(st, socket_info, topic_name, msg)

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -814,8 +814,9 @@ fn handle_leave(
   topic_name: String,
   ref: Option(String),
 ) -> actor.Next(State, Message) {
-  let state = terminate_channel(state, socket_id, topic_name, channel.Normal)
-
+  // Acknowledge the leave before terminating, so the client sees the reply
+  // to its own ref first and the `phx_close` emitted by termination second —
+  // matching the frame order Phoenix produces.
   case ref, dict.get(state.sockets, socket_id) {
     Some(r), Ok(socket_info) -> {
       let reply =
@@ -833,7 +834,7 @@ fn handle_leave(
     _, _ -> Nil
   }
 
-  actor.continue(state)
+  actor.continue(terminate_channel(state, socket_id, topic_name, channel.Normal))
 }
 
 fn handle_in(
@@ -1950,6 +1951,36 @@ fn dispatch_handle_binary(
   }
 }
 
+/// Notify the client that its channel instance ended. Phoenix clients rely
+/// on `phx_close`/`phx_error` to leave the joined state (and, for errors,
+/// schedule a rejoin) instead of waiting out push timeouts. Codecs without
+/// close/error encoders skip the notification.
+fn send_terminal_frame(
+  state: State,
+  socket_info: SocketInfo,
+  topic_name: String,
+  reason: StopReason,
+) -> Nil {
+  let encoder = case reason {
+    channel.Error(_) -> codec.encode_error(socket_info.codec)
+    channel.Normal | channel.Shutdown | channel.HeartbeatTimeout ->
+      codec.encode_close(socket_info.codec)
+  }
+  case encoder {
+    Some(encode) -> {
+      let _send_result =
+        send_frame_logged(
+          state,
+          socket_info,
+          topic_name,
+          encode(None, topic_name),
+        )
+      Nil
+    }
+    None -> Nil
+  }
+}
+
 fn do_terminate_channel(
   state: State,
   socket_info: SocketInfo,
@@ -1991,6 +2022,8 @@ fn do_terminate_channel(
     }
     None -> Nil
   }
+
+  send_terminal_frame(state, socket_info, topic_name, reason)
 
   rate_limit.remove_optional(
     state.config.channel_limiter,

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -52,6 +52,8 @@ pub type SocketContext {
     send: fn(String) -> Result(Nil, Nil),
     /// Function to send binary data to this socket
     send_binary: fn(BitArray) -> Result(Nil, Nil),
+    /// Ask the transport to close this socket's connection
+    close: fn() -> Nil,
   )
 }
 
@@ -236,6 +238,9 @@ type SocketInfo {
     send: fn(String) -> Result(Nil, Nil),
     /// Function to send binary to this socket's WebSocket
     send_binary: fn(BitArray) -> Result(Nil, Nil),
+    /// Ask the transport to close this socket's connection. Registered by
+    /// the transport via `RegisterCloser`; a no-op until then.
+    close: fn() -> Nil,
     /// Wire codec negotiated for this connection. Used to decode inbound
     /// binary frames and encode replies/pushes destined for this socket, so
     /// different connections can use different serializers concurrently.
@@ -317,6 +322,11 @@ pub type Message {
     connect_assigns: Dynamic,
   )
   SocketDisconnected(socket_id: String)
+  /// Register a function that closes the socket's underlying connection.
+  /// Transports send this after `SocketConnected` so the coordinator can
+  /// actively close connections it evicts (e.g. heartbeat timeout) instead
+  /// of leaving zombie sockets whose frames are silently dropped.
+  RegisterCloser(socket_id: String, close: fn() -> Nil)
   // Channel operations
   HandleBinary(socket_id: String, data: BitArray)
   HandleInfo(
@@ -505,6 +515,9 @@ fn handle_message(
     SocketDisconnected(socket_id) ->
       handle_socket_disconnected(state, socket_id)
 
+    RegisterCloser(socket_id, close) ->
+      handle_register_closer(state, socket_id, close)
+
     HandleBinary(socket_id, data) -> handle_binary_in(state, socket_id, data)
 
     HandleInfo(socket_id, topic_name, channel_id, callback) ->
@@ -603,6 +616,7 @@ fn handle_socket_connected(
       id: socket_id,
       send: send,
       send_binary: send_binary,
+      close: fn() { Nil },
       codec: option.unwrap(codec, state.config.codec),
       subscribed_topics: set.new(),
       channel_assigns: dict.new(),
@@ -615,6 +629,25 @@ fn handle_socket_connected(
   logger |> log.info("Socket connected", [#("socket_id", socket_id)])
   let new_sockets = dict.insert(state.sockets, socket_id, socket_info)
   actor.continue(State(..state, sockets: new_sockets))
+}
+
+fn handle_register_closer(
+  state: State,
+  socket_id: String,
+  close: fn() -> Nil,
+) -> actor.Next(State, Message) {
+  case dict.get(state.sockets, socket_id) {
+    Error(Nil) -> actor.continue(state)
+    Ok(socket_info) -> {
+      let new_sockets =
+        dict.insert(
+          state.sockets,
+          socket_id,
+          SocketInfo(..socket_info, close: close),
+        )
+      actor.continue(State(..state, sockets: new_sockets))
+    }
+  }
 }
 
 fn handle_socket_disconnected(
@@ -1222,6 +1255,14 @@ fn disconnect_socket(
 
       let new_sockets = dict.delete(state.sockets, socket_id)
 
+      // Actively close the transport connection after the terminal frames
+      // above have been queued. Without this, evicted sockets stay open as
+      // zombies: the client believes it is connected while every frame it
+      // sends (including rejoins) is dropped, and per-IP connection slots
+      // remain held. A no-op when the transport already closed (Normal
+      // disconnects) or never registered a closer.
+      socket_info.close()
+
       State(..state, sockets: new_sockets, topics: new_topics)
     }
   }
@@ -1592,6 +1633,7 @@ fn dispatch_join(
       assigns: socket_info.connect_assigns,
       send: socket_info.send,
       send_binary: socket_info.send_binary,
+      close: socket_info.close,
     )
 
   case rescue(fn() { handler.join(topic_name, payload, ctx) }) {
@@ -1750,6 +1792,7 @@ fn dispatch_handle_in(
       assigns: assigns,
       send: socket_info.send,
       send_binary: socket_info.send_binary,
+      close: socket_info.close,
     )
 
   case rescue(fn() { handler.handle_in(event, payload, ctx) }) {
@@ -1885,6 +1928,7 @@ fn dispatch_handle_info(
       assigns: assigns,
       send: socket_info.send,
       send_binary: socket_info.send_binary,
+      close: socket_info.close,
     )
 
   case rescue(fn() { callback(ctx) }) {
@@ -1981,6 +2025,7 @@ fn dispatch_handle_binary(
       assigns: assigns,
       send: socket_info.send,
       send_binary: socket_info.send_binary,
+      close: socket_info.close,
     )
 
   case rescue(fn() { handler.handle_binary(data, ctx) }) {
@@ -2107,6 +2152,7 @@ fn do_terminate_channel(
           assigns: assigns,
           send: socket_info.send,
           send_binary: socket_info.send_binary,
+          close: socket_info.close,
         )
       case rescue(fn() { handler.terminate(reason, ctx) }) {
         Ok(Nil) -> Nil

--- a/src/beryl/group.gleam
+++ b/src/beryl/group.gleam
@@ -85,7 +85,10 @@ pub fn start() -> Result(Groups, GroupStartError) {
   })
 }
 
-/// Start the groups actor with a registered name (for supervision)
+// nolint: unused_exports -- package-internal constructor for supervised groups; hidden from public docs with @internal
+/// Start the groups actor with a registered name. Package-internal: used by
+/// `beryl/supervisor`; end users get supervision via `supervisor.child_spec`.
+@internal
 pub fn start_named(
   name: process.Name(Message),
 ) -> Result(actor.Started(Subject(Message)), actor.StartError) {

--- a/src/beryl/presence.gleam
+++ b/src/beryl/presence.gleam
@@ -260,7 +260,10 @@ pub fn start(config: Config) -> Result(Presence, PresenceError) {
   })
 }
 
-/// Start the presence actor with a registered name (for supervision)
+// nolint: unused_exports -- package-internal constructor for supervised presence; hidden from public docs with @internal
+/// Start the presence actor with a registered name. Package-internal: used by
+/// `beryl/supervisor`; end users get supervision via `supervisor.child_spec`.
+@internal
 pub fn start_named(
   config: Config,
   name: process.Name(Message),
@@ -380,40 +383,42 @@ fn generate_ref() -> String {
 /// client-supplied `phx_ref` is replaced. Non-object metas are stored
 /// unchanged (Phoenix requires object metas for its Presence helpers).
 fn meta_with_phx_ref(meta: json.Json, ref: String) -> json.Json {
-  let parsed =
-    json.parse(
-      from: json.to_string(meta),
-      using: gdecode.dict(gdecode.string, gdecode.dynamic),
-    )
-  case parsed {
-    Ok(fields) ->
-      fields
-      |> dict.delete("phx_ref")
-      |> dict.to_list
-      |> list.map(fn(field) { #(field.0, wire.dynamic_to_json(field.1)) })
-      |> list.append([#("phx_ref", json.string(ref))])
-      |> json.object
-    Error(_) -> meta
-  }
+  json.parse(
+    from: json.to_string(meta),
+    using: gdecode.dict(gdecode.string, gdecode.dynamic),
+  )
+  |> result.map(fn(fields) {
+    fields
+    |> dict.delete("phx_ref")
+    |> dict.to_list
+    |> list.map(fn(field) { #(field.0, wire.dynamic_to_json(field.1)) })
+    |> list.append([#("phx_ref", json.string(ref))])
+    |> json.object
+  })
+  |> result.unwrap(meta)
 }
 
 /// Track a presence in a topic.
 ///
+/// `session_id` identifies the session (e.g. socket) that owns this presence
+/// and is the value `untrack_all` matches on when the session disconnects.
+///
 /// Returns a server-generated tracking ref: an opaque, unique handle for this
 /// specific presence. Pass it to `untrack` to remove exactly this entry later.
-/// The ref is not the `pid`/session id — it is minted by the presence actor and
-/// is only meaningful to that actor.
+/// The ref is not the session id — it is minted by the presence actor and is
+/// only meaningful to that actor. The ref is also merged into object metas as
+/// `phx_ref` for Phoenix client compatibility.
 ///
 /// Panics if the presence actor is unavailable or does not reply within 5 seconds.
 pub fn track(
   presence: Presence,
   topic: String,
   key: String,
-  pid: String,
+  session_id: String,
   meta: json.Json,
 ) -> String {
   process.call(presence.subject, 5000, fn(reply) {
-    Track(topic, key, pid, meta, reply)
+    Track(topic, key, session_id, meta, reply)
   })
 }
 
@@ -426,11 +431,13 @@ pub fn untrack(presence: Presence, ref: String) -> Nil {
   process.call(presence.subject, 5000, fn(reply) { Untrack(ref, reply) })
 }
 
-/// Untrack all presences for a pid (e.g., when a socket disconnects)
+/// Untrack all presences for a session (e.g., when a socket disconnects)
 ///
 /// Panics if the presence actor is unavailable or does not reply within 5 seconds.
-pub fn untrack_all(presence: Presence, pid: String) -> Nil {
-  process.call(presence.subject, 5000, fn(reply) { UntrackAll(pid, reply) })
+pub fn untrack_all(presence: Presence, session_id: String) -> Nil {
+  process.call(presence.subject, 5000, fn(reply) {
+    UntrackAll(session_id, reply)
+  })
 }
 
 /// List all presences for a topic

--- a/src/beryl/presence.gleam
+++ b/src/beryl/presence.gleam
@@ -23,6 +23,7 @@ import beryl/error as beryl_error
 import beryl/internal
 import beryl/log
 import beryl/pubsub.{type PubSub}
+import beryl/wire
 import gleam/bit_array
 import gleam/bool
 import gleam/crypto
@@ -372,6 +373,30 @@ fn generate_ref() -> String {
   |> bit_array.base16_encode()
 }
 
+/// Merge the server-generated tracking ref into the tracked meta as
+/// `phx_ref`, matching Phoenix behaviour. Phoenix client `Presence` helpers
+/// identify individual metas by `phx_ref` when applying diffs; without it a
+/// single leave would remove every meta stored under the same key. Any
+/// client-supplied `phx_ref` is replaced. Non-object metas are stored
+/// unchanged (Phoenix requires object metas for its Presence helpers).
+fn meta_with_phx_ref(meta: json.Json, ref: String) -> json.Json {
+  let parsed =
+    json.parse(
+      from: json.to_string(meta),
+      using: gdecode.dict(gdecode.string, gdecode.dynamic),
+    )
+  case parsed {
+    Ok(fields) ->
+      fields
+      |> dict.delete("phx_ref")
+      |> dict.to_list
+      |> list.map(fn(field) { #(field.0, wire.dynamic_to_json(field.1)) })
+      |> list.append([#("phx_ref", json.string(ref))])
+      |> json.object
+    Error(_) -> meta
+  }
+}
+
 /// Track a presence in a topic.
 ///
 /// Returns a server-generated tracking ref: an opaque, unique handle for this
@@ -436,6 +461,7 @@ fn handle_message(
   case message {
     Track(topic, key, pid, meta, reply) -> {
       let ref = generate_ref()
+      let meta = meta_with_phx_ref(meta, ref)
       let new_crdt = state.join(actor_state.crdt, pid, topic, key, meta)
       maybe_invoke_on_diff(
         actor_state.config,

--- a/src/beryl/presence.gleam
+++ b/src/beryl/presence.gleam
@@ -211,12 +211,17 @@ type ActorState {
   )
 }
 
-/// Default configuration (no PubSub, no replication)
+/// Default configuration (no PubSub).
+///
+/// The broadcast interval defaults to 1500 ms so that adding `with_pubsub`
+/// yields working two-way replication out of the box; without PubSub the
+/// interval is unused. Use `with_broadcast_interval(0)` to disable periodic
+/// broadcasts and control replication manually.
 pub fn default_config(replica: String) -> Config {
   Config(
     pubsub: None,
     replica: replica,
-    broadcast_interval_ms: 0,
+    broadcast_interval_ms: 1500,
     on_diff: None,
   )
 }

--- a/src/beryl/presence.gleam
+++ b/src/beryl/presence.gleam
@@ -151,7 +151,12 @@ pub opaque type Config {
   Config(
     /// PubSub instance for cross-node replication
     pubsub: Option(PubSub),
-    /// This node's replica name (must be unique across the cluster)
+    /// This node's replica base name. Must identify at most one live node
+    /// in the cluster. Each actor start derives a unique incarnation name
+    /// from it (`base@suffix`), so restarting a node never reuses the
+    /// previous incarnation's CRDT clocks; state from older incarnations
+    /// of the same base is pruned automatically. Two *live* nodes sharing
+    /// a base will continuously prune each other — do not do that.
     replica: String,
     /// How often to broadcast state for replication (ms). 0 = disabled.
     broadcast_interval_ms: Int,
@@ -281,7 +286,13 @@ pub fn start_named(
 fn build_presence(
   config: Config,
 ) -> actor.Builder(ActorState, Message, Subject(Message)) {
-  let crdt = state.new(config.replica)
+  // Each actor start is a fresh CRDT incarnation. Reusing the bare replica
+  // name after a restart would reset its clocks while peers still remember
+  // the old ones: new joins would be silently filtered as already-seen,
+  // and the previous incarnation's entries would resurrect via merges.
+  // A unique per-start suffix makes every incarnation a distinct replica;
+  // `prune_superseded` cleans up the dead predecessors.
+  let crdt = state.new(incarnate_replica(config.replica))
 
   actor.new_with_initialiser(5000, fn(subject) {
     let initial =
@@ -351,7 +362,9 @@ fn maybe_broadcast_state(actor_state: ActorState, ps: PubSub) -> ActorState {
   let payload =
     json.object([
       #("v", json.int(1)),
-      #("sender", json.string(actor_state.config.replica)),
+      // The sender is the full incarnation name; receivers use its base to
+      // prune state left behind by this node's previous incarnations.
+      #("sender", json.string(state.replica(actor_state.crdt))),
       #("state", state_json.to_json(actor_state.crdt)),
     ])
 
@@ -379,6 +392,56 @@ fn coerce_to_pubsub_message(value: Dynamic) -> pubsub.Message
 fn generate_ref() -> String {
   crypto.strong_random_bytes(16)
   |> bit_array.base16_encode()
+}
+
+/// Separates a replica base name from its per-start incarnation suffix.
+const incarnation_separator = "@"
+
+/// Derive a unique incarnation name for this actor start.
+fn incarnate_replica(base: String) -> String {
+  base
+  <> incarnation_separator
+  <> bit_array.base16_encode(crypto.strong_random_bytes(4))
+}
+
+/// Recover the configured base from an incarnation-qualified replica name.
+///
+/// The suffix we mint never contains the separator, so everything before
+/// the last separator is the base — even when the base itself contains one
+/// (e.g. Erlang-style `app@host` names). Names without a separator (from
+/// nodes running older beryl versions) are their own base.
+fn base_replica(replica: String) -> String {
+  case list.reverse(string.split(replica, incarnation_separator)) {
+    [_suffix, ..rest] if rest != [] ->
+      string.join(list.reverse(rest), incarnation_separator)
+    _ -> replica
+  }
+}
+
+/// Prune CRDT state left behind by dead incarnations of the given live
+/// replicas (the sync sender and ourselves).
+///
+/// This is the beryl-side workaround for replica reuse across restarts
+/// (first-class incarnations are proposed upstream in lattice): any replica
+/// sharing a live replica's base but not its suffix belongs to a dead
+/// predecessor. Hide it (emitting leave diffs through `on_diff`) and prune
+/// it. A lagging peer can briefly resurrect pruned entries until it
+/// observes the live incarnation itself; the prune re-applies on every
+/// sync, so the cluster converges within about one broadcast interval.
+fn prune_superseded(config: Config, crdt: State, live: List(String)) -> State {
+  let stale =
+    dict.keys(state.compacted_clocks(crdt))
+    |> list.filter(fn(replica) {
+      list.any(live, fn(live_replica) {
+        replica != live_replica
+        && base_replica(replica) == base_replica(live_replica)
+      })
+    })
+  list.fold(stale, crdt, fn(crdt, replica) {
+    let #(crdt, down_diff) = state.replica_down(crdt, replica)
+    maybe_invoke_on_diff(config, wrap_state_diff(down_diff))
+    state.remove_down_replica(crdt, replica)
+  })
 }
 
 /// Merge the server-generated tracking ref into the tracked meta as
@@ -682,12 +745,21 @@ fn handle_sync_payload(
       ])
       actor.continue(actor_state)
     }
-    Ok(#(_sender, remote_state)) -> {
+    Ok(#(sender, remote_state)) -> {
       let #(new_crdt, state_diff) =
         state.merge_with_diff(actor_state.crdt, remote_state)
       let diff = wrap_state_diff(state_diff)
       let changed = !{ dict.is_empty(diff.joins) && dict.is_empty(diff.leaves) }
       maybe_invoke_on_diff(actor_state.config, diff)
+      // The merge may have (re)admitted state from dead incarnations —
+      // the sender's predecessors, or our own pre-restart self echoed back
+      // by a peer. Prune anything superseded by the two incarnations known
+      // to be live right now: the sender and ourselves.
+      let new_crdt =
+        prune_superseded(actor_state.config, new_crdt, [
+          sender,
+          state.replica(new_crdt),
+        ])
       actor.continue(
         ActorState(
           ..actor_state,

--- a/src/beryl/presence/wire.gleam
+++ b/src/beryl/presence/wire.gleam
@@ -24,6 +24,24 @@ pub fn encode_diff(diff: Diff, topic: String) -> json.Json {
   ])
 }
 
+/// Encode a topic's full presence list as a Phoenix-compatible
+/// `presence_state` payload.
+///
+/// The resulting JSON is a map keyed by presence key, where each value
+/// contains the tracked metadata under `metas` — the same shape as one side
+/// of a `presence_diff`:
+///
+/// ```json
+/// { "user:1": { "metas": [{ "status": "online", "phx_ref": "..." }] } }
+/// ```
+///
+/// Phoenix clients expect a `presence_state` event carrying this payload
+/// after joining a presence-enabled topic (followed by incremental
+/// `presence_diff` events). Build the entry list with `presence.list`.
+pub fn encode_state(entries: List(PresenceEntry)) -> json.Json {
+  encode_entries(entries)
+}
+
 fn encode_entries(entries: List(PresenceEntry)) -> json.Json {
   entries
   |> group_metas_by_key

--- a/src/beryl/pubsub.gleam
+++ b/src/beryl/pubsub.gleam
@@ -21,11 +21,24 @@ import gleam/list
 ///
 /// This type is intentionally transparent so subscribers can inspect the topic,
 /// event, payload, and sender metadata delivered to their process mailbox.
+///
+/// ## Frozen wire contract
+///
+/// `Message` is sent **raw between nodes** via `pg`, so its runtime shape —
+/// the record tag and its four fields, in this order — is a frozen v1 wire
+/// contract, not just a source-level API. It will not change within 1.x:
+/// subscribers select it as a 4-field `message` record, and a rolling
+/// cluster upgrade must never mis-parse a frame from an older node. If the
+/// envelope ever needs new fields, they will arrive as a **new record tag**
+/// (a new variant), which old nodes' selectors simply do not match — never
+/// as a change to this record. The same applies to `PubSubFrom`.
 pub type Message {
   Message(topic: String, event: String, payload: json.Json, from: PubSubFrom)
 }
 
-/// Identifies the sender of a broadcast
+/// Identifies the sender of a broadcast.
+///
+/// Part of the frozen v1 wire contract described on `Message`.
 pub type PubSubFrom {
   /// Broadcast originated from the system (no sender pid)
   System

--- a/src/beryl/rate_limit.gleam
+++ b/src/beryl/rate_limit.gleam
@@ -1,16 +1,13 @@
-//// Rate limiting for channels using a token bucket algorithm.
+//// Pure token-bucket rate limiting.
 ////
-//// Provides per-key rate limiting backed by a single OTP registry actor. Each
-//// key (e.g. socket ID, topic) stores token bucket state in the registry.
+//// A `Bucket` is plain data refilled against the monotonic clock — there is
+//// no registry actor and no messaging. Callers own bucket storage (the
+//// coordinator keeps per-socket and per-channel buckets in its own state;
+//// transports keep one per connection), so a check costs a dict update
+//// instead of a blocking cross-process call, cleanup is deleting the entry,
+//// and nothing leaks when a supervisor restarts the owner.
 
-import gleam/bool
-import gleam/dict.{type Dict}
-import gleam/erlang/process.{type Subject}
 import gleam/int
-import gleam/list
-import gleam/option.{type Option, None, Some}
-import gleam/otp/actor
-import gleam/result
 
 /// Erlang monotonic time in nanoseconds
 @external(erlang, "beryl_ffi", "monotonic_time_ns")
@@ -37,10 +34,11 @@ pub fn config(per_second per_second: Int, burst burst: Int) -> RateLimitConfig {
   RateLimitConfig(per_second: per_second, burst: effective_burst)
 }
 
-// ── Token bucket state ─────────────────────────────────────────────────────
+// ── Token bucket ────────────────────────────────────────────────────────────
 
-type BucketState {
-  BucketState(
+/// A token bucket. Create with `new_bucket`, consume with `take`.
+pub opaque type Bucket {
+  Bucket(
     tokens_ns: Int,
     max_tokens_ns: Int,
     ns_per_token: Int,
@@ -50,11 +48,10 @@ type BucketState {
 
 const one_second_ns = 1_000_000_000
 
-const registry_call_timeout_ms = 100
-
-fn new_bucket_state(cfg: RateLimitConfig) -> BucketState {
+/// Create a full bucket for the given config.
+pub fn new_bucket(cfg: RateLimitConfig) -> Bucket {
   let ns_per_token = one_second_ns / int.max(cfg.per_second, 1)
-  BucketState(
+  Bucket(
     tokens_ns: cfg.burst * ns_per_token,
     max_tokens_ns: cfg.burst * ns_per_token,
     ns_per_token: ns_per_token,
@@ -62,311 +59,29 @@ fn new_bucket_state(cfg: RateLimitConfig) -> BucketState {
   )
 }
 
-fn refill(state: BucketState) -> BucketState {
-  let now = monotonic_time_ns()
-  let elapsed = now - state.last_refill_ns
-  case elapsed > 0 {
-    False -> state
-    True -> {
-      let new_tokens = int.min(state.tokens_ns + elapsed, state.max_tokens_ns)
-      BucketState(..state, tokens_ns: new_tokens, last_refill_ns: now)
-    }
-  }
-}
-
-fn take_token(state: BucketState) -> #(BucketState, Result(Nil, Nil)) {
-  let state = refill(state)
-  case state.tokens_ns >= state.ns_per_token {
+/// Refill the bucket for elapsed time and try to take one token.
+///
+/// Returns the updated bucket and `Ok(Nil)` when a token was available, or
+/// `Error(Nil)` when the caller is rate limited.
+pub fn take(bucket: Bucket) -> #(Bucket, Result(Nil, Nil)) {
+  let bucket = refill(bucket)
+  case bucket.tokens_ns >= bucket.ns_per_token {
     True -> #(
-      BucketState(..state, tokens_ns: state.tokens_ns - state.ns_per_token),
+      Bucket(..bucket, tokens_ns: bucket.tokens_ns - bucket.ns_per_token),
       Ok(Nil),
     )
-    False -> #(state, Error(Nil))
+    False -> #(bucket, Error(Nil))
   }
 }
 
-// ── Registry (per-key rate limiters) ────────────────────────────────────────
-
-/// Opaque rate limiter registry that manages per-key token buckets.
-pub opaque type RateLimiter {
-  RateLimiter(subject: Subject(RegistryMsg))
-}
-
-type RegistryState {
-  RegistryState(config: RateLimitConfig, buckets: Dict(String, BucketState))
-}
-
-type RegistryMsg {
-  Check(key: String, reply: Subject(Result(Nil, Nil)))
-  CheckCapped(
-    key: String,
-    prefix: String,
-    max_keys: Int,
-    reply: Subject(Result(Nil, Nil)),
-  )
-  Count(reply: Subject(Int))
-  CountByPrefix(prefix: String, reply: Subject(Int))
-  RemoveKey(key: String)
-  RemoveByPrefix(prefix: String)
-  RegistryStop(reply: Subject(Nil))
-}
-
-fn handle_registry_msg(
-  state: RegistryState,
-  msg: RegistryMsg,
-) -> actor.Next(RegistryState, RegistryMsg) {
-  case msg {
-    RegistryStop(reply) -> {
-      process.send(reply, Nil)
-      actor.stop()
+fn refill(bucket: Bucket) -> Bucket {
+  let now = monotonic_time_ns()
+  let elapsed = now - bucket.last_refill_ns
+  case elapsed > 0 {
+    False -> bucket
+    True -> {
+      let new_tokens = int.min(bucket.tokens_ns + elapsed, bucket.max_tokens_ns)
+      Bucket(..bucket, tokens_ns: new_tokens, last_refill_ns: now)
     }
-
-    Check(key, reply) -> actor.continue(check_key(state, key, reply))
-
-    CheckCapped(key, prefix, max_keys, reply) ->
-      actor.continue(check_key_capped(state, key, prefix, max_keys, reply))
-
-    Count(reply) -> {
-      process.send(reply, list.length(dict.to_list(state.buckets)))
-      actor.continue(state)
-    }
-
-    CountByPrefix(prefix, reply) -> {
-      process.send(reply, count_by_prefix(state.buckets, prefix))
-      actor.continue(state)
-    }
-
-    RemoveKey(key) -> {
-      actor.continue(
-        RegistryState(..state, buckets: dict.delete(state.buckets, key)),
-      )
-    }
-
-    RemoveByPrefix(prefix) -> {
-      let to_keep =
-        dict.to_list(state.buckets)
-        |> list.filter(fn(entry) { !string_starts_with(entry.0, prefix) })
-      actor.continue(RegistryState(..state, buckets: dict.from_list(to_keep)))
-    }
-  }
-}
-
-fn count_by_prefix(buckets: Dict(String, BucketState), prefix: String) -> Int {
-  dict.to_list(buckets)
-  |> list.filter(fn(entry) { string_starts_with(entry.0, prefix) })
-  |> list.length
-}
-
-fn check_key(
-  state: RegistryState,
-  key: String,
-  reply: Subject(Result(Nil, Nil)),
-) -> RegistryState {
-  case dict.get(state.buckets, key) {
-    Ok(bucket) -> {
-      let #(updated_bucket, check_result) = take_token(bucket)
-      process.send(reply, check_result)
-      RegistryState(
-        ..state,
-        buckets: dict.insert(state.buckets, key, updated_bucket),
-      )
-    }
-    Error(Nil) -> {
-      let #(new_bucket, check_result) =
-        take_token(new_bucket_state(state.config))
-      process.send(reply, check_result)
-      RegistryState(
-        ..state,
-        buckets: dict.insert(state.buckets, key, new_bucket),
-      )
-    }
-  }
-}
-
-fn check_key_capped(
-  state: RegistryState,
-  key: String,
-  prefix: String,
-  max_keys: Int,
-  reply: Subject(Result(Nil, Nil)),
-) -> RegistryState {
-  case dict.get(state.buckets, key) {
-    Ok(_) -> check_key(state, key, reply)
-    Error(Nil) -> {
-      case max_keys > 0 && count_by_prefix(state.buckets, prefix) >= max_keys {
-        True -> {
-          process.send(reply, Error(Nil))
-          state
-        }
-        False -> check_key(state, key, reply)
-      }
-    }
-  }
-}
-
-@external(erlang, "beryl_ffi", "string_starts_with")
-fn string_starts_with(string: String, prefix: String) -> Bool
-
-// Send a registry request without letting timeouts or dead subjects exit the
-// caller. If the limiter is unavailable, return the provided fallback so rate
-// limiting fails open instead of taking down the coordinator.
-fn request(
-  subject: Subject(message),
-  timeout_ms: Int,
-  build_message: fn(Subject(response)) -> message,
-  fallback: response,
-) -> response {
-  case process.subject_owner(subject) {
-    Error(Nil) -> fallback
-    Ok(_) -> {
-      let reply_subject = process.new_subject()
-      process.send(subject, build_message(reply_subject))
-      case process.receive(reply_subject, timeout_ms) {
-        Ok(value) -> value
-        Error(Nil) -> fallback
-      }
-    }
-  }
-}
-
-// ── Public API ──────────────────────────────────────────────────────────────
-
-/// Start a new rate limiter registry with the given config.
-/// All keys managed by this registry share the same rate/burst settings.
-pub fn start(cfg: RateLimitConfig) -> Result(RateLimiter, Nil) {
-  let state = RegistryState(config: cfg, buckets: dict.new())
-  actor.new(state)
-  |> actor.on_message(handle_registry_msg)
-  |> actor.start
-  |> result.map(fn(started) { RateLimiter(subject: started.data) })
-  |> result.replace_error(Nil)
-}
-
-/// Check if a request for the given key is allowed.
-/// Returns Ok(Nil) if allowed, Error(Nil) if rate limited.
-pub fn check(limiter: RateLimiter, key: String) -> Result(Nil, Nil) {
-  request(
-    limiter.subject,
-    registry_call_timeout_ms,
-    fn(reply) { Check(key, reply) },
-    Ok(Nil),
-  )
-}
-
-/// Check if a request is allowed, rejecting new keys after a per-prefix cap.
-pub fn check_capped(
-  limiter: RateLimiter,
-  key: String,
-  prefix: String,
-  max_keys: Int,
-) -> Result(Nil, Nil) {
-  request(
-    limiter.subject,
-    registry_call_timeout_ms,
-    fn(reply) {
-      CheckCapped(key: key, prefix: prefix, max_keys: max_keys, reply: reply)
-    },
-    Ok(Nil),
-  )
-}
-
-/// Check an optional rate limiter. If None, always allows.
-pub fn check_optional(
-  limiter: Option(RateLimiter),
-  key: String,
-) -> Result(Nil, Nil) {
-  case limiter {
-    None -> Ok(Nil)
-    Some(l) -> check(l, key)
-  }
-}
-
-/// Check an optional rate limiter with a per-prefix key cap.
-pub fn check_capped_optional(
-  limiter: Option(RateLimiter),
-  key: String,
-  prefix: String,
-  max_keys: Int,
-) -> Result(Nil, Nil) {
-  case limiter {
-    None -> Ok(Nil)
-    Some(l) -> check_capped(l, key, prefix, max_keys)
-  }
-}
-
-/// Return the number of active token buckets in the registry.
-pub fn bucket_count(limiter: RateLimiter) -> Int {
-  request(
-    limiter.subject,
-    registry_call_timeout_ms,
-    fn(reply) { Count(reply: reply) },
-    0,
-  )
-}
-
-/// Return the number of active token buckets matching a key prefix.
-pub fn bucket_count_by_prefix(limiter: RateLimiter, prefix: String) -> Int {
-  request(
-    limiter.subject,
-    registry_call_timeout_ms,
-    fn(reply) { CountByPrefix(prefix: prefix, reply: reply) },
-    0,
-  )
-}
-
-/// Remove rate limit state for an exact key.
-fn remove(limiter: RateLimiter, key: String) -> Nil {
-  process.send(limiter.subject, RemoveKey(key))
-}
-
-/// Remove rate limit state for an exact key (optional limiter).
-pub fn remove_optional(limiter: Option(RateLimiter), key: String) -> Nil {
-  case limiter {
-    None -> Nil
-    Some(l) -> remove(l, key)
-  }
-}
-
-/// Remove all rate limit state for keys matching a prefix.
-/// Call this when a socket disconnects to clean up its buckets.
-pub fn remove_by_prefix(limiter: RateLimiter, prefix: String) -> Nil {
-  process.send(limiter.subject, RemoveByPrefix(prefix))
-}
-
-/// Remove rate limit state for keys matching a prefix (optional limiter).
-pub fn remove_by_prefix_optional(
-  limiter: Option(RateLimiter),
-  prefix: String,
-) -> Nil {
-  case limiter {
-    None -> Nil
-    Some(l) -> remove_by_prefix(l, prefix)
-  }
-}
-
-/// Start an optional rate limiter. Returns None if rate is 0 (unlimited).
-pub fn start_optional(rate: Int, burst: Int) -> Option(RateLimiter) {
-  use <- bool.guard(when: rate <= 0, return: None)
-  case start(config(per_second: rate, burst: burst)) {
-    Ok(limiter) -> Some(limiter)
-    Error(Nil) -> None
-  }
-}
-
-/// Stop the rate limiter registry.
-pub fn stop(limiter: RateLimiter) -> Nil {
-  request(
-    limiter.subject,
-    registry_call_timeout_ms,
-    fn(reply) { RegistryStop(reply) },
-    Nil,
-  )
-}
-
-/// Stop the rate limiter if one is present; a no-op when `None`.
-pub fn stop_optional(limiter: Option(RateLimiter)) -> Nil {
-  case limiter {
-    Some(limiter) -> stop(limiter)
-    None -> Nil
   }
 }

--- a/src/beryl/socket.gleam
+++ b/src/beryl/socket.gleam
@@ -27,9 +27,6 @@ import gleam/dynamic.{type Dynamic}
 /// Wraps the underlying connection (e.g. a Mist WebSocket) with functions to
 /// send text/binary frames and close the connection.
 ///
-/// Note: as constructed by the built-in Mist transport, `close` is a no-op
-/// that returns `Ok(Nil)`. Closing is driven by the transport's own
-/// connection lifecycle rather than by calling this function.
 /// `Transport` is opaque; build one with `new_transport`. Its behaviour is
 /// read through the `@internal` accessors below.
 pub opaque type Transport {

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -149,6 +149,7 @@ fn start_supervised(
   // Create names for each subsystem up front. The supervisor starts children
   // via callbacks, so we use named actors to retrieve subjects afterward.
   // Names must be created before supervisor start (not dynamically in loops).
+  let registry_name = process.new_name("beryl_registry")
   let coordinator_name = process.new_name("beryl_coordinator")
 
   let presence_name = case config.presence {
@@ -162,17 +163,35 @@ fn start_supervised(
   }
 
   // Build coordinator config from channels config (same mapping and
-  // half-timeout check interval as beryl.start).
-  let coord_config = beryl.to_coordinator_config(config.channels)
+  // half-timeout check interval as beryl.start), pointing the coordinator
+  // at the supervised registry so restarts recover registrations.
+  let registry = coordinator.registry_from_name(registry_name)
+  let coord_config =
+    coordinator.CoordinatorConfig(
+      ..beryl.to_coordinator_config(config.channels),
+      registry: Some(registry),
+    )
 
   // Build the supervisor with rest-for-one strategy.
   // If the coordinator crashes, presence and groups restart too to maintain
-  // consistency — a fresh coordinator has empty state.
+  // consistency — a fresh coordinator reloads its handler registrations
+  // from the registry, which starts earlier and survives the restart.
   let builder =
     static_supervisor.new(static_supervisor.RestForOne)
     |> static_supervisor.restart_tolerance(intensity: 3, period: 5)
 
-  // Always add coordinator as the first child
+  // The registry is the first child: with rest-for-one, a coordinator crash
+  // restarts everything after it but never the registry itself, so channel
+  // registrations survive.
+  let builder =
+    builder
+    |> static_supervisor.add(
+      supervision.worker(fn() {
+        coordinator.start_registry_named(registry_name)
+      }),
+    )
+
+  // The coordinator follows the registry
   let builder =
     builder
     |> static_supervisor.add(
@@ -248,6 +267,7 @@ fn start_supervised(
         beryl.channels_from_coordinator(
           coordinator: coord_subject,
           config: config.channels,
+          registry: Some(registry),
         )
 
       let pres = case presence_name {

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -114,7 +114,9 @@ pub fn supervisor_pid(supervised: SupervisedChannels) -> process.Pid {
 pub type StartError {
   /// The supervisor failed to start
   SupervisorStartFailed(beryl_error.StartFailure)
-  /// heartbeat_timeout_ms must be > 0
+  /// `heartbeat_timeout_ms` must be at least 2 — the same validation as
+  /// `beryl.start` (the staleness check interval is derived as
+  /// `heartbeat_timeout_ms / 2`, so 1 would silently disable eviction).
   InvalidHeartbeatTimeout
 }
 
@@ -129,9 +131,10 @@ pub type StartError {
 pub fn start(
   config: SupervisedConfig,
 ) -> Result(SupervisedChannels, StartError) {
-  // Validate heartbeat_timeout_ms before deriving check_interval
+  // Validate heartbeat_timeout_ms before deriving check_interval, using the
+  // same bound as beryl.start so both entry points reject the same configs.
   use <- bool.guard(
-    when: beryl.config_heartbeat_timeout_ms(config.channels) <= 0,
+    when: beryl.config_heartbeat_timeout_ms(config.channels) < 2,
     return: Error(InvalidHeartbeatTimeout),
   )
   start_supervised(config)
@@ -187,7 +190,8 @@ fn start_supervised(
         |> result.map_error(fn(err) {
           case err {
             coordinator.ActorStartFailed(e) -> e
-            coordinator.InvalidHeartbeatTimeout -> actor.InitTimeout
+            coordinator.InvalidHeartbeatTimeout ->
+              actor.InitFailed("invalid heartbeat timeout")
           }
         })
       }),
@@ -306,7 +310,8 @@ pub fn child_spec(
           Ok(actor.Started(pid: supervised.supervisor_pid, data: supervised))
         Error(SupervisorStartFailed(failure)) ->
           Error(actor.InitFailed(beryl_error.describe_start_failure(failure)))
-        Error(InvalidHeartbeatTimeout) -> Error(actor.InitTimeout)
+        Error(InvalidHeartbeatTimeout) ->
+          Error(actor.InitFailed("invalid heartbeat timeout"))
       }
     },
     restart: supervision.Permanent,

--- a/src/beryl/supervisor.gleam
+++ b/src/beryl/supervisor.gleam
@@ -137,6 +137,7 @@ pub fn start(
     when: beryl.config_heartbeat_timeout_ms(config.channels) < 2,
     return: Error(InvalidHeartbeatTimeout),
   )
+  beryl.warn_if_unprotected(config.channels)
   start_supervised(config)
 }
 

--- a/src/beryl/topic.gleam
+++ b/src/beryl/topic.gleam
@@ -286,11 +286,13 @@ pub fn validate_event(event: String) -> Result(String, TopicError) {
   Ok(event)
 }
 
+// nolint: unused_exports -- package-internal logging helper; hidden from public docs with @internal
 /// Escape control characters in a string for safe use in log metadata.
 ///
 /// Replaces codepoints in the range 0–31 and 127 with `?` so that
 /// client-supplied strings cannot inject additional fields into structured
 /// log output.
+@internal
 pub fn sanitize_for_log(value: String) -> String {
   string.to_utf_codepoints(value)
   |> list.map(fn(codepoint) {

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -7,6 +7,7 @@ import beryl.{type Channels}
 import beryl/connection_limit
 import beryl/coordinator.{type Message as CoordinatorMessage}
 import gleam/bit_array
+import gleam/bool
 import gleam/bytes_tree
 import gleam/crypto
 import gleam/dynamic.{type Dynamic}
@@ -159,18 +160,38 @@ fn handle_matched_upgrade(
   channels: Channels,
   config: TransportConfig(assigns),
 ) -> Response(ResponseData) {
-  case origin_allowed(request, config.allowed_origins) {
-    False -> forbidden()
-    True -> {
-      let ip = request_ip(request)
-      case beryl.acquire_connection_slot(channels, ip) {
-        Error(Nil) ->
-          response.new(429)
-          |> response.set_body(mist.Bytes(bytes_tree.new()))
-        Ok(connection_permit) ->
-          run_connect_and_upgrade(request, channels, config, connection_permit)
+  use <- bool.lazy_guard(
+    when: !origin_allowed(request, config.allowed_origins),
+    return: forbidden,
+  )
+  use <- bool.lazy_guard(when: !vsn_supported(request), return: forbidden)
+  let ip = request_ip(request)
+  case beryl.acquire_connection_slot(channels, ip) {
+    Error(Nil) ->
+      response.new(429)
+      |> response.set_body(mist.Bytes(bytes_tree.new()))
+    Ok(connection_permit) ->
+      run_connect_and_upgrade(request, channels, config, connection_permit)
+  }
+}
+
+/// Check the client's requested wire protocol version (`?vsn=` query
+/// parameter, sent by Phoenix clients) before upgrading.
+///
+/// Beryl speaks the Phoenix V2 array framing, so `vsn=2.x` is accepted. A
+/// missing `vsn` is accepted for non-Phoenix clients speaking the configured
+/// codec. Anything else (e.g. the V1 object framing's `vsn=1.0.0`) is
+/// rejected with `403 Forbidden` at the handshake — failing loudly instead
+/// of accepting a connection whose every frame would be undecodable.
+fn vsn_supported(request: Request(Connection)) -> Bool {
+  case request.get_query(request) {
+    Ok(params) ->
+      case list.key_find(params, "vsn") {
+        Ok(vsn) -> string.starts_with(vsn, "2.")
+        Error(Nil) -> True
       }
-    }
+    // No query string / unparseable query: no version was requested.
+    Error(Nil) -> True
   }
 }
 

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -105,6 +105,8 @@ type ConnectionState {
 type SendRequest {
   SendText(String)
   SendBinary(BitArray)
+  /// Coordinator-initiated close (e.g. heartbeat eviction).
+  Close
 }
 
 /// Upgrade a request to WebSocket if it matches the configured path
@@ -314,22 +316,36 @@ fn do_upgrade(
   connection_permit: Option(beryl.ConnectionPermit),
 ) -> Response(ResponseData) {
   let max_inbound_frame_bytes = beryl.max_inbound_frame_bytes(channels)
-  mist.websocket(
-    request: request,
-    handler: fn(state, message, connection) {
-      on_message(state, message, connection)
-    },
-    on_init: fn(connection) {
-      on_init(
-        connection,
-        beryl.coordinator_subject(channels),
-        connect_assigns,
-        connection_permit,
-        max_inbound_frame_bytes,
-      )
-    },
-    on_close: on_close,
-  )
+  let response =
+    mist.websocket(
+      request: request,
+      handler: fn(state, message, connection) {
+        on_message(state, message, connection)
+      },
+      on_init: fn(connection) {
+        on_init(
+          connection,
+          beryl.coordinator_subject(channels),
+          connect_assigns,
+          connection_permit,
+          max_inbound_frame_bytes,
+        )
+      },
+      on_close: on_close,
+    )
+  // A failed handshake (e.g. missing Sec-WebSocket-Key) never runs
+  // on_init/on_close, so the acquired per-IP slot must be released here or
+  // repeated bad handshakes would permanently exhaust the IP's slots.
+  case response.status >= 400 {
+    True -> {
+      case connection_permit {
+        Some(permit) -> beryl.release_connection_slot(permit)
+        None -> Nil
+      }
+      response
+    }
+    False -> response
+  }
 }
 
 /// Initialize WebSocket connection
@@ -340,6 +356,13 @@ fn on_init(
   connection_permit: Option(beryl.ConnectionPermit),
   max_inbound_frame_bytes: Int,
 ) -> #(ConnectionState, Option(process.Selector(SendRequest))) {
+  // Bind the per-IP slot to this WebSocket process so it is reclaimed even
+  // if the process dies without running on_close.
+  case connection_permit {
+    Some(permit) -> beryl.bind_connection_slot(permit)
+    None -> Nil
+  }
+
   // Generate unique socket ID
   let socket_id = generate_socket_id()
   let send_subject = process.new_subject()
@@ -368,6 +391,15 @@ fn on_init(
       None,
       connect_assigns,
     ),
+  )
+
+  // Let the coordinator actively close this connection (heartbeat eviction,
+  // server-side disconnects) instead of leaving a zombie socket open.
+  process.send(
+    coordinator,
+    coordinator.RegisterCloser(socket_id, fn() {
+      process.send(send_subject, Close)
+    }),
   )
 
   let state =
@@ -417,6 +449,7 @@ fn on_message(
     }
 
     mist.Closed | mist.Shutdown -> mist.stop()
+    mist.Custom(Close) -> mist.stop()
     mist.Custom(SendText(text)) -> {
       mist.send_text_frame(connection, text)
       |> result.replace(mist.continue(state))

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -5,6 +5,10 @@
 
 import beryl.{type Channels}
 import beryl/coordinator.{type Message as CoordinatorMessage}
+import beryl/internal
+import beryl/log
+import beryl/rate_limit
+import beryl/wire/codec
 import gleam/bit_array
 import gleam/bool
 import gleam/bytes_tree
@@ -99,6 +103,14 @@ type ConnectionState {
     coordinator: Subject(CoordinatorMessage),
     connection_permit: Option(beryl.ConnectionPermit),
     max_inbound_frame_bytes: Int,
+    /// Wire codec for decoding inbound frames here in the connection
+    /// process, so parse cost and malformed input never reach the shared
+    /// coordinator.
+    codec: codec.Codec,
+    /// Per-connection message-rate token bucket (`None` = unlimited).
+    /// Enforced at the edge: frames over the rate are shed before decode,
+    /// so a flooding socket cannot fill the coordinator's mailbox.
+    message_bucket: Option(rate_limit.Bucket),
   )
 }
 
@@ -316,6 +328,8 @@ fn do_upgrade(
   connection_permit: Option(beryl.ConnectionPermit),
 ) -> Response(ResponseData) {
   let max_inbound_frame_bytes = beryl.max_inbound_frame_bytes(channels)
+  let active_codec = beryl.configured_codec(channels)
+  let message_limits = beryl.message_limits(channels)
   let response =
     mist.websocket(
       request: request,
@@ -329,6 +343,8 @@ fn do_upgrade(
           connect_assigns,
           connection_permit,
           max_inbound_frame_bytes,
+          active_codec,
+          message_limits,
         )
       },
       on_close: on_close,
@@ -355,6 +371,8 @@ fn on_init(
   connect_assigns: Dynamic,
   connection_permit: Option(beryl.ConnectionPermit),
   max_inbound_frame_bytes: Int,
+  active_codec: codec.Codec,
+  message_limits: Option(rate_limit.RateLimitConfig),
 ) -> #(ConnectionState, Option(process.Selector(SendRequest))) {
   // Bind the per-IP slot to this WebSocket process so it is reclaimed even
   // if the process dies without running on_close.
@@ -408,6 +426,8 @@ fn on_init(
       coordinator: coordinator,
       connection_permit: connection_permit,
       max_inbound_frame_bytes: max_inbound_frame_bytes,
+      codec: active_codec,
+      message_bucket: option.map(message_limits, rate_limit.new_bucket),
     )
 
   #(state, Some(selector))
@@ -427,10 +447,7 @@ fn on_message(
         frame_too_large(state.max_inbound_frame_bytes, string.byte_size(text))
       {
         True -> mist.stop()
-        False -> {
-          coordinator.route_message(state.coordinator, state.socket_id, text)
-          mist.continue(state)
-        }
+        False -> handle_inbound_text(state, text)
       }
     }
     mist.Binary(data) -> {
@@ -441,10 +458,7 @@ fn on_message(
         )
       {
         True -> mist.stop()
-        False -> {
-          coordinator.route_binary(state.coordinator, state.socket_id, data)
-          mist.continue(state)
-        }
+        False -> handle_inbound_binary(state, data)
       }
     }
 
@@ -461,6 +475,82 @@ fn on_message(
       |> result.unwrap(mist.continue(state))
     }
   }
+}
+
+/// Rate-check and decode a text frame in the connection process, so parse
+/// cost stays here and only valid, rate-admitted messages reach the shared
+/// coordinator.
+fn handle_inbound_text(
+  state: ConnectionState,
+  text: String,
+) -> mist.Next(ConnectionState, SendRequest) {
+  let #(state, allowed) = take_message_token(state)
+  use <- bool.guard(when: !allowed, return: mist.continue(state))
+  case codec.decode_text(state.codec)(text) {
+    Ok(msg) -> {
+      coordinator.route_decoded(state.coordinator, state.socket_id, msg)
+      mist.continue(state)
+    }
+    Error(err) -> {
+      transport_logger()
+      |> log.warn("Failed to decode wire protocol message", [
+        #("socket_id", state.socket_id),
+        #("error", codec.format_decode_error(err)),
+      ])
+      mist.continue(state)
+    }
+  }
+}
+
+/// Rate-check and decode a binary frame in the connection process. Codecs
+/// without a binary decoder keep the raw `handle_binary` fan-out, routed
+/// through the coordinator.
+fn handle_inbound_binary(
+  state: ConnectionState,
+  data: BitArray,
+) -> mist.Next(ConnectionState, SendRequest) {
+  let #(state, allowed) = take_message_token(state)
+  use <- bool.guard(when: !allowed, return: mist.continue(state))
+  case codec.decode_binary(state.codec) {
+    None -> {
+      coordinator.route_binary(state.coordinator, state.socket_id, data)
+      mist.continue(state)
+    }
+    Some(decode_binary) ->
+      case decode_binary(data) {
+        Ok(msg) -> {
+          coordinator.route_decoded(state.coordinator, state.socket_id, msg)
+          mist.continue(state)
+        }
+        Error(err) -> {
+          transport_logger()
+          |> log.warn("Failed to decode binary wire protocol message", [
+            #("socket_id", state.socket_id),
+            #("error", codec.format_decode_error(err)),
+          ])
+          mist.continue(state)
+        }
+      }
+  }
+}
+
+/// Take a token from the connection's message bucket; always allowed when
+/// no message rate is configured.
+fn take_message_token(state: ConnectionState) -> #(ConnectionState, Bool) {
+  case state.message_bucket {
+    None -> #(state, True)
+    Some(bucket) -> {
+      let #(bucket, taken) = rate_limit.take(bucket)
+      #(
+        ConnectionState(..state, message_bucket: Some(bucket)),
+        result.is_ok(taken),
+      )
+    }
+  }
+}
+
+fn transport_logger() -> log.Logger {
+  internal.logger("beryl.transport.mist")
 }
 
 fn frame_too_large(max_bytes: Int, actual_bytes: Int) -> Bool {

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -4,7 +4,6 @@
 //// and the beryl coordinator using Mist request and response types directly.
 
 import beryl.{type Channels}
-import beryl/connection_limit
 import beryl/coordinator.{type Message as CoordinatorMessage}
 import gleam/bit_array
 import gleam/bool
@@ -98,7 +97,7 @@ type ConnectionState {
   ConnectionState(
     socket_id: String,
     coordinator: Subject(CoordinatorMessage),
-    connection_permit: Option(connection_limit.Permit),
+    connection_permit: Option(beryl.ConnectionPermit),
     max_inbound_frame_bytes: Int,
   )
 }
@@ -218,7 +217,7 @@ fn run_connect_and_upgrade(
   request: Request(Connection),
   channels: Channels,
   config: TransportConfig(assigns),
-  connection_permit: Option(connection_limit.Permit),
+  connection_permit: beryl.ConnectionPermit,
 ) -> Response(ResponseData) {
   // Run on_connect callback if configured
   case config.on_connect {
@@ -229,7 +228,7 @@ fn run_connect_and_upgrade(
             request,
             channels,
             unsafe_coerce_to_dynamic(assigns),
-            connection_permit,
+            Some(connection_permit),
           )
         Error(ConnectRejected) -> {
           beryl.release_connection_slot(connection_permit)
@@ -237,7 +236,8 @@ fn run_connect_and_upgrade(
           |> response.set_body(mist.Bytes(bytes_tree.new()))
         }
       }
-    None -> do_upgrade(request, channels, dynamic.nil(), connection_permit)
+    None ->
+      do_upgrade(request, channels, dynamic.nil(), Some(connection_permit))
   }
 }
 
@@ -311,7 +311,7 @@ fn do_upgrade(
   request: Request(Connection),
   channels: Channels,
   connect_assigns: Dynamic,
-  connection_permit: Option(connection_limit.Permit),
+  connection_permit: Option(beryl.ConnectionPermit),
 ) -> Response(ResponseData) {
   let max_inbound_frame_bytes = beryl.max_inbound_frame_bytes(channels)
   mist.websocket(
@@ -337,7 +337,7 @@ fn on_init(
   _connection: WebsocketConnection,
   coordinator: Subject(CoordinatorMessage),
   connect_assigns: Dynamic,
-  connection_permit: Option(connection_limit.Permit),
+  connection_permit: Option(beryl.ConnectionPermit),
   max_inbound_frame_bytes: Int,
 ) -> #(ConnectionState, Option(process.Selector(SendRequest))) {
   // Generate unique socket ID
@@ -436,7 +436,10 @@ fn frame_too_large(max_bytes: Int, actual_bytes: Int) -> Bool {
 
 /// Cleanup when connection closes
 fn on_close(state: ConnectionState) -> Nil {
-  beryl.release_connection_slot(state.connection_permit)
+  case state.connection_permit {
+    Some(permit) -> beryl.release_connection_slot(permit)
+    None -> Nil
+  }
   process.send(
     state.coordinator,
     coordinator.SocketDisconnected(state.socket_id),

--- a/src/beryl/wire.gleam
+++ b/src/beryl/wire.gleam
@@ -16,6 +16,7 @@ import beryl/wire/codec.{
   type ReplyStatus, Event, Heartbeat, InvalidFormat, InvalidJson, Join, Leave,
   StatusError, StatusOk, TextFrame,
 }
+import gleam/bit_array
 import gleam/bool
 import gleam/dict
 import gleam/dynamic.{type Dynamic}
@@ -30,6 +31,11 @@ const expected_array_message = "Expected array of 5 elements [join_ref, ref, top
 const max_json_nesting_depth = 64
 
 /// The canonical Phoenix wire codec. Pass to `beryl.config/1`.
+///
+/// Handles both the JSON array framing on text frames and the Phoenix V2
+/// binary framing on binary frames (see `decode_binary_message`). Binary
+/// push payloads reach `handle_in` as a `BitArray` wrapped in `Dynamic`;
+/// decode them with `gleam/dynamic/decode.bit_array`.
 pub fn phoenix_codec() -> Codec {
   codec.new(
     decode_text: decode_message,
@@ -39,6 +45,7 @@ pub fn phoenix_codec() -> Codec {
   )
   |> codec.with_close_encoder(channel_close)
   |> codec.with_error_encoder(channel_error)
+  |> codec.with_binary_decoder(decode_binary_message)
 }
 
 /// Parse a JSON string into an `Inbound`.
@@ -366,6 +373,172 @@ fn option_to_json(opt: Option(String)) -> json.Json {
   case opt {
     None -> json.null()
     Some(s) -> json.string(s)
+  }
+}
+
+// ── Phoenix V2 binary framing ───────────────────────────────────────────────
+//
+// Phoenix clients switch to a compact binary framing whenever a push payload
+// is raw bytes (an ArrayBuffer in the JS client). Frames start with a kind
+// byte, then u8 lengths for each metadata component, then the components,
+// then the payload as the remaining bytes:
+//
+//   client push:      <<0, jr_len, ref_len, topic_len, event_len,
+//                       jr, ref, topic, event, payload>>
+//   server push:      <<0, jr_len, topic_len, event_len, jr, topic, event, payload>>
+//   server reply:     <<1, jr_len, ref_len, topic_len, status_len,
+//                       jr, ref, topic, status, payload>>
+//   server broadcast: <<2, topic_len, event_len, topic, event, payload>>
+
+const binary_push_kind = 0
+
+const binary_reply_kind = 1
+
+const binary_broadcast_kind = 2
+
+const expected_binary_message = "Expected Phoenix V2 binary push frame"
+
+/// Decode a Phoenix V2 binary push frame from a client into an `Inbound`.
+///
+/// The payload is delivered to `handle_in` as raw bytes (`BitArray` wrapped
+/// in `Dynamic`); decode it with `gleam/dynamic/decode.bit_array`. Zero-length
+/// join_ref/ref components decode as `None`. Reserved protocol events are
+/// classified the same way as on the text framing.
+pub fn decode_binary_message(data: BitArray) -> Result(Inbound, DecodeError) {
+  case data {
+    <<
+      0,
+      join_ref_size,
+      ref_size,
+      topic_size,
+      event_size,
+      join_ref:bytes-size(join_ref_size),
+      ref:bytes-size(ref_size),
+      topic:bytes-size(topic_size),
+      event:bytes-size(event_size),
+      payload:bytes,
+    >> -> {
+      use join_ref <- result.try(optional_utf8(join_ref))
+      use ref <- result.try(optional_utf8(ref))
+      use topic <- result.try(required_utf8(topic, "topic"))
+      use event <- result.try(required_utf8(event, "event"))
+      Ok(codec.inbound(
+        join_ref: join_ref,
+        ref: ref,
+        topic: topic,
+        kind: classify_phoenix_event(topic, event),
+        payload: dynamic.bit_array(payload),
+      ))
+    }
+    _ -> Error(InvalidFormat(expected_binary_message))
+  }
+}
+
+fn optional_utf8(bytes: BitArray) -> Result(Option(String), DecodeError) {
+  case bit_array.byte_size(bytes) {
+    0 -> Ok(None)
+    _ ->
+      required_utf8(bytes, "ref")
+      |> result.map(Some)
+  }
+}
+
+fn required_utf8(bytes: BitArray, name: String) -> Result(String, DecodeError) {
+  bit_array.to_string(bytes)
+  |> result.replace_error(InvalidFormat(name <> " is not valid UTF-8"))
+}
+
+/// Encode a Phoenix V2 binary server push: `(join_ref, topic, event, payload)`.
+///
+/// Errors when a metadata component exceeds the framing's 255-byte length
+/// limit.
+pub fn binary_push(
+  join_ref join_ref: Option(String),
+  topic topic: String,
+  event event: String,
+  payload payload: BitArray,
+) -> Result(Frame, Nil) {
+  use #(jr_size, jr) <- result.try(u8_component(option.unwrap(join_ref, "")))
+  use #(topic_size, topic) <- result.try(u8_component(topic))
+  use #(event_size, event) <- result.try(u8_component(event))
+  Ok(
+    codec.BinaryFrame(<<
+      binary_push_kind,
+      jr_size,
+      topic_size,
+      event_size,
+      jr:bits,
+      topic:bits,
+      event:bits,
+      payload:bits,
+    >>),
+  )
+}
+
+/// Encode a Phoenix V2 binary reply: `(join_ref, ref, topic, status, payload)`.
+///
+/// Errors when a metadata component exceeds the framing's 255-byte length
+/// limit.
+pub fn binary_reply(
+  join_ref join_ref: Option(String),
+  ref ref: Option(String),
+  topic topic: String,
+  status status: ReplyStatus,
+  payload payload: BitArray,
+) -> Result(Frame, Nil) {
+  let status_string = case status {
+    StatusOk -> "ok"
+    StatusError -> "error"
+  }
+  use #(jr_size, jr) <- result.try(u8_component(option.unwrap(join_ref, "")))
+  use #(ref_size, ref) <- result.try(u8_component(option.unwrap(ref, "")))
+  use #(topic_size, topic) <- result.try(u8_component(topic))
+  use #(status_size, status) <- result.try(u8_component(status_string))
+  Ok(
+    codec.BinaryFrame(<<
+      binary_reply_kind,
+      jr_size,
+      ref_size,
+      topic_size,
+      status_size,
+      jr:bits,
+      ref:bits,
+      topic:bits,
+      status:bits,
+      payload:bits,
+    >>),
+  )
+}
+
+/// Encode a Phoenix V2 binary broadcast: `(topic, event, payload)`.
+///
+/// Errors when a metadata component exceeds the framing's 255-byte length
+/// limit.
+pub fn binary_broadcast(
+  topic topic: String,
+  event event: String,
+  payload payload: BitArray,
+) -> Result(Frame, Nil) {
+  use #(topic_size, topic) <- result.try(u8_component(topic))
+  use #(event_size, event) <- result.try(u8_component(event))
+  Ok(
+    codec.BinaryFrame(<<
+      binary_broadcast_kind,
+      topic_size,
+      event_size,
+      topic:bits,
+      event:bits,
+      payload:bits,
+    >>),
+  )
+}
+
+fn u8_component(value: String) -> Result(#(Int, BitArray), Nil) {
+  let bytes = bit_array.from_string(value)
+  let size = bit_array.byte_size(bytes)
+  case size <= 255 {
+    True -> Ok(#(size, bytes))
+    False -> Error(Nil)
   }
 }
 

--- a/src/beryl/wire.gleam
+++ b/src/beryl/wire.gleam
@@ -81,7 +81,7 @@ fn decode_inbound_fields(value: Dynamic) -> Result(Inbound, DecodeError) {
       join_ref: join_ref,
       ref: ref,
       topic: topic,
-      kind: classify_phoenix_event(event),
+      kind: classify_phoenix_event(topic, event),
       payload: payload,
     ))
   }
@@ -118,12 +118,18 @@ pub fn encode(msg: Inbound) -> String {
   )
 }
 
-fn classify_phoenix_event(event: String) -> InboundKind {
-  case event {
-    "phx_join" -> Join
-    "phx_leave" -> Leave
-    "heartbeat" -> Heartbeat
-    other -> Event(other)
+/// Classify a Phoenix event name into a structural kind.
+///
+/// `phx_join`/`phx_leave` are reserved event names on every topic, but
+/// `heartbeat` is only special on the reserved `"phoenix"` topic — an
+/// application is free to define its own `"heartbeat"` channel event, which
+/// must reach `handle_in` rather than refresh the socket's liveness timer.
+fn classify_phoenix_event(topic: String, event: String) -> InboundKind {
+  case topic, event {
+    _, "phx_join" -> Join
+    _, "phx_leave" -> Leave
+    "phoenix", "heartbeat" -> Heartbeat
+    _, other -> Event(other)
   }
 }
 

--- a/src/beryl/wire.gleam
+++ b/src/beryl/wire.gleam
@@ -13,8 +13,8 @@
 
 import beryl/wire/codec.{
   type Codec, type DecodeError, type Frame, type Inbound, type InboundKind,
-  type ReplyStatus, Event, Heartbeat, Inbound, InvalidFormat, InvalidJson, Join,
-  Leave, StatusError, StatusOk, TextFrame,
+  type ReplyStatus, Event, Heartbeat, InvalidFormat, InvalidJson, Join, Leave,
+  StatusError, StatusOk, TextFrame,
 }
 import gleam/bool
 import gleam/dict
@@ -77,7 +77,7 @@ fn decode_inbound_fields(value: Dynamic) -> Result(Inbound, DecodeError) {
     use topic <- decode.subfield([2], decode.string)
     use event <- decode.subfield([3], decode.string)
     use payload <- decode.subfield([4], decode.dynamic)
-    decode.success(Inbound(
+    decode.success(codec.inbound(
       join_ref: join_ref,
       ref: ref,
       topic: topic,
@@ -94,7 +94,7 @@ fn decode_inbound_fields(value: Dynamic) -> Result(Inbound, DecodeError) {
 
 fn validate_inbound_depth(msg: Inbound) -> Result(Inbound, DecodeError) {
   use <- bool.guard(
-    when: !within_json_depth(msg.payload, max_json_nesting_depth),
+    when: !within_json_depth(codec.inbound_payload(msg), max_json_nesting_depth),
     return: Error(InvalidFormat("JSON nesting depth exceeded")),
   )
   Ok(msg)
@@ -102,16 +102,16 @@ fn validate_inbound_depth(msg: Inbound) -> Result(Inbound, DecodeError) {
 
 /// Encode an `Inbound` back to a Phoenix wire JSON string.
 pub fn encode(msg: Inbound) -> String {
-  let join_ref_json = option_to_json(msg.join_ref)
-  let ref_json = option_to_json(msg.ref)
-  let payload_json = dynamic_to_json(msg.payload)
-  let event = phoenix_event_name(msg.kind)
+  let join_ref_json = option_to_json(codec.inbound_join_ref(msg))
+  let ref_json = option_to_json(codec.inbound_ref(msg))
+  let payload_json = dynamic_to_json(codec.inbound_payload(msg))
+  let event = phoenix_event_name(codec.inbound_kind(msg))
 
   json.to_string(
     json.preprocessed_array([
       join_ref_json,
       ref_json,
-      json.string(msg.topic),
+      json.string(codec.inbound_topic(msg)),
       json.string(event),
       payload_json,
     ]),

--- a/src/beryl/wire.gleam
+++ b/src/beryl/wire.gleam
@@ -37,6 +37,8 @@ pub fn phoenix_codec() -> Codec {
     encode_push: push,
     encode_heartbeat_reply: heartbeat_reply,
   )
+  |> codec.with_close_encoder(channel_close)
+  |> codec.with_error_encoder(channel_error)
 }
 
 /// Parse a JSON string into an `Inbound`.
@@ -300,6 +302,37 @@ pub fn push(topic: String, event: String, payload: json.Json) -> Frame {
         json.string(topic),
         json.string(event),
         payload,
+      ]),
+    ),
+  )
+}
+
+/// Create a Phoenix `phx_close` frame, sent when a channel terminates
+/// gracefully. Phoenix mirrors the channel's `join_ref` into the `ref` slot.
+pub fn channel_close(join_ref: Option(String), topic: String) -> Frame {
+  terminal_event(join_ref, topic, "phx_close")
+}
+
+/// Create a Phoenix `phx_error` frame, sent when a channel terminates
+/// abnormally. Phoenix clients respond by scheduling an automatic rejoin.
+pub fn channel_error(join_ref: Option(String), topic: String) -> Frame {
+  terminal_event(join_ref, topic, "phx_error")
+}
+
+fn terminal_event(
+  join_ref: Option(String),
+  topic: String,
+  event: String,
+) -> Frame {
+  let join_ref_json = option_to_json(join_ref)
+  TextFrame(
+    json.to_string(
+      json.preprocessed_array([
+        join_ref_json,
+        join_ref_json,
+        json.string(topic),
+        json.string(event),
+        json.object([]),
       ]),
     ),
   )

--- a/src/beryl/wire/codec.gleam
+++ b/src/beryl/wire/codec.gleam
@@ -146,6 +146,7 @@ pub opaque type Codec {
     encode_heartbeat_reply: fn(Option(String)) -> Frame,
     encode_close: Option(fn(Option(String), String) -> Frame),
     encode_error: Option(fn(Option(String), String) -> Frame),
+    topicless_events: Bool,
   )
 }
 
@@ -180,6 +181,7 @@ pub fn new(
     encode_heartbeat_reply:,
     encode_close: None,
     encode_error: None,
+    topicless_events: False,
   )
 }
 
@@ -261,6 +263,23 @@ pub fn encode_close(
   codec: Codec,
 ) -> Option(fn(Option(String), String) -> Frame) {
   codec.encode_close
+}
+
+/// Mark a codec's events as topicless.
+///
+/// Some framings (e.g. Socket.IO-style protocols) do not carry a per-frame
+/// topic. When set, an inbound event whose topic is empty is routed to the
+/// socket's single joined topic; with zero or multiple joins it is dropped.
+/// Topic-carrying codecs (like the Phoenix codec) must leave this off so
+/// empty-topic frames are rejected instead of guessed at.
+pub fn with_topicless_events(codec: Codec) -> Codec {
+  Codec(..codec, topicless_events: True)
+}
+
+/// Accessor for the codec's topicless-events flag.
+@internal
+pub fn topicless_events(codec: Codec) -> Bool {
+  codec.topicless_events
 }
 
 /// Accessor for the codec's optional channel-error encoder.

--- a/src/beryl/wire/codec.gleam
+++ b/src/beryl/wire/codec.gleam
@@ -104,6 +104,8 @@ pub opaque type Codec {
     ) -> Frame,
     encode_push: fn(String, String, json.Json) -> Frame,
     encode_heartbeat_reply: fn(Option(String)) -> Frame,
+    encode_close: Option(fn(Option(String), String) -> Frame),
+    encode_error: Option(fn(Option(String), String) -> Frame),
   )
 }
 
@@ -136,6 +138,8 @@ pub fn new(
     encode_reply:,
     encode_push:,
     encode_heartbeat_reply:,
+    encode_close: None,
+    encode_error: None,
   )
 }
 
@@ -149,6 +153,32 @@ pub fn with_binary_decoder(
   decode_binary: fn(BitArray) -> Result(Inbound, DecodeError),
 ) -> Codec {
   Codec(..codec, decode_binary: Some(decode_binary))
+}
+
+/// Attach a channel-close encoder to a codec.
+///
+/// When set, the coordinator emits this frame to a client whenever one of
+/// its channels terminates gracefully (leave, server shutdown, heartbeat
+/// eviction): `(join_ref, topic)`. Phoenix clients rely on `phx_close` to
+/// leave the joined state instead of waiting out push timeouts.
+pub fn with_close_encoder(
+  codec: Codec,
+  encode_close: fn(Option(String), String) -> Frame,
+) -> Codec {
+  Codec(..codec, encode_close: Some(encode_close))
+}
+
+/// Attach a channel-error encoder to a codec.
+///
+/// When set, the coordinator emits this frame to a client whenever one of
+/// its channels terminates abnormally (crashed or stopped with an error):
+/// `(join_ref, topic)`. Phoenix clients rely on `phx_error` to schedule an
+/// automatic rejoin.
+pub fn with_error_encoder(
+  codec: Codec,
+  encode_error: fn(Option(String), String) -> Frame,
+) -> Codec {
+  Codec(..codec, encode_error: Some(encode_error))
 }
 
 /// Accessor for the codec's text decoder.
@@ -183,4 +213,20 @@ pub fn encode_push(codec: Codec) -> fn(String, String, json.Json) -> Frame {
 @internal
 pub fn encode_heartbeat_reply(codec: Codec) -> fn(Option(String)) -> Frame {
   codec.encode_heartbeat_reply
+}
+
+/// Accessor for the codec's optional channel-close encoder.
+@internal
+pub fn encode_close(
+  codec: Codec,
+) -> Option(fn(Option(String), String) -> Frame) {
+  codec.encode_close
+}
+
+/// Accessor for the codec's optional channel-error encoder.
+@internal
+pub fn encode_error(
+  codec: Codec,
+) -> Option(fn(Option(String), String) -> Frame) {
+  codec.encode_error
 }

--- a/src/beryl/wire/codec.gleam
+++ b/src/beryl/wire/codec.gleam
@@ -39,6 +39,21 @@ pub type InboundKind {
 
 /// Normalised inbound message shape.
 ///
+/// `Inbound` is opaque: construct it with `inbound` and read it with the
+/// `inbound_*` accessors. Keeping the record hidden lets Beryl add fields
+/// (which default sensibly) without breaking every custom codec.
+pub opaque type Inbound {
+  Inbound(
+    join_ref: Option(String),
+    ref: Option(String),
+    topic: String,
+    kind: InboundKind,
+    payload: Dynamic,
+  )
+}
+
+/// Construct a normalised inbound message.
+///
 /// - `join_ref`: optional client-side reference assigned at join time
 ///   (used by some Phoenix replies; codecs without this concept should
 ///   pass `None`)
@@ -47,14 +62,39 @@ pub type InboundKind {
 /// - `kind`: structural protocol event or user event
 /// - `payload`: message body as a `Dynamic` for the channel handler to
 ///   decode
-pub type Inbound {
-  Inbound(
-    join_ref: Option(String),
-    ref: Option(String),
-    topic: String,
-    kind: InboundKind,
-    payload: Dynamic,
-  )
+pub fn inbound(
+  join_ref join_ref: Option(String),
+  ref ref: Option(String),
+  topic topic: String,
+  kind kind: InboundKind,
+  payload payload: Dynamic,
+) -> Inbound {
+  Inbound(join_ref:, ref:, topic:, kind:, payload:)
+}
+
+/// The inbound message's join-time client reference, if any.
+pub fn inbound_join_ref(inbound: Inbound) -> Option(String) {
+  inbound.join_ref
+}
+
+/// The inbound message's per-message reference for reply correlation, if any.
+pub fn inbound_ref(inbound: Inbound) -> Option(String) {
+  inbound.ref
+}
+
+/// The inbound message's subscription topic.
+pub fn inbound_topic(inbound: Inbound) -> String {
+  inbound.topic
+}
+
+/// The inbound message's structural kind.
+pub fn inbound_kind(inbound: Inbound) -> InboundKind {
+  inbound.kind
+}
+
+/// The inbound message's body, for the channel handler to decode.
+pub fn inbound_payload(inbound: Inbound) -> Dynamic {
+  inbound.payload
 }
 
 /// Errors a codec may emit when decoding inbound bytes.

--- a/src/beryl_ffi.erl
+++ b/src/beryl_ffi.erl
@@ -1,9 +1,23 @@
 -module(beryl_ffi).
 -export([identity/1, monotonic_time_ms/0, monotonic_time_ns/0,
-         string_starts_with/2, stop_supervisor/1]).
+         string_starts_with/2, stop_supervisor/1, rescue/1]).
 
 %% Identity function for type erasure
 identity(X) -> X.
+
+%% Run a callback, converting any crash (error/exit/throw) into an
+%% {error, Description} result so a crashing channel callback cannot take
+%% down the shared coordinator actor. The description is depth-limited and
+%% truncated so client-triggered crashes cannot bloat log metadata.
+rescue(Fun) ->
+    try
+        {ok, Fun()}
+    catch
+        Class:Reason ->
+            Formatted = unicode:characters_to_binary(
+                io_lib:format("~p:~P", [Class, Reason, 10])),
+            {error, string:slice(Formatted, 0, 512)}
+    end.
 
 %% Return Erlang monotonic time in milliseconds
 monotonic_time_ms() -> erlang:monotonic_time(millisecond).

--- a/test/beryl_test.gleam
+++ b/test/beryl_test.gleam
@@ -866,20 +866,20 @@ pub fn decode_valid_message_test() {
   result |> should.be_ok
 
   let assert Ok(msg) = result
-  msg.join_ref |> should.equal(option.Some("j1"))
-  msg.ref |> should.equal(option.Some("r1"))
-  msg.topic |> should.equal("room:lobby")
-  msg.kind |> should.equal(codec.Join)
+  codec.inbound_join_ref(msg) |> should.equal(option.Some("j1"))
+  codec.inbound_ref(msg) |> should.equal(option.Some("r1"))
+  codec.inbound_topic(msg) |> should.equal("room:lobby")
+  codec.inbound_kind(msg) |> should.equal(codec.Join)
 }
 
 pub fn decode_message_with_null_refs_test() {
   let assert Ok(msg) =
     wire.decode_message("[null,\"ref\",\"topic\",\"event\",{}]")
 
-  msg.join_ref |> should.equal(option.None)
-  msg.ref |> should.equal(option.Some("ref"))
-  msg.topic |> should.equal("topic")
-  msg.kind |> should.equal(codec.Event("event"))
+  codec.inbound_join_ref(msg) |> should.equal(option.None)
+  codec.inbound_ref(msg) |> should.equal(option.Some("ref"))
+  codec.inbound_topic(msg) |> should.equal("topic")
+  codec.inbound_kind(msg) |> should.equal(codec.Event("event"))
 }
 
 pub fn decode_message_both_refs_null_test() {
@@ -888,10 +888,10 @@ pub fn decode_message_both_refs_null_test() {
       "[null,null,\"room:lobby\",\"new_msg\",{\"text\":\"hi\"}]",
     )
 
-  msg.join_ref |> should.equal(option.None)
-  msg.ref |> should.equal(option.None)
-  msg.topic |> should.equal("room:lobby")
-  msg.kind |> should.equal(codec.Event("new_msg"))
+  codec.inbound_join_ref(msg) |> should.equal(option.None)
+  codec.inbound_ref(msg) |> should.equal(option.None)
+  codec.inbound_topic(msg) |> should.equal("room:lobby")
+  codec.inbound_kind(msg) |> should.equal(codec.Event("new_msg"))
 }
 
 pub fn decode_invalid_json_test() {

--- a/test/binary_codec_test.gleam
+++ b/test/binary_codec_test.gleam
@@ -39,7 +39,7 @@ fn decode_binary_text(raw: String) -> Result(codec.Inbound, codec.DecodeError) {
   case string.split(raw, "|") {
     ["J", join_ref, ref, topic, payload_json] -> {
       use payload <- result_try(decode_payload(payload_json))
-      Ok(codec.Inbound(
+      Ok(codec.inbound(
         join_ref: Some(join_ref),
         ref: Some(ref),
         topic: topic,
@@ -48,7 +48,7 @@ fn decode_binary_text(raw: String) -> Result(codec.Inbound, codec.DecodeError) {
       ))
     }
     ["L", ref, topic] ->
-      Ok(codec.Inbound(
+      Ok(codec.inbound(
         join_ref: None,
         ref: Some(ref),
         topic: topic,
@@ -56,7 +56,7 @@ fn decode_binary_text(raw: String) -> Result(codec.Inbound, codec.DecodeError) {
         payload: dynamic_nil(),
       ))
     ["H", ref] ->
-      Ok(codec.Inbound(
+      Ok(codec.inbound(
         join_ref: None,
         ref: Some(ref),
         topic: "phoenix",
@@ -65,7 +65,7 @@ fn decode_binary_text(raw: String) -> Result(codec.Inbound, codec.DecodeError) {
       ))
     ["E", ref, topic, event, payload_json] -> {
       use payload <- result_try(decode_payload(payload_json))
-      Ok(codec.Inbound(
+      Ok(codec.inbound(
         join_ref: None,
         ref: Some(ref),
         topic: topic,

--- a/test/binary_codec_test.gleam
+++ b/test/binary_codec_test.gleam
@@ -330,10 +330,20 @@ pub fn binary_codec_broadcast_uses_binary_send_test() {
   process.receive(sent_text, 50) |> should.be_error
 }
 
-pub fn phoenix_codec_without_binary_decoder_preserves_raw_binary_handler_test() {
+pub fn codec_without_binary_decoder_preserves_raw_binary_handler_test() {
   let sent_text = process.new_subject()
   let seen_binary = process.new_subject()
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  // A text-only codec (no binary decoder): raw binary frames fan out to
+  // handle_binary. The Phoenix codec now ships its own binary decoder, so
+  // this path applies only to custom codecs that opt out.
+  let text_only =
+    codec.new(
+      decode_text: wire.decode_message,
+      encode_reply: wire.reply_json,
+      encode_push: wire.push,
+      encode_heartbeat_reply: wire.heartbeat_reply,
+    )
+  let assert Ok(channels) = beryl.start(beryl.config(text_only))
 
   process.send(
     beryl.coordinator_subject(channels),

--- a/test/callback_crash_test.gleam
+++ b/test/callback_crash_test.gleam
@@ -134,6 +134,12 @@ pub fn handle_in_crash_terminates_channel_but_not_coordinator_test() {
   // The crashing channel's terminate ran with an Error reason
   let assert Ok(channel.Error(_)) = process.receive(terminated, 500)
 
+  // The client is told its channel instance died
+  let assert Ok(error_frame) = process.receive(crasher, 500)
+  error_frame
+  |> string.contains("phx_error")
+  |> should.be_true
+
   // The coordinator survived: broadcasts still reach the other socket
   beryl.broadcast(channels, "room:lobby", "still_alive", json.object([]))
   let assert Ok(message) = process.receive(other, 500)
@@ -210,10 +216,16 @@ pub fn terminate_crash_does_not_kill_coordinator_test() {
     "[null,\"leave-1\",\"room:lobby\",\"phx_leave\",{}]",
   )
 
-  // The leave reply is still delivered after the crashing terminate
+  // The leave reply is still delivered despite the crashing terminate
   let assert Ok(reply) = process.receive(socket, 500)
   reply
   |> string.contains("phx_reply")
+  |> should.be_true
+
+  // Followed by the phx_close for the terminated channel
+  let assert Ok(close) = process.receive(socket, 500)
+  close
+  |> string.contains("phx_close")
   |> should.be_true
 
   assert_heartbeat_answered(channels, "socket-1", socket)
@@ -236,5 +248,12 @@ pub fn handle_info_crash_terminates_channel_not_coordinator_test() {
   )
 
   let assert Ok(channel.Error(_)) = process.receive(terminated, 500)
+
+  // The client is told its channel instance died
+  let assert Ok(error_frame) = process.receive(socket, 500)
+  error_frame
+  |> string.contains("phx_error")
+  |> should.be_true
+
   assert_heartbeat_answered(channels, "socket-1", socket)
 }

--- a/test/callback_crash_test.gleam
+++ b/test/callback_crash_test.gleam
@@ -132,7 +132,7 @@ pub fn handle_in_crash_terminates_channel_but_not_coordinator_test() {
   )
 
   // The crashing channel's terminate ran with an Error reason
-  let assert Ok(channel.Error(_)) = process.receive(terminated, 500)
+  let assert Ok(channel.Errored(_)) = process.receive(terminated, 500)
 
   // The client is told its channel instance died
   let assert Ok(error_frame) = process.receive(crasher, 500)
@@ -247,7 +247,7 @@ pub fn handle_info_crash_terminates_channel_not_coordinator_test() {
     }),
   )
 
-  let assert Ok(channel.Error(_)) = process.receive(terminated, 500)
+  let assert Ok(channel.Errored(_)) = process.receive(terminated, 500)
 
   // The client is told its channel instance died
   let assert Ok(error_frame) = process.receive(socket, 500)

--- a/test/callback_crash_test.gleam
+++ b/test/callback_crash_test.gleam
@@ -1,0 +1,240 @@
+//// Crash isolation tests: a panicking channel callback must terminate only
+//// the offending channel, never the shared coordinator.
+
+import beryl
+import beryl/channel
+import beryl/coordinator
+import beryl/topic
+import beryl/wire
+import gleam/dynamic
+import gleam/erlang/process
+import gleam/json
+import gleam/option.{None}
+import gleam/string
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+fn register_channel(
+  channels: beryl.Channels,
+  handler: coordinator.ChannelHandler,
+) -> Int {
+  let reply = process.new_subject()
+  process.send(
+    beryl.coordinator_subject(channels),
+    coordinator.RegisterChannel("room:*", handler, reply),
+  )
+  let assert Ok(Ok(id)) = process.receive(reply, 500)
+  id
+}
+
+fn connect_socket(
+  channels: beryl.Channels,
+  socket_id: String,
+) -> process.Subject(String) {
+  let sent = process.new_subject()
+  let send = fn(message: String) -> Result(Nil, Nil) {
+    process.send(sent, message)
+    Ok(Nil)
+  }
+
+  process.send(
+    beryl.coordinator_subject(channels),
+    coordinator.SocketConnected(
+      socket_id,
+      send,
+      fn(_) { Ok(Nil) },
+      None,
+      dynamic.nil(),
+    ),
+  )
+  process.sleep(10)
+  sent
+}
+
+fn join_topic(
+  channels: beryl.Channels,
+  socket_id: String,
+  topic_name: String,
+  sent: process.Subject(String),
+) -> Nil {
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    socket_id,
+    "[null,\"join-ref\",\"" <> topic_name <> "\",\"phx_join\",{}]",
+  )
+
+  let assert Ok(reply) = process.receive(sent, 500)
+  reply
+  |> string.contains("phx_reply")
+  |> should.be_true
+}
+
+fn drain(subject: process.Subject(String)) -> Nil {
+  case process.receive(subject, 0) {
+    Ok(_) -> drain(subject)
+    Error(_) -> Nil
+  }
+}
+
+fn assert_heartbeat_answered(
+  channels: beryl.Channels,
+  socket_id: String,
+  sent: process.Subject(String),
+) -> Nil {
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    socket_id,
+    "[null,\"hb-1\",\"phoenix\",\"heartbeat\",{}]",
+  )
+  let assert Ok(reply) = process.receive(sent, 500)
+  reply
+  |> string.contains("phx_reply")
+  |> should.be_true
+}
+
+fn crashing_handle_in_handler(
+  terminated: process.Subject(channel.StopReason),
+) -> coordinator.ChannelHandler {
+  coordinator.ChannelHandler(
+    id: 0,
+    pattern: topic.parse_pattern("room:*"),
+    join: fn(_topic, _payload, _ctx) {
+      coordinator.JoinOkErased(reply: None, assigns: dynamic.nil())
+    },
+    handle_in: fn(_event, _payload, _ctx) { panic as "handle_in boom" },
+    handle_binary: fn(_data, ctx) {
+      coordinator.NoReplyErased(assigns: ctx.assigns)
+    },
+    terminate: fn(reason, _ctx) { process.send(terminated, reason) },
+  )
+}
+
+pub fn handle_in_crash_terminates_channel_but_not_coordinator_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let terminated = process.new_subject()
+  let _id = register_channel(channels, crashing_handle_in_handler(terminated))
+
+  let crasher = connect_socket(channels, "crash-socket")
+  let other = connect_socket(channels, "other-socket")
+  join_topic(channels, "crash-socket", "room:lobby", crasher)
+  join_topic(channels, "other-socket", "room:lobby", other)
+  drain(crasher)
+  drain(other)
+
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "crash-socket",
+    "[null,\"ref-2\",\"room:lobby\",\"boom\",{}]",
+  )
+
+  // The crashing channel's terminate ran with an Error reason
+  let assert Ok(channel.Error(_)) = process.receive(terminated, 500)
+
+  // The coordinator survived: broadcasts still reach the other socket
+  beryl.broadcast(channels, "room:lobby", "still_alive", json.object([]))
+  let assert Ok(message) = process.receive(other, 500)
+  message
+  |> string.contains("still_alive")
+  |> should.be_true
+
+  // The crashed channel was torn down: its socket is unsubscribed
+  process.receive(crasher, 100)
+  |> should.be_error
+}
+
+pub fn join_crash_sends_error_reply_and_coordinator_survives_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let handler =
+    coordinator.ChannelHandler(
+      id: 0,
+      pattern: topic.parse_pattern("room:*"),
+      join: fn(_topic, _payload, _ctx) { panic as "join boom" },
+      handle_in: fn(_event, _payload, ctx) {
+        coordinator.NoReplyErased(assigns: ctx.assigns)
+      },
+      handle_binary: fn(_data, ctx) {
+        coordinator.NoReplyErased(assigns: ctx.assigns)
+      },
+      terminate: fn(_reason, _ctx) { Nil },
+    )
+  let _id = register_channel(channels, handler)
+
+  let socket = connect_socket(channels, "socket-1")
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[null,\"ref-1\",\"room:lobby\",\"phx_join\",{}]",
+  )
+
+  let assert Ok(reply) = process.receive(socket, 500)
+  reply
+  |> string.contains("\"error\"")
+  |> should.be_true
+  reply
+  |> string.contains("join crashed")
+  |> should.be_true
+
+  assert_heartbeat_answered(channels, "socket-1", socket)
+}
+
+pub fn terminate_crash_does_not_kill_coordinator_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let handler =
+    coordinator.ChannelHandler(
+      id: 0,
+      pattern: topic.parse_pattern("room:*"),
+      join: fn(_topic, _payload, _ctx) {
+        coordinator.JoinOkErased(reply: None, assigns: dynamic.nil())
+      },
+      handle_in: fn(_event, _payload, ctx) {
+        coordinator.NoReplyErased(assigns: ctx.assigns)
+      },
+      handle_binary: fn(_data, ctx) {
+        coordinator.NoReplyErased(assigns: ctx.assigns)
+      },
+      terminate: fn(_reason, _ctx) { panic as "terminate boom" },
+    )
+  let _id = register_channel(channels, handler)
+
+  let socket = connect_socket(channels, "socket-1")
+  join_topic(channels, "socket-1", "room:lobby", socket)
+  drain(socket)
+
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[null,\"leave-1\",\"room:lobby\",\"phx_leave\",{}]",
+  )
+
+  // The leave reply is still delivered after the crashing terminate
+  let assert Ok(reply) = process.receive(socket, 500)
+  reply
+  |> string.contains("phx_reply")
+  |> should.be_true
+
+  assert_heartbeat_answered(channels, "socket-1", socket)
+}
+
+pub fn handle_info_crash_terminates_channel_not_coordinator_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let terminated = process.new_subject()
+  let id = register_channel(channels, crashing_handle_in_handler(terminated))
+
+  let socket = connect_socket(channels, "socket-1")
+  join_topic(channels, "socket-1", "room:lobby", socket)
+  drain(socket)
+
+  process.send(
+    beryl.coordinator_subject(channels),
+    coordinator.HandleInfo("socket-1", "room:lobby", id, fn(_ctx) {
+      panic as "info boom"
+    }),
+  )
+
+  let assert Ok(channel.Error(_)) = process.receive(terminated, 500)
+  assert_heartbeat_answered(channels, "socket-1", socket)
+}

--- a/test/channel_close_test.gleam
+++ b/test/channel_close_test.gleam
@@ -1,0 +1,161 @@
+//// Terminal channel event tests: the coordinator must tell clients when a
+//// channel instance ends (`phx_close` for graceful stops, `phx_error` for
+//// abnormal ones) so Phoenix clients leave the joined state and rejoin.
+
+import beryl
+import beryl/channel
+import beryl/coordinator
+import beryl/topic
+import beryl/wire
+import gleam/dynamic
+import gleam/erlang/process
+import gleam/option.{None}
+import gleam/string
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+fn register_stopping_channel(
+  channels: beryl.Channels,
+  stop_reason: channel.StopReason,
+) -> Nil {
+  let handler =
+    coordinator.ChannelHandler(
+      id: 0,
+      pattern: topic.parse_pattern("room:*"),
+      join: fn(_topic, _payload, _ctx) {
+        coordinator.JoinOkErased(reply: None, assigns: dynamic.nil())
+      },
+      handle_in: fn(event, _payload, ctx) {
+        case event {
+          "stop" -> coordinator.StopErased(reason: stop_reason)
+          _ -> coordinator.NoReplyErased(assigns: ctx.assigns)
+        }
+      },
+      handle_binary: fn(_data, ctx) {
+        coordinator.NoReplyErased(assigns: ctx.assigns)
+      },
+      terminate: fn(_reason, _ctx) { Nil },
+    )
+
+  let reply = process.new_subject()
+  process.send(
+    beryl.coordinator_subject(channels),
+    coordinator.RegisterChannel("room:*", handler, reply),
+  )
+  let assert Ok(Ok(_)) = process.receive(reply, 500)
+  Nil
+}
+
+fn connect_socket(
+  channels: beryl.Channels,
+  socket_id: String,
+) -> process.Subject(String) {
+  let sent = process.new_subject()
+  let send = fn(message: String) -> Result(Nil, Nil) {
+    process.send(sent, message)
+    Ok(Nil)
+  }
+
+  process.send(
+    beryl.coordinator_subject(channels),
+    coordinator.SocketConnected(
+      socket_id,
+      send,
+      fn(_) { Ok(Nil) },
+      None,
+      dynamic.nil(),
+    ),
+  )
+  process.sleep(10)
+  sent
+}
+
+fn join_topic(
+  channels: beryl.Channels,
+  socket_id: String,
+  topic_name: String,
+  sent: process.Subject(String),
+) -> Nil {
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    socket_id,
+    "[null,\"join-ref\",\"" <> topic_name <> "\",\"phx_join\",{}]",
+  )
+
+  let assert Ok(reply) = process.receive(sent, 500)
+  reply
+  |> string.contains("phx_reply")
+  |> should.be_true
+}
+
+pub fn leave_sends_reply_then_phx_close_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  register_stopping_channel(channels, channel.Normal)
+
+  let socket = connect_socket(channels, "socket-1")
+  join_topic(channels, "socket-1", "room:lobby", socket)
+
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[null,\"leave-1\",\"room:lobby\",\"phx_leave\",{}]",
+  )
+
+  let assert Ok(reply) = process.receive(socket, 500)
+  reply
+  |> string.contains("phx_reply")
+  |> should.be_true
+  reply
+  |> string.contains("leave-1")
+  |> should.be_true
+
+  let assert Ok(close) = process.receive(socket, 500)
+  close
+  |> string.contains("phx_close")
+  |> should.be_true
+}
+
+pub fn stop_with_error_sends_phx_error_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  register_stopping_channel(channels, channel.Error("boom"))
+
+  let socket = connect_socket(channels, "socket-1")
+  join_topic(channels, "socket-1", "room:lobby", socket)
+
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[null,\"ref-2\",\"room:lobby\",\"stop\",{}]",
+  )
+
+  let assert Ok(frame) = process.receive(socket, 500)
+  frame
+  |> string.contains("phx_error")
+  |> should.be_true
+  frame
+  |> string.contains("room:lobby")
+  |> should.be_true
+}
+
+pub fn stop_with_normal_sends_phx_close_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  register_stopping_channel(channels, channel.Normal)
+
+  let socket = connect_socket(channels, "socket-1")
+  join_topic(channels, "socket-1", "room:lobby", socket)
+
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[null,\"ref-2\",\"room:lobby\",\"stop\",{}]",
+  )
+
+  let assert Ok(frame) = process.receive(socket, 500)
+  frame
+  |> string.contains("phx_close")
+  |> should.be_true
+}

--- a/test/channel_close_test.gleam
+++ b/test/channel_close_test.gleam
@@ -121,7 +121,7 @@ pub fn leave_sends_reply_then_phx_close_test() {
 
 pub fn stop_with_error_sends_phx_error_test() {
   let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
-  register_stopping_channel(channels, channel.Error("boom"))
+  register_stopping_channel(channels, channel.Errored("boom"))
 
   let socket = connect_socket(channels, "socket-1")
   join_topic(channels, "socket-1", "room:lobby", socket)

--- a/test/channel_rate_limit_security_test.gleam
+++ b/test/channel_rate_limit_security_test.gleam
@@ -1,3 +1,7 @@
+//// Behavioural tests for per-channel rate-limit bucket accounting: buckets
+//// are only created for joined topics, are capped per socket, and are
+//// released when the channel or socket goes away.
+
 import beryl/coordinator
 import beryl/rate_limit
 import beryl/topic
@@ -7,7 +11,6 @@ import gleam/erlang/process
 import gleam/int
 import gleam/json
 import gleam/option
-import gleam/string
 import gleeunit
 import gleeunit/should
 
@@ -15,47 +18,71 @@ pub fn main() {
   gleeunit.main()
 }
 
-pub fn unjoined_events_do_not_create_channel_buckets_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 1000, burst: 1000))
+fn start_capped_coordinator(
+  max_keys: Int,
+) -> process.Subject(coordinator.Message) {
   let assert Ok(coord) =
     coordinator.start_with_config(
       coordinator.CoordinatorConfig(
         ..coordinator.config(wire.phoenix_codec()),
-        channel_limiter: option.Some(limiter),
-        channel_limiter_max_keys_per_socket: 1000,
+        channel_limits: option.Some(rate_limit.config(
+          per_second: 1000,
+          burst: 1000,
+        )),
+        channel_limiter_max_keys_per_socket: max_keys,
       ),
     )
+  coord
+}
 
-  process.send(
-    coord,
-    coordinator.SocketConnected(
-      "socket-131",
-      fn(_) { Ok(Nil) },
-      fn(_) { Ok(Nil) },
-      option.None,
-      dynamic.nil(),
-    ),
-  )
+/// Wait for a "handled" marker from the channel, skipping wire frames (join
+/// replies etc.) that share the same capture subject.
+fn expect_handled(sent: process.Subject(String)) -> Nil {
+  case process.receive(sent, 500) {
+    Ok("handled") -> Nil
+    Ok(_frame) -> expect_handled(sent)
+    Error(Nil) -> should.fail()
+  }
+}
 
+/// Assert that no "handled" marker arrives, skipping wire frames.
+fn expect_dropped(sent: process.Subject(String)) -> Nil {
+  case process.receive(sent, 100) {
+    Ok("handled") -> should.fail()
+    Ok(_frame) -> expect_dropped(sent)
+    Error(Nil) -> Nil
+  }
+}
+
+/// Discard everything currently queued on the capture subject.
+fn drain_replies(subject: process.Subject(String)) -> Nil {
+  case process.receive(subject, 0) {
+    Ok(_) -> drain_replies(subject)
+    Error(Nil) -> Nil
+  }
+}
+
+pub fn unjoined_events_do_not_consume_channel_bucket_cap_test() {
+  let coord = start_capped_coordinator(1)
+  let sent = process.new_subject()
+  let assert Ok(_) = register_test_channel(coord, sent)
+
+  connect(coord, sent, "socket-131")
+
+  // A flood of events for never-joined topics must not create buckets and
+  // must not consume the per-socket cap.
   send_unjoined_events(coord, 50)
   process.sleep(50)
+  drain_replies(sent)
 
-  rate_limit.bucket_count(limiter) |> should.equal(0)
-  rate_limit.stop(limiter)
+  // The single cap slot is still available for a legitimately joined topic.
+  join(coord, "socket-131", "room:one")
+  event(coord, "socket-131", "room:one", "ref-one")
+  expect_handled(sent)
 }
 
 pub fn joined_topics_cannot_exceed_channel_bucket_cap_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 1000, burst: 1000))
-  let assert Ok(coord) =
-    coordinator.start_with_config(
-      coordinator.CoordinatorConfig(
-        ..coordinator.config(wire.phoenix_codec()),
-        channel_limiter: option.Some(limiter),
-        channel_limiter_max_keys_per_socket: 2,
-      ),
-    )
+  let coord = start_capped_coordinator(2)
   let sent = process.new_subject()
   let assert Ok(_) = register_test_channel(coord, sent)
 
@@ -65,24 +92,26 @@ pub fn joined_topics_cannot_exceed_channel_bucket_cap_test() {
   join(coord, "socket-cap", "room:three")
 
   event(coord, "socket-cap", "room:one", "ref-one")
+  expect_handled(sent)
   event(coord, "socket-cap", "room:two", "ref-two")
-  event(coord, "socket-cap", "room:three", "ref-three")
-  process.sleep(50)
+  expect_handled(sent)
 
-  rate_limit.bucket_count(limiter) |> should.equal(2)
-  rate_limit.stop(limiter)
+  // The third topic would need a third bucket, over the cap: dropped.
+  event(coord, "socket-cap", "room:three", "ref-three")
+  expect_dropped(sent)
 }
 
-pub fn heartbeat_eviction_removes_channel_buckets_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 1000, burst: 1000))
+pub fn heartbeat_eviction_releases_channel_buckets_test() {
   let assert Ok(coord) =
     coordinator.start_with_config(
       coordinator.CoordinatorConfig(
         ..coordinator.config(wire.phoenix_codec()),
         heartbeat_timeout_ms: 20,
-        channel_limiter: option.Some(limiter),
-        channel_limiter_max_keys_per_socket: 1000,
+        channel_limits: option.Some(rate_limit.config(
+          per_second: 1000,
+          burst: 1000,
+        )),
+        channel_limiter_max_keys_per_socket: 1,
       ),
     )
   let sent = process.new_subject()
@@ -91,28 +120,24 @@ pub fn heartbeat_eviction_removes_channel_buckets_test() {
   connect(coord, sent, "socket-heartbeat")
   join(coord, "socket-heartbeat", "room:one")
   event(coord, "socket-heartbeat", "room:one", "ref-one")
-  process.sleep(20)
-  rate_limit.bucket_count(limiter) |> should.equal(1)
+  expect_handled(sent)
 
+  // Let the socket go stale and evict it.
   process.sleep(30)
   process.send(coord, coordinator.CheckHeartbeats)
   process.sleep(20)
 
-  rate_limit.bucket_count(limiter) |> should.equal(0)
-  rate_limit.stop(limiter)
+  // A reconnect under the same socket id starts with a free cap: if the old
+  // bucket had leaked, this event would exceed max_keys_per_socket = 1.
+  connect(coord, sent, "socket-heartbeat")
+  join(coord, "socket-heartbeat", "room:two")
+  drain_replies(sent)
+  event(coord, "socket-heartbeat", "room:two", "ref-two")
+  expect_handled(sent)
 }
 
 pub fn leave_removes_channel_bucket_so_cap_recovers_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 1000, burst: 1000))
-  let assert Ok(coord) =
-    coordinator.start_with_config(
-      coordinator.CoordinatorConfig(
-        ..coordinator.config(wire.phoenix_codec()),
-        channel_limiter: option.Some(limiter),
-        channel_limiter_max_keys_per_socket: 2,
-      ),
-    )
+  let coord = start_capped_coordinator(2)
   let sent = process.new_subject()
   let assert Ok(_) = register_test_channel(coord, sent)
 
@@ -120,42 +145,17 @@ pub fn leave_removes_channel_bucket_so_cap_recovers_test() {
   join(coord, "socket-leave", "room:one")
   join(coord, "socket-leave", "room:two")
   event(coord, "socket-leave", "room:one", "ref-one")
+  expect_handled(sent)
   event(coord, "socket-leave", "room:two", "ref-two")
-  process.sleep(20)
-  rate_limit.bucket_count(limiter) |> should.equal(2)
+  expect_handled(sent)
 
+  // Leaving frees room:one's bucket, so a third topic fits under the cap.
   leave(coord, "socket-leave", "room:one", "leave-one")
   join(coord, "socket-leave", "room:three")
   process.sleep(20)
-  drain(sent)
+  drain_replies(sent)
   event(coord, "socket-leave", "room:three", "ref-three")
-  process.sleep(20)
-
-  let assert Ok("handled") = process.receive(sent, 100)
-  rate_limit.bucket_count(limiter) |> should.equal(2)
-  rate_limit.stop(limiter)
-}
-
-pub fn stopped_join_limiter_does_not_crash_coordinator_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 1000, burst: 1000))
-  let assert Ok(coord) =
-    coordinator.start_with_config(
-      coordinator.CoordinatorConfig(
-        ..coordinator.config(wire.phoenix_codec()),
-        join_limiter: option.Some(limiter),
-      ),
-    )
-  let sent = process.new_subject()
-  let assert Ok(_) = register_test_channel(coord, sent)
-  connect(coord, sent, "socket-dead-limiter")
-  rate_limit.stop(limiter)
-
-  join(coord, "socket-dead-limiter", "room:alive")
-
-  let assert Ok(join_reply) = process.receive(sent, 200)
-  join_reply |> string.contains("phx_reply") |> should.be_true
-  join_reply |> string.contains("\"status\":\"ok\"") |> should.be_true
+  expect_handled(sent)
 }
 
 fn send_unjoined_events(
@@ -198,6 +198,7 @@ fn connect(
       dynamic.nil(),
     ),
   )
+  process.sleep(10)
 }
 
 fn join(
@@ -221,13 +222,7 @@ fn event(
   coordinator.route_message(
     coord,
     socket_id,
-    "[\"join-"
-      <> topic
-      <> "\",\""
-      <> ref
-      <> "\",\""
-      <> topic
-      <> "\",\"client_event\",{}]",
+    "[null,\"" <> ref <> "\",\"" <> topic <> "\",\"client_event\",{}]",
   )
 }
 
@@ -240,21 +235,8 @@ fn leave(
   coordinator.route_message(
     coord,
     socket_id,
-    "[\"join-"
-      <> topic
-      <> "\",\""
-      <> ref
-      <> "\",\""
-      <> topic
-      <> "\",\"phx_leave\",{}]",
+    "[null,\"" <> ref <> "\",\"" <> topic <> "\",\"phx_leave\",{}]",
   )
-}
-
-fn drain(subject: process.Subject(String)) -> Nil {
-  case process.receive(subject, 0) {
-    Ok(_) -> drain(subject)
-    Error(Nil) -> Nil
-  }
 }
 
 fn register_test_channel(

--- a/test/connection_limit_test.gleam
+++ b/test/connection_limit_test.gleam
@@ -7,6 +7,7 @@
 
 import beryl
 import beryl/wire
+import gleam/erlang/process
 import gleeunit/should
 
 fn start_with_limit(max_connections: Int) -> beryl.Channels {
@@ -84,6 +85,28 @@ pub fn limit_is_per_ip_test() {
   beryl.acquire_connection_slot(channels, "10.0.0.5")
   |> should.equal(Error(Nil))
 
+  beryl.stop(channels)
+}
+
+// A slot is reclaimed when its holder process dies without releasing —
+// crashed connection handlers must not permanently exhaust an IP's slots.
+pub fn slot_reclaimed_when_holder_dies_without_release_test() {
+  let channels = start_with_limit(1)
+
+  let acquired = process.new_subject()
+  let _pid =
+    process.spawn_unlinked(fn() {
+      let assert Ok(permit) =
+        beryl.acquire_connection_slot(channels, "10.0.0.7")
+      beryl.bind_connection_slot(permit)
+      process.send(acquired, Nil)
+    })
+  let assert Ok(Nil) = process.receive(acquired, 500)
+
+  // Give the limiter time to observe the holder's exit.
+  process.sleep(50)
+
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.7"))
   beryl.stop(channels)
 }
 

--- a/test/connection_limit_test.gleam
+++ b/test/connection_limit_test.gleam
@@ -7,7 +7,6 @@
 
 import beryl
 import beryl/wire
-import gleam/option.{None, Some}
 import gleeunit/should
 
 fn start_with_limit(max_connections: Int) -> beryl.Channels {
@@ -19,17 +18,17 @@ fn start_with_limit(max_connections: Int) -> beryl.Channels {
   channels
 }
 
-// A limit of 0 means unlimited: every acquire from the same IP succeeds and no
-// permit is handed back (there is nothing to release).
+// A limit of 0 means unlimited: every acquire from the same IP succeeds, and
+// releasing the placeholder permit is a harmless no-op.
 pub fn zero_means_unlimited_test() {
   let channels = start_with_limit(0)
 
-  beryl.acquire_connection_slot(channels, "1.2.3.4")
-  |> should.equal(Ok(None))
-  beryl.acquire_connection_slot(channels, "1.2.3.4")
-  |> should.equal(Ok(None))
-  beryl.acquire_connection_slot(channels, "1.2.3.4")
-  |> should.equal(Ok(None))
+  let assert Ok(first) = beryl.acquire_connection_slot(channels, "1.2.3.4")
+  should.be_ok(beryl.acquire_connection_slot(channels, "1.2.3.4"))
+  should.be_ok(beryl.acquire_connection_slot(channels, "1.2.3.4"))
+
+  beryl.release_connection_slot(first)
+  |> should.equal(Nil)
 
   beryl.stop(channels)
 }
@@ -88,21 +87,11 @@ pub fn limit_is_per_ip_test() {
   beryl.stop(channels)
 }
 
-// Releasing an unlimited (`None`) permit is a harmless no-op.
-pub fn releasing_none_permit_is_noop_test() {
-  beryl.release_connection_slot(None)
-  |> should.equal(Nil)
-}
-
 // A permit obtained under a limit can be released explicitly.
-pub fn some_permit_can_be_released_test() {
+pub fn permit_can_be_released_test() {
   let channels = start_with_limit(1)
 
   let assert Ok(permit) = beryl.acquire_connection_slot(channels, "10.0.0.6")
-  case permit {
-    Some(_) -> Nil
-    None -> should.fail()
-  }
   beryl.release_connection_slot(permit)
 
   beryl.stop(channels)

--- a/test/duplicate_join_test.gleam
+++ b/test/duplicate_join_test.gleam
@@ -1,0 +1,185 @@
+//// Duplicate-join and join_ref staleness tests, matching Phoenix semantics:
+//// a rejoin replaces the previous channel instance (terminating it first),
+//// and messages carrying a previous instance's join_ref are dropped.
+
+import beryl
+import beryl/channel
+import beryl/coordinator
+import beryl/topic
+import beryl/wire
+import gleam/dynamic
+import gleam/erlang/process
+import gleam/json
+import gleam/option.{None}
+import gleam/string
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+fn register_channel(
+  channels: beryl.Channels,
+  terminated: process.Subject(channel.StopReason),
+) -> Nil {
+  let handler =
+    coordinator.ChannelHandler(
+      id: 0,
+      pattern: topic.parse_pattern("room:*"),
+      join: fn(_topic, _payload, _ctx) {
+        coordinator.JoinOkErased(reply: None, assigns: dynamic.nil())
+      },
+      handle_in: fn(_event, _payload, ctx) {
+        coordinator.ReplyErased(
+          event: "reply",
+          payload: json.object([]),
+          assigns: ctx.assigns,
+        )
+      },
+      handle_binary: fn(_data, ctx) {
+        coordinator.NoReplyErased(assigns: ctx.assigns)
+      },
+      terminate: fn(reason, _ctx) { process.send(terminated, reason) },
+    )
+
+  let reply = process.new_subject()
+  process.send(
+    beryl.coordinator_subject(channels),
+    coordinator.RegisterChannel("room:*", handler, reply),
+  )
+  let assert Ok(Ok(_)) = process.receive(reply, 500)
+  Nil
+}
+
+fn connect_socket(
+  channels: beryl.Channels,
+  socket_id: String,
+) -> process.Subject(String) {
+  let sent = process.new_subject()
+  let send = fn(message: String) -> Result(Nil, Nil) {
+    process.send(sent, message)
+    Ok(Nil)
+  }
+
+  process.send(
+    beryl.coordinator_subject(channels),
+    coordinator.SocketConnected(
+      socket_id,
+      send,
+      fn(_) { Ok(Nil) },
+      None,
+      dynamic.nil(),
+    ),
+  )
+  process.sleep(10)
+  sent
+}
+
+fn join_with_ref(
+  channels: beryl.Channels,
+  socket_id: String,
+  join_ref: String,
+) -> Nil {
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    socket_id,
+    "[\""
+      <> join_ref
+      <> "\",\""
+      <> join_ref
+      <> "\",\"room:lobby\",\"phx_join\",{}]",
+  )
+}
+
+pub fn duplicate_join_terminates_previous_instance_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let terminated = process.new_subject()
+  register_channel(channels, terminated)
+
+  let socket = connect_socket(channels, "socket-1")
+  join_with_ref(channels, "socket-1", "j1")
+  let assert Ok(first_reply) = process.receive(socket, 500)
+  first_reply |> string.contains("phx_reply") |> should.be_true
+
+  // Rejoin the same topic: the old instance terminates (phx_close), then the
+  // new join is accepted.
+  join_with_ref(channels, "socket-1", "j2")
+
+  let assert Ok(reason) = process.receive(terminated, 500)
+  reason |> should.equal(channel.Normal)
+
+  let assert Ok(close_frame) = process.receive(socket, 500)
+  close_frame |> string.contains("phx_close") |> should.be_true
+  // The close is attributed to the old instance's join_ref.
+  close_frame |> string.contains("j1") |> should.be_true
+
+  let assert Ok(second_reply) = process.receive(socket, 500)
+  second_reply |> string.contains("phx_reply") |> should.be_true
+  second_reply |> string.contains("j2") |> should.be_true
+}
+
+pub fn stale_join_ref_messages_are_dropped_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let terminated = process.new_subject()
+  register_channel(channels, terminated)
+
+  let socket = connect_socket(channels, "socket-1")
+  join_with_ref(channels, "socket-1", "j1")
+  let assert Ok(_first_reply) = process.receive(socket, 500)
+  join_with_ref(channels, "socket-1", "j2")
+  let assert Ok(_terminated) = process.receive(terminated, 500)
+  let assert Ok(_close) = process.receive(socket, 500)
+  let assert Ok(_second_reply) = process.receive(socket, 500)
+
+  // An event from the old instance (join_ref j1) must not reach the channel.
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[\"j1\",\"ref-1\",\"room:lobby\",\"ping\",{}]",
+  )
+  process.receive(socket, 100) |> should.be_error
+
+  // The current instance (j2) still works.
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[\"j2\",\"ref-2\",\"room:lobby\",\"ping\",{}]",
+  )
+  let assert Ok(reply) = process.receive(socket, 500)
+  reply |> string.contains("phx_reply") |> should.be_true
+  reply |> string.contains("ref-2") |> should.be_true
+  // The reply echoes the channel's join_ref, matching Phoenix.
+  reply |> string.contains("j2") |> should.be_true
+}
+
+pub fn stale_join_ref_leave_is_ignored_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let terminated = process.new_subject()
+  register_channel(channels, terminated)
+
+  let socket = connect_socket(channels, "socket-1")
+  join_with_ref(channels, "socket-1", "j1")
+  let assert Ok(_first_reply) = process.receive(socket, 500)
+  join_with_ref(channels, "socket-1", "j2")
+  let assert Ok(_terminated) = process.receive(terminated, 500)
+  let assert Ok(_close) = process.receive(socket, 500)
+  let assert Ok(_second_reply) = process.receive(socket, 500)
+
+  // A leave from the old instance must not close the new one.
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[\"j1\",\"leave-1\",\"room:lobby\",\"phx_leave\",{}]",
+  )
+  process.receive(terminated, 100) |> should.be_error
+
+  // The current instance still handles events.
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[\"j2\",\"ref-2\",\"room:lobby\",\"ping\",{}]",
+  )
+  let assert Ok(reply) = process.receive(socket, 500)
+  reply |> string.contains("phx_reply") |> should.be_true
+}

--- a/test/error_reply_test.gleam
+++ b/test/error_reply_test.gleam
@@ -1,0 +1,119 @@
+//// Tests for channel error replies: `channel.ReplyError` must reach the
+//// client as a `phx_reply` with `"status": "error"`, correlated to the
+//// client's ref (Phoenix `push.receive("error", ...)`).
+
+import beryl
+import beryl/channel
+import beryl/coordinator
+import beryl/wire
+import gleam/dynamic
+import gleam/erlang/process
+import gleam/option.{None}
+import gleam/string
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+fn start_with_error_channel() -> beryl.Channels {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let handler =
+    channel.new(fn(_topic, _payload, socket) {
+      channel.JoinOk(reply: None, socket: socket)
+    })
+    |> channel.with_handle_in(fn(event, _payload, socket) {
+      case event {
+        "fail" -> channel.ReplyError(payload: channel.error("nope"), socket:)
+        _ -> channel.NoReply(socket)
+      }
+    })
+  let assert Ok(_) = beryl.register(channels, "room:*", handler)
+  channels
+}
+
+fn connect_socket(
+  channels: beryl.Channels,
+  socket_id: String,
+) -> process.Subject(String) {
+  let sent = process.new_subject()
+  let send = fn(message: String) -> Result(Nil, Nil) {
+    process.send(sent, message)
+    Ok(Nil)
+  }
+
+  process.send(
+    beryl.coordinator_subject(channels),
+    coordinator.SocketConnected(
+      socket_id,
+      send,
+      fn(_) { Ok(Nil) },
+      None,
+      dynamic.nil(),
+    ),
+  )
+  process.sleep(10)
+  sent
+}
+
+fn join_topic(
+  channels: beryl.Channels,
+  socket_id: String,
+  topic_name: String,
+  sent: process.Subject(String),
+) -> Nil {
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    socket_id,
+    "[null,\"join-ref\",\"" <> topic_name <> "\",\"phx_join\",{}]",
+  )
+
+  let assert Ok(reply) = process.receive(sent, 500)
+  reply
+  |> string.contains("phx_reply")
+  |> should.be_true
+}
+
+pub fn reply_error_sends_error_status_reply_test() {
+  let channels = start_with_error_channel()
+  let socket = connect_socket(channels, "socket-1")
+  join_topic(channels, "socket-1", "room:lobby", socket)
+
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[null,\"ref-9\",\"room:lobby\",\"fail\",{}]",
+  )
+
+  let assert Ok(reply) = process.receive(socket, 500)
+  reply
+  |> string.contains("phx_reply")
+  |> should.be_true
+  reply
+  |> string.contains("\"status\":\"error\"")
+  |> should.be_true
+  reply
+  |> string.contains("nope")
+  |> should.be_true
+  reply
+  |> string.contains("ref-9")
+  |> should.be_true
+}
+
+pub fn reply_error_without_ref_is_dropped_test() {
+  let channels = start_with_error_channel()
+  let socket = connect_socket(channels, "socket-1")
+  join_topic(channels, "socket-1", "room:lobby", socket)
+
+  // No ref on the inbound message: there is nothing to correlate an error
+  // reply with, so no frame is sent.
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[null,null,\"room:lobby\",\"fail\",{}]",
+  )
+
+  process.receive(socket, 100)
+  |> should.be_error
+}

--- a/test/error_reply_test.gleam
+++ b/test/error_reply_test.gleam
@@ -101,6 +101,44 @@ pub fn reply_error_sends_error_status_reply_test() {
   |> should.be_true
 }
 
+pub fn event_on_unjoined_topic_gets_unmatched_topic_error_test() {
+  let channels = start_with_error_channel()
+  let socket = connect_socket(channels, "socket-1")
+
+  // Push to a topic this socket never joined: Phoenix clients expect an
+  // immediate error reply rather than a push timeout.
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[null,\"ref-1\",\"room:lobby\",\"hello\",{}]",
+  )
+
+  let assert Ok(reply) = process.receive(socket, 500)
+  reply
+  |> string.contains("\"status\":\"error\"")
+  |> should.be_true
+  reply
+  |> string.contains("unmatched topic")
+  |> should.be_true
+  reply
+  |> string.contains("ref-1")
+  |> should.be_true
+}
+
+pub fn unjoined_event_without_ref_is_dropped_test() {
+  let channels = start_with_error_channel()
+  let socket = connect_socket(channels, "socket-1")
+
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[null,null,\"room:lobby\",\"hello\",{}]",
+  )
+
+  process.receive(socket, 100)
+  |> should.be_error
+}
+
 pub fn reply_error_without_ref_is_dropped_test() {
   let channels = start_with_error_channel()
   let socket = connect_socket(channels, "socket-1")

--- a/test/heartbeat_test.gleam
+++ b/test/heartbeat_test.gleam
@@ -168,6 +168,23 @@ pub fn periodic_check_runs_repeatedly_test() {
   |> should.be_false
 }
 
+pub fn heartbeat_eviction_closes_the_transport_connection_test() {
+  let coord = start_coordinator_with_heartbeat(20, 50)
+  let closed = process.new_subject()
+
+  let _sent = connect_mock_socket(coord, "zombie-socket")
+  process.send(
+    coord,
+    coordinator.RegisterCloser("zombie-socket", fn() {
+      process.send(closed, Nil)
+    }),
+  )
+
+  // Never send a heartbeat: eviction must actively close the connection
+  // instead of leaving a zombie socket whose frames are silently dropped.
+  let assert Ok(Nil) = process.receive(closed, 1000)
+}
+
 pub fn no_heartbeat_check_when_interval_is_zero_test() {
   let coord = start_coordinator_with_heartbeat(0, 50)
   let sent = connect_mock_socket(coord, "socket-1")

--- a/test/logging_test.gleam
+++ b/test/logging_test.gleam
@@ -71,17 +71,17 @@ pub fn default_logging_preserves_info_without_payloads_test() {
   let config = beryl.config(wire.phoenix_codec())
 
   let logging = beryl.config_logging(config)
-  logging.level
-  |> should.equal(beryl.Info)
-  logging.include_payloads
+  beryl.logging_level(logging)
+  |> should.equal(beryl.InfoLevel)
+  beryl.logging_include_payloads(logging)
   |> should.be_false
-  logging.payload_preview_bytes
+  beryl.logging_payload_preview_bytes(logging)
   |> should.equal(200)
 }
 
 pub fn with_logging_replaces_logging_config_test() {
   let logging =
-    beryl.logging_config(level: beryl.Error, include_payloads: True)
+    beryl.logging_config(level: beryl.ErrorLevel, include_payloads: True)
     |> beryl.with_payload_preview_bytes(bytes: 64)
 
   let config =
@@ -89,11 +89,11 @@ pub fn with_logging_replaces_logging_config_test() {
     |> beryl.with_logging(logging)
 
   let logging = beryl.config_logging(config)
-  logging.level
-  |> should.equal(beryl.Error)
-  logging.include_payloads
+  beryl.logging_level(logging)
+  |> should.equal(beryl.ErrorLevel)
+  beryl.logging_include_payloads(logging)
   |> should.be_true
-  logging.payload_preview_bytes
+  beryl.logging_payload_preview_bytes(logging)
   |> should.equal(64)
 }
 
@@ -101,7 +101,7 @@ pub fn channels_start_accepts_debug_logging_config_test() {
   let config =
     beryl.config(wire.phoenix_codec())
     |> beryl.with_logging(beryl.logging_config(
-      level: beryl.Debug,
+      level: beryl.DebugLevel,
       include_payloads: False,
     ))
 
@@ -122,10 +122,10 @@ pub fn coordinator_config_has_safe_logging_defaults_test() {
 
 pub fn payload_preview_bytes_never_negative_test() {
   let logging =
-    beryl.logging_config(level: beryl.Debug, include_payloads: True)
+    beryl.logging_config(level: beryl.DebugLevel, include_payloads: True)
     |> beryl.with_payload_preview_bytes(bytes: -1)
 
-  logging.payload_preview_bytes
+  beryl.logging_payload_preview_bytes(logging)
   |> should.equal(0)
 }
 
@@ -163,7 +163,7 @@ pub fn debug_decode_log_omits_frame_preview_by_default_test() {
   let config =
     beryl.config(wire.phoenix_codec())
     |> beryl.with_logging(beryl.logging_config(
-      level: beryl.Debug,
+      level: beryl.DebugLevel,
       include_payloads: False,
     ))
   let assert Ok(channels) = beryl.start(config)
@@ -207,7 +207,7 @@ pub fn debug_join_missing_handler_logs_routing_and_send_test() {
   let config =
     beryl.config(wire.phoenix_codec())
     |> beryl.with_logging(beryl.logging_config(
-      level: beryl.Debug,
+      level: beryl.DebugLevel,
       include_payloads: False,
     ))
   let assert Ok(channels) = beryl.start(config)
@@ -250,7 +250,7 @@ pub fn debug_channel_callback_logs_push_result_test() {
   let config =
     beryl.config(wire.phoenix_codec())
     |> beryl.with_logging(beryl.logging_config(
-      level: beryl.Debug,
+      level: beryl.DebugLevel,
       include_payloads: False,
     ))
   let assert Ok(channels) = beryl.start(config)

--- a/test/logging_test.gleam
+++ b/test/logging_test.gleam
@@ -297,6 +297,34 @@ pub fn debug_channel_callback_logs_push_result_test() {
   stop_capture()
 }
 
+pub fn start_warns_when_no_abuse_controls_configured_test() {
+  let selector = begin_capture()
+
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+
+  receive_log(selector, "No abuse controls configured", 10)
+  |> should.be_ok
+
+  beryl.stop(channels)
+  stop_capture()
+}
+
+pub fn start_does_not_warn_when_a_limit_is_configured_test() {
+  let selector = begin_capture()
+
+  let assert Ok(channels) =
+    beryl.start(
+      beryl.config(wire.phoenix_codec())
+      |> beryl.with_message_rate(per_second: 100, burst: 200),
+    )
+
+  receive_log(selector, "No abuse controls configured", 2)
+  |> should.be_error
+
+  beryl.stop(channels)
+  stop_capture()
+}
+
 fn receive_log(
   selector: process.Selector(CapturedLog),
   message: String,

--- a/test/mist_handler_test.gleam
+++ b/test/mist_handler_test.gleam
@@ -219,6 +219,45 @@ pub fn handler_allows_unlimited_connections_when_limit_is_zero_test() {
   stop_supervisor(server_pid)
 }
 
+pub fn handler_sheds_message_flood_at_the_edge_test() {
+  let assert Ok(channels) =
+    beryl.start(
+      beryl.config(wire.phoenix_codec())
+      |> beryl.with_message_rate(per_second: 1, burst: 2),
+    )
+  let #(port, server_pid) = start_server(channels)
+  let assert Ok(client) = connect_websocket(port, "/socket")
+
+  // Flood heartbeats: only the burst allowance may produce replies. The
+  // rest are shed by the connection process before reaching the
+  // coordinator.
+  send_heartbeats(client, 10)
+  let replies = count_replies(client, 0)
+  { replies <= 2 } |> should.be_true
+  { replies >= 1 } |> should.be_true
+
+  close(client)
+  stop_supervisor(server_pid)
+}
+
+fn send_heartbeats(client: WebsocketClient, remaining: Int) -> Nil {
+  case remaining <= 0 {
+    True -> Nil
+    False -> {
+      let assert Ok(_) =
+        send_text(client, "[null,\"hb\",\"phoenix\",\"heartbeat\",{}]")
+      send_heartbeats(client, remaining - 1)
+    }
+  }
+}
+
+fn count_replies(client: WebsocketClient, count: Int) -> Int {
+  case receive_text(client, 200) {
+    Ok(_) -> count_replies(client, count + 1)
+    Error(Nil) -> count
+  }
+}
+
 pub fn handler_closes_socket_on_oversized_text_frame_test() {
   let #(port, server_pid) = start_frame_limited_server()
   let assert Ok(client) = connect_websocket(port, "/socket")

--- a/test/mist_handler_test.gleam
+++ b/test/mist_handler_test.gleam
@@ -169,6 +169,24 @@ pub fn handler_rejects_disallowed_origin_and_allows_allowed_origin_test() {
   stop_supervisor(server_pid)
 }
 
+pub fn handler_rejects_unsupported_protocol_version_test() {
+  let channels = start_channels()
+  let #(port, server_pid) = start_server(channels)
+
+  // Phoenix V1 clients are rejected at the handshake instead of connecting
+  // successfully and having every frame silently fail to decode.
+  websocket_upgrade_status(port, "/socket?vsn=1.0.0")
+  |> should.equal(Ok(403))
+
+  // The V2 version Phoenix JS sends is accepted, as is omitting vsn.
+  let assert Ok(v2_client) = connect_websocket(port, "/socket?vsn=2.0.0")
+  close(v2_client)
+  let assert Ok(bare_client) = connect_websocket(port, "/socket")
+  close(bare_client)
+
+  stop_supervisor(server_pid)
+}
+
 pub fn handler_rejects_connections_over_per_ip_limit_test() {
   let #(port, server_pid) = start_limited_server()
 

--- a/test/phoenix_binary_test.gleam
+++ b/test/phoenix_binary_test.gleam
@@ -1,0 +1,269 @@
+//// Phoenix V2 binary framing tests: byte-exact spec vectors for the
+//// encoders/decoder, plus end-to-end dispatch through the coordinator.
+
+import beryl
+import beryl/channel
+import beryl/coordinator
+import beryl/wire
+import beryl/wire/codec
+import gleam/dynamic
+import gleam/dynamic/decode
+import gleam/erlang/process
+import gleam/json
+import gleam/option.{None, Some}
+import gleam/string
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// === Decoder spec vectors ===
+
+pub fn decode_binary_client_push_test() {
+  // <<push=0, jr_len=2, ref_len=2, topic_len=10, event_len=4,
+  //   "j1", "r1", "room:lobby", "ping", payload...>>
+  let frame = <<
+    0,
+    2,
+    2,
+    10,
+    4,
+    "j1":utf8,
+    "r1":utf8,
+    "room:lobby":utf8,
+    "ping":utf8,
+    1,
+    2,
+    3,
+  >>
+
+  let assert Ok(inbound) = wire.decode_binary_message(frame)
+  codec.inbound_join_ref(inbound) |> should.equal(Some("j1"))
+  codec.inbound_ref(inbound) |> should.equal(Some("r1"))
+  codec.inbound_topic(inbound) |> should.equal("room:lobby")
+  codec.inbound_kind(inbound) |> should.equal(codec.Event("ping"))
+
+  let assert Ok(payload) =
+    decode.run(codec.inbound_payload(inbound), decode.bit_array)
+  payload |> should.equal(<<1, 2, 3>>)
+}
+
+pub fn decode_binary_zero_length_refs_are_none_test() {
+  let frame = <<0, 0, 0, 3, 3, "t:1":utf8, "evt":utf8>>
+
+  let assert Ok(inbound) = wire.decode_binary_message(frame)
+  codec.inbound_join_ref(inbound) |> should.equal(None)
+  codec.inbound_ref(inbound) |> should.equal(None)
+
+  // Empty payload survives as empty bytes.
+  let assert Ok(payload) =
+    decode.run(codec.inbound_payload(inbound), decode.bit_array)
+  payload |> should.equal(<<>>)
+}
+
+pub fn decode_binary_classifies_reserved_events_test() {
+  let join = <<
+    0,
+    2,
+    2,
+    6,
+    8,
+    "j1":utf8,
+    "r1":utf8,
+    "room:a":utf8,
+    "phx_join":utf8,
+  >>
+  let assert Ok(inbound) = wire.decode_binary_message(join)
+  codec.inbound_kind(inbound) |> should.equal(codec.Join)
+}
+
+pub fn decode_binary_rejects_truncated_frame_test() {
+  // Declares a 10-byte topic but the frame ends early.
+  let truncated = <<0, 0, 0, 10, 4, "sho":utf8>>
+  let assert Error(codec.InvalidFormat(_)) =
+    wire.decode_binary_message(truncated)
+
+  // Wrong kind byte (only client pushes are decodable server-side).
+  let wrong_kind = <<2, 3, 4, "abc":utf8, "defg":utf8>>
+  let assert Error(codec.InvalidFormat(_)) =
+    wire.decode_binary_message(wrong_kind)
+}
+
+// === Encoder spec vectors ===
+
+pub fn binary_push_encodes_spec_shape_test() {
+  let assert Ok(codec.BinaryFrame(frame)) =
+    wire.binary_push(
+      join_ref: Some("j1"),
+      topic: "room:lobby",
+      event: "tick",
+      payload: <<9, 8>>,
+    )
+  frame
+  |> should.equal(<<
+    0,
+    2,
+    10,
+    4,
+    "j1":utf8,
+    "room:lobby":utf8,
+    "tick":utf8,
+    9,
+    8,
+  >>)
+}
+
+pub fn binary_reply_encodes_spec_shape_test() {
+  let assert Ok(codec.BinaryFrame(frame)) =
+    wire.binary_reply(
+      join_ref: Some("j1"),
+      ref: Some("r7"),
+      topic: "room:a",
+      status: codec.StatusOk,
+      payload: <<1>>,
+    )
+  frame
+  |> should.equal(<<
+    1,
+    2,
+    2,
+    6,
+    2,
+    "j1":utf8,
+    "r7":utf8,
+    "room:a":utf8,
+    "ok":utf8,
+    1,
+  >>)
+}
+
+pub fn binary_broadcast_encodes_spec_shape_test() {
+  let assert Ok(codec.BinaryFrame(frame)) =
+    wire.binary_broadcast(topic: "room:a", event: "tick", payload: <<7>>)
+  frame
+  |> should.equal(<<2, 6, 4, "room:a":utf8, "tick":utf8, 7>>)
+}
+
+pub fn binary_encoders_reject_oversized_components_test() {
+  let long = string.repeat("a", 256)
+  wire.binary_push(join_ref: None, topic: long, event: "e", payload: <<>>)
+  |> should.be_error
+  wire.binary_broadcast(topic: "t", event: long, payload: <<>>)
+  |> should.be_error
+}
+
+// === End-to-end through the coordinator ===
+
+pub fn phoenix_binary_push_routes_to_handle_in_with_reply_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let seen = process.new_subject()
+
+  let handler =
+    channel.new(fn(_topic, _payload, socket) {
+      channel.JoinOk(reply: None, socket: socket)
+    })
+    |> channel.with_handle_in(fn(event, payload, socket) {
+      let assert Ok(bits) = channel.decode_payload(payload, decode.bit_array)
+      process.send(seen, #(event, bits))
+      channel.Reply(event: "ok", payload: json.object([]), socket: socket)
+    })
+  let assert Ok(_) = beryl.register(channels, "room:*", handler)
+
+  let sent = process.new_subject()
+  process.send(
+    beryl.coordinator_subject(channels),
+    coordinator.SocketConnected(
+      "socket-1",
+      fn(text) {
+        process.send(sent, text)
+        Ok(Nil)
+      },
+      fn(_) { Ok(Nil) },
+      None,
+      dynamic.nil(),
+    ),
+  )
+  process.sleep(10)
+
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[\"j1\",\"j1\",\"room:lobby\",\"phx_join\",{}]",
+  )
+  let assert Ok(_join_reply) = process.receive(sent, 500)
+
+  // Client binary push: routed to the joined channel, not fanned out raw.
+  coordinator.route_binary(beryl.coordinator_subject(channels), "socket-1", <<
+    0,
+    2,
+    2,
+    10,
+    6,
+    "j1":utf8,
+    "r9":utf8,
+    "room:lobby":utf8,
+    "put_op":utf8,
+    42,
+    43,
+  >>)
+
+  let assert Ok(#(event, bits)) = process.receive(seen, 500)
+  event |> should.equal("put_op")
+  bits |> should.equal(<<42, 43>>)
+
+  // The reply correlates with the binary push's ref and join_ref.
+  let assert Ok(reply) = process.receive(sent, 500)
+  reply |> string.contains("phx_reply") |> should.be_true
+  reply |> string.contains("r9") |> should.be_true
+  reply |> string.contains("j1") |> should.be_true
+}
+
+pub fn phoenix_malformed_binary_frame_is_dropped_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let seen_binary = process.new_subject()
+
+  let handler =
+    channel.new(fn(_topic, _payload, socket) {
+      channel.JoinOk(reply: None, socket: socket)
+    })
+    |> channel.with_handle_binary(fn(data, socket) {
+      process.send(seen_binary, data)
+      channel.NoReply(socket)
+    })
+  let assert Ok(_) = beryl.register(channels, "room:*", handler)
+
+  let sent = process.new_subject()
+  process.send(
+    beryl.coordinator_subject(channels),
+    coordinator.SocketConnected(
+      "socket-1",
+      fn(text) {
+        process.send(sent, text)
+        Ok(Nil)
+      },
+      fn(_) { Ok(Nil) },
+      None,
+      dynamic.nil(),
+    ),
+  )
+  process.sleep(10)
+
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "socket-1",
+    "[\"j1\",\"j1\",\"room:lobby\",\"phx_join\",{}]",
+  )
+  let assert Ok(_join_reply) = process.receive(sent, 500)
+
+  // Undecodable bytes are dropped for the Phoenix codec — they no longer
+  // fan out raw to handle_binary.
+  coordinator.route_binary(beryl.coordinator_subject(channels), "socket-1", <<
+    255,
+    1,
+    2,
+    3,
+  >>)
+  process.receive(seen_binary, 100) |> should.be_error
+}

--- a/test/phoenix_contract_test.gleam
+++ b/test/phoenix_contract_test.gleam
@@ -322,7 +322,9 @@ pub fn json_contract_join_custom_broadcast_heartbeat_leave_test() {
       ),
     )
   let reply = latest_text_message(client)
-  let frame = assert_reply(serializer, reply, None, "event-1", "room:lobby")
+  // Event replies echo the channel's join_ref, matching Phoenix.
+  let frame =
+    assert_reply(serializer, reply, Some("join-ref"), "event-1", "room:lobby")
   let response = dynamic_field(frame.payload, "response")
   assert_json_bool(response, "pong", True)
 
@@ -392,7 +394,8 @@ pub fn json_contract_join_custom_broadcast_heartbeat_leave_test() {
       serializer.leave("join-ref", "leave-1", "room:lobby", json.object([])),
     )
   let leave = latest_text_message(client)
-  let _ = assert_reply(serializer, leave, None, "leave-1", "room:lobby")
+  let _ =
+    assert_reply(serializer, leave, Some("join-ref"), "leave-1", "room:lobby")
   let assert Ok(reason) = process.receive(terminated, 200)
   reason |> should.equal(channel.Normal)
 

--- a/test/presence_replication_test.gleam
+++ b/test/presence_replication_test.gleam
@@ -357,3 +357,95 @@ fn drain_mailbox() -> Nil {
     Error(_) -> Nil
   }
 }
+
+// ── Restart safety: incarnation-unique replicas ───────────────────────
+
+/// Kill a presence actor's process, simulating a crash without cleanup.
+fn kill_presence(p: presence.Presence) -> Nil {
+  let assert Ok(pid) = process.subject_owner(presence.subject(p))
+  // The actor is linked to this (test) process; unlink before killing so
+  // the exit signal does not take the test runner down with it.
+  process.unlink(pid)
+  process.kill(pid)
+  // Wait for the process to actually be gone.
+  test_helpers.wait_until(fn() { !process.is_alive(pid) }, 1000, 5)
+  Nil
+}
+
+pub fn restarted_node_presences_replicate_to_peers_test() {
+  let ps = test_pubsub("restart_join")
+  let assert Ok(p1) = presence.start(test_config(ps, "node1", 30))
+  let assert Ok(p2) = presence.start(test_config(ps, "node2", 30))
+
+  // Seed replication both ways so node2's context covers node1's clocks.
+  let _ =
+    presence.track(p1, "room:lobby", "user:old", "socket-old", json.null())
+  test_helpers.wait_until(
+    fn() { list.length(presence.list(p2, "room:lobby")) == 1 },
+    2000,
+    10,
+  )
+
+  // Crash node1 and restart it under the same configured base name.
+  kill_presence(p1)
+  let assert Ok(p1b) = presence.start(test_config(ps, "node1", 30))
+
+  // A presence tracked by the restarted incarnation must become visible on
+  // node2. Without incarnation-unique replicas, node2's causal context
+  // already covered the reused clocks and silently dropped this join.
+  let _ =
+    presence.track(p1b, "room:lobby", "user:new", "socket-new", json.null())
+  test_helpers.wait_until(
+    fn() {
+      presence.list(p2, "room:lobby")
+      |> list.any(fn(entry) { entry.key == "user:new" })
+    },
+    2000,
+    10,
+  )
+  presence.list(p2, "room:lobby")
+  |> list.any(fn(entry) { entry.key == "user:new" })
+  |> should.be_true
+}
+
+pub fn restart_prunes_previous_incarnations_ghosts_test() {
+  let ps = test_pubsub("restart_ghosts")
+  let assert Ok(p1) = presence.start(test_config(ps, "node1", 30))
+  let assert Ok(p2) = presence.start(test_config(ps, "node2", 30))
+
+  // node1 tracks a presence whose session dies with the node.
+  let _ =
+    presence.track(p1, "room:lobby", "user:ghost", "socket-dead", json.null())
+  test_helpers.wait_until(
+    fn() { list.length(presence.list(p2, "room:lobby")) == 1 },
+    2000,
+    10,
+  )
+
+  kill_presence(p1)
+  let assert Ok(p1b) = presence.start(test_config(ps, "node1", 30))
+  // Give the new incarnation something to gossip so peers observe it.
+  let _ =
+    presence.track(p1b, "room:lobby", "user:live", "socket-live", json.null())
+
+  // The dead incarnation's entry disappears from the peer once it observes
+  // the new incarnation, and it must not resurrect into the restarted node
+  // via merges of the peer's state.
+  test_helpers.wait_until(
+    fn() {
+      let on_p2 =
+        presence.list(p2, "room:lobby") |> list.map(fn(entry) { entry.key })
+      let on_p1b =
+        presence.list(p1b, "room:lobby") |> list.map(fn(entry) { entry.key })
+      on_p2 == ["user:live"] && on_p1b == ["user:live"]
+    },
+    3000,
+    10,
+  )
+  presence.list(p2, "room:lobby")
+  |> list.map(fn(entry) { entry.key })
+  |> should.equal(["user:live"])
+  presence.list(p1b, "room:lobby")
+  |> list.map(fn(entry) { entry.key })
+  |> should.equal(["user:live"])
+}

--- a/test/presence_replication_test.gleam
+++ b/test/presence_replication_test.gleam
@@ -130,6 +130,7 @@ pub fn remote_state_triggers_merge_via_pubsub_test() {
   let config1 =
     presence.default_config("node1")
     |> presence.with_pubsub(ps)
+    |> presence.with_broadcast_interval(0)
   let assert Ok(p1) = presence.start(config1)
 
   // Node2 with broadcasting enabled

--- a/test/presence_test.gleam
+++ b/test/presence_test.gleam
@@ -2,6 +2,7 @@ import beryl/presence
 import gleam/erlang/process
 import gleam/json
 import gleam/list
+import gleam/string
 import gleeunit
 import gleeunit/should
 
@@ -196,14 +197,17 @@ pub fn on_diff_callback_receives_local_track_diff_test() {
   let assert Ok(diff) = process.receive(diff_subject, 1000)
   presence.diff_topics(diff)
   |> should.equal(["room:lobby"])
-  presence.diff_joins(diff, "room:lobby")
-  |> should.equal([
-    presence.PresenceEntry(
-      session_id: "socket-1",
-      key: "user:1",
-      meta: json.object([#("status", json.string("online"))]),
-    ),
-  ])
+  let assert [entry] = presence.diff_joins(diff, "room:lobby")
+  entry.session_id |> should.equal("socket-1")
+  entry.key |> should.equal("user:1")
+  // The tracked meta carries the original fields plus the injected phx_ref
+  let encoded_meta = json.to_string(entry.meta)
+  encoded_meta
+  |> string.contains("\"status\":\"online\"")
+  |> should.be_true
+  encoded_meta
+  |> string.contains("phx_ref")
+  |> should.be_true
   presence.diff_leaves(diff, "room:lobby") |> should.equal([])
 }
 
@@ -231,14 +235,17 @@ pub fn on_diff_callback_receives_local_untrack_diff_test() {
   presence.diff_topics(diff)
   |> should.equal(["room:lobby"])
   presence.diff_joins(diff, "room:lobby") |> should.equal([])
-  presence.diff_leaves(diff, "room:lobby")
-  |> should.equal([
-    presence.PresenceEntry(
-      session_id: "socket-1",
-      key: "user:1",
-      meta: json.object([#("status", json.string("online"))]),
-    ),
-  ])
+  let assert [entry] = presence.diff_leaves(diff, "room:lobby")
+  entry.session_id |> should.equal("socket-1")
+  entry.key |> should.equal("user:1")
+  // The leave carries the same meta the track stored, including its phx_ref
+  let encoded_meta = json.to_string(entry.meta)
+  encoded_meta
+  |> string.contains("\"status\":\"online\"")
+  |> should.be_true
+  encoded_meta
+  |> string.contains("phx_ref")
+  |> should.be_true
 }
 
 pub fn on_diff_callback_receives_all_rapid_diffs_test() {

--- a/test/presence_wire_test.gleam
+++ b/test/presence_wire_test.gleam
@@ -120,3 +120,124 @@ pub fn encode_diff_omits_other_topics_test() {
   |> string.contains("ignored")
   |> should.be_false
 }
+
+pub fn encode_state_groups_metas_by_presence_key_test() {
+  let entries = [
+    presence.PresenceEntry(
+      session_id: "socket-1",
+      key: "user:1",
+      meta: json.object([#("status", json.string("online"))]),
+    ),
+    presence.PresenceEntry(
+      session_id: "socket-2",
+      key: "user:1",
+      meta: json.object([#("status", json.string("away"))]),
+    ),
+    presence.PresenceEntry(
+      session_id: "socket-3",
+      key: "user:2",
+      meta: json.object([#("device", json.string("mobile"))]),
+    ),
+  ]
+
+  let encoded = json.to_string(presence_wire.encode_state(entries))
+
+  let user1_decoder = {
+    use metas <- decode.field("user:1", {
+      use metas <- decode.field(
+        "metas",
+        decode.list({
+          use status <- decode.field("status", decode.string)
+          decode.success(status)
+        }),
+      )
+      decode.success(metas)
+    })
+    decode.success(metas)
+  }
+  let assert Ok(user1_metas) = json.parse(encoded, user1_decoder)
+  user1_metas |> list.length |> should.equal(2)
+
+  let user2_decoder = {
+    use metas <- decode.field("user:2", {
+      use metas <- decode.field(
+        "metas",
+        decode.list({
+          use device <- decode.field("device", decode.string)
+          decode.success(device)
+        }),
+      )
+      decode.success(metas)
+    })
+    decode.success(metas)
+  }
+  let assert Ok(user2_metas) = json.parse(encoded, user2_decoder)
+  user2_metas |> should.equal(["mobile"])
+}
+
+pub fn tracked_metas_carry_phx_ref_test() {
+  let assert Ok(p) = presence.start(presence.default_config("wire-node"))
+
+  let ref =
+    presence.track(
+      p,
+      "room:lobby",
+      "user:1",
+      "socket-1",
+      json.object([#("status", json.string("online"))]),
+    )
+
+  let assert [entry] = presence.list(p, "room:lobby")
+
+  let phx_ref_decoder = {
+    use phx_ref <- decode.field("phx_ref", decode.string)
+    decode.success(phx_ref)
+  }
+  let assert Ok(phx_ref) =
+    json.parse(json.to_string(entry.meta), phx_ref_decoder)
+  phx_ref |> should.equal(ref)
+
+  // The user's own meta fields are preserved alongside phx_ref
+  let status_decoder = {
+    use status <- decode.field("status", decode.string)
+    decode.success(status)
+  }
+  let assert Ok(status) = json.parse(json.to_string(entry.meta), status_decoder)
+  status |> should.equal("online")
+}
+
+pub fn tracked_multi_session_metas_have_distinct_phx_refs_test() {
+  let assert Ok(p) = presence.start(presence.default_config("wire-node-2"))
+
+  let ref1 =
+    presence.track(p, "room:lobby", "user:1", "socket-1", json.object([]))
+  let ref2 =
+    presence.track(p, "room:lobby", "user:1", "socket-2", json.object([]))
+
+  { ref1 != ref2 } |> should.be_true
+
+  let entries = presence.list(p, "room:lobby")
+  entries |> list.length |> should.equal(2)
+
+  let phx_ref_decoder = {
+    use phx_ref <- decode.field("phx_ref", decode.string)
+    decode.success(phx_ref)
+  }
+  let refs =
+    list.filter_map(entries, fn(entry) {
+      json.parse(json.to_string(entry.meta), phx_ref_decoder)
+    })
+  refs |> list.length |> should.equal(2)
+  list.contains(refs, ref1) |> should.be_true
+  list.contains(refs, ref2) |> should.be_true
+}
+
+pub fn non_object_meta_is_stored_unchanged_test() {
+  let assert Ok(p) = presence.start(presence.default_config("wire-node-3"))
+
+  let _ref =
+    presence.track(p, "room:lobby", "user:1", "socket-1", json.string("plain"))
+
+  let assert [entry] = presence.list(p, "room:lobby")
+  json.to_string(entry.meta) |> should.equal("\"plain\"")
+}

--- a/test/protocol_hardening_test.gleam
+++ b/test/protocol_hardening_test.gleam
@@ -73,13 +73,11 @@ fn count_messages(subject: process.Subject(String), count: Int) -> Int {
 }
 
 pub fn heartbeat_flood_is_message_rate_limited_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 1, burst: 2))
   let assert Ok(coord) =
     coordinator.start_with_config(
       coordinator.CoordinatorConfig(
         ..coordinator.config(wire.phoenix_codec()),
-        message_limiter: Some(limiter),
+        message_limits: Some(rate_limit.config(per_second: 1, burst: 2)),
       ),
     )
 
@@ -90,7 +88,6 @@ pub fn heartbeat_flood_is_message_rate_limited_test() {
   let replies = count_messages(sent, 0)
   { replies <= 2 } |> should.be_true
   { replies >= 1 } |> should.be_true
-  rate_limit.stop(limiter)
 }
 
 fn send_heartbeats(

--- a/test/protocol_hardening_test.gleam
+++ b/test/protocol_hardening_test.gleam
@@ -1,0 +1,160 @@
+//// Protocol hardening tests: reserved names and rate-limit coverage for
+//// protocol frames.
+
+import beryl/coordinator
+import beryl/rate_limit
+import beryl/topic
+import beryl/wire
+import gleam/dynamic
+import gleam/erlang/process
+import gleam/option.{None, Some}
+import gleam/string
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+fn connect(
+  coord: process.Subject(coordinator.Message),
+  socket_id: String,
+) -> process.Subject(String) {
+  let sent = process.new_subject()
+  let send = fn(message: String) -> Result(Nil, Nil) {
+    process.send(sent, message)
+    Ok(Nil)
+  }
+  process.send(
+    coord,
+    coordinator.SocketConnected(
+      socket_id,
+      send,
+      fn(_) { Ok(Nil) },
+      None,
+      dynamic.nil(),
+    ),
+  )
+  process.sleep(10)
+  sent
+}
+
+fn register_notifying_channel(
+  coord: process.Subject(coordinator.Message),
+  handled: process.Subject(String),
+) -> Nil {
+  let handler =
+    coordinator.ChannelHandler(
+      id: 0,
+      pattern: topic.parse_pattern("*"),
+      join: fn(_topic, _payload, _ctx) {
+        coordinator.JoinOkErased(reply: None, assigns: dynamic.nil())
+      },
+      handle_in: fn(event, _payload, ctx) {
+        process.send(handled, event)
+        coordinator.NoReplyErased(assigns: ctx.assigns)
+      },
+      handle_binary: fn(_data, ctx) {
+        coordinator.NoReplyErased(assigns: ctx.assigns)
+      },
+      terminate: fn(_reason, _ctx) { Nil },
+    )
+  let reply = process.new_subject()
+  process.send(coord, coordinator.RegisterChannel("*", handler, reply))
+  let assert Ok(Ok(_)) = process.receive(reply, 500)
+  Nil
+}
+
+fn count_messages(subject: process.Subject(String), count: Int) -> Int {
+  case process.receive(subject, 50) {
+    Ok(_) -> count_messages(subject, count + 1)
+    Error(_) -> count
+  }
+}
+
+pub fn heartbeat_flood_is_message_rate_limited_test() {
+  let assert Ok(limiter) =
+    rate_limit.start(rate_limit.config(per_second: 1, burst: 2))
+  let assert Ok(coord) =
+    coordinator.start_with_config(
+      coordinator.CoordinatorConfig(
+        ..coordinator.config(wire.phoenix_codec()),
+        message_limiter: Some(limiter),
+      ),
+    )
+
+  let sent = connect(coord, "socket-1")
+  send_heartbeats(coord, "socket-1", 10)
+
+  // Only the burst allowance produces replies; the flood is shed.
+  let replies = count_messages(sent, 0)
+  { replies <= 2 } |> should.be_true
+  { replies >= 1 } |> should.be_true
+  rate_limit.stop(limiter)
+}
+
+fn send_heartbeats(
+  coord: process.Subject(coordinator.Message),
+  socket_id: String,
+  remaining: Int,
+) -> Nil {
+  case remaining {
+    0 -> Nil
+    _ -> {
+      coordinator.route_message(
+        coord,
+        socket_id,
+        "[null,\"hb\",\"phoenix\",\"heartbeat\",{}]",
+      )
+      send_heartbeats(coord, socket_id, remaining - 1)
+    }
+  }
+}
+
+pub fn join_to_reserved_beryl_topic_is_rejected_test() {
+  let assert Ok(coord) = coordinator.start(wire.phoenix_codec())
+  let handled = process.new_subject()
+  register_notifying_channel(coord, handled)
+
+  let sent = connect(coord, "socket-1")
+  coordinator.route_message(
+    coord,
+    "socket-1",
+    "[null,\"ref-1\",\"beryl:presence:sync\",\"phx_join\",{}]",
+  )
+
+  // Rejected with an error reply even though a catch-all handler matches.
+  let assert Ok(reply) = process.receive(sent, 500)
+  reply |> string.contains("\"error\"") |> should.be_true
+  reply |> string.contains("invalid_topic") |> should.be_true
+}
+
+pub fn client_sent_reserved_phx_events_never_reach_handlers_test() {
+  let assert Ok(coord) = coordinator.start(wire.phoenix_codec())
+  let handled = process.new_subject()
+  register_notifying_channel(coord, handled)
+
+  let sent = connect(coord, "socket-1")
+  coordinator.route_message(
+    coord,
+    "socket-1",
+    "[null,\"j1\",\"room:lobby\",\"phx_join\",{}]",
+  )
+  let assert Ok(_join_reply) = process.receive(sent, 500)
+
+  // A forged protocol event must be dropped before the channel handler.
+  coordinator.route_message(
+    coord,
+    "socket-1",
+    "[\"j1\",\"ref-2\",\"room:lobby\",\"phx_reply\",{}]",
+  )
+  process.receive(handled, 100) |> should.be_error
+
+  // Ordinary events still flow.
+  coordinator.route_message(
+    coord,
+    "socket-1",
+    "[\"j1\",\"ref-3\",\"room:lobby\",\"shout\",{}]",
+  )
+  let assert Ok("shout") = process.receive(handled, 500)
+}

--- a/test/rate_limit_test.gleam
+++ b/test/rate_limit_test.gleam
@@ -1,197 +1,84 @@
+//// Tests for the pure token-bucket rate limiter.
+
 import beryl/rate_limit
 import gleam/erlang/process
-import gleam/option
+import gleam/list
 import gleeunit/should
 
-// ── Token bucket basic behavior ─────────────────────────────────────────────
-
-pub fn rate_limiter_allows_within_limit_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 100, burst: 10))
-
-  // First 10 requests should be allowed (burst capacity)
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-
-  rate_limit.stop(limiter)
+fn take_n(
+  bucket: rate_limit.Bucket,
+  count: Int,
+) -> #(rate_limit.Bucket, List(Result(Nil, Nil))) {
+  case count <= 0 {
+    True -> #(bucket, [])
+    False -> {
+      let #(bucket, taken) = rate_limit.take(bucket)
+      let #(bucket, rest) = take_n(bucket, count - 1)
+      #(bucket, [taken, ..rest])
+    }
+  }
 }
 
-pub fn rate_limiter_rejects_over_limit_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 100, burst: 3))
+pub fn burst_allows_up_to_capacity_test() {
+  let bucket = rate_limit.new_bucket(rate_limit.config(per_second: 1, burst: 3))
 
-  // Exhaust the burst
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
+  let #(bucket, results) = take_n(bucket, 3)
+  results |> list.all(fn(taken) { taken == Ok(Nil) }) |> should.be_true
 
-  // Should be rate limited now
-  should.be_error(rate_limit.check(limiter, "key1"))
-
-  rate_limit.stop(limiter)
+  // The bucket is empty now; the next take is limited.
+  let #(_bucket, taken) = rate_limit.take(bucket)
+  taken |> should.equal(Error(Nil))
 }
 
-pub fn rate_limiter_per_key_isolation_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
+pub fn burst_defaults_to_per_second_when_zero_test() {
+  let bucket = rate_limit.new_bucket(rate_limit.config(per_second: 5, burst: 0))
 
-  // Exhaust key1's bucket
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_error(rate_limit.check(limiter, "key1"))
+  let #(bucket, results) = take_n(bucket, 5)
+  results |> list.all(fn(taken) { taken == Ok(Nil) }) |> should.be_true
 
-  // key2 should still have full bucket
-  should.be_ok(rate_limit.check(limiter, "key2"))
-  should.be_ok(rate_limit.check(limiter, "key2"))
-
-  rate_limit.stop(limiter)
+  let #(_bucket, taken) = rate_limit.take(bucket)
+  taken |> should.equal(Error(Nil))
 }
 
-pub fn rate_limiter_refills_over_time_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
+pub fn tokens_refill_over_time_test() {
+  // 100 tokens/second = one token every 10ms.
+  let bucket =
+    rate_limit.new_bucket(rate_limit.config(per_second: 100, burst: 1))
 
-  // Exhaust the bucket
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_error(rate_limit.check(limiter, "key1"))
+  let #(bucket, taken) = rate_limit.take(bucket)
+  taken |> should.equal(Ok(Nil))
+  let #(bucket, taken) = rate_limit.take(bucket)
+  taken |> should.equal(Error(Nil))
 
-  // Wait for tokens to refill (at 100/sec, 1 token every 10ms)
-  process.sleep(25)
-
-  // Should have tokens again
-  should.be_ok(rate_limit.check(limiter, "key1"))
-
-  rate_limit.stop(limiter)
+  // After enough time for at least one token to refill, a take succeeds.
+  process.sleep(30)
+  let #(_bucket, taken) = rate_limit.take(bucket)
+  taken |> should.equal(Ok(Nil))
 }
 
-// ── Optional limiter ────────────────────────────────────────────────────────
+pub fn refill_never_exceeds_burst_capacity_test() {
+  let bucket =
+    rate_limit.new_bucket(rate_limit.config(per_second: 1000, burst: 2))
 
-pub fn check_optional_none_always_allows_test() {
-  // None limiter should always allow
-  should.be_ok(rate_limit.check_optional(option.None, "any_key"))
+  // Wait long enough to refill far more than the burst if uncapped.
+  process.sleep(50)
+
+  let #(bucket, results) = take_n(bucket, 2)
+  results |> list.all(fn(taken) { taken == Ok(Nil) }) |> should.be_true
+
+  let #(_bucket, taken) = rate_limit.take(bucket)
+  taken |> should.equal(Error(Nil))
 }
 
-pub fn check_optional_some_applies_limit_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 100, burst: 1))
+pub fn independent_buckets_do_not_share_tokens_test() {
+  let config = rate_limit.config(per_second: 1, burst: 1)
+  let one = rate_limit.new_bucket(config)
+  let two = rate_limit.new_bucket(config)
 
-  should.be_ok(rate_limit.check_optional(option.Some(limiter), "key1"))
-  should.be_error(rate_limit.check_optional(option.Some(limiter), "key1"))
+  let #(_one, taken_one) = rate_limit.take(one)
+  taken_one |> should.equal(Ok(Nil))
 
-  rate_limit.stop(limiter)
-}
-
-// ── Cleanup ─────────────────────────────────────────────────────────────────
-
-pub fn remove_by_prefix_cleans_up_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
-
-  // Create some buckets
-  should.be_ok(rate_limit.check(limiter, "ch:socket1:room:lobby"))
-  should.be_ok(rate_limit.check(limiter, "ch:socket1:room:lobby"))
-  should.be_error(rate_limit.check(limiter, "ch:socket1:room:lobby"))
-
-  // Remove by prefix for socket1
-  rate_limit.remove_by_prefix(limiter, "ch:socket1:")
-
-  // After cleanup, a new bucket is created — should be allowed again
-  should.be_ok(rate_limit.check(limiter, "ch:socket1:room:lobby"))
-
-  rate_limit.stop(limiter)
-}
-
-pub fn remove_by_prefix_preserves_other_keys_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
-
-  // Create buckets for two sockets
-  should.be_ok(rate_limit.check(limiter, "ch:socket1:topic"))
-  should.be_ok(rate_limit.check(limiter, "ch:socket1:topic"))
-  should.be_ok(rate_limit.check(limiter, "ch:socket2:topic"))
-  should.be_ok(rate_limit.check(limiter, "ch:socket2:topic"))
-
-  // Remove socket1 only
-  rate_limit.remove_by_prefix(limiter, "ch:socket1:")
-
-  // socket2's state should be preserved (still limited)
-  should.be_error(rate_limit.check(limiter, "ch:socket2:topic"))
-
-  rate_limit.stop(limiter)
-}
-
-// ── Burst defaults ──────────────────────────────────────────────────────────
-
-pub fn burst_defaults_to_per_second_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 5, burst: 0))
-
-  // With burst=0, it defaults to per_second (5)
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_error(rate_limit.check(limiter, "key1"))
-
-  rate_limit.stop(limiter)
-}
-
-// ── Remove by prefix optional ───────────────────────────────────────────────
-
-pub fn remove_by_prefix_optional_none_is_noop_test() {
-  // Should not crash
-  rate_limit.remove_by_prefix_optional(option.None, "anything")
-}
-
-pub fn bucket_count_reports_active_keys_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
-
-  rate_limit.bucket_count(limiter) |> should.equal(0)
-  should.be_ok(rate_limit.check(limiter, "socket:one"))
-  should.be_ok(rate_limit.check(limiter, "socket:two"))
-  rate_limit.bucket_count(limiter) |> should.equal(2)
-
-  rate_limit.remove_by_prefix(limiter, "socket:")
-  process.sleep(10)
-  rate_limit.bucket_count(limiter) |> should.equal(0)
-
-  rate_limit.stop(limiter)
-}
-
-pub fn check_capped_rejects_new_keys_after_cap_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 100, burst: 2))
-
-  should.be_ok(rate_limit.check_capped(limiter, "socket:one", "socket:", 2))
-  should.be_ok(rate_limit.check_capped(limiter, "socket:two", "socket:", 2))
-  should.be_error(rate_limit.check_capped(limiter, "socket:three", "socket:", 2))
-  rate_limit.bucket_count(limiter) |> should.equal(2)
-
-  should.be_ok(rate_limit.check_capped(limiter, "other:one", "other:", 2))
-  rate_limit.bucket_count(limiter) |> should.equal(3)
-  rate_limit.bucket_count_by_prefix(limiter, "socket:") |> should.equal(2)
-
-  should.be_ok(rate_limit.check_capped(limiter, "socket:one", "socket:", 2))
-
-  rate_limit.stop(limiter)
-}
-
-pub fn stopped_limiter_checks_fail_open_test() {
-  let assert Ok(limiter) =
-    rate_limit.start(rate_limit.config(per_second: 100, burst: 1))
-
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  rate_limit.bucket_count(limiter) |> should.equal(1)
-
-  rate_limit.stop(limiter)
-
-  should.be_ok(rate_limit.check(limiter, "key1"))
-  should.be_ok(rate_limit.check_capped(limiter, "key1", "key:", 1))
-  rate_limit.bucket_count(limiter) |> should.equal(0)
+  // Draining bucket one leaves bucket two untouched.
+  let #(_two, taken_two) = rate_limit.take(two)
+  taken_two |> should.equal(Ok(Nil))
 }

--- a/test/supervisor_test.gleam
+++ b/test/supervisor_test.gleam
@@ -1,12 +1,15 @@
 import beryl
 import beryl/channel
+import beryl/coordinator
 import beryl/group
 import beryl/presence
 import beryl/supervisor
 import beryl/wire
+import gleam/dynamic
 import gleam/erlang/process
 import gleam/json
 import gleam/option.{None, Some}
+import gleam/string
 import gleeunit/should
 import test_helpers
 
@@ -202,6 +205,63 @@ pub fn supervised_coordinator_restarts_on_crash_test() {
   let result =
     beryl.register(supervisor.channels(supervised), "post-crash:*", handler2)
   result |> should.be_ok
+}
+
+pub fn registrations_survive_coordinator_restart_test() {
+  let config = supervisor.config(beryl.config(wire.phoenix_codec()))
+  let assert Ok(supervised) = supervisor.start(config)
+  let channels = supervisor.channels(supervised)
+
+  // Register before the crash — and never again afterwards.
+  let handler =
+    channel.new(fn(_topic, _payload, socket) {
+      channel.JoinOk(reply: None, socket: socket)
+    })
+  let assert Ok(_) = beryl.register(channels, "survivor:*", handler)
+
+  // Crash the coordinator and wait for the supervisor to restart it.
+  let assert Ok(name) =
+    process.subject_name(beryl.coordinator_subject(channels))
+  let coord_subject = process.named_subject(name)
+  let assert Ok(old_pid) = get_subject_pid(coord_subject)
+  process.send_abnormal_exit(old_pid, crash_reason())
+  test_helpers.wait_until(
+    fn() {
+      case get_subject_pid(coord_subject) {
+        Ok(new_pid) -> new_pid != old_pid && process.is_alive(new_pid)
+        Error(_) -> False
+      }
+    },
+    2000,
+    10,
+  )
+
+  // A join on the pre-crash pattern succeeds without re-registering: the
+  // restarted coordinator re-seeded its handlers from the registry.
+  let sent = process.new_subject()
+  process.send(
+    coord_subject,
+    coordinator.SocketConnected(
+      "post-restart-socket",
+      fn(text) {
+        process.send(sent, text)
+        Ok(Nil)
+      },
+      fn(_) { Ok(Nil) },
+      None,
+      dynamic.nil(),
+    ),
+  )
+  process.sleep(10)
+  coordinator.route_message(
+    coord_subject,
+    "post-restart-socket",
+    "[\"j1\",\"j1\",\"survivor:lobby\",\"phx_join\",{}]",
+  )
+
+  let assert Ok(reply) = process.receive(sent, 1000)
+  reply |> string.contains("phx_reply") |> should.be_true
+  reply |> string.contains("\"status\":\"ok\"") |> should.be_true
 }
 
 // ── RestForOne cascading restart tests ─────────────────────────────────────

--- a/test/topic_fallback_test.gleam
+++ b/test/topic_fallback_test.gleam
@@ -11,7 +11,10 @@ import gleam/string
 import gleeunit/should
 
 fn start_with_socket(socket_id) {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  // Empty-topic fallback is an explicit codec capability for topicless
+  // framings; the plain Phoenix codec drops empty-topic events instead.
+  let topicless = wire.phoenix_codec() |> codec.with_topicless_events()
+  let assert Ok(channels) = beryl.start(beryl.config(topicless))
   let sent = process.new_subject()
   process.send(
     beryl.coordinator_subject(channels),
@@ -56,6 +59,41 @@ pub fn topicless_event_routes_to_single_join_test() {
   )
   let assert Ok(reply) = process.receive(sent, 500)
   reply |> string.contains("echoed") |> should.be_true
+}
+
+// The plain Phoenix codec never guesses: an empty-topic event is dropped
+// even when the socket has exactly one join, matching Phoenix.
+pub fn phoenix_codec_drops_topicless_events_test() {
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let sent = process.new_subject()
+  process.send(
+    beryl.coordinator_subject(channels),
+    coordinator.SocketConnected(
+      "s3",
+      fn(text) {
+        process.send(sent, text)
+        Ok(Nil)
+      },
+      fn(_) { Ok(Nil) },
+      option.None,
+      dynamic.nil(),
+    ),
+  )
+  let assert Ok(_) = beryl.register(channels, "room:*", echo_channel())
+
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "s3",
+    "[null,\"jr\",\"room:lobby\",\"phx_join\",{}]",
+  )
+  let assert Ok(_) = process.receive(sent, 500)
+
+  coordinator.route_message(
+    beryl.coordinator_subject(channels),
+    "s3",
+    "[null,null,\"\",\"submitOp\",{}]",
+  )
+  process.receive(sent, 200) |> should.be_error
 }
 
 // With no join, a topic-less event is dropped (nothing sent back).

--- a/test/wire_codec_test.gleam
+++ b/test/wire_codec_test.gleam
@@ -21,8 +21,8 @@ pub fn phoenix_codec_round_trip_test() {
   let encoded =
     text_frame(codec.encode_push(phoenix)("room:1", "msg", json.string("hi")))
   let assert Ok(inbound) = codec.decode_text(phoenix)(encoded)
-  inbound.topic |> should.equal("room:1")
-  inbound.kind |> should.equal(codec.Event("msg"))
+  codec.inbound_topic(inbound) |> should.equal("room:1")
+  codec.inbound_kind(inbound) |> should.equal(codec.Event("msg"))
 }
 
 pub fn phoenix_codec_decodes_system_events_to_kinds_test() {
@@ -30,25 +30,25 @@ pub fn phoenix_codec_decodes_system_events_to_kinds_test() {
 
   let assert Ok(join) =
     codec.decode_text(phoenix)("[\"j\",\"r\",\"room:1\",\"phx_join\",{}]")
-  join.kind |> should.equal(codec.Join)
+  codec.inbound_kind(join) |> should.equal(codec.Join)
 
   let assert Ok(leave) =
     codec.decode_text(phoenix)("[null,\"r\",\"room:1\",\"phx_leave\",{}]")
-  leave.kind |> should.equal(codec.Leave)
+  codec.inbound_kind(leave) |> should.equal(codec.Leave)
 
   let assert Ok(heartbeat) =
     codec.decode_text(phoenix)("[null,\"r\",\"phoenix\",\"heartbeat\",{}]")
-  heartbeat.kind |> should.equal(codec.Heartbeat)
+  codec.inbound_kind(heartbeat) |> should.equal(codec.Heartbeat)
 
   // "heartbeat" is only reserved on the "phoenix" topic; elsewhere it is an
   // ordinary application event that must reach the channel's handle_in.
   let assert Ok(app_heartbeat) =
     codec.decode_text(phoenix)("[null,\"r\",\"room:1\",\"heartbeat\",{}]")
-  app_heartbeat.kind |> should.equal(codec.Event("heartbeat"))
+  codec.inbound_kind(app_heartbeat) |> should.equal(codec.Event("heartbeat"))
 
   let assert Ok(event) =
     codec.decode_text(phoenix)("[null,\"r\",\"room:1\",\"new_msg\",{}]")
-  event.kind |> should.equal(codec.Event("new_msg"))
+  codec.inbound_kind(event) |> should.equal(codec.Event("new_msg"))
 }
 
 pub fn phoenix_codec_reply_accepts_missing_ref_test() {
@@ -119,27 +119,27 @@ pub fn phoenix_codec_preserves_missing_ref_reply_shape_test() {
 pub fn inbound_record_holds_normalized_fields_test() {
   let payload = dynamic.string("body")
   let inbound =
-    codec.Inbound(
+    codec.inbound(
       join_ref: Some("j"),
       ref: Some("r"),
       topic: "room:1",
       kind: codec.Event("evt"),
       payload: payload,
     )
-  inbound.topic |> should.equal("room:1")
-  inbound.join_ref |> should.equal(Some("j"))
+  codec.inbound_topic(inbound) |> should.equal("room:1")
+  codec.inbound_join_ref(inbound) |> should.equal(Some("j"))
 }
 
 pub fn inbound_supports_optional_refs_test() {
   let inbound =
-    codec.Inbound(
+    codec.inbound(
       join_ref: None,
       ref: None,
       topic: "t",
       kind: codec.Event("e"),
       payload: dynamic.nil(),
     )
-  inbound.ref |> should.equal(None)
+  codec.inbound_ref(inbound) |> should.equal(None)
 }
 
 // === Reply status ===
@@ -165,13 +165,13 @@ pub fn phoenix_codec_decodes_shared_inbound_fixtures_test() {
   fixtures.inbound_common()
   |> list.each(fn(case_) {
     let assert Ok(inbound) = codec.decode_text(phoenix)(case_.encoded)
-    inbound.join_ref |> should.equal(case_.join_ref)
-    inbound.ref |> should.equal(case_.ref)
-    inbound.topic |> should.equal(case_.topic)
-    inbound.kind |> should.equal(phoenix_kind(case_.event))
+    codec.inbound_join_ref(inbound) |> should.equal(case_.join_ref)
+    codec.inbound_ref(inbound) |> should.equal(case_.ref)
+    codec.inbound_topic(inbound) |> should.equal(case_.topic)
+    codec.inbound_kind(inbound) |> should.equal(phoenix_kind(case_.event))
     let assert Ok(expected_payload) =
       json.parse(from: json.to_string(case_.payload), using: decode.dynamic)
-    inbound.payload |> should.equal(expected_payload)
+    codec.inbound_payload(inbound) |> should.equal(expected_payload)
   })
 }
 

--- a/test/wire_codec_test.gleam
+++ b/test/wire_codec_test.gleam
@@ -40,6 +40,12 @@ pub fn phoenix_codec_decodes_system_events_to_kinds_test() {
     codec.decode_text(phoenix)("[null,\"r\",\"phoenix\",\"heartbeat\",{}]")
   heartbeat.kind |> should.equal(codec.Heartbeat)
 
+  // "heartbeat" is only reserved on the "phoenix" topic; elsewhere it is an
+  // ordinary application event that must reach the channel's handle_in.
+  let assert Ok(app_heartbeat) =
+    codec.decode_text(phoenix)("[null,\"r\",\"room:1\",\"heartbeat\",{}]")
+  app_heartbeat.kind |> should.equal(codec.Event("heartbeat"))
+
   let assert Ok(event) =
     codec.decode_text(phoenix)("[null,\"r\",\"room:1\",\"new_msg\",{}]")
   event.kind |> should.equal(codec.Event("new_msg"))

--- a/test/wire_codec_test.gleam
+++ b/test/wire_codec_test.gleam
@@ -207,6 +207,36 @@ pub fn phoenix_codec_encodes_shared_reply_fixtures_test() {
   })
 }
 
+pub fn phoenix_codec_encodes_shared_terminal_event_fixtures_test() {
+  let phoenix = wire.phoenix_codec()
+  let assert Some(encode_close) = codec.encode_close(phoenix)
+  let assert Some(encode_error) = codec.encode_error(phoenix)
+  fixtures.server_outbound()
+  |> list.each(fn(case_) {
+    case case_.event {
+      "phx_error" ->
+        encode_error(case_.join_ref, case_.topic)
+        |> text_frame()
+        |> should.equal(case_.encoded)
+      "phx_close" ->
+        encode_close(case_.join_ref, case_.topic)
+        |> text_frame()
+        |> should.equal(case_.encoded)
+      _ -> Nil
+    }
+  })
+}
+
+pub fn phoenix_terminal_events_mirror_join_ref_into_ref_test() {
+  wire.channel_close(Some("join-7"), "room:1")
+  |> text_frame()
+  |> should.equal("[\"join-7\",\"join-7\",\"room:1\",\"phx_close\",{}]")
+
+  wire.channel_error(Some("join-7"), "room:1")
+  |> text_frame()
+  |> should.equal("[\"join-7\",\"join-7\",\"room:1\",\"phx_error\",{}]")
+}
+
 pub fn phoenix_codec_rejects_shared_invalid_fixtures_test() {
   let phoenix = wire.phoenix_codec()
   fixtures.invalid_frames()

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -114,6 +114,10 @@ export default defineConfig({
 							label: "Backend Integration",
 							slug: "guides/backend-integration",
 						},
+						{
+							label: "Production Hardening",
+							slug: "guides/production-hardening",
+						},
 					],
 				},
 				{

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -1,0 +1,86 @@
+---
+title: Production Hardening
+---
+
+Beryl ships with all rate and connection limits **disabled**, because no
+default is right for every deployment. That is fine for development, but a
+production server with no abuse controls can be degraded by a single hostile
+(or buggy) client. Beryl logs a warning at startup when every control is
+off; this guide explains what to turn on and why.
+
+## What is always on
+
+Even with no configuration, beryl enforces:
+
+- **Frame size**: inbound WebSocket frames over 1 MiB close the connection
+  (`with_max_inbound_frame_bytes` to adjust).
+- **Topic and event lengths**: topics over 256 bytes and event names over 64
+  bytes are rejected before reaching a channel
+  (`with_max_topic_length`, `with_max_event_length`).
+- **Joined-topic cap**: a socket may join at most 1000 topics
+  (`with_max_joined_topics_per_socket`).
+- **Protocol hygiene**: reserved `phx_*` events, reserved `beryl:*` topics,
+  and messages carrying a stale `join_ref` are dropped; heartbeat and leave
+  frames count against the message rate limit when one is configured.
+- **Heartbeat eviction**: sockets that stop sending heartbeats are evicted
+  and their connections closed (60 s window by default, `with_heartbeat`).
+
+## What you should configure for production
+
+```gleam
+let config =
+  beryl.config(wire.phoenix_codec())
+  // Cap messages per socket. Size to your chattiest legitimate client:
+  // for most interactive apps 50-100 msg/s with 2x burst is generous.
+  |> beryl.with_message_rate(per_second: 100, burst: 200)
+  // Joins are much rarer than messages. 10/s per socket tolerates
+  // aggressive reconnect/rejoin loops while stopping join floods.
+  |> beryl.with_join_rate(per_second: 10, burst: 20)
+  // Concurrent connections per client IP. Size to your expected
+  // clients-behind-one-NAT worst case; see the caveat below.
+  |> beryl.with_max_connections_per_ip(max_connections: 100)
+```
+
+Optionally, `with_channel_rate` adds a per-socket-per-topic limit on top of
+the global per-socket message rate, useful when a single busy topic must not
+starve others.
+
+### The per-IP caveat
+
+The connection limit uses the **real TCP peer address** and deliberately
+ignores forwarded headers like `X-Forwarded-For`, which clients can forge.
+Two consequences:
+
+- Behind a reverse proxy or load balancer, every connection appears to come
+  from the proxy's IP, so a per-IP cap would throttle all clients together.
+  Enforce per-client limits at the proxy layer instead.
+- Users behind carrier-grade NAT or a corporate gateway share one IP. Set
+  the cap high enough for your worst legitimate case, or leave it off and
+  rely on rate limits.
+
+### Rate limits reset on reconnect
+
+Per-socket limits are keyed by connection, so a client that hits a limit
+can reconnect for a fresh allowance. They bound the damage of any single
+connection; they are not a substitute for infrastructure-level controls
+(load balancer connection/request limits, WAF rules) against determined
+attackers rotating connections.
+
+## Origin checking and authentication
+
+- `with_allowed_origins` on the Mist transport rejects browser connections
+  from unexpected origins before the WebSocket handshake.
+- `with_on_connect` authenticates the connection once, before upgrade —
+  reject unauthenticated clients with a 403 rather than at join time.
+- Authorize each topic in your channel's `join` callback; clients cannot
+  send events to topics they have not joined.
+
+## Operational notes
+
+- The coordinator is a single actor per channels system. The transport
+  sheds oversized frames and (when configured) rate-limited traffic before
+  it, but extreme fan-out workloads may want multiple channels systems
+  sharded by topic space.
+- If beryl is embedded in your own supervision tree via
+  `supervisor.child_spec`, restarts of the beryl subtree are bounded by a
+  rest-for-one strategy with an intensity of 3 restarts per 5 seconds.

--- a/website/src/content/docs/reference/api/beryl-bridge.md
+++ b/website/src/content/docs/reference/api/beryl-bridge.md
@@ -15,8 +15,12 @@ Bridge - Forward an external OTP actor's message stream to a socket channel.
  `bridge` packages that plumbing into a single helper. Start a bridge inside
  a channel `join`, store the handle in the socket assigns, subscribe the
  returned `Subject` to your domain actor, and stop the bridge in `terminate`.
- The forwarder also monitors the owning channel process, so it is cleaned up
- automatically if that process dies — no leaked processes.
+
+ Calling `stop` from `terminate` is **required** for cleanup: channels are
+ dispatched by a shared coordinator rather than one process per channel, so
+ the process the forwarder monitors is the coordinator itself — the monitor
+ is a backstop for coordinator death, not a per-channel lifecycle. A bridge
+ whose `stop` is never called keeps running until the coordinator exits.
 
  ## Example
 
@@ -95,9 +99,11 @@ Start a bridge that forwards values from an external `Subject` to a socket's
  `handle_info` expects. If no translation is needed, pass the identity
  function `fn(value) { value }`.
 
- The forwarder monitors the calling (channel) process and exits if it dies,
- so a missed `stop` will not leak a process. Always call `stop` from your
- channel's `terminate` for prompt, deterministic cleanup.
+ Always call `stop` from your channel's `terminate` — that is the only
+ per-channel cleanup. The forwarder also monitors the calling process, but
+ because channel callbacks run inside the shared coordinator, that monitor
+ fires only if the coordinator itself dies; it does not detect an
+ individual channel ending.
 
 ```gleam
 pub fn start(

--- a/website/src/content/docs/reference/api/beryl-channel.md
+++ b/website/src/content/docs/reference/api/beryl-channel.md
@@ -55,6 +55,10 @@ pub type HandleResult(a) {
     payload: json.Json,
     socket: socket.Socket(a)
   )
+  ReplyError(
+    payload: json.Json,
+    socket: socket.Socket(a)
+  )
   Push(
     event: String,
     payload: json.Json,
@@ -82,6 +86,19 @@ Send a reply to the client in response to their message.
  tied to the original client ref — the `event` field is ignored by the
  coordinator. When returned from `handle_info` (where no client ref
  exists), it is sent as a push using `event` as the event name.
+
+##### `ReplyError(
+  payload: json.Json,
+  socket: socket.Socket(a)
+)`
+
+Send an error reply to the client in response to their message
+ (`"status": "error"` in Phoenix framing, delivered to the client's
+ `push.receive("error", ...)` hook).
+
+ Only meaningful from `handle_in` for messages carrying a client ref;
+ from `handle_info`/`handle_binary` (where no ref exists) the reply is
+ dropped with a warning.
 
 ##### `Push(
   event: String,
@@ -124,14 +141,17 @@ Join failed with error payload
 
 ### `StopReason`
 
-Why a channel is stopping
+Why a channel is stopping.
+
+ Delivered to every channel's `terminate` callback. Match with a catch-all
+ (`_`) arm: new stop reasons may be added in minor releases.
 
 ```gleam
 pub type StopReason {
   Normal
   Shutdown
   HeartbeatTimeout
-  Error(String)
+  Errored(String)
 }
 ```
 
@@ -149,9 +169,11 @@ Server-initiated shutdown
 
 Client failed to send heartbeat within the configured timeout
 
-##### `Error(String)`
+##### `Errored(String)`
 
-Error occurred
+The channel stopped because of an error (named `Errored` so importing
+ it unqualified does not shadow the prelude's `Result` `Error`
+ constructor)
 
 ## Functions
 

--- a/website/src/content/docs/reference/api/beryl-group.md
+++ b/website/src/content/docs/reference/api/beryl-group.md
@@ -168,14 +168,6 @@ Start the groups actor
 pub fn start() -> Result(Groups, GroupStartError)
 ```
 
-### `start_named`
-
-Start the groups actor with a registered name (for supervision)
-
-```gleam
-pub fn start_named(process.Name(Message)) -> Result(actor.Started(process.Subject(Message)), actor.StartError)
-```
-
 ### `topics`
 
 Get all topics in a group

--- a/website/src/content/docs/reference/api/beryl-presence-wire.md
+++ b/website/src/content/docs/reference/api/beryl-presence-wire.md
@@ -27,3 +27,24 @@ pub fn encode_diff(
   String
 ) -> json.Json
 ```
+
+### `encode_state`
+
+Encode a topic's full presence list as a Phoenix-compatible
+ `presence_state` payload.
+
+ The resulting JSON is a map keyed by presence key, where each value
+ contains the tracked metadata under `metas` — the same shape as one side
+ of a `presence_diff`:
+
+ ```json
+ { "user:1": { "metas": [{ "status": "online", "phx_ref": "..." }] } }
+ ```
+
+ Phoenix clients expect a `presence_state` event carrying this payload
+ after joining a presence-enabled topic (followed by incremental
+ `presence_diff` events). Build the entry list with `presence.list`.
+
+```gleam
+pub fn encode_state(List(presence.PresenceEntry)) -> json.Json
+```

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -189,25 +189,18 @@ Start the presence actor
 pub fn start(Config) -> Result(Presence, PresenceError)
 ```
 
-### `start_named`
-
-Start the presence actor with a registered name (for supervision)
-
-```gleam
-pub fn start_named(
-  Config,
-  process.Name(Message)
-) -> Result(actor.Started(process.Subject(Message)), actor.StartError)
-```
-
 ### `track`
 
 Track a presence in a topic.
 
+ `session_id` identifies the session (e.g. socket) that owns this presence
+ and is the value `untrack_all` matches on when the session disconnects.
+
  Returns a server-generated tracking ref: an opaque, unique handle for this
  specific presence. Pass it to `untrack` to remove exactly this entry later.
- The ref is not the `pid`/session id — it is minted by the presence actor and
- is only meaningful to that actor.
+ The ref is not the session id — it is minted by the presence actor and is
+ only meaningful to that actor. The ref is also merged into object metas as
+ `phx_ref` for Phoenix client compatibility.
 
  Panics if the presence actor is unavailable or does not reply within 5 seconds.
 
@@ -238,7 +231,7 @@ pub fn untrack(
 
 ### `untrack_all`
 
-Untrack all presences for a pid (e.g., when a socket disconnects)
+Untrack all presences for a session (e.g., when a socket disconnects)
 
  Panics if the presence actor is unavailable or does not reply within 5 seconds.
 

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -104,7 +104,12 @@ The presence actor failed to start.
 
 ### `default_config`
 
-Default configuration (no PubSub, no replication)
+Default configuration (no PubSub).
+
+ The broadcast interval defaults to 1500 ms so that adding `with_pubsub`
+ yields working two-way replication out of the box; without PubSub the
+ interval is unused. Use `with_broadcast_interval(0)` to disable periodic
+ broadcasts and control replication manually.
 
 ```gleam
 pub fn default_config(String) -> Config

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -26,6 +26,17 @@ A PubSub message delivered to subscribers.
  This type is intentionally transparent so subscribers can inspect the topic,
  event, payload, and sender metadata delivered to their process mailbox.
 
+ ## Frozen wire contract
+
+ `Message` is sent **raw between nodes** via `pg`, so its runtime shape —
+ the record tag and its four fields, in this order — is a frozen v1 wire
+ contract, not just a source-level API. It will not change within 1.x:
+ subscribers select it as a 4-field `message` record, and a rolling
+ cluster upgrade must never mis-parse a frame from an older node. If the
+ envelope ever needs new fields, they will arrive as a **new record tag**
+ (a new variant), which old nodes' selectors simply do not match — never
+ as a change to this record. The same applies to `PubSubFrom`.
+
 ```gleam
 pub type Message {
   Message(
@@ -61,7 +72,9 @@ pub type PubSubConfig
 
 ### `PubSubFrom`
 
-Identifies the sender of a broadcast
+Identifies the sender of a broadcast.
+
+ Part of the frozen v1 wire contract described on `Message`.
 
 ```gleam
 pub type PubSubFrom {

--- a/website/src/content/docs/reference/api/beryl-socket.md
+++ b/website/src/content/docs/reference/api/beryl-socket.md
@@ -45,9 +45,6 @@ Transport abstraction for sending messages
  Wraps the underlying connection (e.g. a Mist WebSocket) with functions to
  send text/binary frames and close the connection.
 
- Note: as constructed by the built-in Mist transport, `close` is a no-op
- that returns `Ok(Nil)`. Closing is driven by the transport's own
- connection lifecycle rather than by calling this function.
  `Transport` is opaque; build one with `new_transport`. Its behaviour is
  read through the `@internal` accessors below.
 

--- a/website/src/content/docs/reference/api/beryl-supervisor.md
+++ b/website/src/content/docs/reference/api/beryl-supervisor.md
@@ -51,7 +51,9 @@ The supervisor failed to start
 
 ##### `InvalidHeartbeatTimeout`
 
-heartbeat_timeout_ms must be > 0
+`heartbeat_timeout_ms` must be at least 2 — the same validation as
+ `beryl.start` (the staleness check interval is derived as
+ `heartbeat_timeout_ms / 2`, so 1 would silently disable eviction).
 
 ### `SupervisedChannels`
 

--- a/website/src/content/docs/reference/api/beryl-topic.md
+++ b/website/src/content/docs/reference/api/beryl-topic.md
@@ -205,18 +205,6 @@ Parse a pattern string into TopicPattern
 pub fn parse_pattern(String) -> TopicPattern
 ```
 
-### `sanitize_for_log`
-
-Escape control characters in a string for safe use in log metadata.
-
- Replaces codepoints in the range 0–31 and 127 with `?` so that
- client-supplied strings cannot inject additional fields into structured
- log output.
-
-```gleam
-pub fn sanitize_for_log(String) -> String
-```
-
 ### `segments`
 
 Parse a topic into segments by splitting on ":"

--- a/website/src/content/docs/reference/api/beryl-wire-codec.md
+++ b/website/src/content/docs/reference/api/beryl-wire-codec.md
@@ -287,3 +287,17 @@ pub fn with_error_encoder(
   fn(option.Option(String), String) -> Frame
 ) -> Codec
 ```
+
+### `with_topicless_events`
+
+Mark a codec's events as topicless.
+
+ Some framings (e.g. Socket.IO-style protocols) do not carry a per-frame
+ topic. When set, an inbound event whose topic is empty is routed to the
+ socket's single joined topic; with zero or multiple joins it is dropped.
+ Topic-carrying codecs (like the Phoenix codec) must leave this off so
+ empty-topic frames are rejected instead of guessed at.
+
+```gleam
+pub fn with_topicless_events(Codec) -> Codec
+```

--- a/website/src/content/docs/reference/api/beryl-wire-codec.md
+++ b/website/src/content/docs/reference/api/beryl-wire-codec.md
@@ -84,25 +84,12 @@ A binary frame.
 
 Normalised inbound message shape.
 
- - `join_ref`: optional client-side reference assigned at join time
-   (used by some Phoenix replies; codecs without this concept should
-   pass `None`)
- - `ref`: optional per-message reference for reply correlation
- - `topic`: subscription topic (e.g. `"room:lobby"`, `"doc:abc"`)
- - `kind`: structural protocol event or user event
- - `payload`: message body as a `Dynamic` for the channel handler to
-   decode
+ `Inbound` is opaque: construct it with `inbound` and read it with the
+ `inbound_*` accessors. Keeping the record hidden lets Beryl add fields
+ (which default sensibly) without breaking every custom codec.
 
 ```gleam
-pub type Inbound {
-  Inbound(
-    join_ref: option.Option(String),
-    ref: option.Option(String),
-    topic: String,
-    kind: InboundKind,
-    payload: dynamic.Dynamic
-  )
-}
+pub type Inbound
 ```
 
 ### `InboundKind`
@@ -168,6 +155,69 @@ Format a `DecodeError` as a human-readable string. Used by the
 pub fn format_decode_error(DecodeError) -> String
 ```
 
+### `inbound`
+
+Construct a normalised inbound message.
+
+ - `join_ref`: optional client-side reference assigned at join time
+   (used by some Phoenix replies; codecs without this concept should
+   pass `None`)
+ - `ref`: optional per-message reference for reply correlation
+ - `topic`: subscription topic (e.g. `"room:lobby"`, `"doc:abc"`)
+ - `kind`: structural protocol event or user event
+ - `payload`: message body as a `Dynamic` for the channel handler to
+   decode
+
+```gleam
+pub fn inbound(
+  join_ref: option.Option(String),
+  ref: option.Option(String),
+  topic: String,
+  kind: InboundKind,
+  payload: dynamic.Dynamic
+) -> Inbound
+```
+
+### `inbound_join_ref`
+
+The inbound message's join-time client reference, if any.
+
+```gleam
+pub fn inbound_join_ref(Inbound) -> option.Option(String)
+```
+
+### `inbound_kind`
+
+The inbound message's structural kind.
+
+```gleam
+pub fn inbound_kind(Inbound) -> InboundKind
+```
+
+### `inbound_payload`
+
+The inbound message's body, for the channel handler to decode.
+
+```gleam
+pub fn inbound_payload(Inbound) -> dynamic.Dynamic
+```
+
+### `inbound_ref`
+
+The inbound message's per-message reference for reply correlation, if any.
+
+```gleam
+pub fn inbound_ref(Inbound) -> option.Option(String)
+```
+
+### `inbound_topic`
+
+The inbound message's subscription topic.
+
+```gleam
+pub fn inbound_topic(Inbound) -> String
+```
+
 ### `new`
 
 Build a text-only wire codec.
@@ -203,5 +253,37 @@ Attach a binary decoder to a codec.
 pub fn with_binary_decoder(
   Codec,
   fn(BitArray) -> Result(Inbound, DecodeError)
+) -> Codec
+```
+
+### `with_close_encoder`
+
+Attach a channel-close encoder to a codec.
+
+ When set, the coordinator emits this frame to a client whenever one of
+ its channels terminates gracefully (leave, server shutdown, heartbeat
+ eviction): `(join_ref, topic)`. Phoenix clients rely on `phx_close` to
+ leave the joined state instead of waiting out push timeouts.
+
+```gleam
+pub fn with_close_encoder(
+  Codec,
+  fn(option.Option(String), String) -> Frame
+) -> Codec
+```
+
+### `with_error_encoder`
+
+Attach a channel-error encoder to a codec.
+
+ When set, the coordinator emits this frame to a client whenever one of
+ its channels terminates abnormally (crashed or stopped with an error):
+ `(join_ref, topic)`. Phoenix clients rely on `phx_error` to schedule an
+ automatic rejoin.
+
+```gleam
+pub fn with_error_encoder(
+  Codec,
+  fn(option.Option(String), String) -> Frame
 ) -> Codec
 ```

--- a/website/src/content/docs/reference/api/beryl-wire.md
+++ b/website/src/content/docs/reference/api/beryl-wire.md
@@ -18,6 +18,54 @@ Phoenix Wire Protocol — encoding/decoding helpers and the canonical
 
 ## Functions
 
+### `binary_broadcast`
+
+Encode a Phoenix V2 binary broadcast: `(topic, event, payload)`.
+
+ Errors when a metadata component exceeds the framing's 255-byte length
+ limit.
+
+```gleam
+pub fn binary_broadcast(
+  topic: String,
+  event: String,
+  payload: BitArray
+) -> Result(codec.Frame, Nil)
+```
+
+### `binary_push`
+
+Encode a Phoenix V2 binary server push: `(join_ref, topic, event, payload)`.
+
+ Errors when a metadata component exceeds the framing's 255-byte length
+ limit.
+
+```gleam
+pub fn binary_push(
+  join_ref: option.Option(String),
+  topic: String,
+  event: String,
+  payload: BitArray
+) -> Result(codec.Frame, Nil)
+```
+
+### `binary_reply`
+
+Encode a Phoenix V2 binary reply: `(join_ref, ref, topic, status, payload)`.
+
+ Errors when a metadata component exceeds the framing's 255-byte length
+ limit.
+
+```gleam
+pub fn binary_reply(
+  join_ref: option.Option(String),
+  ref: option.Option(String),
+  topic: String,
+  status: codec.ReplyStatus,
+  payload: BitArray
+) -> Result(codec.Frame, Nil)
+```
+
 ### `channel_close`
 
 Create a Phoenix `phx_close` frame, sent when a channel terminates
@@ -40,6 +88,19 @@ pub fn channel_error(
   option.Option(String),
   String
 ) -> codec.Frame
+```
+
+### `decode_binary_message`
+
+Decode a Phoenix V2 binary push frame from a client into an `Inbound`.
+
+ The payload is delivered to `handle_in` as raw bytes (`BitArray` wrapped
+ in `Dynamic`); decode it with `gleam/dynamic/decode.bit_array`. Zero-length
+ join_ref/ref components decode as `None`. Reserved protocol events are
+ classified the same way as on the text framing.
+
+```gleam
+pub fn decode_binary_message(BitArray) -> Result(codec.Inbound, codec.DecodeError)
 ```
 
 ### `decode_message`
@@ -88,6 +149,11 @@ pub fn heartbeat_reply(option.Option(String)) -> codec.Frame
 ### `phoenix_codec`
 
 The canonical Phoenix wire codec. Pass to `beryl.config/1`.
+
+ Handles both the JSON array framing on text frames and the Phoenix V2
+ binary framing on binary frames (see `decode_binary_message`). Binary
+ push payloads reach `handle_in` as a `BitArray` wrapped in `Dynamic`;
+ decode them with `gleam/dynamic/decode.bit_array`.
 
 ```gleam
 pub fn phoenix_codec() -> codec.Codec

--- a/website/src/content/docs/reference/api/beryl-wire.md
+++ b/website/src/content/docs/reference/api/beryl-wire.md
@@ -18,6 +18,30 @@ Phoenix Wire Protocol — encoding/decoding helpers and the canonical
 
 ## Functions
 
+### `channel_close`
+
+Create a Phoenix `phx_close` frame, sent when a channel terminates
+ gracefully. Phoenix mirrors the channel's `join_ref` into the `ref` slot.
+
+```gleam
+pub fn channel_close(
+  option.Option(String),
+  String
+) -> codec.Frame
+```
+
+### `channel_error`
+
+Create a Phoenix `phx_error` frame, sent when a channel terminates
+ abnormally. Phoenix clients respond by scheduling an automatic rejoin.
+
+```gleam
+pub fn channel_error(
+  option.Option(String),
+  String
+) -> codec.Frame
+```
+
 ### `decode_message`
 
 Parse a JSON string into an `Inbound`.

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -81,30 +81,45 @@ Configuration for the channels system.
 pub type Config
 ```
 
+### `ConnectionPermit`
+
+A held per-IP connection slot returned by `acquire_connection_slot`.
+
+ Opaque so Beryl can restructure the connection limiter without breaking
+ transport authors. Hold it for the lifetime of the connection and pass it
+ to `release_connection_slot` when the connection closes. When no per-IP
+ limit is configured the permit is an admit-everything placeholder and
+ releasing it is a no-op.
+
+```gleam
+pub type ConnectionPermit
+```
+
 ### `LoggingConfig`
 
 Logging configuration for Beryl diagnostics.
 
+ This type is opaque: construct it with `logging_config` and adjust it with
+ the `with_*` builder functions so Beryl can add logging options without a
+ breaking change.
+
 ```gleam
-pub type LoggingConfig {
-  LoggingConfig(
-    level: LogLevel,
-    include_payloads: Bool,
-    payload_preview_bytes: Int
-  )
-}
+pub type LoggingConfig
 ```
 
 ### `LogLevel`
 
 Logging verbosity for Beryl's internal loggers.
 
+ The variants carry a `Level` suffix so `ErrorLevel` does not shadow the
+ prelude's `Result` `Error` constructor when imported unqualified.
+
 ```gleam
 pub type LogLevel {
-  Debug
-  Info
-  Warn
-  Error
+  DebugLevel
+  InfoLevel
+  WarnLevel
+  ErrorLevel
 }
 ```
 
@@ -176,15 +191,16 @@ Try to acquire a configured per-IP connection slot for transports.
  Transports call this before admitting a connection, passing the **real
  socket peer IP**. Do not pass a client-supplied address (e.g. from
  `X-Forwarded-For`): a spoofed value would defeat the per-IP limit. Returns
- `Ok(Some(permit))` when admitted (release the permit with
- `release_connection_slot` on close), `Ok(None)` when no limit is configured
- (unlimited), or `Error(Nil)` when the peer is already at its limit.
+ `Ok(permit)` when admitted (release the permit with
+ `release_connection_slot` on close; when no limit is configured every
+ connection is admitted), or `Error(Nil)` when the peer is already at its
+ limit.
 
 ```gleam
 pub fn acquire_connection_slot(
   Channels,
   String
-) -> Result(option.Option(connection_limit.Permit), Nil)
+) -> Result(ConnectionPermit, Nil)
 ```
 
 ### `broadcast`
@@ -356,7 +372,7 @@ pub fn register(
 Release a per-IP connection slot acquired by a transport.
 
 ```gleam
-pub fn release_connection_slot(option.Option(connection_limit.Permit)) -> Nil
+pub fn release_connection_slot(ConnectionPermit) -> Nil
 ```
 
 ### `send_info`

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -203,6 +203,20 @@ pub fn acquire_connection_slot(
 ) -> Result(ConnectionPermit, Nil)
 ```
 
+### `bind_connection_slot`
+
+Bind an acquired connection slot to the calling process.
+
+ Call this from the long-lived connection process (e.g. the WebSocket
+ handler's init) after `acquire_connection_slot`. The limiter monitors the
+ caller so the slot is reclaimed even if the connection process dies
+ without running its close path — otherwise crashed connections would
+ permanently exhaust their IP's slots.
+
+```gleam
+pub fn bind_connection_slot(ConnectionPermit) -> Nil
+```
+
 ### `broadcast`
 
 Broadcast a message to all subscribers of a topic
@@ -370,6 +384,9 @@ pub fn register(
 ### `release_connection_slot`
 
 Release a per-IP connection slot acquired by a transport.
+
+ Call from the process the permit was bound to (or from an unbound
+ process when releasing before the connection was established).
 
 ```gleam
 pub fn release_connection_slot(ConnectionPermit) -> Nil


### PR DESCRIPTION
## Summary

This release hardens Beryl for production by implementing the Phoenix V2 binary subprotocol, isolating channel callback crashes from the shared coordinator, adding missing terminal channel events, and introducing crash-survivable handler registries. Rate limiting is refactored from a registry actor to pure token buckets owned by callers, improving performance and eliminating cross-process calls. The public API is locked down ahead of 1.0 with opaque types for `LoggingConfig` and `codec.Inbound`.

## Key Changes

### Protocol & Wire Format
- **Phoenix V2 binary framing**: Implement `decode_binary_message` and binary push/broadcast encoders; clients can now send binary payloads as `BitArray` in `Dynamic`
- **Wire protocol version negotiation**: Mist transport reads `?vsn=` query parameter; V1 clients are rejected at handshake
- **Terminal channel events**: Send `phx_close` (graceful) and `phx_error` (abnormal) frames when channels terminate; add `channel.ReplyError` for error-status replies
- **Reserved event hardening**: Heartbeat is now reserved only on the "phoenix" topic; unjoined topic events get "unmatched topic" errors

### Crash Isolation & Reliability
- **Callback crash isolation**: Wrap all user channel callbacks (`join`, `handle_in`, `handle_info`, `handle_binary`, `terminate`) with `rescue` FFI to convert panics into `channel.Errored` results; faulty channels no longer crash the coordinator
- **Join_ref tracking**: Track per-channel join_refs to drop stale messages after rejoin; implement Phoenix duplicate-join semantics (rejoin terminates previous instance)
- **Handler registry**: Add crash-survivable `Registry` actor seeded at coordinator init; registrations survive coordinator restarts via supervised rest-for-one
- **Presence incarnation safety**: Each presence actor start derives a unique incarnation name; restarts never reuse old CRDT clocks, preventing ghost entries

### Rate Limiting & Performance
- **Pure token buckets**: Refactor from registry actor to plain `Bucket` data owned by callers (coordinator, transport); eliminate blocking cross-process calls
- **Transport-edge enforcement**: Mist transport now decodes frames and enforces per-socket message rate limits before coordinator; shed hostile traffic early
- **Per-socket/channel buckets**: Coordinator maintains `Dict(String, Bucket)` for message and join limits, `Dict(String, Dict(String, Bucket))` for per-channel limits with per-socket caps
- **Connection slot cleanup**: Monitor permit-holder processes; slots self-release on crash without explicit close path

### API Hardening
- **Opaque types**: `LoggingConfig` and `codec.Inbound` are now opaque; use `logging_config()`, `inbound()`, and `inbound_*` accessors
- **LogLevel suffix**: Rename `Debug`/`Info`/`Warn`/`Error` to `DebugLevel`/`InfoLevel`/`WarnLevel`/`ErrorLevel` to avoid shadowing `Result.Error`
- **Rate limit config rename**: `message_limiter`/`join_limiter`/`channel_limiter` → `message_limits`/`join_limits`/`channel_limits` (reflect plural buckets)
- **Codec builder pattern**: Add `with_close_encoder`, `with_error_encoder`, `with_binary_decoder`, `with_topicless_events` for extensibility

### Transport & Connection Management
- **Socket close callback**: Add `close: fn() -> Nil` to `SocketContext` and `SocketInfo`; `RegisterCloser` message lets transport register the close function
- **Heartbeat eviction closes connection**: Evicted sockets now actively close instead of becoming zombies; coordinator can terminate connections it evicts
- **Mist transport hardening**: Decode frames in connection process (not coordinator); enforce per-connection message rate limits; support binary frames

### Documentation & Warnings
- **Production hardening guide**: New guide explaining rate/connection limits and why they're opt-in
- **Startup warnings**: Warn when no abuse controls are configured
- **API documentation**:

https://claude.ai/code/session_011JqQn1kPsfGLwXxc1Lid7v