### PR TITLE
feat(transport): default to same-origin WebSocket policy

### DIFF
--- a/.changes/unreleased/Changed-20260711-165425.yaml
+++ b/.changes/unreleased/Changed-20260711-165425.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: |-
+    WebSocket transport now defaults to a same-origin Origin policy, rejecting cross-site upgrades before the handshake.
+    This mitigates Cross-Site WebSocket Hijacking (CSWSH) for cookie/session-authenticated apps (#193). Same-origin upgrades and non-browser clients (no Origin header) still connect without configuration. To restore the previous allow-all behaviour use with_allow_all_origins; to pin specific origins use with_allowed_origins (now an explicit allow-list).
+time: 2026-07-11T09:54:25-0700

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -41,9 +41,9 @@ pub opaque type TransportConfig(assigns) {
     /// with a 403 Forbidden response. When None, all connections are allowed
     /// and assigns start empty (`Nil`).
     on_connect: Option(fn(Request(Connection)) -> Result(assigns, ConnectError)),
-    /// Optional exact Origin header allow-list checked before the WebSocket
-    /// handshake. When None, all origins are allowed.
-    allowed_origins: Option(List(String)),
+    /// Policy applied to the request `Origin` header before the WebSocket
+    /// handshake. Defaults to [`SameOrigin`](#OriginPolicy).
+    origin_policy: OriginPolicy,
   )
 }
 
@@ -53,12 +53,60 @@ pub type ConnectError {
   ConnectRejected
 }
 
+/// Policy for validating the browser `Origin` header before a WebSocket
+/// upgrade completes.
+///
+/// The `Origin` check is the primary defence against Cross-Site WebSocket
+/// Hijacking (CSWSH): a browser attaches ambient cookies/session credentials
+/// to a WebSocket handshake regardless of which site initiated it, so a socket
+/// that authenticates from those credentials must reject upgrades that
+/// originate from other sites.
+///
+/// In every policy, a request with **no** `Origin` header is allowed: browsers
+/// always send `Origin` on WebSocket handshakes, so an absent header signals a
+/// non-browser client (native app, server-to-server, CLI) that is not subject
+/// to the browser same-origin model and cannot be tricked into a cross-site
+/// upgrade. The one exception is [`AllowList`](#OriginPolicy), which requires a
+/// matching `Origin` and therefore rejects absent ones.
+pub type OriginPolicy {
+  /// Allow an upgrade only when the request `Origin` authority (host plus any
+  /// port, with the scheme stripped) matches the request `Host` authority.
+  /// This is the default and rejects cross-site upgrades before the handshake.
+  ///
+  /// A malformed or opaque `Origin` (e.g. `null` from a sandboxed iframe, or a
+  /// value with no host) is rejected. Comparison is over the full `host:port`
+  /// authority, so a non-default port must match on both sides.
+  ///
+  /// Behind a reverse proxy this compares against the `Host` header as the app
+  /// sees it: ensure the proxy forwards the public `Host` unchanged, or use
+  /// [`AllowList`](#OriginPolicy) with the public origins instead. Forwarded
+  /// headers such as `X-Forwarded-Host` are not trusted, because clients can
+  /// spoof them.
+  SameOrigin
+  /// Allow an upgrade only when the request `Origin` header matches one of the
+  /// listed values exactly (including scheme, host, and any port), such as
+  /// `"https://app.example.com"`. Requests without an `Origin` header, or with
+  /// a non-matching one, are rejected.
+  AllowList(List(String))
+  /// Allow every upgrade regardless of `Origin`. This is an explicit opt-out
+  /// of CSWSH protection: only use it for sockets that do not rely on ambient
+  /// browser credentials (or that authenticate every message independently).
+  AllowAll
+}
+
 /// Create a default transport config with no connect hook.
 ///
-/// The resulting config seeds `Nil` assigns. Add `with_on_connect` to
-/// authenticate connections and/or seed initial assigns.
+/// The resulting config seeds `Nil` assigns and applies the
+/// [`SameOrigin`](#OriginPolicy) origin policy, which rejects cross-site
+/// WebSocket upgrades before the handshake (CSWSH protection). Same-origin
+/// upgrades and non-browser clients (no `Origin` header) are admitted without
+/// configuration.
+///
+/// Add `with_on_connect` to authenticate connections and/or seed initial
+/// assigns. Use `with_allowed_origins` to pin an explicit allow-list, or
+/// `with_allow_all_origins` to opt out of origin checking entirely.
 pub fn default_config(path: String) -> TransportConfig(Nil) {
-  TransportConfig(path: path, on_connect: None, allowed_origins: None)
+  TransportConfig(path: path, on_connect: None, origin_policy: SameOrigin)
 }
 
 /// Set a socket-level connect/authentication callback on the transport config.
