### PR TITLE
docs: use the supervised startup pattern throughout

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -230,7 +230,7 @@ The adapter manages the full WebSocket lifecycle: connection, message routing to
 | PubSub | **Complete** | pg-backed, local + distributed broadcast |
 | Presence CRDT | **Complete** | Pure state module, property-based tested |
 | Presence actor | **Complete** | Actor wraps CRDT; periodic delta replication via PubSub |
-| Supervisor | **Complete** | Rest-for-one strategy, child_spec, validation |
+| Supervisor | **Complete** | One-for-one + nested rest-for-one strategy, child specification via `start`, validation |
 | Groups | **Complete** | Named topic collections with broadcast |
 | Mist transport | **Complete** | WebSocket upgrade + lifecycle management, no Wisp dependency |
 | Binary transport | **Complete** | Raw BitArray frames, opt-in via `with_handle_binary` |

--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ beryl targets the **Erlang/BEAM** runtime only. It does not support the JavaScri
 import beryl
 import beryl/channel.{type Channel, type HandleResult, type JoinResult}
 import beryl/socket.{type Socket}
+import beryl/supervisor
 import beryl_mist as mist_transport
 import beryl/wire
 import gleam/dynamic/decode
 import gleam/erlang/process
 import gleam/json
 import gleam/option.{None}
+import gleam/otp/static_supervisor
 import mist
 
 pub type RoomAssigns { RoomAssigns(username: String) }
@@ -56,7 +58,16 @@ fn new_channel() -> Channel(RoomAssigns, info) {
 }
 
 pub fn main() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  // beryl doesn't start an unmanaged process; add its child specification to
+  // your own application supervisor.
+  let beryl_config = supervisor.config(beryl.config(wire.phoenix_codec()))
+
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(supervisor.start(beryl_config))
+    |> static_supervisor.start()
+
+  let channels = supervisor.channels(beryl_config)
   let assert Ok(_) = beryl.register(channels, "room:*", new_channel())
 
   let assert Ok(_) =

--- a/docs/architecture-deck.md
+++ b/docs/architecture-deck.md
@@ -121,16 +121,19 @@ and you scale across nodes via pg, not by adding coordinator threads.
 
 ```mermaid
 flowchart TB
-  S["supervisor (rest-for-one)"]
-  S --> CO["coordinator"]
-  S --> PR["presence (optional)"]
-  S --> GR["groups (optional)"]
+  S["beryl supervisor (one-for-one)"]
+  S --> LI["connection limiter (optional)"]
+  S --> CH["channel supervisor (rest-for-one)"]
+  CH --> RE["registry"]
+  CH --> CO["coordinator"]
+  CH --> PR["presence (optional)"]
+  CH --> GR["groups (optional)"]
   CO -. "crash restarts downstream" .-> PR
   PR -. .-> GR
 ```
 
-- `rest-for-one`: coordinator crash restarts presence and groups
-- Embeddable via `beryl/supervisor.child_spec/1`
+- `rest-for-one`: coordinator crash restarts presence and groups (registry survives)
+- Embeddable via `beryl/supervisor.start/1`, which returns a child specification
 - Presence and groups are optional; omit from config if unused
 
 <!--
@@ -142,8 +145,8 @@ deliberate — presence and groups hold references and subscriptions that assume
 a live coordinator, so restarting them together avoids stale state pointing at
 a dead process. The reverse is not true: a presence crash does not take down
 the coordinator. Mention that the whole tree is embeddable via
-`child_spec/1`, so beryl drops into a user's existing supervision tree rather
-than demanding to be the top of the application.
+`supervisor.start/1`, so beryl drops into a user's existing supervision tree
+rather than demanding to be the top of the application.
 -->
 
 ---

--- a/docs/talks/beryl-interview/deck.md
+++ b/docs/talks/beryl-interview/deck.md
@@ -191,7 +191,7 @@ The diagram — explain rest-for-one concretely, top to bottom:
   their view of the world routed through it. Fresh, consistent state
   for all three — no half-alive system.
 
-beryl embeds into YOUR app's supervision tree via `child_spec`, so
+beryl embeds into YOUR app's supervision tree via `supervisor.start`, so
 channels recover alongside the rest of your application — same
 mechanism, one tree.
 
@@ -351,7 +351,7 @@ Walk it line by line — this is the whole server, not an excerpt:
    both jobs.
 4. `process.sleep_forever()` — keeps main alive for a demo. In a real
    app you'd skip this and put beryl under your OTP supervision tree
