### PR TITLE
docs: fix inaccurate code samples and API references

### DIFF
--- a/packages/beryl_mist/README.md
+++ b/packages/beryl_mist/README.md
@@ -15,11 +15,12 @@ gleam add beryl beryl_mist
 
 ```gleam
 import beryl
+import beryl/wire
 import beryl_mist as mist_transport
 import mist
 
 pub fn main() {
-  let assert Ok(channels) = beryl.start(beryl.default_config())
+  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
   // register channels...
 
   let assert Ok(_) =

--- a/website/src/content/docs/guides/authentication.md
+++ b/website/src/content/docs/guides/authentication.md
@@ -65,10 +65,13 @@ fn query_param(req: Request(mist.Connection), name: String) -> Result(String, Ni
 
 ## 3. Verify the token in `on_connect`
 
-`verify_token` is where you plug in your token library — for example a JWT
-verifier such as [`vestibule`](https://hex.pm/) or a call to
-[`gleam_crypto`](https://hexdocs.pm/gleam_crypto/) to check an HMAC signature.
-It must validate the signature and expiry and return typed `Claims`:
+`verify_token` is where you plug in your token library — for example a call to
+[`gleam_crypto`](https://hexdocs.pm/gleam_crypto/) to check an HMAC signature, or
+a JWT library to validate a signed token issued by your identity provider. It
+must validate the signature and expiry and return typed `Claims`. (The upstream
+sign-in flow that mints these tokens is a separate concern — an OAuth2 library
+such as [`vestibule`](https://vestibule.tylerbutler.com) handles social login
+and hands you an authenticated identity to build the token from.)
 
 ```gleam
 import beryl_mist as mist_transport

--- a/website/src/content/docs/guides/channels.md
+++ b/website/src/content/docs/guides/channels.md
@@ -194,7 +194,7 @@ fn terminate(
     channel.Normal -> Nil           // Clean disconnect
     channel.Shutdown -> Nil         // Server-initiated
     channel.HeartbeatTimeout -> Nil // Client went silent
-    channel.Error(msg) -> Nil       // Something went wrong
+    channel.Errored(msg) -> Nil     // Something went wrong
   }
 }
 ```
@@ -289,9 +289,9 @@ import beryl/wire
 let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
 
 // Register handlers for different topic patterns
-let assert Ok(Nil) = beryl.register(channels, "room:*", room_channel.new())
-let assert Ok(Nil) = beryl.register(channels, "user:*", user_channel.new())
-let assert Ok(Nil) = beryl.register(channels, "system", system_channel.new())
+let assert Ok(_) = beryl.register(channels, "room:*", room_channel.new())
+let assert Ok(_) = beryl.register(channels, "user:*", user_channel.new())
+let assert Ok(_) = beryl.register(channels, "system", system_channel.new())
 ```
 
 ## Broadcasting

--- a/website/src/content/docs/guides/error-handling.md
+++ b/website/src/content/docs/guides/error-handling.md
@@ -51,13 +51,15 @@ The client never receives a WebSocket handshake and cannot send any messages.
 
 beryl parses incoming frames as Phoenix protocol arrays `[join_ref, ref, topic, event, payload]`. Frames that cannot be decoded are dropped silently — no error is sent to the client. This is intentional: malformed frames are treated as protocol violations and do not warrant a reply.
 
-If you need to surface decode errors in your own payload handling, use `gleam/json.decode` and return an explicit `Reply` or `Push` from `handle_in`:
+If you need to surface decode errors in your own payload handling, decode the
+`Dynamic` payload with `channel.decode_payload` and return an explicit `Reply`
+or `Push` from `handle_in`:
 
 ```gleam
 fn handle_in(event, payload, socket) -> HandleResult(MyAssigns) {
   case event {
     "create_item" -> {
-      case json.decode(json.to_string(payload), item_decoder()) {
+      case channel.decode_payload(payload, item_decoder()) {
         Ok(item) -> {
           // process item
           channel.Reply("ok", json.object([#("id", json.string(item.id))]), socket)
@@ -145,7 +147,7 @@ case supervisor.start(config) {
     // proceed
   }
   Error(supervisor.InvalidHeartbeatTimeout) -> {
-    // Config error: heartbeat_timeout_ms must be > 0
+    // Config error: heartbeat_timeout_ms must be >= 2
     panic
   }
   Error(supervisor.SupervisorStartFailed(err)) -> {

--- a/website/src/content/docs/guides/groups.md
+++ b/website/src/content/docs/guides/groups.md
@@ -16,7 +16,7 @@ import beryl/group
 let assert Ok(groups) = group.start()
 ```
 
