### PR TITLE
feat(transport): add node-wide concurrent connection ceiling

### DIFF
--- a/.changes/unreleased/Added-20260711-165638.yaml
+++ b/.changes/unreleased/Added-20260711-165638.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: |-
+    Add `with_max_connections` to configure a node-wide ceiling on concurrent connections across all source IPs.
+    Connections above the ceiling are rejected with a 429 before any long-lived channel or coordinator state is allocated, and capacity is reclaimed on normal close, transport failure, heartbeat eviction, crash, and setup failure. It composes with the per-IP limit (`with_max_connections_per_ip`): a connection must be under both to be admitted, so distributed or rotating source addresses that a per-IP limit cannot stop still cannot exhaust the node. The ceiling is enforced per BEAM node; use an external load balancer for a cluster-wide cap.
+time: 2026-07-11T16:56:38.000000000Z

--- a/src/beryl.gleam
+++ b/src/beryl.gleam
@@ -159,6 +159,8 @@ pub opaque type Config {
     heartbeat_timeout_ms: Int,
     /// Max connections per IP (0 = unlimited)
     max_connections_per_ip: Int,
+    /// Max concurrent connections node-wide across all IPs (0 = unlimited)
+    max_connections: Int,
     /// Optional PubSub for distributed broadcasts across nodes
     pubsub: Option(PubSub),
     /// Per-socket message rate limit (messages/sec, 0 = unlimited)
@@ -221,6 +223,7 @@ pub fn config(codec: codec.Codec) -> Config {
     heartbeat_interval_ms: 30_000,
     heartbeat_timeout_ms: 60_000,
     max_connections_per_ip: 0,
+    max_connections: 0,
     pubsub: None,
     message_rate: 0,
     message_burst: 0,
@@ -293,6 +296,41 @@ pub fn with_max_connections_per_ip(
   max_connections max_connections: Int,
 ) -> Config {
   Config(..config, max_connections_per_ip: max_connections)
+}
+
+/// Configure the maximum number of concurrent connections allowed across the
+/// whole node, regardless of source IP.
+///
+/// A value of 0 (the default) means unlimited. When a limit is set, a transport
+/// admits a new connection only while the node is below the limit and rejects
+/// it (before allocating any long-lived channel/coordinator state) otherwise;
+/// the slot is freed when the connection closes, its process dies, or its
+/// handshake/setup fails. The check-and-increment is atomic inside the limiter
+/// actor, so a burst of concurrent opens cannot materially exceed the ceiling.
+///
+/// ## Composition with per-IP limits
+///
+/// This node-wide ceiling composes with `with_max_connections_per_ip`: when
+/// both are set a connection must be under *both* limits to be admitted. The
+/// per-IP limit throttles any single abusive peer, while this global ceiling
+/// bounds the node's total resource use so that many distinct source addresses
+/// (for example a botnet or IPv6 address rotation) still cannot exhaust the
+/// node's process, socket, and coordinator budget — a case a per-IP limit alone
+/// cannot stop.
+///
+/// ## Composition with external load balancers
+///
+/// This ceiling is enforced per BEAM node. If you run several nodes behind a
+/// load balancer, each node enforces its own limit independently, so the
+/// cluster's effective ceiling is roughly `max_connections × node_count`
+/// (subject to how the balancer distributes connections). Size the per-node
+/// value against a single node's capacity, and use the load balancer's own
+/// global connection/rate controls when you need a cluster-wide cap.
+pub fn with_max_connections(
+  config: Config,
+  max_connections max_connections: Int,
+) -> Config {
+  Config(..config, max_connections: max_connections)
 }
 
 /// Configure Beryl's internal logging.
@@ -429,6 +467,11 @@ pub fn config_max_connections_per_ip(config: Config) -> Int {
 }
 
 @internal
+pub fn config_max_connections(config: Config) -> Int {
+  config.max_connections
+}
+
+@internal
 pub fn config_pubsub(config: Config) -> Option(PubSub) {
   config.pubsub
 }
@@ -493,6 +536,7 @@ pub fn config_max_joined_topics_per_socket(config: Config) -> Int {
 pub fn warn_if_unprotected(config: Config) -> Nil {
   let unprotected =
     config.max_connections_per_ip <= 0
+    && config.max_connections <= 0
     && config.message_rate <= 0
     && config.join_rate <= 0
     && config.channel_rate <= 0
@@ -503,8 +547,8 @@ pub fn warn_if_unprotected(config: Config) -> Nil {
       "hint",
       "rate and connection limits are all disabled; fine for development, "
         <> "but for production configure with_message_rate, with_join_rate, "
-        <> "and with_max_connections_per_ip (see the production hardening "
-        <> "guide)",
+        <> "with_max_connections_per_ip, and with_max_connections (see the "
+        <> "production hardening guide)",
     ),
   ])
 }
@@ -587,6 +631,7 @@ pub fn channels_from_coordinator(
     pubsub: config.pubsub,
     connection_limiter: connection_limit.start_optional(
       config.max_connections_per_ip,
+      config.max_connections,
     ),
     registry: registry,
   )

--- a/src/beryl/connection_limit.gleam
+++ b/src/beryl/connection_limit.gleam
@@ -1,8 +1,21 @@
-//// Shared per-IP connection counter for transports.
+//// Shared connection counter for transports.
+////
+//// Enforces two independent dimensions in a single serialized actor:
+////
+//// - a per-IP ceiling (`max_per_ip`), which throttles a single peer, and
+//// - a node-wide ceiling (`max_total`), which caps concurrent connections
+////   across every IP so distributed/rotating source addresses cannot exhaust
+////   the node's process, socket, and coordinator budget.
+////
+//// Both are checked atomically inside `handle_message` on acquire, so
+//// concurrent opens cannot race past either ceiling. A single `Permit` tracks
+//// both dimensions and the same process monitor reclaims both when the holder
+//// dies without releasing.
 
 import gleam/bool
 import gleam/dict.{type Dict}
 import gleam/erlang/process.{type Monitor, type Pid, type Subject}
+import gleam/int
 import gleam/option.{type Option, None, Some}
 import gleam/otp/actor
 import gleam/result
@@ -21,7 +34,12 @@ pub opaque type Permit {
 
 type State {
   State(
+    /// Per-IP ceiling; 0 disables the per-IP check.
     max_per_ip: Int,
+    /// Node-wide ceiling across all IPs; 0 disables the global check.
+    max_total: Int,
+    /// Live connection count across every IP, checked against `max_total`.
+    total: Int,
     counts: Dict(String, Int),
     /// Monitors on bound permit-holder processes, so slots self-release when
     /// the holder dies without running its close path (crash, brutal kill).
@@ -54,7 +72,13 @@ fn handle_message(
         dict.get(state.counts, ip)
         |> result.unwrap(0)
 
-      case current >= state.max_per_ip {
+      // Both ceilings are checked here, inside the actor, so concurrent opens
+      // are serialized and cannot race past either limit. A 0 ceiling disables
+      // that dimension.
+      let ip_full = state.max_per_ip > 0 && current >= state.max_per_ip
+      let total_full = state.max_total > 0 && state.total >= state.max_total
+
+      case ip_full || total_full {
         True -> {
           process.send(reply, Error(Nil))
           actor.continue(state)
@@ -62,7 +86,11 @@ fn handle_message(
         False -> {
           process.send(reply, Ok(Permit(limiter: limiter, ip: ip)))
           actor.continue(
-            State(..state, counts: dict.insert(state.counts, ip, current + 1)),
+            State(
+              ..state,
+              total: state.total + 1,
+              counts: dict.insert(state.counts, ip, current + 1),
+            ),
           )
         }
       }
@@ -82,7 +110,7 @@ fn handle_message(
         }
         Error(Nil) -> state
       }
-      actor.continue(release_ip(state, ip))
+      actor.continue(release_slot(state, ip))
     }
     HolderDown(down) ->
       case down {
@@ -95,7 +123,7 @@ fn handle_message(
                   monitors: dict.delete(state.monitors, monitor),
                   holders: dict.delete(state.holders, pid),
                 )
-              actor.continue(release_ip(state, ip))
+              actor.continue(release_slot(state, ip))
             }
             // Already explicitly released (or an unrelated monitor).
             Error(Nil) -> actor.continue(state)
@@ -121,11 +149,19 @@ fn bind_holder(state: State, ip: String, owner: Pid) -> State {
   )
 }
 
-fn release_ip(state: State, ip: String) -> State {
+/// Reclaim a slot in both dimensions: decrement the node-wide total and the
+/// per-IP count. Every acquire increments both, so every release (explicit or
+/// via a holder's death) decrements both symmetrically.
+fn release_slot(state: State, ip: String) -> State {
+  let total = int.max(state.total - 1, 0)
   case dict.get(state.counts, ip) {
     Ok(count) if count > 1 ->
-      State(..state, counts: dict.insert(state.counts, ip, count - 1))
-    _ -> State(..state, counts: dict.delete(state.counts, ip))
+      State(
+        ..state,
+        total: total,
+        counts: dict.insert(state.counts, ip, count - 1),
+      )
+    _ -> State(..state, total: total, counts: dict.delete(state.counts, ip))
   }
 }
 
@@ -146,11 +182,17 @@ fn request(
   }
 }
 
-/// Start a connection limiter with a maximum active connection count per IP.
-fn start(max_per_ip: Int) -> Result(ConnectionLimiter, actor.StartError) {
+/// Start a connection limiter enforcing a per-IP ceiling and/or a node-wide
+/// ceiling. A ceiling of 0 disables that dimension.
+fn start(
+  max_per_ip: Int,
+  max_total: Int,
+) -> Result(ConnectionLimiter, actor.StartError) {
   let state =
     State(
       max_per_ip: max_per_ip,
+      max_total: max_total,
+      total: 0,
       counts: dict.new(),
       monitors: dict.new(),
       holders: dict.new(),
@@ -170,10 +212,18 @@ fn start(max_per_ip: Int) -> Result(ConnectionLimiter, actor.StartError) {
   |> result.map(fn(started) { ConnectionLimiter(subject: started.data) })
 }
 
-/// Start a limiter only when `max_per_ip` is positive.
-pub fn start_optional(max_per_ip: Int) -> Option(ConnectionLimiter) {
-  use <- bool.guard(when: max_per_ip <= 0, return: None)
-  let assert Ok(limiter) = start(max_per_ip)
+/// Start a limiter only when at least one ceiling is positive.
+///
+/// `max_per_ip` caps concurrent connections from a single peer; `max_total`
+/// caps concurrent connections across the whole node. They compose: a
+/// connection is admitted only when it is under both configured ceilings. When
+/// both are 0 no limiter is started and every connection is admitted.
+pub fn start_optional(
+  max_per_ip: Int,
+  max_total: Int,
+) -> Option(ConnectionLimiter) {
+  use <- bool.guard(when: max_per_ip <= 0 && max_total <= 0, return: None)
+  let assert Ok(limiter) = start(max_per_ip, max_total)
   Some(limiter)
 }
 

--- a/src/beryl/transport/mist.gleam
+++ b/src/beryl/transport/mist.gleam
@@ -215,7 +215,7 @@ type SendRequest {
 /// config path written with a trailing slash (e.g. `"/socket/"`) will never
 /// match. Configure the path without a trailing slash (e.g. `"/socket"`).
 ///
-/// ## Per-IP connection limits
+/// ## Connection limits
 ///
 /// When `beryl.with_max_connections_per_ip` is configured, this transport
 /// enforces the limit before completing the handshake and returns `429 Too
@@ -225,6 +225,16 @@ type SendRequest {
 /// them and would otherwise spoof their address to bypass the limit. Behind a
 /// trusted reverse proxy, all connections share the proxy's IP — resolve the
 /// real client IP at the proxy layer. See the WebSocket transport guide.
+///
+/// When `beryl.with_max_connections` is configured, this transport also
+/// enforces a node-wide ceiling on concurrent connections across all IPs,
+/// likewise returning `429` and rejecting the upgrade before allocating any
+/// long-lived channel/coordinator state. The two limits compose: a connection
+/// must be under both to be admitted. The node-wide ceiling bounds total
+/// resource use when a per-IP limit alone cannot (many distributed source
+/// addresses / IPv6 rotation). It is enforced per BEAM node, so across a
+/// load-balanced cluster the effective ceiling scales with the node count —
+/// use the load balancer's own controls for a cluster-wide cap.
 pub fn upgrade(
   request: Request(Connection),
   channels: Channels,

--- a/test/global_connection_limit_test.gleam
+++ b/test/global_connection_limit_test.gleam
@@ -1,0 +1,214 @@
+//// Node-wide (global) connection ceiling enforcement tests.
+////
+//// These exercise the same public transport-facing API
+//// (`beryl.acquire_connection_slot` / `beryl.bind_connection_slot` /
+//// `beryl.release_connection_slot`) the Mist transport uses, but focus on the
+//// node-wide ceiling configured with `beryl.with_max_connections` — the limit
+//// that bounds concurrent connections across *all* source IPs, which a per-IP
+//// limit alone cannot enforce against distributed/rotating addresses.
+
+import beryl
+import beryl/wire
+import gleam/erlang/process
+import gleam/int
+import gleam/list
+import gleeunit/should
+
+// Build the list [1, 2, ..., n] without depending on a specific stdlib
+// `list.range` availability.
+fn seq(n: Int) -> List(Int) {
+  seq_loop(n, [])
+}
+
+fn seq_loop(n: Int, acc: List(Int)) -> List(Int) {
+  case n <= 0 {
+    True -> acc
+    False -> seq_loop(n - 1, [n, ..acc])
+  }
+}
+
+fn start_with_global_limit(max_connections: Int) -> beryl.Channels {
+  let assert Ok(channels) =
+    beryl.start(
+      beryl.config(wire.phoenix_codec())
+      |> beryl.with_max_connections(max_connections: max_connections),
+    )
+  channels
+}
+
+fn start_with_both_limits(
+  max_per_ip: Int,
+  max_connections: Int,
+) -> beryl.Channels {
+  let assert Ok(channels) =
+    beryl.start(
+      beryl.config(wire.phoenix_codec())
+      |> beryl.with_max_connections_per_ip(max_connections: max_per_ip)
+      |> beryl.with_max_connections(max_connections: max_connections),
+    )
+  channels
+}
+
+// A global limit of 0 means unlimited: acquisitions from many distinct IPs all
+// succeed, and releasing a placeholder permit is a harmless no-op.
+pub fn global_zero_means_unlimited_test() {
+  let channels = start_with_global_limit(0)
+
+  let assert Ok(first) = beryl.acquire_connection_slot(channels, "1.1.1.1")
+  should.be_ok(beryl.acquire_connection_slot(channels, "2.2.2.2"))
+  should.be_ok(beryl.acquire_connection_slot(channels, "3.3.3.3"))
+
+  beryl.release_connection_slot(first)
+  |> should.equal(Nil)
+
+  beryl.stop(channels)
+}
+
+// Connections at or below the node-wide limit are admitted regardless of which
+// IP they come from.
+pub fn admits_connections_under_global_limit_test() {
+  let channels = start_with_global_limit(3)
+
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.1"))
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.2"))
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.3"))
+
+  beryl.stop(channels)
+}
+
+// A connection that would exceed the node-wide limit is rejected even though it
+// comes from a brand-new IP — this is the distributed-source case a per-IP
+// limit cannot stop.
+pub fn rejects_connection_over_global_limit_test() {
+  let channels = start_with_global_limit(2)
+
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.1.1"))
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.1.2"))
+
+  // A third, unique source address is refused because the node is full.
+  beryl.acquire_connection_slot(channels, "10.0.1.3")
+  |> should.equal(Error(Nil))
+
+  beryl.stop(channels)
+}
+
+// Releasing a slot frees node-wide capacity so a subsequent connection (from
+// any IP) succeeds. Guards against global-slot leaks on normal close.
+pub fn releasing_slot_frees_global_capacity_test() {
+  let channels = start_with_global_limit(1)
+
+  let assert Ok(permit) = beryl.acquire_connection_slot(channels, "10.0.2.1")
+  // The node is at its ceiling now.
+  beryl.acquire_connection_slot(channels, "10.0.2.2")
+  |> should.equal(Error(Nil))
+
+  // Freeing the slot admits the next connection from a different IP.
+  beryl.release_connection_slot(permit)
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.2.2"))
+
+  beryl.stop(channels)
+}
+
+// A global slot is reclaimed when its holder process dies without releasing —
+// crashed handlers, transport failures, and heartbeat evictions all surface as
+// the holder process exiting, so the monitor path must free node-wide capacity.
+pub fn global_slot_reclaimed_when_holder_dies_without_release_test() {
+  let channels = start_with_global_limit(1)
+
+  let acquired = process.new_subject()
+  let _pid =
+    process.spawn_unlinked(fn() {
+      let assert Ok(permit) =
+        beryl.acquire_connection_slot(channels, "10.0.3.1")
+      beryl.bind_connection_slot(permit)
+      process.send(acquired, Nil)
+      // Return immediately: the process exits without releasing, which must
+      // still free the node-wide slot via the limiter's monitor.
+    })
+  let assert Ok(Nil) = process.receive(acquired, 500)
+
+  // Give the limiter time to observe the holder's exit.
+  process.sleep(50)
+
+  // The reclaimed slot admits a connection from a *different* IP, proving the
+  // global count (not just the per-IP count) was decremented.
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.3.2"))
+  beryl.stop(channels)
+}
+
+// The per-IP and node-wide ceilings compose: a connection must be under both.
+// Here the node-wide ceiling refuses a second IP even though that IP is under
+// its own per-IP limit.
+pub fn per_ip_and_global_compose_test() {
+  // Per-IP allows 5 each, but the node as a whole allows only 1.
+  let channels = start_with_both_limits(5, 1)
+
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.4.1"))
+  // Different IP, well under its per-IP limit, but the node is full.
+  beryl.acquire_connection_slot(channels, "10.0.4.2")
+  |> should.equal(Error(Nil))
+
+  beryl.stop(channels)
+}
+
+// The per-IP limit still bites under a generous node-wide ceiling: a single IP
+// cannot exceed its per-IP allotment even when the node has global room.
+pub fn per_ip_limit_still_enforced_under_global_test() {
+  let channels = start_with_both_limits(1, 10)
+
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.5.1"))
+  // Same IP is at its per-IP limit even though the node has room.
+  beryl.acquire_connection_slot(channels, "10.0.5.1")
+  |> should.equal(Error(Nil))
+  // A different IP is admitted (node still under its global ceiling).
+  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.5.2"))
+
+  beryl.stop(channels)
+}
+
+// Concurrent opens cannot race past the node-wide ceiling. Many processes
+// attempt to acquire at once; because the check-and-increment is serialized
+// inside the limiter actor, exactly `ceiling` of them succeed.
+pub fn concurrent_opens_do_not_exceed_global_ceiling_test() {
+  let ceiling = 5
+  let attempts = 40
+  let channels = start_with_global_limit(ceiling)
+
+  let results = process.new_subject()
+  seq(attempts)
+  |> list.each(fn(i) {
+    process.spawn_unlinked(fn() {
+      // Each attempt uses a unique IP so per-IP tracking cannot be what caps
+      // the total — only the node-wide ceiling can.
+      let ip = "10.9." <> int.to_string(i) <> ".1"
+      let outcome = case beryl.acquire_connection_slot(channels, ip) {
+        Ok(permit) -> {
+          beryl.bind_connection_slot(permit)
+          True
+        }
+        Error(Nil) -> False
+      }
+      process.send(results, outcome)
+      // Stay alive holding the slot until the test has finished counting, so
+      // no slot is released and reused mid-count (which would let more than
+      // `ceiling` acquisitions succeed over the test's lifetime).
+      process.sleep(2000)
+    })
+    Nil
+  })
+
+  let successes =
+    seq(attempts)
+    |> list.fold(0, fn(acc, _) {
+      case process.receive(results, 1000) {
+        Ok(True) -> acc + 1
+        Ok(False) -> acc
+        Error(Nil) -> acc
+      }
+    })
+
+  successes
+  |> should.equal(ceiling)
+
+  beryl.stop(channels)
+}

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -39,11 +39,34 @@ let config =
   // Concurrent connections per client IP. Size to your expected
   // clients-behind-one-NAT worst case; see the caveat below.
   |> beryl.with_max_connections_per_ip(max_connections: 100)
+  // Node-wide ceiling on concurrent connections across all IPs. Size to a
+  // single node's process/socket/coordinator budget; see below.
+  |> beryl.with_max_connections(max_connections: 10_000)
 ```
 
 Optionally, `with_channel_rate` adds a per-socket-per-topic limit on top of
 the global per-socket message rate, useful when a single busy topic must not
 starve others.
+
+### Per-IP and node-wide limits compose
+
+`with_max_connections_per_ip` throttles a single abusive peer, while
+`with_max_connections` caps concurrent connections across the whole node. When
+both are set a connection must be under **both** ceilings to be admitted;
+otherwise the transport rejects it with `429` **before** allocating any
+long-lived channel or coordinator state. Freed capacity is reclaimed on normal
+close, transport failure, heartbeat eviction, crash, and setup failure.
+
+The node-wide ceiling exists because a per-IP limit alone cannot stop many
+**distinct** source addresses — a botnet, or a single host rotating through an
+IPv6 range — from each opening a few connections and collectively exhausting
+the node's process, socket, and coordinator budget. The global ceiling bounds
+that total regardless of how the connections are spread across IPs.
+
+Because it is enforced per BEAM node, a load-balanced cluster of N nodes has an
+effective ceiling of roughly `max_connections × N`. Size the per-node value
+against one node's capacity, and use your load balancer's own global
+connection/rate controls when you need a cluster-wide cap.
 
 ### The per-IP caveat
 

--- a/website/src/content/docs/reference/api/beryl-transport-mist.md
+++ b/website/src/content/docs/reference/api/beryl-transport-mist.md
@@ -167,7 +167,7 @@ Upgrade a request to WebSocket if it matches the configured path
  config path written with a trailing slash (e.g. `"/socket/"`) will never
  match. Configure the path without a trailing slash (e.g. `"/socket"`).
 
- ## Per-IP connection limits
+ ## Connection limits
 
  When `beryl.with_max_connections_per_ip` is configured, this transport
  enforces the limit before completing the handshake and returns `429 Too
@@ -177,6 +177,16 @@ Upgrade a request to WebSocket if it matches the configured path
  them and would otherwise spoof their address to bypass the limit. Behind a
  trusted reverse proxy, all connections share the proxy's IP — resolve the
  real client IP at the proxy layer. See the WebSocket transport guide.
+
+ When `beryl.with_max_connections` is configured, this transport also
+ enforces a node-wide ceiling on concurrent connections across all IPs,
+ likewise returning `429` and rejecting the upgrade before allocating any
+ long-lived channel/coordinator state. The two limits compose: a connection
+ must be under both to be admitted. The node-wide ceiling bounds total
+ resource use when a per-IP limit alone cannot (many distributed source
+ addresses / IPv6 rotation). It is enforced per BEAM node, so across a
+ load-balanced cluster the effective ceiling scales with the node count —
+ use the load balancer's own controls for a cluster-wide cap.
 
 ```gleam
 pub fn upgrade(

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -531,6 +531,44 @@ pub fn with_logging(
 ) -> Config
 ```
 
+### `with_max_connections`
+
+Configure the maximum number of concurrent connections allowed across the
+ whole node, regardless of source IP.
+
+ A value of 0 (the default) means unlimited. When a limit is set, a transport
+ admits a new connection only while the node is below the limit and rejects
+ it (before allocating any long-lived channel/coordinator state) otherwise;
+ the slot is freed when the connection closes, its process dies, or its
+ handshake/setup fails. The check-and-increment is atomic inside the limiter
+ actor, so a burst of concurrent opens cannot materially exceed the ceiling.
+
+ ## Composition with per-IP limits
+
+ This node-wide ceiling composes with `with_max_connections_per_ip`: when
+ both are set a connection must be under *both* limits to be admitted. The
+ per-IP limit throttles any single abusive peer, while this global ceiling
+ bounds the node's total resource use so that many distinct source addresses
+ (for example a botnet or IPv6 address rotation) still cannot exhaust the
+ node's process, socket, and coordinator budget — a case a per-IP limit alone
+ cannot stop.
+
+ ## Composition with external load balancers
+
+ This ceiling is enforced per BEAM node. If you run several nodes behind a
+ load balancer, each node enforces its own limit independently, so the
+ cluster's effective ceiling is roughly `max_connections × node_count`
+ (subject to how the balancer distributes connections). Size the per-node
+ value against a single node's capacity, and use the load balancer's own
+ global connection/rate controls when you need a cluster-wide cap.
+
+```gleam
+pub fn with_max_connections(
+  Config,
+  max_connections: Int
+) -> Config
+```
+
 ### `with_max_connections_per_ip`
 
 Configure the maximum number of concurrent connections allowed per client


### PR DESCRIPTION
Fixes #195.

Adds an optional node-wide concurrent connection ceiling. Per-IP limits alone don't protect against distributed source addresses or IPv6 rotation; every accepted connection consumes a BEAM process, socket/coordinator state, heartbeat work, and PubSub memberships.

## Design
Extended the existing `connection_limit` actor with a `total`/`max_total` dimension rather than adding a parallel limiter. The per-IP limiter already serializes acquire/release and reclaims slots when a bound holder process dies, so the global slot is released by the **same** path — capacity is reclaimed on normal close, transport failure, heartbeat eviction, crash, and setup failure with zero new code paths and one monitor per connection.

## Changes
- `Config.max_connections` (default 0 = unlimited), `with_max_connections`, `config_max_connections`.
- `Acquire` atomically checks both ceilings and increments `total`; release decrements it (floored at 0).
- `warn_if_unprotected` and the transport docs updated; production-hardening guide gains a "Per-IP and node-wide limits compose" section.

## Tests
8 new tests: rejection above the ceiling (distinct IPs), release on explicit close and on holder death, per-IP/global composition both ways, and a 40-way concurrency race proving exactly `ceiling` acquirers succeed. Full suite green.

## Note
The ceiling is per BEAM node; a load-balanced cluster's effective cap is ~`max_connections × node_count` — documented, with the LB as the cluster-wide cap.