-   via `beryl/supervisor.child_spec` — there's a supervision guide.
+   via `beryl/supervisor.start` — there's a supervision guide.
 
 Caveat to say out loud so nobody copies it blindly: `let assert Ok(..)`
 is demo-grade "crash if startup fails" — which, per the supervision

--- a/examples/chatrooms/src/chatrooms.gleam
+++ b/examples/chatrooms/src/chatrooms.gleam
@@ -1,6 +1,7 @@
 import beryl
 import beryl/group
 import beryl/presence
+import beryl/supervisor
 import beryl/wire
 import beryl_mist as mist_transport
 import chatrooms/chat_channel
@@ -9,25 +10,34 @@ import gleam/erlang/process
 import gleam/http/request
 import gleam/io
 import gleam/list
+import gleam/option.{Some}
+import gleam/otp/static_supervisor
 import gleam/result
 import mist
 
 pub fn main() {
-  // Start beryl channels with rate limiting
-  let config =
-    beryl.config(wire.phoenix_codec())
-    |> beryl.with_message_rate(per_second: 30, burst: 60)
-    |> beryl.with_join_rate(per_second: 5, burst: 10)
-    |> beryl.with_channel_rate(per_second: 10, burst: 20)
+  // Configure beryl channels with rate limiting, presence, and groups, then
+  // add beryl's child specification to this application's own supervisor.
+  let beryl_config =
+    supervisor.config(
+      beryl.config(wire.phoenix_codec())
+      |> beryl.with_message_rate(per_second: 30, burst: 60)
+      |> beryl.with_join_rate(per_second: 5, burst: 10)
+      |> beryl.with_channel_rate(per_second: 10, burst: 20),
+    )
+    |> supervisor.with_presence(presence.default_config("node1"))
+    |> supervisor.with_groups()
 
-  let assert Ok(channels) = beryl.start(config)
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(supervisor.start(beryl_config))
+    |> static_supervisor.start()
 
-  // Start presence tracking
-  let presence_config = presence.default_config("node1")
-  let assert Ok(presence_actor) = presence.start(presence_config)
+  let channels = supervisor.channels(beryl_config)
+  let assert Some(presence_actor) = supervisor.presence(beryl_config)
+  let assert Some(groups) = supervisor.groups(beryl_config)
 
-  // Start groups and create default room group
-  let assert Ok(groups) = group.start()
+  // Create default room group
   let assert Ok(_) = group.create(groups, "public")
   let assert Ok(_) = group.add(groups, "public", "room:general")
   let assert Ok(_) = group.add(groups, "public", "room:random")

--- a/examples/collab_docs/src/collab_docs.gleam
+++ b/examples/collab_docs/src/collab_docs.gleam
@@ -1,4 +1,5 @@
 import beryl
+import beryl/supervisor
 import beryl/wire
 import beryl_mist as mist_transport
 import collab_docs/auth
@@ -7,12 +8,21 @@ import collab_docs/doc_store
 import collab_docs/router
 import gleam/erlang/process
 import gleam/io
+import gleam/otp/static_supervisor
 import mist
 
 pub fn main() {
   let secret = auth.new_secret()
   let assert Ok(store) = doc_store.start()
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+
+  let beryl_config = supervisor.config(beryl.config(wire.phoenix_codec()))
+
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(supervisor.start(beryl_config))
+    |> static_supervisor.start()
+
+  let channels = supervisor.channels(beryl_config)
   let handler = channel.new_handler(channels, store, secret)
   let assert Ok(_) = beryl.register(channels, "document:*:*", handler)
 

--- a/examples/cursors/src/cursors.gleam
+++ b/examples/cursors/src/cursors.gleam
@@ -1,5 +1,6 @@
 import beryl
 import beryl/presence
+import beryl/supervisor
 import beryl/wire
 import beryl_mist as mist_transport
 import cursors/cursor_channel
@@ -8,20 +9,29 @@ import envoy
 import gleam/erlang/process
 import gleam/int
 import gleam/io
+import gleam/option.{Some}
+import gleam/otp/static_supervisor
 import gleam/result
 import mist
 
 pub fn main() {
-  // Start beryl channels with rate limiting for cursor events
-  let config =
-    beryl.config(wire.phoenix_codec())
-    |> beryl.with_message_rate(per_second: 30, burst: 60)
+  // Configure beryl channels with rate limiting for cursor events, plus
+  // presence tracking, then add beryl's child specification to this
+  // application's own supervisor.
+  let beryl_config =
+    supervisor.config(
+      beryl.config(wire.phoenix_codec())
+      |> beryl.with_message_rate(per_second: 30, burst: 60),
+    )
+    |> supervisor.with_presence(presence.default_config("node1"))
 
-  let assert Ok(channels) = beryl.start(config)
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(supervisor.start(beryl_config))
+    |> static_supervisor.start()
 
-  // Start presence tracking
-  let presence_config = presence.default_config("node1")
-  let assert Ok(presence_actor) = presence.start(presence_config)
+  let channels = supervisor.channels(beryl_config)
+  let assert Some(presence_actor) = supervisor.presence(beryl_config)
 
   // Register the cursor channel handler
   let handler = cursor_channel.new_handler(channels, presence_actor)

--- a/examples/showcase/src/showcase.gleam
+++ b/examples/showcase/src/showcase.gleam
@@ -1,6 +1,7 @@
 import beryl
 import beryl/group
 import beryl/presence
+import beryl/supervisor
 import beryl/wire
 import beryl_mist as mist_transport
 import chatrooms/chat_channel
@@ -15,6 +16,8 @@ import envoy
 import gleam/erlang/process
 import gleam/int
 import gleam/io
+import gleam/option.{Some}
+import gleam/otp/static_supervisor
 import gleam/result
 import mist
 import showcase/router
@@ -22,21 +25,28 @@ import showcase/router
 pub fn main() {
   // Single beryl instance, rate-limited using cursors' tighter knobs
   // (cursors emits the most messages per second of the three examples).
-  let config =
-    beryl.config(wire.phoenix_codec())
-    |> beryl.with_message_rate(per_second: 30, burst: 60)
-    |> beryl.with_join_rate(per_second: 5, burst: 10)
-    |> beryl.with_channel_rate(per_second: 10, burst: 20)
-
-  let assert Ok(channels) = beryl.start(config)
-
   // Shared presence actor — each example's handler scopes presence to its
   // own topic namespace, so a single actor is safe.
-  let presence_config = presence.default_config("node1")
-  let assert Ok(presence_actor) = presence.start(presence_config)
+  let beryl_config =
+    supervisor.config(
+      beryl.config(wire.phoenix_codec())
+      |> beryl.with_message_rate(per_second: 30, burst: 60)
+      |> beryl.with_join_rate(per_second: 5, burst: 10)
+      |> beryl.with_channel_rate(per_second: 10, burst: 20),
+    )
+    |> supervisor.with_presence(presence.default_config("node1"))
+    |> supervisor.with_groups()
+
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(supervisor.start(beryl_config))
+    |> static_supervisor.start()
+
+  let channels = supervisor.channels(beryl_config)
+  let assert Some(presence_actor) = supervisor.presence(beryl_config)
 
   // Chatrooms-specific state.
-  let assert Ok(groups) = group.start()
+  let assert Some(groups) = supervisor.groups(beryl_config)
   let assert Ok(_) = group.create(groups, "public")
   let assert Ok(_) = group.add(groups, "public", "room:general")
   let assert Ok(_) = group.add(groups, "public", "room:random")

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -17,30 +17,42 @@
 ////
 //// ## Quick Start
 ////
+//// beryl doesn't start an unmanaged process — `beryl/supervisor` builds a
+//// child specification for your application's own OTP supervisor.
+////
 //// ```gleam
 //// import beryl
 //// import beryl/channel
-//// import beryl/pubsub
-//// import beryl/presence
 //// import beryl/group
+//// import beryl/presence
+//// import beryl/pubsub
+//// import beryl/supervisor
 //// import beryl/wire
+//// import gleam/option.{Some}
+//// import gleam/otp/static_supervisor
 ////
 //// pub fn main() {
 ////   // Optional: start PubSub for distributed messaging
 ////   let ps = pubsub.start(pubsub.default_config())
 ////
-////   // Start channels system (with or without PubSub)
-////   let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
-////   let assert Ok(channels) = beryl.start(config)
+////   // Configure channels (with presence and groups), then add beryl's
+////   // child specification to your application supervisor.
+////   let beryl_config =
+////     supervisor.config(beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps))
+////     |> supervisor.with_presence(presence.default_config("node1"))
+////     |> supervisor.with_groups()
+////
+////   let assert Ok(_root) =
+////     static_supervisor.new(static_supervisor.OneForOne)
+////     |> static_supervisor.add(supervisor.start(beryl_config))
+////     |> static_supervisor.start()
+////
+////   let channels = supervisor.channels(beryl_config)
+////   let assert Some(groups) = supervisor.groups(beryl_config)
 ////
 ////   // Register a channel handler
 ////   let _ = beryl.register(channels, "room:*", room_channel.new())
 ////
-////   // Start presence tracking
-////   let assert Ok(p) = presence.start(presence.default_config("node1"))
-////
-////   // Start channel groups
-////   let assert Ok(groups) = group.start()
 ////   let assert Ok(Nil) = group.create(groups, "team:eng")
 ////   let assert Ok(Nil) = group.add(groups, "team:eng", "room:frontend")
 ////

--- a/packages/beryl_ewe/README.md
+++ b/packages/beryl_ewe/README.md
@@ -15,11 +15,23 @@ gleam add beryl beryl_ewe
 
 ```gleam
 import beryl
+import beryl/supervisor
+import beryl/wire
 import beryl_ewe as ewe_transport
 import ewe
+import gleam/otp/static_supervisor
 
 pub fn main() {
-  let assert Ok(channels) = beryl.start(beryl.default_config())
+  // beryl doesn't start an unmanaged process; add its child specification to
+  // your own application supervisor.
+  let beryl_config = supervisor.config(beryl.config(wire.phoenix_codec()))
+
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(supervisor.start(beryl_config))
+    |> static_supervisor.start()
+
+  let channels = supervisor.channels(beryl_config)
   // register channels...
 
   let assert Ok(_) =

--- a/packages/beryl_mist/README.md
+++ b/packages/beryl_mist/README.md
@@ -15,12 +15,23 @@ gleam add beryl beryl_mist
 
 ```gleam
 import beryl
+import beryl/supervisor
 import beryl/wire
 import beryl_mist as mist_transport
+import gleam/otp/static_supervisor
 import mist
 
 pub fn main() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  // beryl doesn't start an unmanaged process; add its child specification to
+  // your own application supervisor.
+  let beryl_config = supervisor.config(beryl.config(wire.phoenix_codec()))
+
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(supervisor.start(beryl_config))
+    |> static_supervisor.start()
+
+  let channels = supervisor.channels(beryl_config)
   // register channels...
 
   let assert Ok(_) =

--- a/website/src/content/docs/architecture/overview.md
+++ b/website/src/content/docs/architecture/overview.md
@@ -45,7 +45,7 @@ flowchart TB
 | `beryl/wire` | Pluggable codec surface; ships `phoenix_codec()` for `[join_ref, ref, topic, event, payload]` framing | [Wire & Transport](/architecture/wire-and-transport) |
 | `beryl/wire/codec` | `Codec` type contract: `decode_text`, `decode_binary`, `encode_*` — lets you swap framing | [Wire & Transport](/architecture/wire-and-transport) |
 | `beryl_mist` | Mist WebSocket adapter: assigns socket IDs, registers send functions, routes frames to coordinator | [Wire & Transport](/architecture/wire-and-transport) |
-| `beryl/supervisor` | rest-for-one supervision tree (coordinator → presence → groups); embeddable via `child_spec/1` | [Coordinator](/architecture/coordinator) |
+| `beryl/supervisor` | one-for-one supervision tree isolating an optional connection limiter from a nested rest-for-one channel subtree (registry → coordinator → presence → groups); returns a child specification via `start/1` | [Coordinator](/architecture/coordinator) |
 | `beryl/group` | Named topic collections managed by an OTP actor; supports grouped broadcast | — |
 | `beryl/topic` | Topic pattern matching: exact strings, `"ns:*"` prefix wildcards, and segment wildcards (`"document:*:ops"`) | — |
 | `beryl/socket` | Opaque connected-client type with typed assigns; `id`, `get_assigns`, `set_assigns`, `map_assigns` | — |
@@ -60,10 +60,13 @@ flowchart TB
 
 ```mermaid
 flowchart TB
-  S["supervisor (rest-for-one)"]
-  S --> CO["coordinator"]
-  S --> PR["presence (optional)"]
-  S --> GR["groups (optional)"]
+  S["beryl supervisor (one-for-one)"]
+  S --> LI["connection limiter (optional)"]
+  S --> CH["channel supervisor (rest-for-one)"]
+  CH --> RE["registry"]
+  CH --> CO["coordinator"]
+  CH --> PR["presence (optional)"]
+  CH --> GR["groups (optional)"]
   CO -. "crash restarts downstream" .-> PR
   PR -. .-> GR
 ```

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -128,23 +128,37 @@ fn handle_in(
 
 ## 2. Start beryl and register the channel
 
-Wire everything together in your application entry point:
+beryl doesn't expose a way to start an unmanaged process — `beryl/supervisor`
+is how you start it, and it returns a child specification for your
+application's own OTP supervisor. Wire everything together in your
+application entry point:
 
 ```gleam
 // src/my_app.gleam
 import beryl
+import beryl/supervisor
 import beryl_mist as mist_transport
 import beryl/wire
 import gleam/bytes_tree
 import gleam/erlang/process
 import gleam/http/request
 import gleam/http/response
+import gleam/otp/static_supervisor
 import mist
 import my_app/room_channel
 
 pub fn main() {
-  // Start the beryl channel system.
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  // Build the supervised config, then add its child specification to your
+  // application's root supervisor.
+  let beryl_config = supervisor.config(beryl.config(wire.phoenix_codec()))
+
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(supervisor.start(beryl_config))
+    |> static_supervisor.start()
+
+  // Resolve the channels handle now that the supervisor is running.
+  let channels = supervisor.channels(beryl_config)
 
   // Register the room channel for all "room:*" topics.
   let assert Ok(_) =
@@ -187,6 +201,14 @@ fn handle_http(
 requests on `/socket/websocket`. When you create a Phoenix JS socket with
 `new Socket("/socket")`, the client appends `/websocket` automatically — so
 the paths line up.
+</Aside>
+
+<Aside type="note" title="Why a supervisor">
+Putting beryl under your application's supervision tree means a crash in the
+channel coordinator (a bad `join` callback, for example) restarts just that
+subtree instead of taking down your whole server. See the
+[Supervision guide](/guides/supervision/) for the restart strategy, adding
+presence and groups to the supervised config, and handling startup errors.
 </Aside>
 
 ## 3. Connect from the browser

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -22,30 +22,42 @@ Beryl - Type-safe real-time communication
 
  ## Quick Start
 
+ beryl doesn't start an unmanaged process — `beryl/supervisor` builds a
+ child specification for your application's own OTP supervisor.
+
  ```gleam
  import beryl
  import beryl/channel
- import beryl/pubsub
- import beryl/presence
  import beryl/group
+ import beryl/presence
+ import beryl/pubsub
+ import beryl/supervisor
  import beryl/wire
+ import gleam/option.{Some}
+ import gleam/otp/static_supervisor
 
  pub fn main() {
    // Optional: start PubSub for distributed messaging
    let ps = pubsub.start(pubsub.default_config())
 
-   // Start channels system (with or without PubSub)
-   let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
-   let assert Ok(channels) = beryl.start(config)
+   // Configure channels (with presence and groups), then add beryl's
+   // child specification to your application supervisor.
+   let beryl_config =
+     supervisor.config(beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps))
+     |> supervisor.with_presence(presence.default_config("node1"))
+     |> supervisor.with_groups()
+
+   let assert Ok(_root) =
+     static_supervisor.new(static_supervisor.OneForOne)
+     |> static_supervisor.add(supervisor.start(beryl_config))
+     |> static_supervisor.start()
+
+   let channels = supervisor.channels(beryl_config)
+   let assert Some(groups) = supervisor.groups(beryl_config)
 
    // Register a channel handler
    let _ = beryl.register(channels, "room:*", room_channel.new())
 
-   // Start presence tracking
-   let assert Ok(p) = presence.start(presence.default_config("node1"))
-
-   // Start channel groups
-   let assert Ok(groups) = group.start()
    let assert Ok(Nil) = group.create(groups, "team:eng")
    let assert Ok(Nil) = group.add(groups, "team:eng", "room:frontend")
 


### PR DESCRIPTION
## Summary

- The supervisor rewrite (#214) made `supervisor.start` the required way to run beryl in production, but the quick-start guide, top-level READMEs, the `beryl.gleam` moduledoc, and all four example apps still showed unsupervised `beryl.start`/`presence.start`/`group.start` as the primary pattern. All updated to build a `SupervisedConfig` and add beryl's child specification to the application's own `static_supervisor`.
- Fixed stale `beryl/supervisor.child_spec` references (renamed to `start` in #214) in `PRD.md`, the architecture deck, and the interview deck.
- Corrected the supervision-tree diagrams in `architecture/overview.md` and the architecture deck to match the actual one-for-one + nested rest-for-one tree.
- Fixed a `beryl.default_config()` reference in `beryl_ewe/README.md` that doesn't exist (the real function is `beryl.config(codec)`).
- Regenerated `reference/api/beryl.md` via `just docs` to match the updated moduledoc.