### PR TITLE
fix(presence): guard RemoteSync merge with an exception boundary

### DIFF
--- a/.changes/unreleased/Fixed-20260711-165724.yaml
+++ b/.changes/unreleased/Fixed-20260711-165724.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Presence RemoteSync merge/prune now runs inside an exception boundary, so a malformed or hostile cluster sync message can no longer crash the shared presence actor or partially mutate presence state.
+time: 2026-07-11T16:57:24.000000Z

--- a/src/beryl/coordinator.gleam
+++ b/src/beryl/coordinator.gleam
@@ -387,12 +387,6 @@ fn monotonic_time_ms() -> Int
 @external(erlang, "beryl_ffi", "identity")
 fn coerce_to_pubsub_message(value: Dynamic) -> pubsub.Message
 
-// nolint: stringly_typed_error -- the error is the formatted BEAM crash description; it is wrapped in channel.Errored at use sites
-/// Run a user-supplied channel callback, converting any crash into an error
-/// so a faulty channel cannot take down the shared coordinator actor.
-@external(erlang, "beryl_ffi", "rescue")
-fn rescue(callback: fn() -> value) -> Result(value, String)
-
 // ── Handler registry ────────────────────────────────────────────────────────
 
 /// A crash-survivable store for channel registrations.
@@ -702,7 +696,9 @@ fn handle_message(
       // The pg-delivered record is coerced without validation, so a
       // malformed message (mixed-version cluster, stray tuple sent to the
       // coordinator's pid) must not crash the coordinator.
-      case rescue(fn() { handle_remote_broadcast(state, pubsub_msg) }) {
+      case
+        internal.rescue(fn() { handle_remote_broadcast(state, pubsub_msg) })
+      {
         Ok(next) -> next
         Error(crash) -> {
           coordinator_logger(state)
@@ -2075,7 +2071,7 @@ fn dispatch_join(
       close: socket_info.close,
     )
 
-  case rescue(fn() { handler.join(topic_name, payload, ctx) }) {
+  case internal.rescue(fn() { handler.join(topic_name, payload, ctx) }) {
     Error(crash) ->
       reject_crashed_join(state, socket_info, topic_name, join_ref, ref, crash)
     Ok(JoinErrorErased(reason)) -> {
@@ -2237,7 +2233,7 @@ fn dispatch_handle_in(
       close: socket_info.close,
     )
 
-  case rescue(fn() { handler.handle_in(event, payload, ctx) }) {
+  case internal.rescue(fn() { handler.handle_in(event, payload, ctx) }) {
     Error(crash) ->
       actor.continue(handle_callback_crash(
         state,
@@ -2373,7 +2369,7 @@ fn dispatch_handle_info(
       close: socket_info.close,
     )
 
-  case rescue(fn() { callback(ctx) }) {
+  case internal.rescue(fn() { callback(ctx) }) {
     Error(crash) ->
       actor.continue(handle_callback_crash(
         state,
@@ -2469,7 +2465,7 @@ fn dispatch_handle_binary(
       close: socket_info.close,
     )
 
-  case rescue(fn() { handler.handle_binary(data, ctx) }) {
+  case internal.rescue(fn() { handler.handle_binary(data, ctx) }) {
     Error(crash) ->
       handle_callback_crash(st, socket_id, topic_name, "handle_binary", crash)
     Ok(NoReplyErased(new_assigns)) -> {
@@ -2604,7 +2600,7 @@ fn do_terminate_channel(
           send_binary: socket_info.send_binary,
           close: socket_info.close,
         )
-      case rescue(fn() { handler.terminate(reason, ctx) }) {
+      case internal.rescue(fn() { handler.terminate(reason, ctx) }) {
         Ok(Nil) -> Nil
         Error(crash) ->
           logger

--- a/src/beryl/internal.gleam
+++ b/src/beryl/internal.gleam
@@ -48,6 +48,16 @@ pub fn result_error(error: e) -> Result(a, e) {
   Error(error)
 }
 
+// nolint: stringly_typed_error -- the error is the formatted BEAM crash description; callers wrap or log it at use sites
+/// Run a callback, converting any BEAM crash (error/exit/throw) into an
+/// `Error(description)` so a faulty callback cannot take down the shared actor
+/// that invoked it.
+///
+/// The description is depth-limited and truncated by the FFI so a
+/// client-triggered crash cannot bloat log metadata.
+@external(erlang, "beryl_ffi", "rescue")
+pub fn rescue(callback: fn() -> value) -> Result(value, String)
+
 /// Return a named logger.
 pub fn logger(name: String) -> Logger {
   log.new(name)

--- a/src/beryl/presence.gleam
+++ b/src/beryl/presence.gleam
@@ -752,27 +752,47 @@ fn handle_sync_payload(
       actor.continue(actor_state)
     }
     Ok(#(sender, remote_state)) -> {
-      let #(new_crdt, state_diff) =
-        state.merge_with_diff(actor_state.crdt, remote_state)
-      let diff = wrap_state_diff(state_diff)
-      let changed = !{ dict.is_empty(diff.joins) && dict.is_empty(diff.leaves) }
-      maybe_invoke_on_diff(actor_state.config, diff)
-      // The merge may have (re)admitted state from dead incarnations —
-      // the sender's predecessors, or our own pre-restart self echoed back
-      // by a peer. Prune anything superseded by the two incarnations known
-      // to be live right now: the sender and ourselves.
-      let new_crdt =
-        prune_superseded(actor_state.config, new_crdt, [
-          sender,
-          state.replica(new_crdt),
-        ])
-      actor.continue(
-        ActorState(
-          ..actor_state,
-          crdt: new_crdt,
-          dirty: actor_state.dirty || changed,
-        ),
-      )
+      // Merge, diff, on_diff, and prune all run inside a crash boundary. The
+      // remote state originates from another cluster node (possibly a mixed
+      // version, a compromised peer, or a malformed dynamic value); an
+      // exception here must not terminate the shared presence actor. On
+      // failure we return the previous, unchanged `actor_state` so invalid
+      // sync input cannot partially mutate presence state.
+      let processed =
+        internal.rescue(fn() {
+          let #(new_crdt, state_diff) =
+            state.merge_with_diff(actor_state.crdt, remote_state)
+          let diff = wrap_state_diff(state_diff)
+          let changed =
+            !{ dict.is_empty(diff.joins) && dict.is_empty(diff.leaves) }
+          maybe_invoke_on_diff(actor_state.config, diff)
+          // The merge may have (re)admitted state from dead incarnations —
+          // the sender's predecessors, or our own pre-restart self echoed back
+          // by a peer. Prune anything superseded by the two incarnations known
+          // to be live right now: the sender and ourselves.
+          let new_crdt =
+            prune_superseded(actor_state.config, new_crdt, [
+              sender,
+              state.replica(new_crdt),
+            ])
+          ActorState(
+            ..actor_state,
+            crdt: new_crdt,
+            dirty: actor_state.dirty || changed,
+          )
+        })
+      case processed {
+        Ok(next_state) -> actor.continue(next_state)
+        Error(crash) -> {
+          let logger = internal.logger("beryl.presence")
+          logger
+          |> log.error("Remote presence sync dropped: processing failed", [
+            #("crash", crash),
+            #("payload_length", int.to_string(string.length(payload_str))),
+          ])
+          actor.continue(actor_state)
+        }
+      }
     }
   }
 }

--- a/test/presence_replication_test.gleam
+++ b/test/presence_replication_test.gleam
@@ -345,6 +345,55 @@ pub fn survives_wrong_types_payload_test() {
   list.length(presence.list(p, "room:lobby")) |> should.equal(2)
 }
 
+// ── Resilience: exception raised inside the merge/processing path ─────
+
+/// A valid remote sync can decode successfully yet still crash while the
+/// merge result is processed — for example, a user-supplied `on_diff`
+/// callback that panics, a mixed-version peer, or a compromised node. The
+/// exception must be contained: the shared presence actor stays alive and its
+/// state is not partially mutated by the poisoned sync.
+pub fn survives_exception_in_processing_path_test() {
+  let ps = test_pubsub("processing_crash")
+
+  // Node1's on_diff panics whenever a diff touches "room:poison". Diffs for
+  // any other topic pass through untouched, so local tracking still works.
+  let config1 =
+    presence.default_config("node1")
+    |> presence.with_pubsub(ps)
+    |> presence.with_on_diff(fn(diff) {
+      case presence.diff_joins(diff, "room:poison") {
+        [] -> Nil
+        _ -> panic as "poisoned diff"
+      }
+    })
+  let assert Ok(p1) = presence.start(config1)
+
+  // Prove the actor is alive and record its state before the poisoned sync.
+  let _ =
+    presence.track(p1, "room:lobby", "user:safe", "socket-safe", json.null())
+  list.length(presence.list(p1, "room:lobby")) |> should.equal(1)
+
+  // Node2 broadcasts a *valid* sync that decodes cleanly but produces a diff
+  // touching "room:poison", tripping node1's panicking callback inside the
+  // merge/processing path.
+  let config2 = test_config(ps, "node2", 50)
+  let assert Ok(p2) = presence.start(config2)
+  let _ =
+    presence.track(p2, "room:poison", "user:boom", "socket-boom", json.null())
+
+  // Give node1 time to receive and reject several broadcasts of the poison.
+  process.sleep(200)
+
+  // The actor is still alive: a fresh local track succeeds.
+  let _ =
+    presence.track(p1, "room:lobby", "user:safe2", "socket-safe2", json.null())
+  list.length(presence.list(p1, "room:lobby")) |> should.equal(2)
+
+  // State was not partially mutated: the poisoned sync never merged, so
+  // "room:poison" remains empty on node1.
+  presence.list(p1, "room:poison") |> should.equal([])
+}
+
 // ── Helper to drain stray messages ──────────────────────────────────
 
 fn drain_mailbox() -> Nil {


### PR DESCRIPTION
Fixes #199.

Adds an exception boundary around the presence actor's `RemoteSync` decode/merge path, mirroring the coordinator's existing `rescue` guard for remote broadcasts. A malformed or hostile cluster sync message can no longer crash the shared presence actor or partially mutate its state.

## Changes
- Lifted the private `rescue` helper into `beryl/internal.gleam` as a shared `pub fn rescue` (the backing FFI was already shared, so no `.erl` change). Coordinator repointed to `internal.rescue`; behavior unchanged.
- Wrapped the entire merge/prune branch of `handle_sync_payload` in `internal.rescue`. On failure it logs via `beryl.presence` (`crash` + `payload_length` only — no payload dump) and returns the previous, unchanged state.
- Existing decode-error handling (`SyncDecodeFailed` / `UnknownEnvelopeVersion`) untouched.

## Tests
New `survives_exception_in_processing_path_test`: a panicking `on_diff` callback fires *inside* the guarded region (triggered by a valid sync from a second real presence actor), proving the actor survives and state isn't partially mutated. Existing decode-error tests retained. Full suite green.
