### PR TITLE
docs(security): document trusted Erlang cluster boundary

### DIFF
--- a/.changes/unreleased/Security-20260709-203618.yaml
+++ b/.changes/unreleased/Security-20260709-203618.yaml
@@ -1,0 +1,11 @@
+kind: Security
+body: |-
+    Document the trusted Erlang cluster boundary for distributed PubSub and presence.
+    Production and architecture docs now explicitly state that every Erlang distribution peer
+    is fully trusted, and include requirements for a strong Erlang cookie, TLS distribution,
+    restricted EPMD/distribution port access, and avoiding shared untrusted clusters. The docs
+    distinguish internal PubSub/presence messages from Erlang peers (trusted) from WebSocket
+    client messages (untrusted, gated by authorization callbacks). The `pubsub.config_with_scope`
+    API doc now clearly states the argument must be a compile-time constant and must never
+    receive user-derived values.
+time: 2026-07-09T20:36:18.576000-00:00

--- a/.changes/unreleased/Security-20260709-203618.yaml
+++ b/.changes/unreleased/Security-20260709-203618.yaml
@@ -6,6 +6,6 @@ body: |-
     restricted EPMD/distribution port access, and avoiding shared untrusted clusters. The docs
     distinguish internal PubSub/presence messages from Erlang peers (trusted) from WebSocket
     client messages (untrusted, gated by authorization callbacks). The `pubsub.config_with_scope`
-    API doc now clearly states the argument must be a compile-time constant and must never
-    receive user-derived values.
+    API doc now clearly states the argument must be a static, bounded deployment or
+    configuration value and must never receive raw user-derived or unbounded input.
 time: 2026-07-09T20:36:18.576000-00:00