-`group.start()` returns `Result(Groups, GroupError)`. The only failure case is `StartFailed` — an OTP actor spawn failure.
+`group.start()` returns `Result(Groups, GroupStartError)`. The only failure case is `GroupActorStartFailed` — an OTP actor spawn failure.
 
 ## Creating and deleting groups
 

--- a/website/src/content/docs/guides/supervision.md
+++ b/website/src/content/docs/guides/supervision.md
@@ -123,11 +123,11 @@ static_supervisor.new(static_supervisor.OneForOne)
 ```gleam
 pub type StartError {
   SupervisorStartFailed(error.StartFailure)
-  InvalidHeartbeatTimeout   // heartbeat_timeout_ms must be > 0
+  InvalidHeartbeatTimeout   // heartbeat_timeout_ms must be >= 2
 }
 ```
 
-`InvalidHeartbeatTimeout` is a configuration mistake — check that `heartbeat_timeout_ms` in your `beryl.Config` is a positive integer.
+`InvalidHeartbeatTimeout` is a configuration mistake — check that `heartbeat_timeout_ms` in your `beryl.Config` is at least 2 (the staleness check interval is derived as `heartbeat_timeout_ms / 2`, so 1 would disable eviction).
 
 ## Production checklist
 

--- a/website/src/content/docs/installation.md
+++ b/website/src/content/docs/installation.md
@@ -31,6 +31,5 @@ beryl brings in these Gleam packages automatically:
 | `gleam_otp` | OTP actors |
 | `gleam_json` | JSON encoding/decoding |
 | `gleam_crypto` | Socket ID generation |
-| `gleam_http` | HTTP request types for transport integration |
-| `mist` | WebSocket and HTTP server |
+| `lattice_presence` | CRDT-backed presence tracking |
 | `palabres` | Structured logging |

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -47,7 +47,7 @@ Presence state uses an **add-wins observed-remove set** (AWORSet) with causal co
 
 ### Focused dependencies
 
-The core library depends on `gleam_stdlib`, `gleam_erlang`, `gleam_otp`, `gleam_json`, `gleam_crypto`, `gleam_http`, `mist`, and `palabres` — all standard BEAM ecosystem packages. No external message brokers or databases required.
+The core library depends on `gleam_stdlib`, `gleam_erlang`, `gleam_otp`, `gleam_json`, `gleam_crypto`, `lattice_presence`, and `palabres` — all standard BEAM ecosystem packages. A WebSocket transport such as `beryl_mist` adds `mist` and `gleam_http`, but the core library pulls in neither. No external message brokers or databases required.
 
 ### Phoenix wire protocol compatibility
 

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -74,7 +74,7 @@ Beryl uses [palabres](https://hexdocs.pm/palabres/) loggers under the `beryl.*` 
 let config =
   beryl.config(wire.phoenix_codec())
   |> beryl.with_logging(beryl.logging_config(
-    level: beryl.Debug,
+    level: beryl.DebugLevel,
     include_payloads: False,
   ))
 ```
@@ -83,7 +83,7 @@ Debug logs cover frame decode, join routing, callback results, reply/push send o
 
 ```gleam
 let logging =
-  beryl.logging_config(level: beryl.Debug, include_payloads: True)
+  beryl.logging_config(level: beryl.DebugLevel, include_payloads: True)
   |> beryl.with_payload_preview_bytes(bytes: 100)
 ```
 


### PR DESCRIPTION
Corrects documentation that referenced nonexistent or wrong API, verified against the actual public surface in `packages/*/src`. All changes are documentation-only.

- **beryl_mist README** — replaced `beryl.default_config()` (no such function) with `beryl.config(wire.phoenix_codec())` and added the missing `beryl/wire` import, so the landing-page example compiles.
- **channels guide** — `beryl.register` returns a `RegisteredChannel`, not `Nil`, so `let assert Ok(Nil)` won't match (now `Ok(_)`); the `StopReason` variant is `Errored`, not `Error`.
- **error-handling guide** — decode `Dynamic` payloads with `channel.decode_payload` instead of `json.decode(json.to_string(...))`, which passed a `Dynamic` to `json.to_string` and used a removed API.
- **troubleshooting guide** — `LogLevel` variant is `DebugLevel`, not `Debug`.
- **installation & introduction** — core `beryl` dependencies are `lattice_presence` + `palabres`; `gleam_http`/`mist` belong to `beryl_mist`, not core.
- **groups guide** — `group.start()` returns `GroupStartError`/`GroupActorStartFailed`, not `GroupError`/`StartFailed`.
- **supervision & error-handling** — heartbeat validation rejects values below 2, not `> 0`.
- **authentication guide** — describe `vestibule` accurately as an OAuth2 sign-in library rather than a JWT verifier, and fix its link.

Relevance: these are copy-paste examples and dependency/type claims on the docs site and package READMEs; several would fail to compile as written.