### PR TITLE
ci: fix release PR title, changelog, and docs checks

### DIFF
--- a/.github/actions/install-trellis/action.yml
+++ b/.github/actions/install-trellis/action.yml
@@ -6,9 +6,10 @@ description: >
 inputs:
   version:
     description: trellis release tag to install
-    # Requires >= 0.3.0 for git-dependency parsing and glob member skipping
-    # (tylerbutler/trellis#9).
-    default: v0.3.0
+    # Requires >= 0.4.1 for the lowercase `release:` PR title
+    # (tylerbutler/trellis#17); >= 0.3.0 added git-dependency parsing and
+    # glob member skipping (tylerbutler/trellis#9).
+    default: v0.4.1
 
 runs:
   using: composite

--- a/.github/actions/install-trellis/action.yml
+++ b/.github/actions/install-trellis/action.yml
@@ -6,9 +6,6 @@ description: >
 inputs:
   version:
     description: trellis release tag to install
-    # Requires >= 0.4.1 for the lowercase `release:` PR title
-    # (tylerbutler/trellis#17); >= 0.3.0 added git-dependency parsing and
-    # glob member skipping (tylerbutler/trellis#9).
     default: v0.4.1
 
 runs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,7 +44,10 @@ jobs:
       - name: Check workspace invariants
         run: trellis doctor
 
+      # The release PR (branch release/pending) consumes all unreleased
+      # fragments into the CHANGELOGs, so it can never satisfy this check.
       - name: Check changelog fragments
+        if: github.head_ref != 'release/pending'
         run: |
           trellis changelog check \
             --base ${{ github.event.pull_request.base.sha }} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,29 @@ jobs:
       - name: Install trellis
         uses: ./.github/actions/install-trellis
 
+      # Toolchain needed to regenerate the website API reference after the
+      # version bump (mirrors the Docs job in ci.yml).
+      - name: Setup environment
+        uses: tylerbutler/actions/setup-gleam@77f80621309fc7443b628802e08a815d41dd4b47 # ratchet:tylerbutler/actions/setup-gleam@main
+        with:
+          run-deps: false
+
+      - name: Install Gleam dependencies
+        run: just deps-gleam
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # ratchet:pnpm/action-setup@v6
+        with:
+          package_json_file: website/package.json
+
+      - name: Install website dependencies
+        run: pnpm -C website install --frozen-lockfile
+
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"
@@ -33,3 +56,25 @@ jobs:
         run: trellis release pr
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # The release PR bumps package versions, and the generated API reference
+      # stamps the version into its headings. Regenerate on the release branch
+      # so the Docs check passes on the release PR. Pushing with the app token
+      # re-triggers the PR's checks. No release/pending branch → nothing to do.
+      - name: Regenerate reference docs on the release branch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if ! git fetch origin release/pending; then
+            echo "No release/pending branch; skipping docs regeneration."
+            exit 0
+          fi
+          git checkout -B release/pending FETCH_HEAD
+          just site-reference
+          if git diff --quiet -- website/src/content/docs/reference/api; then
+            echo "Reference docs already up to date."
+            exit 0
+          fi
+          git add website/src/content/docs/reference/api
+          git commit -m "docs: regenerate API reference for release"
+          git push origin HEAD:release/pending

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,9 +1,10 @@
 [tools]
 erlang = "28"
 rebar = "latest"
-# Requires >= 0.3.0 for git-dependency parsing and glob member skipping
-# (tylerbutler/trellis#9).
-"github:tylerbutler/trellis" = "0.3.0"
+# Requires >= 0.4.1 for the lowercase `release:` PR title
+# (tylerbutler/trellis#17); >= 0.3.0 added git-dependency parsing and glob
+# member skipping (tylerbutler/trellis#9).
+"github:tylerbutler/trellis" = "0.4.1"
 
 [env]
 LC_ALL = "en_US.UTF-8"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,9 +1,6 @@
 [tools]
 erlang = "28"
 rebar = "latest"
-# Requires >= 0.4.1 for the lowercase `release:` PR title
-# (tylerbutler/trellis#17); >= 0.3.0 added git-dependency parsing and glob
-# member skipping (tylerbutler/trellis#9).
 "github:tylerbutler/trellis" = "0.4.1"
 
 [env]


### PR DESCRIPTION
The auto-generated release PR (`trellis release pr`, branch `release/pending`) failed three CI checks it couldn't satisfy as generated (see #209). This fixes all three.

- **Changelog** (`pr.yml`) — a release PR consumes every unreleased fragment into the CHANGELOGs, so `trellis changelog check` always reports them missing. Skip that step on `release/pending`; `trellis doctor` still runs.
- **Docs** (`release.yml`) — `trellis release pr` bumps package versions, which the generated API reference stamps into its headings, leaving the committed docs stale. Added the Docs toolchain and a step that regenerates the reference on the release branch after the bump and pushes it via the app token, re-triggering the PR's checks.
- **PR Title** (`.mise.toml`, `install-trellis`) — bumped the trellis pin to `v0.4.1`, which emits a conventional-commit-compliant lowercase `release:` title (tylerbutler/trellis#17).
