### PR TITLE
ci: pin and verify rebar3 downloads

### DIFF
--- a/.changes/unreleased/Security-20260711-165121.yaml
+++ b/.changes/unreleased/Security-20260711-165121.yaml
@@ -1,0 +1,4 @@
+kind: Security
+body: |-
+    CI now pins and SHA-256 verifies the rebar3 binary before execution.
+time: 2026-07-11T16:51:21.000000-00:00

--- a/.github/actions/install-rebar3/action.yml
+++ b/.github/actions/install-rebar3/action.yml
@@ -1,0 +1,35 @@
+name: Install rebar3
+description: >-
+  Download a version-pinned rebar3 binary from the official GitHub releases and
+  verify its SHA-256 checksum before installing it. Fails closed on mismatch.
+
+# Single source of truth for the pinned rebar3 version and checksum.
+# To upgrade: bump REBAR3_VERSION, download the artifact from
+# https://github.com/erlang/rebar3/releases/download/<version>/rebar3 and
+# update REBAR3_SHA256 with `sha256sum` of that file.
+inputs:
+  install-dir:
+    description: Directory to install the rebar3 binary into (must be on PATH).
+    required: false
+    default: /usr/local/bin
+
+runs:
+  using: composite
+  steps:
+    - name: Install rebar3 (pinned + verified)
+      shell: bash
+      env:
+        REBAR3_VERSION: "3.24.0"
+        REBAR3_SHA256: "d2d31cfb98904b8e4917300a75f870de12cb5167cd6214d1043e973a56668a54"
+        INSTALL_DIR: ${{ inputs.install-dir }}
+      run: |
+        set -euo pipefail
+        url="https://github.com/erlang/rebar3/releases/download/${REBAR3_VERSION}/rebar3"
+        tmp="$(mktemp)"
+        echo "Downloading rebar3 ${REBAR3_VERSION} from ${url}"
+        curl -fsSL "${url}" -o "${tmp}"
+        echo "Verifying SHA-256 checksum"
+        echo "${REBAR3_SHA256}  ${tmp}" | sha256sum -c -
+        install -m 0755 "${tmp}" "${INSTALL_DIR}/rebar3"
+        rm -f "${tmp}"
+        echo "Installed rebar3 ${REBAR3_VERSION} to ${INSTALL_DIR}/rebar3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,7 @@ jobs:
           run-deps: false
 
       - name: Install rebar3
-        run: |
-          wget -q https://s3.amazonaws.com/rebar3/rebar3 -O /usr/local/bin/rebar3
-          chmod +x /usr/local/bin/rebar3
+        uses: ./.github/actions/install-rebar3
 
       - name: Install Gleam dependencies
         run: gleam deps download
@@ -106,9 +104,7 @@ jobs:
         uses: tylerbutler/actions/setup-gleam@77f80621309fc7443b628802e08a815d41dd4b47 # ratchet:tylerbutler/actions/setup-gleam@main
 
       - name: Install rebar3
-        run: |
-          wget -q https://s3.amazonaws.com/rebar3/rebar3 -O /usr/local/bin/rebar3
-          chmod +x /usr/local/bin/rebar3
+        uses: ./.github/actions/install-rebar3
 
       - name: Install Playwright browsers
         run: pnpm -C examples exec playwright install --with-deps chromium


### PR DESCRIPTION
Fixes #197.

CI downloaded `rebar3` over HTTPS from a floating S3 path and executed it with no integrity verification, in two duplicated snippets.

## Changes
- New composite action `.github/actions/install-rebar3` — single source of truth for version + checksum. Downloads the version-pinned artifact from official GitHub releases, verifies SHA-256 with `sha256sum -c`, then installs. Runs under `set -euo pipefail`, so a mismatch or download failure fails the job **closed**.
- Both `ci.yml` jobs now call `uses: ./.github/actions/install-rebar3`.

## Pinned
- rebar3 **3.24.0**, SHA-256 `d2d31cfb98904b8e4917300a75f870de12cb5167cd6214d1043e973a56668a54` — obtained by downloading the exact artifact and hashing it (verified it is a genuine rebar3 escript first).

## Note
`tylerbutler/actions/setup-gleam` may already provision rebar3, which could make these explicit steps redundant — left them (now hardened) since that couldn't be verified without risking CI. Possible follow-up simplification.