@@ -75,16 +123,22 @@ pub fn with_on_connect(
   TransportConfig(
     path: config.path,
     on_connect: Some(callback),
-    allowed_origins: config.allowed_origins,
+    origin_policy: config.origin_policy,
   )
 }
 
-/// Restrict WebSocket upgrades to requests with an allowed `Origin` header.
+/// Restrict WebSocket upgrades to requests whose `Origin` header exactly
+/// matches one of the given values.
 ///
-/// Values are matched exactly against the full Origin header value, including
-/// scheme and host (and port when present), such as
-/// `"https://app.example.com"`. When configured, missing or non-matching
-/// origins are rejected with `403 Forbidden` before the WebSocket handshake.
+/// This replaces the default [`SameOrigin`](#OriginPolicy) policy with an
+/// [`AllowList`](#OriginPolicy). Values are matched exactly against the full
+/// `Origin` header, including scheme and host (and port when present), such as
+/// `"https://app.example.com"`. Missing or non-matching origins are rejected
+/// with `403 Forbidden` before the WebSocket handshake.
+///
+/// Prefer this over `with_allow_all_origins` when you know the exact origins
+/// that should be allowed (e.g. behind a reverse proxy that rewrites the
+/// `Host` header, where `SameOrigin` cannot see the public host).
 pub fn with_allowed_origins(
   config: TransportConfig(assigns),
   origins: List(String),
@@ -92,7 +146,25 @@ pub fn with_allowed_origins(
   TransportConfig(
     path: config.path,
     on_connect: config.on_connect,
-    allowed_origins: Some(origins),
+    origin_policy: AllowList(origins),
+  )
+}
+
+/// Disable `Origin` checking, allowing WebSocket upgrades from any origin.
+///
+/// This is an explicit opt-out of the default [`SameOrigin`](#OriginPolicy)
+/// CSWSH protection and restores the pre-1.0 allow-all behaviour. Only use it
+/// for sockets that do not rely on ambient browser credentials (cookies,
+/// sessions) for authorization, or that authenticate every message
+/// independently. For cookie/session-authenticated apps, prefer the default
+/// `SameOrigin` policy or `with_allowed_origins`.
+pub fn with_allow_all_origins(
+  config: TransportConfig(assigns),
+) -> TransportConfig(assigns) {
+  TransportConfig(
+    path: config.path,
+    on_connect: config.on_connect,
+    origin_policy: AllowAll,
   )
 }
 
@@ -174,7 +246,7 @@ fn handle_matched_upgrade(
   config: TransportConfig(assigns),
 ) -> Response(ResponseData) {
   use <- bool.lazy_guard(
-    when: !origin_allowed(request, config.allowed_origins),
+    when: !origin_allowed(request, config.origin_policy),
     return: forbidden,
   )
   use <- bool.lazy_guard(when: !vsn_supported(request), return: forbidden)
@@ -208,17 +280,64 @@ fn vsn_supported(request: Request(Connection)) -> Bool {
   }
 }
 
-fn origin_allowed(
-  request: Request(Connection),
-  allowed_origins: Option(List(String)),
-) -> Bool {
-  case allowed_origins {
-    None -> True
-    Some(origins) ->
+/// Decide whether an upgrade is allowed under the configured origin policy.
+///
+/// A request with no `Origin` header is admitted for `SameOrigin` and
+/// `AllowAll` (non-browser clients omit `Origin`), but rejected for
+/// `AllowList`, which requires an explicit match.
+fn origin_allowed(request: Request(Connection), policy: OriginPolicy) -> Bool {
+  case policy {
+    AllowAll -> True
+    AllowList(origins) ->
       case request.get_header(request, "origin") {
         Ok(origin) -> list.contains(origins, origin)
         Error(Nil) -> False
       }
+    SameOrigin ->
+      case request.get_header(request, "origin") {
+        // Non-browser clients don't send Origin; they can't be driven into a
+        // cross-site upgrade, so admit them.
+        Error(Nil) -> True
+        Ok(origin) ->
+          case request.get_header(request, "host") {
+            Ok(host) -> same_origin(origin, host)
+            // Without a Host header we cannot establish the request's own
+            // authority, so fail closed.
+            Error(Nil) -> False
+          }
+      }
+  }
+}
+
+/// Compare an `Origin` header value against a `Host` header value under the
+/// same-origin rule: strip the scheme from the origin and compare its
+/// authority (host plus any port) to the host authority, case-insensitively.
+///
+/// A malformed or opaque origin (no `scheme://host`, e.g. `null`) never
+/// matches. Comparison is over the full `host:port` authority, so a
+/// non-default port must be present and equal on both sides.
+@internal
+pub fn same_origin(origin: String, host: String) -> Bool {
+  case origin_authority(origin) {
+    Ok(authority) -> authority == string.lowercase(host)
+    Error(Nil) -> False
+  }
+}
+
+/// Extract the lower-cased authority (`host[:port]`) from an `Origin` header
+/// value, stripping the `scheme://` prefix. Returns `Error(Nil)` for values
+/// without a scheme-delimited host (malformed or opaque origins such as
+/// `null`).
+fn origin_authority(origin: String) -> Result(String, Nil) {
+  use #(_scheme, rest) <- result.try(string.split_once(origin, "://"))
+  // An Origin has no path, but strip a trailing path defensively.
+  let authority = case string.split_once(rest, "/") {
+    Ok(#(authority, _path)) -> authority
+    Error(Nil) -> rest
+  }
+  case authority {
+    "" -> Error(Nil)
+    _ -> Ok(string.lowercase(authority))
   }
 }
 

--- a/test/mist_handler_test.gleam
+++ b/test/mist_handler_test.gleam
@@ -9,6 +9,7 @@ import beryl/wire
 import gleam/bytes_tree
 import gleam/erlang/process
 import gleam/http/response
+import gleam/int
 import gleam/string
 import gleeunit/should
 import mist
@@ -166,6 +167,63 @@ pub fn handler_rejects_disallowed_origin_and_allows_allowed_origin_test() {
   let assert Ok(client) =
     connect_websocket_with_origin(port, "/socket", "https://app.example.com")
   close(client)
+  stop_supervisor(server_pid)
+}
+
+pub fn handler_default_rejects_cross_origin_upgrade_test() {
+  // The default config uses the SameOrigin policy, so a browser upgrade whose
+  // Origin does not match the request Host is rejected before the handshake.
+  let channels = start_channels()
+  let #(port, server_pid) = start_server(channels)
+
+  websocket_upgrade_status_with_origin(
+    port,
+    "/socket",
+    "https://evil.example.com",
+  )
+  |> should.equal(Ok(403))
+
+  stop_supervisor(server_pid)
+}
+
+pub fn handler_default_allows_same_origin_upgrade_test() {
+  // A same-origin browser upgrade (Origin authority matches the Host authority
+  // `127.0.0.1:<port>`) is admitted under the default SameOrigin policy.
+  let channels = start_channels()
+  let #(port, server_pid) = start_server(channels)
+
+  let origin = "http://127.0.0.1:" <> int.to_string(port)
+  let assert Ok(client) = connect_websocket_with_origin(port, "/socket", origin)
+  close(client)
+
+  stop_supervisor(server_pid)
+}
+
+pub fn handler_default_allows_absent_origin_upgrade_test() {
+  // Non-browser clients omit the Origin header entirely; the SameOrigin policy
+  // admits them (they are not subject to the browser same-origin model).
+  let channels = start_channels()
+  let #(port, server_pid) = start_server(channels)
+
+  let assert Ok(client) = connect_websocket(port, "/socket")
+  close(client)
+
+  stop_supervisor(server_pid)
+}
+
+pub fn handler_allow_all_origins_admits_cross_origin_test() {
+  // Explicit opt-out: with_allow_all_origins restores the pre-1.0 allow-all
+  // behaviour for apps that intentionally accept cross-origin sockets.
+  let channels = start_channels()
+  let config =
+    mist_transport.default_config("/socket")
+    |> mist_transport.with_allow_all_origins()
+  let #(port, server_pid) = start_server_with_config(channels, config)
+
+  let assert Ok(client) =
+    connect_websocket_with_origin(port, "/socket", "https://evil.example.com")
+  close(client)
+
   stop_supervisor(server_pid)
 }
 

--- a/test/mist_transport_test.gleam
+++ b/test/mist_transport_test.gleam
@@ -80,3 +80,80 @@ pub fn upgrade_connection_is_exported_test() {
   let _upgrade = mist_transport.upgrade_connection
   should.be_true(True)
 }
+
+pub fn with_allowed_origins_sets_list_test() {
+  let config =
+    mist_transport.default_config("/socket")
+    |> mist_transport.with_allowed_origins(["https://app.example.com"])
+
+  let _typed_config: mist_transport.TransportConfig(Nil) = config
+  should.be_true(True)
+}
+
+pub fn with_allow_all_origins_is_exported_test() {
+  let config =
+    mist_transport.default_config("/socket")
+    |> mist_transport.with_allow_all_origins()
+
+  let _typed_config: mist_transport.TransportConfig(Nil) = config
+  should.be_true(True)
+}
+
+// --- same_origin authority comparison ---------------------------------------
+//
+// `same_origin` implements the SameOrigin policy at the string level: it
+// strips the scheme from the `Origin` header value and compares the resulting
+// authority (host + optional port) against the request `Host` authority.
+
+pub fn same_origin_matches_host_ignoring_scheme_test() {
+  mist_transport.same_origin("http://app.example.com", "app.example.com")
+  |> should.be_true
+
+  mist_transport.same_origin("https://app.example.com", "app.example.com")
+  |> should.be_true
+}
+
+pub fn same_origin_rejects_cross_origin_test() {
+  mist_transport.same_origin("https://evil.example.com", "app.example.com")
+  |> should.be_false
+}
+
+pub fn same_origin_matches_non_default_port_test() {
+  mist_transport.same_origin("http://127.0.0.1:8080", "127.0.0.1:8080")
+  |> should.be_true
+}
+
+pub fn same_origin_rejects_port_mismatch_test() {
+  mist_transport.same_origin("http://127.0.0.1:8080", "127.0.0.1:9090")
+  |> should.be_false
+}
+
+pub fn same_origin_is_case_insensitive_on_host_test() {
+  mist_transport.same_origin("https://APP.Example.COM", "app.example.com")
+  |> should.be_true
+}
+
+pub fn same_origin_rejects_opaque_origin_test() {
+  // Sandboxed iframes / file:// documents send `Origin: null`.
+  mist_transport.same_origin("null", "app.example.com")
+  |> should.be_false
+}
+
+pub fn same_origin_rejects_malformed_origin_test() {
+  mist_transport.same_origin("garbage", "app.example.com")
+  |> should.be_false
+
+  // Scheme present but no host authority.
+  mist_transport.same_origin("https://", "app.example.com")
+  |> should.be_false
+}
+
+pub fn same_origin_matches_forwarded_host_authority_test() {
+  // Behind a reverse proxy that preserves the public Host header, the browser
+  // Origin authority (host:port) must match the forwarded Host authority.
+  mist_transport.same_origin(
+    "https://public.example.com:8443",
+    "public.example.com:8443",
+  )
+  |> should.be_true
+}

--- a/website/src/content/docs/reference/api/beryl-transport-mist.md
+++ b/website/src/content/docs/reference/api/beryl-transport-mist.md
@@ -26,6 +26,63 @@ pub type ConnectError {
 
 Reject the WebSocket upgrade with `403 Forbidden`.
 
+### `OriginPolicy`
+
+Policy for validating the browser `Origin` header before a WebSocket
+ upgrade completes.
+
+ The `Origin` check is the primary defence against Cross-Site WebSocket
+ Hijacking (CSWSH): a browser attaches ambient cookies/session credentials
+ to a WebSocket handshake regardless of which site initiated it, so a socket
+ that authenticates from those credentials must reject upgrades that
+ originate from other sites.
+
+ In every policy, a request with **no** `Origin` header is allowed: browsers
+ always send `Origin` on WebSocket handshakes, so an absent header signals a
+ non-browser client (native app, server-to-server, CLI) that is not subject
+ to the browser same-origin model and cannot be tricked into a cross-site
+ upgrade. The one exception is [`AllowList`](#OriginPolicy), which requires a
+ matching `Origin` and therefore rejects absent ones.
+
+```gleam
+pub type OriginPolicy {
+  SameOrigin
+  AllowList(List(String))
+  AllowAll
+}
+```
+
+#### Constructors
+
+##### `SameOrigin`
+
+Allow an upgrade only when the request `Origin` authority (host plus any
+ port, with the scheme stripped) matches the request `Host` authority.
+ This is the default and rejects cross-site upgrades before the handshake.
+
+ A malformed or opaque `Origin` (e.g. `null` from a sandboxed iframe, or a
+ value with no host) is rejected. Comparison is over the full `host:port`
+ authority, so a non-default port must match on both sides.
+
+ Behind a reverse proxy this compares against the `Host` header as the app
+ sees it: ensure the proxy forwards the public `Host` unchanged, or use
+ [`AllowList`](#OriginPolicy) with the public origins instead. Forwarded
+ headers such as `X-Forwarded-Host` are not trusted, because clients can
+ spoof them.
+
+##### `AllowList(List(String))`
+
+Allow an upgrade only when the request `Origin` header matches one of the
+ listed values exactly (including scheme, host, and any port), such as
+ `"https://app.example.com"`. Requests without an `Origin` header, or with
+ a non-matching one, are rejected.
+
+##### `AllowAll`
+
+Allow every upgrade regardless of `Origin`. This is an explicit opt-out
+ of CSWSH protection: only use it for sockets that do not rely on ambient
+ browser credentials (or that authenticate every message independently).
+
 ### `TransportConfig`
 
 Configuration for the Mist WebSocket transport
@@ -43,8 +100,15 @@ pub type TransportConfig(a)
 
 Create a default transport config with no connect hook.
 
- The resulting config seeds `Nil` assigns. Add `with_on_connect` to
- authenticate connections and/or seed initial assigns.
+ The resulting config seeds `Nil` assigns and applies the
+ [`SameOrigin`](#OriginPolicy) origin policy, which rejects cross-site
+ WebSocket upgrades before the handshake (CSWSH protection). Same-origin
+ upgrades and non-browser clients (no `Origin` header) are admitted without
+ configuration.
+
+ Add `with_on_connect` to authenticate connections and/or seed initial
+ assigns. Use `with_allowed_origins` to pin an explicit allow-list, or
+ `with_allow_all_origins` to opt out of origin checking entirely.
 
 ```gleam
 pub fn default_config(String) -> TransportConfig(Nil)
@@ -139,14 +203,35 @@ pub fn upgrade_connection(
 ) -> response.Response(mist.ResponseData)
 ```
 
+### `with_allow_all_origins`
+
+Disable `Origin` checking, allowing WebSocket upgrades from any origin.
+
+ This is an explicit opt-out of the default [`SameOrigin`](#OriginPolicy)
+ CSWSH protection and restores the pre-1.0 allow-all behaviour. Only use it
+ for sockets that do not rely on ambient browser credentials (cookies,
+ sessions) for authorization, or that authenticate every message
+ independently. For cookie/session-authenticated apps, prefer the default
+ `SameOrigin` policy or `with_allowed_origins`.
+
+```gleam
+pub fn with_allow_all_origins(TransportConfig(a)) -> TransportConfig(a)
+```
+
 ### `with_allowed_origins`
 
-Restrict WebSocket upgrades to requests with an allowed `Origin` header.
+Restrict WebSocket upgrades to requests whose `Origin` header exactly
+ matches one of the given values.
 
- Values are matched exactly against the full Origin header value, including
- scheme and host (and port when present), such as
- `"https://app.example.com"`. When configured, missing or non-matching
- origins are rejected with `403 Forbidden` before the WebSocket handshake.
+ This replaces the default [`SameOrigin`](#OriginPolicy) policy with an
+ [`AllowList`](#OriginPolicy). Values are matched exactly against the full
+ `Origin` header, including scheme and host (and port when present), such as
+ `"https://app.example.com"`. Missing or non-matching origins are rejected
+ with `403 Forbidden` before the WebSocket handshake.
+
+ Prefer this over `with_allow_all_origins` when you know the exact origins
+ that should be allowed (e.g. behind a reverse proxy that rewrites the
+ `Host` header, where `SameOrigin` cannot see the public host).
 
 ```gleam
 pub fn with_allowed_origins(


### PR DESCRIPTION
Fixes #193.

Establishes a secure-by-default WebSocket Origin policy before 1.0, mitigating Cross-Site WebSocket Hijacking (CSWSH) for apps using ambient cookie/session auth.

## Changes
- New public `OriginPolicy` type: `SameOrigin` (new default) | `AllowList(List(String))` | `AllowAll`.
- `default_config` now defaults to `SameOrigin` — the `Origin` authority is compared against the request `Host`.
- `with_allowed_origins` now sets `AllowList` (exact-match behavior preserved).
- New `with_allow_all_origins` for explicit cross-origin opt-out.
- Absent `Origin` allowed under `SameOrigin`/`AllowAll` (non-browser clients); missing `Host` fails closed.

## Decisions
- Does **not** trust `X-Forwarded-Host` (consistent with the existing `X-Forwarded-For` stance). Proxied deployments should preserve the public `Host`, or use `with_allowed_origins`.
- No default-port normalization; `with_allowed_origins` is the escape hatch for exact-port needs.

## Tests
Unit tests for `same_origin` (scheme-stripping, ports, case, malformed/`null`, forwarded-host) plus end-to-end Mist listener tests (cross-origin 403, same-origin allow, absent Origin, allow-all). Full suite green.

⚠️ **Breaking (intended, pre-1.0):** config field type changed and the default now rejects cross-origin browser upgrades. Migration guidance is in the changie entry and doc comments.