--- a/README.md
+++ b/README.md
@@ -205,6 +205,28 @@ See the [GitHub Releases](https://github.com/tylerbutler/beryl/releases) page fo
 release notes. Releases follow [Conventional Commits](https://www.conventionalcommits.org/)
 and the changelog is managed with [changie](https://changie.dev/).
 
+## Security
+
+Beryl uses **Erlang distribution** for its distributed PubSub and presence
+replication, which means **every node in your cluster is fully trusted**.
+Application- and channel-level authorization protects you against untrusted
+WebSocket clients; it does **not** protect you against a hostile Erlang
+distribution peer, which can inject internal beryl traffic and presence state.
+
+Before running beryl in production, read **[SECURITY.md](SECURITY.md)**, which
+covers:
+
+- The Erlang distribution **trust boundary** and what a compromised peer can do.
+- Distribution hardening: a strong protected cookie, TLS distribution, EPMD/port
+  firewalling, and keeping cluster membership closed.
+- Why internal PubSub/presence messages are trusted while client WebSocket
+  messages are validated and rate-limited.
+- The `pubsub.config_with_scope` atom-table constraint (never pass it
+  user-derived values).
+
+For client-facing abuse controls (rate limits, connection caps, origin checks),
+see the [Production Hardening guide](https://beryl.tylerbutler.com/guides/production-hardening/).
+
 ## Development
 
 ### Prerequisites

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,148 @@
+# Security
+
+This document describes beryl's security model and the deployment hardening it
+assumes. Read it before running beryl in production, especially the **trust
+boundary** section — beryl's distributed features inherit the BEAM's cluster
+trust model, and evaluating that boundary is a deployment responsibility, not
+something the library can enforce for you.
+
+> [!IMPORTANT]
+> beryl is not yet 1.0 and is not considered production-ready. This document
+> describes the intended security model, not a guarantee.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately via
+[GitHub Security Advisories](https://github.com/tylerbutler/beryl/security/advisories/new)
+rather than opening a public issue. We will acknowledge the report and
+coordinate a fix and disclosure timeline with you.
+
+## Trust boundary
+
+Beryl runs on the Erlang/BEAM runtime and uses **Erlang distribution** for its
+distributed features:
+
+- **PubSub** (`beryl/pubsub`) is backed by Erlang's `pg` process groups.
+  Broadcasts fan out to subscribers on every connected node.
+- **Presence** (`beryl/presence`) replicates CRDT state between nodes so that
+  presence is eventually consistent across the cluster.
+
+Both of these deliver messages **directly between BEAM nodes**, with no
+application-level authentication or validation on the receiving side. This is
+the standard, correct BEAM model, and it has one blunt consequence:
+
+> **Every Erlang distribution peer is fully trusted.** A node that can connect
+> to your cluster's distribution mesh is, for security purposes, part of your
+> application.
+
+Application- and channel-level authorization — `on_connect`, per-topic `join`
+checks, rate limits — protects you against untrusted **WebSocket clients**. It
+does **not** protect you against a hostile **distribution peer**. A malicious or
+compromised node that has joined your cluster can:
+
+- Publish arbitrary internal beryl PubSub messages, including to reserved
+  `beryl:*` topics that clients are never allowed to reach. Those messages are
+  delivered to channel coordinators as trusted cluster input.
+- Inject or corrupt presence replication (sync) data, distorting who appears
+  present across the cluster.
+- Cause unbounded fan-out work by broadcasting to high-cardinality topics.
+- Exercise any cluster-only code path that assumes its inputs came from a
+  trusted sibling node.
+
+There is no in-library defense against this. **The security boundary is the
+edge of your Erlang cluster**, and keeping that boundary trustworthy is a
+deployment responsibility. The rest of this document is about how to keep
+untrusted nodes out.
+
+## Erlang distribution hardening
+
+If you run more than one node, you must secure Erlang distribution itself.
+None of the following is specific to beryl; it is the baseline for any
+distributed BEAM application, and beryl assumes you have done it.
+
+### Use a strong, protected Erlang cookie
+
+Nodes authenticate to one another with a shared **Erlang cookie**. Any node
+that knows the cookie can join the cluster and is then fully trusted (see the
+trust boundary above).
+
+- Generate a long, high-entropy cookie; never ship the default `~/.erlang.cookie`
+  that some tooling auto-generates, and never commit a cookie to source control.
+- Distribute it as a secret (secrets manager, orchestrator secret, restricted
+  file with `0400` permissions owned by the runtime user) — not in an image
+  layer, environment dump, or log.
+- Rotate it if it may have been exposed.
+
+The cookie is an authentication token, but it is transmitted and used in a way
+that provides **no confidentiality on its own**. It is not a substitute for
+transport encryption.
+
+### Use TLS distribution across untrusted networks
+
+Plain Erlang distribution traffic is unencrypted and unauthenticated at the
+transport layer. For any distribution traffic that crosses a network you do not
+fully control — between availability zones, across a cloud VPC boundary, or over
+the public internet — enable **TLS distribution** (`inet_tls_dist`) with mutual
+certificate verification. This protects cookie exchange and inter-node payloads
+from eavesdropping and tampering. See the Erlang/OTP
+[Using TLS for Erlang Distribution](https://www.erlang.org/doc/apps/ssl/ssl_distribution.html)
+guide.
+
+### Restrict EPMD and distribution ports at the network layer
+
+Erlang distribution is reachable through the **EPMD** port mapper (TCP 4369 by
+default) plus a range of per-node distribution ports. Treat these as internal,
+privileged ports:
+
+- Firewall EPMD and the distribution port range so they are reachable **only**
+  from other cluster nodes — never from the public internet or from general
+  workload networks.
+- Pin the distribution port range (`inet_dist_listen_min` / `inet_dist_listen_max`)
+  so you can write tight firewall/security-group rules instead of opening a wide
+  ephemeral range.
+- Do not co-locate the cluster on a shared network segment where untrusted hosts
+  can reach EPMD.
+
+### Keep cluster membership closed
+
+- **Do not connect beryl nodes to a shared or untrusted cluster.** Because every
+  peer is trusted, adding beryl to a multi-tenant or third-party BEAM cluster
+  hands those peers the ability to inject internal beryl traffic. Run beryl in a
+  dedicated cluster whose membership you control.
+- Prefer explicit, static topologies (or a vetted cluster-formation mechanism)
+  over open auto-discovery that could admit an unexpected node.
+
+## Client messages vs. cluster messages
+
+It is important to keep two very different message sources distinct:
+
+| | Untrusted client (WebSocket) | Trusted cluster (Erlang distribution) |
+|---|---|---|
+| Source | Remote browser / device over the WebSocket transport | A peer BEAM node in your cluster |
+| Trust | **Untrusted** — treat as adversarial input | **Fully trusted** — treated as internal state |
+| Validation | Origin checks, `on_connect` auth, per-topic `join` authorization, frame-size limits, topic/event length limits, reserved `phx_*` / `beryl:*` filtering, message/join rate limits | **None** — delivered directly to coordinators/presence as internal input |
+| Where enforced | Mist transport + coordinator (see the [Production Hardening guide](https://beryl.tylerbutler.com/guides/production-hardening/)) | N/A — enforced by the cluster boundary itself |
+
+The takeaway: beryl validates and rate-limits everything that arrives over a
+client WebSocket, but **internal PubSub and presence traffic between nodes is
+trusted by design.** The defenses that make client input safe do not, and are
+not meant to, apply to inter-node messages.
+
+## The `config_with_scope` atom constraint
+
+`beryl/pubsub` exposes `config_with_scope(name: String)` for selecting a custom
+`pg` scope. It converts `name` to an Erlang atom via `binary_to_atom`.
+
+Erlang atoms are **never garbage-collected**, and the atom table is bounded. If
+an attacker (or a high-cardinality data source) can drive the creation of
+unbounded distinct atoms, the atom table fills and the VM crashes — a
+denial-of-service.
+
+Therefore:
+
+> `config_with_scope` is **configuration-only**. Its argument must be a static,
+> bounded value chosen by the operator. **Never** pass a user-derived,
+> request-derived, or otherwise attacker-influenced value to it.
+
+If you do not need a custom scope, use `pubsub.default_config()`, which uses the
+fixed `beryl_pubsub` scope and creates no dynamic atoms.

--- a/src/beryl/pubsub.gleam
+++ b/src/beryl/pubsub.gleam
@@ -101,16 +101,23 @@ pub fn default_config() -> PubSubConfig {
 ///
 /// The scope name is converted to an Erlang atom via `binary_to_atom`.
 /// Atoms are never garbage-collected, so the scope name must be a
-/// **compile-time constant** — never pass a user-supplied or
-/// runtime-computed value. A malicious or high-cardinality source can
-/// exhaust the BEAM atom table and crash the VM.
+/// **static, bounded deployment or configuration value** — never raw
+/// user-derived, per-request, per-tenant, database-derived, or otherwise
+/// unbounded high-cardinality runtime input. A deployment-controlled value
+/// is acceptable only when validated or selected from a fixed bounded set.
+/// A malicious or high-cardinality source can exhaust the BEAM atom table
+/// and crash the VM.
 ///
 /// ```gleam
-/// // Correct — compile-time constant
+/// // Correct — static deployment constant
 /// pubsub.config_with_scope("my_app_pubsub")
+///
+/// // Correct — deployment-controlled, selected from a fixed bounded set
+/// // pubsub.config_with_scope(config.pubsub_scope())
 ///
 /// // WRONG — never do this
 /// // pubsub.config_with_scope(user_request.tenant_id)
+/// // pubsub.config_with_scope(database_row.name)
 /// ```
 pub fn config_with_scope(name: String) -> PubSubConfig {
   PubSubConfig(scope: binary_to_atom(name))

--- a/src/beryl/pubsub.gleam
+++ b/src/beryl/pubsub.gleam
@@ -100,9 +100,18 @@ pub fn default_config() -> PubSubConfig {
 /// Create a PubSub configuration with a custom scope name
 ///
 /// The scope name is converted to an Erlang atom via `binary_to_atom`.
-/// Atoms are never garbage-collected, so the scope name must be a static,
-/// bounded value — never derive it from user input, or a malicious or
-/// high-cardinality source could exhaust the atom table and crash the VM.
+/// Atoms are never garbage-collected, so the scope name must be a
+/// **compile-time constant** — never pass a user-supplied or
+/// runtime-computed value. A malicious or high-cardinality source can
+/// exhaust the BEAM atom table and crash the VM.
+///
+/// ```gleam
+/// // Correct — compile-time constant
+/// pubsub.config_with_scope("my_app_pubsub")
+///
+/// // WRONG — never do this
+/// // pubsub.config_with_scope(user_request.tenant_id)
+/// ```
 pub fn config_with_scope(name: String) -> PubSubConfig {
   PubSubConfig(scope: binary_to_atom(name))
 }

--- a/website/src/content/docs/architecture/pubsub-and-distribution.md
+++ b/website/src/content/docs/architecture/pubsub-and-distribution.md
@@ -66,6 +66,26 @@ flowchart LR
 
 When socket A sends a message on Node 1, its coordinator calls `broadcast_from`, which iterates the `pg` group members. Members on Node 2 receive the message via Erlang distribution — no extra message-bus infrastructure is required.
 
+## Trust Model
+
+All traffic arriving over Erlang distribution is treated as **fully trusted
+cluster input**. There is no additional authentication layer between nodes:
+the Erlang cookie and network controls are the security boundary.
+
+A process on any peer node can:
+
+- Subscribe to any `pg` group (PubSub topic) and receive all broadcasts.
+- Inject messages that downstream coordinators will process as legitimate
+  internal traffic.
+
+**Channel-level authorization** — the `join` and `handle_in` callbacks —
+applies only to inbound WebSocket frames. It does not screen messages that
+arrive via distribution.
+
+Refer to the [Production Hardening guide](/guides/production-hardening/#erlang-cluster-security-boundary)
+for the full cluster security requirements (cookie strength, TLS
+distribution, EPMD port restrictions, and cluster isolation).
+
 ## Where this lives
 
 | File | Role |

--- a/website/src/content/docs/architecture/pubsub-and-distribution.md
+++ b/website/src/content/docs/architecture/pubsub-and-distribution.md
@@ -77,6 +77,9 @@ A process on any peer node can:
 - Subscribe to any `pg` group (PubSub topic) and receive all broadcasts.
 - Inject messages that downstream coordinators will process as legitimate
   internal traffic.
+- Inject reserved presence sync traffic, delivering false presence state to
+  subscribers on all nodes. Ordinary WebSocket clients cannot reach these
+  reserved internal topics — this vector is exclusive to trusted cluster peers.
 
 **Channel-level authorization** — the `join` and `handle_in` callbacks —
 applies only to inbound WebSocket frames. It does not screen messages that

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -75,6 +75,72 @@ attackers rotating connections.
 - Authorize each topic in your channel's `join` callback; clients cannot
   send events to topics they have not joined.
 
+## Erlang cluster security boundary
+
+Beryl's distributed PubSub and presence replication run over Erlang
+distribution. Every node in your Erlang cluster is **fully trusted**: a
+process on any peer node can subscribe to any topic, receive all
+broadcasts, and deliver messages that beryl's coordinator will process as
+legitimate internal traffic. Channel authorization callbacks and
+WebSocket-layer controls do **not** apply to messages delivered over
+distribution — they protect only inbound WebSocket clients.
+
+### Internal vs. client messages
+
+| Source | Trust level | Gated by |
+|---|---|---|
+| WebSocket clients | Untrusted | `on_connect`, `join`, `handle_in` authorization callbacks |
+| Erlang distribution peers | Fully trusted | Erlang cookie + network controls |
+
+A hostile distribution peer can broadcast arbitrary messages into any
+channel and read all presence state. Secure the cluster boundary **before**
+deploying multi-node beryl.
+
+### Erlang cookie
+
+Set a long, randomly generated cookie in `vm.args` or the
+`RELEASE_COOKIE` environment variable. The cookie is the only
+authentication mechanism for distribution peers; a weak or default cookie
+(`CHANGE_ME`, the hostname, etc.) allows any process that can reach your
+distribution port to join the cluster.
+
+Generate a strong cookie with, for example:
+
+```shell
+openssl rand -base64 48
+```
+
+### TLS distribution
+
+When nodes communicate across networks you do not fully control — cloud
+subnets, VPNs, or any link that may traverse untrusted infrastructure —
+enable TLS distribution. See the
+[Erlang TLS Distribution guide](https://www.erlang.org/doc/apps/ssl/ssl_distribution.html)
+for setup instructions.
+
+### Restrict EPMD and distribution ports
+
+The EPMD port (default 4369) and the Erlang distribution listen range must
+not be reachable from untrusted networks. Use firewall rules or security
+groups to allow only cluster-internal traffic. You can fix the distribution
+port to a known value for simpler rules:
+
+```shell
+# vm.args
+-kernel inet_dist_listen_min 9100
+-kernel inet_dist_listen_max 9100
+```
+
+Or set `ERL_DIST_PORT` when using Elixir/Mix releases. Restrict both 4369
+and your chosen distribution port at the network layer.
+
+### Do not share clusters with untrusted tenants
+
+Adding a node to an existing cluster grants it full visibility into all `pg`
+groups (PubSub topics) and all presence state on every node. Never connect
+beryl to a cluster that contains nodes owned or operated by parties outside
+your trust boundary.
+
 ## Operational notes
 
 - The coordinator is a single actor per channels system. The transport

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -141,6 +141,9 @@ groups (PubSub topics) and all presence state on every node. Never connect
 beryl to a cluster that contains nodes owned or operated by parties outside
 your trust boundary.
 
+See [SECURITY.md](https://github.com/tylerbutler/beryl/blob/main/SECURITY.md)
+for the full trust-boundary and distribution-hardening reference.
+
 ## Operational notes
 
 - The coordinator is a single actor per channels system. The transport

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -89,7 +89,7 @@ distribution — they protect only inbound WebSocket clients.
 
 | Source | Trust level | Gated by |
 |---|---|---|
-| WebSocket clients | Untrusted | `on_connect`, `join`, `handle_in` authorization callbacks |
+| WebSocket clients | Untrusted | `with_on_connect` authentication, channel `join` authorization, and `handle_in` event handling |
 | Erlang distribution peers | Fully trusted | Erlang cookie + network controls |
 
 A hostile distribution peer can broadcast arbitrary messages into any

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -18,9 +18,9 @@ let ps = pubsub.start(pubsub.config_with_scope("my_app_pubsub"))
 
 The scope maps to a `pg` scope atom. Different scopes are completely isolated from each other.
 
-:::danger[Never pass user-derived values to `config_with_scope`]
+:::danger[The scope must be a compile-time constant]
 The scope name is converted to an Erlang atom. Atoms are never
-garbage-collected; exhausting the atom table crashes the VM. Always use a
+garbage-collected; exhausting the BEAM atom table crashes the VM. Always use a
 compile-time constant string literal — never a value derived from a user
 request, environment variable, or database record.
 :::

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -18,6 +18,13 @@ let ps = pubsub.start(pubsub.config_with_scope("my_app_pubsub"))
 
 The scope maps to a `pg` scope atom. Different scopes are completely isolated from each other.
 
+:::danger[Never pass user-derived values to `config_with_scope`]
+The scope name is converted to an Erlang atom. Atoms are never
+garbage-collected; exhausting the atom table crashes the VM. Always use a
+compile-time constant string literal — never a value derived from a user
+request, environment variable, or database record.
+:::
+
 ## Subscribing
 
 The calling process receives `pubsub.Message` values when broadcasts are sent to the topic:

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -18,11 +18,13 @@ let ps = pubsub.start(pubsub.config_with_scope("my_app_pubsub"))
 
 The scope maps to a `pg` scope atom. Different scopes are completely isolated from each other.
 
-:::danger[The scope must be a compile-time constant]
+:::danger[The scope must be a static, bounded deployment value]
 The scope name is converted to an Erlang atom. Atoms are never
-garbage-collected; exhausting the BEAM atom table crashes the VM. Always use a
-compile-time constant string literal — never a value derived from a user
-request, environment variable, or database record.
+garbage-collected; exhausting the BEAM atom table crashes the VM. The scope
+must be a static, bounded deployment or configuration value — never raw
+user-derived, per-request, per-tenant, database-derived, or otherwise
+unbounded high-cardinality runtime input. A deployment-controlled value is
+acceptable only when validated or selected from a fixed bounded set.
 :::
 
 ## Subscribing

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -155,16 +155,23 @@ Create a PubSub configuration with a custom scope name
 
  The scope name is converted to an Erlang atom via `binary_to_atom`.
  Atoms are never garbage-collected, so the scope name must be a
- **compile-time constant** — never pass a user-supplied or
- runtime-computed value. A malicious or high-cardinality source can
- exhaust the BEAM atom table and crash the VM.
+ **static, bounded deployment or configuration value** — never raw
+ user-derived, per-request, per-tenant, database-derived, or otherwise
+ unbounded high-cardinality runtime input. A deployment-controlled value
+ is acceptable only when validated or selected from a fixed bounded set.
+ A malicious or high-cardinality source can exhaust the BEAM atom table
+ and crash the VM.
 
  ```gleam
- // Correct — compile-time constant
+ // Correct — static deployment constant
  pubsub.config_with_scope("my_app_pubsub")
+
+ // Correct — deployment-controlled, selected from a fixed bounded set
+ // pubsub.config_with_scope(config.pubsub_scope())
 
  // WRONG — never do this
  // pubsub.config_with_scope(user_request.tenant_id)
+ // pubsub.config_with_scope(database_row.name)
  ```
 
 ```gleam

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -154,9 +154,18 @@ pub fn broadcast_from_socket(
 Create a PubSub configuration with a custom scope name
 
  The scope name is converted to an Erlang atom via `binary_to_atom`.
- Atoms are never garbage-collected, so the scope name must be a static,
- bounded value — never derive it from user input, or a malicious or
- high-cardinality source could exhaust the atom table and crash the VM.
+ Atoms are never garbage-collected, so the scope name must be a
+ **compile-time constant** — never pass a user-supplied or
+ runtime-computed value. A malicious or high-cardinality source can
+ exhaust the BEAM atom table and crash the VM.
+
+ ```gleam
+ // Correct — compile-time constant
+ pubsub.config_with_scope("my_app_pubsub")
+
+ // WRONG — never do this
+ // pubsub.config_with_scope(user_request.tenant_id)
+ ```
 
 ```gleam
 pub fn config_with_scope(String) -> PubSubConfig


### PR DESCRIPTION
## Summary

- define Erlang distribution peers as fully trusted cluster input
- document cookie, TLS distribution, EPMD/port, and cluster isolation requirements
- clarify internal PubSub/presence traffic and safe `config_with_scope` usage

## Validation

- `just check`
- `just format-check`
- generated reference docs
- Astro check

Closes #192