### PR TITLE
refactor: align code with Gleam conventions guide

### DIFF
--- a/.changes/unreleased/beryl-conventions.toml
+++ b/.changes/unreleased/beryl-conventions.toml
@@ -1,0 +1,3 @@
+project = "beryl"
+kind = "Changed"
+body = "Aligned the API with the Gleam conventions guide. `wire.dynamic_to_json` now returns `Result(Json, Nil)` instead of silently encoding unconvertible values as `null`. PubSub's pg scope is typed as `Atom` end to end and `pubsub.join`/`pubsub.leave` no longer contain assertions. `socket.StopReason` is documented as a closed set: match it exhaustively; new reasons are a breaking change. Internal cleanups: `internal.LogLevel`'s error variant is `ErrorLevel`, presence tracks `session_id` (not `pid`) naming throughout, and dead `connection_limit` start helpers were removed."

--- a/examples/chatrooms/src/chatrooms.gleam
+++ b/examples/chatrooms/src/chatrooms.gleam
@@ -25,7 +25,7 @@ pub fn main() {
   let assert Ok(_) = group.add(groups, "public", "room:help")
 
   // Dependencies the chat logic reads (presence writes flow through effects).
-  let ctx = chat_app.Ctx(presence: presence_actor, groups: groups)
+  let context = chat_app.Context(presence: presence_actor, groups: groups)
 
   // Rate limiting matches the previous channel-module deployment; the
   // presence handle is required for the app's presence effects to apply.
@@ -38,7 +38,7 @@ pub fn main() {
 
   let assert Ok(channels) =
     beryl.start(config, init: chat_app.standalone_init, update: fn(model, ev) {
-      chat_app.standalone_update(ctx, model, ev)
+      chat_app.standalone_update(context, model, ev)
     })
 
   io.println("💬 Chat Rooms Demo")
@@ -48,7 +48,7 @@ pub fn main() {
   // Start the HTTP server. A pre-upgrade token gate rejects connections
   // without the demo token before the WebSocket handshake; accepted
   // connections carry no extra metadata (`Ok([])`).
-  let ctx_router =
+  let router_context =
     router.Context(channels:, presence: presence_actor, groups:, base_path: "")
   let ws_config =
     mist_transport.default_config("/socket/websocket")
@@ -62,7 +62,7 @@ pub fn main() {
   let assert Ok(_) =
     fn(req) {
       mist_transport.upgrade(req, channels, ws_config, fn() {
-        router.handle_request(req, ctx_router)
+        router.handle_request(req, router_context)
       })
     }
     |> mist.new
@@ -72,7 +72,10 @@ pub fn main() {
   process.sleep_forever()
 }
 
-fn get_query_param(req, name: String) -> Result(String, Nil) {
+fn get_query_param(
+  req: request.Request(mist.Connection),
+  name: String,
+) -> Result(String, Nil) {
   case request.get_query(req) {
     Ok(params) ->
       list.find(params, fn(pair) { pair.0 == name })

--- a/examples/chatrooms/src/chatrooms/app.gleam
+++ b/examples/chatrooms/src/chatrooms/app.gleam
@@ -41,13 +41,13 @@ pub type Lobby {
 
 /// Dependencies the chat logic reads: the room group for join validation
 /// and the presence handle for reads (writes go through effects).
-pub type Ctx {
-  Ctx(presence: Presence, groups: Groups)
+pub type Context {
+  Context(presence: Presence, groups: Groups)
 }
 
 /// Handle a join for a `room:*` topic. Returns `None` when rejected.
 pub fn join(
-  ctx: Ctx,
+  context: Context,
   socket_id: String,
   topic: String,
   payload: Dynamic,
@@ -59,7 +59,7 @@ pub fn join(
   }
 
   // Validate the room exists (must be in the "public" group).
-  let room_exists = case group.topics(ctx.groups, "public") {
+  let room_exists = case group.topics(context.groups, "public") {
     Ok(topics) -> set.contains(topics, topic)
     Error(_) -> False
   }
@@ -69,7 +69,7 @@ pub fn join(
       socket.RejectJoin(ref, error("Room not found: " <> room_name)),
     ])
     True -> {
-      let current_users = presence.list(ctx.presence, topic)
+      let current_users = presence.list(context.presence, topic)
       case list.length(current_users) >= max_room_users {
         True -> #(None, [
           socket.RejectJoin(
@@ -85,7 +85,7 @@ pub fn join(
           let color = color.pastel_for(socket_id)
           let meta = presence_meta(username, color, typing: False)
 
-          let sys_payload = system_message(username <> " joined the room")
+          let system_payload = system_message(username <> " joined the room")
 
           let reply =
             json.object([
@@ -107,7 +107,7 @@ pub fn join(
                 "rooms_changed",
                 room_changed(room_name),
               ),
-              socket.Broadcast(topic, "new_msg", sys_payload),
+              socket.Broadcast(topic, "new_msg", system_payload),
               socket.BroadcastPresence(topic, "presence_list", encode_users),
             ],
           )
@@ -119,7 +119,7 @@ pub fn join(
 
 /// Handle a client message on a joined `room:*` topic.
 pub fn update(
-  _ctx: Ctx,
+  _context: Context,
   socket_id: String,
   topic: String,
   model: Model,
@@ -136,7 +136,7 @@ pub fn update(
           reply_ok(ref, error_with_code(422, "Message cannot be empty")),
         )
         trimmed -> {
-          let msg_payload =
+          let message_payload =
             json.object([
               #("text", json.string(trimmed)),
               #("username", json.string(model.username)),
@@ -148,7 +148,7 @@ pub fn update(
           #(
             model,
             list.append(
-              [socket.Broadcast(topic, "new_msg", msg_payload)],
+              [socket.Broadcast(topic, "new_msg", message_payload)],
               reply_ok(
                 ref,
                 json.object([
@@ -174,18 +174,18 @@ pub fn update(
 
 /// Handle the topic closing (leave, kick, crash, or disconnect).
 pub fn closed(
-  _ctx: Ctx,
+  _context: Context,
   _socket_id: String,
   topic: String,
   model: Model,
 ) -> List(Effect) {
-  let sys_payload = system_message(model.username <> " left the room")
+  let system_payload = system_message(model.username <> " left the room")
   // The snapshot encodes after the untrack before it, so the broadcast
   // list already excludes the leaving user.
   [
     socket.PresenceUntrack(topic, model.username),
     socket.Broadcast("lobby", "rooms_changed", room_changed(model.room_name)),
-    socket.Broadcast(topic, "new_msg", sys_payload),
+    socket.Broadcast(topic, "new_msg", system_payload),
     socket.BroadcastPresence(topic, "presence_list", encode_users),
   ]
 }
@@ -234,7 +234,7 @@ pub fn standalone_init(
 /// topic. Non-`room:*` joins are rejected (fail closed), mirroring the old
 /// `room:*` handler registration.
 pub fn standalone_update(
-  ctx: Ctx,
+  context: Context,
   model: Standalone,
   ev: socket.Input(Nil),
 ) -> socket.Next(Standalone, Nil) {
@@ -247,7 +247,7 @@ pub fn standalone_update(
         }
         "room:" <> _ -> {
           let #(joined, effects) =
-            join(ctx, model.socket_id, topic, payload, ref)
+            join(context, model.socket_id, topic, payload, ref)
           case joined {
             Some(sub) ->
               socket.Next(
@@ -282,7 +282,7 @@ pub fn standalone_update(
             Ok(sub) -> {
               let #(sub, effects) =
                 update(
-                  ctx,
+                  context,
                   model.socket_id,
                   topic,
                   sub,
@@ -312,7 +312,7 @@ pub fn standalone_update(
             Ok(sub) ->
               socket.Next(
                 Standalone(..model, rooms: dict.delete(model.rooms, topic)),
-                closed(ctx, model.socket_id, topic, sub),
+                closed(context, model.socket_id, topic, sub),
               )
             Error(Nil) -> socket.Next(model, [])
           }

--- a/examples/chatrooms/src/chatrooms/router.gleam
+++ b/examples/chatrooms/src/chatrooms/router.gleam
@@ -21,23 +21,23 @@ pub type Context {
 
 pub fn handle_request(
   req: Request(Connection),
-  ctx: Context,
+  context: Context,
 ) -> Response(ResponseData) {
-  use <- static.serve_static(
+  use <- static.serve_app_static(
     req,
-    under: ctx.base_path <> "/static",
-    from: static.priv_static("chatrooms"),
+    under: context.base_path <> "/static",
+    app: "chatrooms",
   )
 
-  case static.match_prefix(req, ctx.base_path) {
-    Ok([]) -> index_page(ctx)
-    Ok(["api", "rooms"]) -> rooms_api(ctx)
+  case static.match_prefix(req, context.base_path) {
+    Ok([]) -> index_page(context)
+    Ok(["api", "rooms"]) -> rooms_api(context)
     _ -> static.not_found()
   }
 }
 
-fn rooms_api(ctx: Context) -> Response(ResponseData) {
-  let rooms = case group.topics(ctx.groups, "public") {
+fn rooms_api(context: Context) -> Response(ResponseData) {
+  let rooms = case group.topics(context.groups, "public") {
     Ok(topics) ->
       topics
       |> set.to_list
@@ -46,7 +46,7 @@ fn rooms_api(ctx: Context) -> Response(ResponseData) {
           [_, name] -> name
           _ -> topic
         }
-        let user_count = list.length(presence.list(ctx.presence, topic))
+        let user_count = list.length(presence.list(context.presence, topic))
         json.object([
           #("topic", json.string(topic)),
           #("name", json.string(room_name)),
@@ -60,9 +60,9 @@ fn rooms_api(ctx: Context) -> Response(ResponseData) {
   static.json_response(body)
 }
 
-fn index_page(ctx: Context) -> Response(ResponseData) {
+fn index_page(context: Context) -> Response(ResponseData) {
   // Build room list for initial render
-  let rooms = case group.topics(ctx.groups, "public") {
+  let rooms = case group.topics(context.groups, "public") {
     Ok(topics) ->
       topics
       |> set.to_list
@@ -98,7 +98,7 @@ fn index_page(ctx: Context) -> Response(ResponseData) {
   <meta charset=\"UTF-8\">
   <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
   <title>Chat Rooms — beryl demo</title>
-  <link rel=\"stylesheet\" href=\"" <> ctx.base_path <> "/static/style.css\">
+  <link rel=\"stylesheet\" href=\"" <> context.base_path <> "/static/style.css\">
 </head>
 <body>
   <div id=\"app\">
@@ -126,7 +126,7 @@ fn index_page(ctx: Context) -> Response(ResponseData) {
     </aside>
   </div>
   <script src=\"https://unpkg.com/phoenix@1.7.20/priv/static/phoenix.js\" integrity=\"sha384-9Rsr2KoQMtWNQakugNsDiGsZ/5eQnJHeBhiocJMdHvnyN8ifwcytSTzPpb1xydYk\" crossorigin=\"anonymous\"></script>
-  <script src=\"" <> ctx.base_path <> "/static/app.js\"></script>
+  <script src=\"" <> context.base_path <> "/static/app.js\"></script>
 </body>
 </html>"
 

--- a/examples/chatrooms/test/chatrooms_app_test.gleam
+++ b/examples/chatrooms/test/chatrooms_app_test.gleam
@@ -8,13 +8,13 @@ import gleam/json
 import gleam/option.{None, Some}
 import gleeunit/should
 
-fn context() -> app.Ctx {
+fn context() -> app.Context {
   let assert Ok(presence_handle) =
     presence.start(presence.default_config("chatrooms-lobby-test"))
   let assert Ok(groups) = group.start()
   let assert Ok(_) = group.create(groups, "public")
   let assert Ok(_) = group.add(groups, "public", "room:general")
-  app.Ctx(presence: presence_handle, groups: groups)
+  app.Context(presence: presence_handle, groups: groups)
 }
 
 fn lobby_ref() -> socket.Ref {

--- a/examples/collab_docs/client/src/collab_docs_client.gleam
+++ b/examples/collab_docs/client/src/collab_docs_client.gleam
@@ -15,6 +15,14 @@ pub type RenderBlock {
   RenderBlock(id: String, values: List(String))
 }
 
+/// Failures when restoring or merging a document from encoded state.
+pub type DocumentError {
+  /// The encoded state was not valid document JSON.
+  InvalidState(reason: json.DecodeError)
+  /// The decoded state could not be merged into the local document.
+  MergeFailed(reason: crdt.MergeError)
+}
+
 pub fn new_document(replica: String) -> Document {
   Document(
     replica: replica,
@@ -22,13 +30,16 @@ pub fn new_document(replica: String) -> Document {
   )
 }
 
-pub fn from_json(replica: String, encoded: String) -> Result(Document, String) {
+pub fn from_json(
+  replica: String,
+  encoded: String,
+) -> Result(Document, DocumentError) {
   case or_map.from_json(encoded) {
-    Error(_) -> Error("invalid_state")
+    Error(reason) -> Error(InvalidState(reason))
     Ok(remote) -> {
       let Document(replica: _, state: local) = new_document(replica)
       case or_map.merge(local, remote) {
-        Error(_) -> Error("merge_failed")
+        Error(reason) -> Error(MergeFailed(reason))
         Ok(state) -> Ok(Document(replica: replica, state: state))
       }
     }
@@ -69,13 +80,13 @@ pub fn remove_block(document: Document, block_id: String) -> Document {
 pub fn merge_json(
   document: Document,
   remote_json: String,
-) -> Result(Document, String) {
+) -> Result(Document, DocumentError) {
   let Document(replica, state) = document
   case or_map.from_json(remote_json) {
-    Error(_) -> Error("invalid_state")
+    Error(reason) -> Error(InvalidState(reason))
     Ok(remote) ->
       case or_map.merge(state, remote) {
-        Error(_) -> Error("merge_failed")
+        Error(reason) -> Error(MergeFailed(reason))
         Ok(merged) -> Ok(Document(replica: replica, state: merged))
       }
   }
@@ -87,12 +98,21 @@ pub fn blocks(document: Document) -> List(RenderBlock) {
   |> or_map.keys
   |> list.sort(by: string.compare)
   |> list.map(fn(id) {
+    // Documents only ever store MV-register blocks; render any other CRDT
+    // kind (or a missing key) as an empty block.
     let values = case or_map.get(state, id) {
       Ok(crdt.CrdtMvRegister(register)) ->
         register
         |> mv_register.value
         |> list.sort(by: string.compare)
-      _ -> []
+      Ok(crdt.CrdtGCounter(_))
+      | Ok(crdt.CrdtPnCounter(_))
+      | Ok(crdt.CrdtLwwRegister(_))
+      | Ok(crdt.CrdtGSet(_))
+      | Ok(crdt.CrdtTwoPSet(_))
+      | Ok(crdt.CrdtOrSet(_))
+      | Ok(crdt.CrdtVersionVector(_))
+      | Error(Nil) -> []
     }
     RenderBlock(id: id, values: values)
   })
@@ -120,6 +140,8 @@ pub fn merge_json_or_keep(document: Document, remote_json: String) -> Document {
 fn put_block(document: Document, id: String, block_json: String) -> Document {
   let Document(replica, state) = document
   let replica_id = replica_id.new(replica)
+  // Documents only ever store MV-register blocks; leave any other CRDT
+  // kind untouched.
   let updated =
     or_map.update(state, id, fn(value) {
       case value {
@@ -129,7 +151,13 @@ fn put_block(document: Document, id: String, block_json: String) -> Document {
             |> mv_register.merge(register)
           crdt.CrdtMvRegister(mv_register.set(local_register, block_json))
         }
-        other -> other
+        crdt.CrdtGCounter(_) as other
+        | crdt.CrdtPnCounter(_) as other
+        | crdt.CrdtLwwRegister(_) as other
+        | crdt.CrdtGSet(_) as other
+        | crdt.CrdtTwoPSet(_) as other
+        | crdt.CrdtOrSet(_) as other
+        | crdt.CrdtVersionVector(_) as other -> other
       }
     })
   Document(replica: replica, state: updated)

--- a/examples/collab_docs/client/test/collab_docs_client_test.gleam
+++ b/examples/collab_docs/client/test/collab_docs_client_test.gleam
@@ -105,9 +105,9 @@ pub fn edit_block_with_mismatched_id_is_ignored_test() {
 }
 
 pub fn merge_json_returns_invalid_state_for_invalid_json_test() {
-  client.new_document("a")
-  |> client.merge_json("not json")
-  |> should.equal(Error("invalid_state"))
+  let assert Error(client.InvalidState(_)) =
+    client.new_document("a")
+    |> client.merge_json("not json")
 }
 
 pub fn remove_block_removes_existing_block_test() {
@@ -143,8 +143,7 @@ pub fn from_json_restores_state_with_requested_replica_test() {
 }
 
 pub fn from_json_returns_invalid_state_for_invalid_json_test() {
-  client.from_json("a", "not json")
-  |> should.equal(Error("invalid_state"))
+  let assert Error(client.InvalidState(_)) = client.from_json("a", "not json")
 }
 
 pub fn blocks_json_renders_sorted_blocks_test() {

--- a/examples/collab_docs/src/collab_docs.gleam
+++ b/examples/collab_docs/src/collab_docs.gleam
@@ -15,20 +15,20 @@ pub fn main() {
 
   // Dependencies the document logic needs: the doc store and the shared
   // HMAC secret for join-level tenant token verification.
-  let ctx = docs_app.Ctx(store: store, secret: secret)
+  let context = docs_app.Context(store: store, secret: secret)
 
   let assert Ok(channels) =
     beryl.start(
       beryl.config(wire.phoenix_codec()),
       init: docs_app.standalone_init,
-      update: fn(model, ev) { docs_app.standalone_update(ctx, model, ev) },
+      update: fn(model, ev) { docs_app.standalone_update(context, model, ev) },
     )
 
   io.println("📝 Collaborative CRDT Docs Demo")
   io.println("   Open http://localhost:8002")
   io.println("")
 
-  let ctx_router = router.Context(channels:, store:, secret:, base_path: "")
+  let router_context = router.Context(channels:, store:, secret:, base_path: "")
 
   let assert Ok(_) =
     fn(req) {
@@ -36,7 +36,7 @@ pub fn main() {
         req,
         channels,
         mist_transport.default_config("/socket/websocket"),
-        fn() { router.handle_request(req, ctx_router) },
+        fn() { router.handle_request(req, router_context) },
       )
     }
     |> mist.new

--- a/examples/collab_docs/src/collab_docs/app.gleam
+++ b/examples/collab_docs/src/collab_docs/app.gleam
@@ -39,8 +39,8 @@ pub type Model {
 
 /// Dependencies the document logic needs: the doc store and the shared
 /// HMAC secret for tenant token verification.
-pub type Ctx {
-  Ctx(store: Store, secret: BitArray)
+pub type Context {
+  Context(store: Store, secret: BitArray)
 }
 
 /// Build a collision-resistant key for a tenant/document pair.
@@ -51,7 +51,7 @@ pub fn build_document_key(tenant: String, document: String) -> String {
 
 /// Handle a join for a `document:*:*` topic. Returns `None` when rejected.
 pub fn join(
-  ctx: Ctx,
+  context: Context,
   _socket_id: String,
   topic_name: String,
   payload: Dynamic,
@@ -67,13 +67,15 @@ pub fn join(
           socket.RejectJoin(ref, error_payload("missing_token")),
         ])
         Ok(token) ->
-          case auth.verify_tenant(token, tenant, ctx.secret) {
+          case auth.verify_tenant(token, tenant, context.secret) {
             Error(_) -> #(None, [
               socket.RejectJoin(ref, error_payload("unauthorized")),
             ])
             Ok(Nil) -> {
               let document_key = build_document_key(tenant, document)
-              let state = case doc_store.get_state(ctx.store, document_key) {
+              let state = case
+                doc_store.get_state(context.store, document_key)
+              {
                 Ok(encoded) -> json.string(encoded)
                 Error(doc_store.NotFound) -> json.null()
                 Error(doc_store.Timeout) -> {
@@ -103,7 +105,7 @@ pub fn join(
 
 /// Handle a client message on a joined document topic.
 pub fn update(
-  ctx: Ctx,
+  context: Context,
   _socket_id: String,
   topic_name: String,
   model: Model,
@@ -112,7 +114,7 @@ pub fn update(
   ref: Option(Ref),
 ) -> #(Model, List(Effect)) {
   case event_name {
-    "sync_state" -> sync_state(ctx, topic_name, model, payload, ref)
+    "sync_state" -> sync_state(context, topic_name, model, payload, ref)
     _ -> #(model, reply_error("unknown_event", ref))
   }
 }
@@ -120,7 +122,7 @@ pub fn update(
 /// Handle the topic closing. Documents keep no per-socket server state
 /// beyond the model itself, so there is nothing to clean up.
 pub fn closed(
-  _ctx: Ctx,
+  _context: Context,
   _socket_id: String,
   _topic_name: String,
   _model: Model,
@@ -148,7 +150,7 @@ pub fn standalone_init(
 /// topic. Non-`document:*` joins are rejected (fail closed), mirroring the
 /// old `document:*:*` handler registration.
 pub fn standalone_update(
-  ctx: Ctx,
+  context: Context,
   model: Standalone,
   ev: socket.Input(Nil),
 ) -> socket.Next(Standalone, Nil) {
@@ -157,7 +159,7 @@ pub fn standalone_update(
       case topic {
         "document:" <> _ -> {
           let #(joined, effects) =
-            join(ctx, model.socket_id, topic, payload, ref)
+            join(context, model.socket_id, topic, payload, ref)
           case joined {
             Some(sub) ->
               socket.Next(
@@ -177,7 +179,15 @@ pub fn standalone_update(
       case dict.get(model.docs, topic) {
         Ok(sub) -> {
           let #(sub, effects) =
-            update(ctx, model.socket_id, topic, sub, event_name, payload, ref)
+            update(
+              context,
+              model.socket_id,
+              topic,
+              sub,
+              event_name,
+              payload,
+              ref,
+            )
           socket.Next(
             Standalone(..model, docs: dict.insert(model.docs, topic, sub)),
             effects,
@@ -191,7 +201,7 @@ pub fn standalone_update(
         Ok(sub) ->
           socket.Next(
             Standalone(..model, docs: dict.delete(model.docs, topic)),
-            closed(ctx, model.socket_id, topic, sub),
+            closed(context, model.socket_id, topic, sub),
           )
         Error(Nil) -> socket.Next(model, [])
       }
@@ -201,7 +211,7 @@ pub fn standalone_update(
 }
 
 fn sync_state(
-  ctx: Ctx,
+  context: Context,
   topic_name: String,
   model: Model,
   payload: Dynamic,
@@ -212,7 +222,7 @@ fn sync_state(
       case string.byte_size(state) > max_state_bytes {
         True -> #(model, reply_error("state_too_large", ref))
         False -> {
-          doc_store.merge_state(ctx.store, model.document_key, state)
+          doc_store.merge_state(context.store, model.document_key, state)
           #(model, [
             socket.BroadcastFrom(
               topic_name,

--- a/examples/collab_docs/src/collab_docs/router.gleam
+++ b/examples/collab_docs/src/collab_docs/router.gleam
@@ -21,23 +21,23 @@ pub type Context {
 
 pub fn handle_request(
   req: Request(Connection),
-  ctx: Context,
+  context: Context,
 ) -> Response(ResponseData) {
-  use <- static.serve_static(
+  use <- static.serve_app_static(
     req,
-    under: ctx.base_path <> "/static",
-    from: static.priv_static("collab_docs"),
+    under: context.base_path <> "/static",
+    app: "collab_docs",
   )
 
-  case static.match_prefix(req, ctx.base_path) {
-    Ok([]) -> index_page(ctx)
+  case static.match_prefix(req, context.base_path) {
+    Ok([]) -> index_page(context)
     _ -> static.not_found()
   }
 }
 
-fn index_page(ctx: Context) -> Response(ResponseData) {
-  let token = auth.sign_tenant(demo_tenant, ctx.secret)
-  let base = ctx.base_path
+fn index_page(context: Context) -> Response(ResponseData) {
+  let token = auth.sign_tenant(demo_tenant, context.secret)
+  let base = context.base_path
   let html = "<!DOCTYPE html>
 <html lang=\"en\">
 <head>

--- a/examples/collab_docs/test/app_test.gleam
+++ b/examples/collab_docs/test/app_test.gleam
@@ -39,11 +39,11 @@ pub fn join_with_valid_tenant_token_is_accepted_test() {
   let assert Ok(store) = doc_store.start()
   let secret = auth.new_secret()
   let token = auth.sign_tenant("demo", secret)
-  let ctx = app.Ctx(store: store, secret: secret)
+  let context = app.Context(store: store, secret: secret)
 
   let payload = payload_from_json("{\"token\":\"" <> token <> "\"}")
   let #(model, effects) =
-    app.join(ctx, "s1", "document:demo:readme", payload, document_ref())
+    app.join(context, "s1", "document:demo:readme", payload, document_ref())
 
   model |> should.be_some
   case effects {
@@ -55,11 +55,11 @@ pub fn join_with_valid_tenant_token_is_accepted_test() {
 pub fn join_without_token_is_rejected_test() {
   let assert Ok(store) = doc_store.start()
   let secret = auth.new_secret()
-  let ctx = app.Ctx(store: store, secret: secret)
+  let context = app.Context(store: store, secret: secret)
 
   let #(model, effects) =
     app.join(
-      ctx,
+      context,
       "s1",
       "document:demo:readme",
       payload_from_json("{}"),
@@ -78,11 +78,11 @@ pub fn join_with_token_for_other_tenant_is_rejected_test() {
   let secret = auth.new_secret()
   // A token signed for a different tenant must not authorize this document.
   let token = auth.sign_tenant("someone-else", secret)
-  let ctx = app.Ctx(store: store, secret: secret)
+  let context = app.Context(store: store, secret: secret)
 
   let payload = payload_from_json("{\"token\":\"" <> token <> "\"}")
   let #(model, effects) =
-    app.join(ctx, "s1", "document:demo:readme", payload, document_ref())
+    app.join(context, "s1", "document:demo:readme", payload, document_ref())
 
   model |> should.be_none
   case effects {

--- a/examples/collab_docs/test/doc_store_test.gleam
+++ b/examples/collab_docs/test/doc_store_test.gleam
@@ -81,7 +81,13 @@ fn put_block(map: ORMap, id: String, block_json: String) -> ORMap {
         register
         |> mv_register.set(block_json)
         |> crdt.CrdtMvRegister
-      other -> other
+      crdt.CrdtGCounter(_) as other
+      | crdt.CrdtPnCounter(_) as other
+      | crdt.CrdtLwwRegister(_) as other
+      | crdt.CrdtGSet(_) as other
+      | crdt.CrdtTwoPSet(_) as other
+      | crdt.CrdtOrSet(_) as other
+      | crdt.CrdtVersionVector(_) as other -> other
     }
   })
 }

--- a/examples/cursors/src/cursors.gleam
+++ b/examples/cursors/src/cursors.gleam
@@ -17,7 +17,7 @@ pub fn main() {
   let assert Ok(presence_actor) = presence.start(presence_config)
 
   // Dependencies the cursor logic reads (presence writes flow through effects).
-  let ctx = cursors_app.Ctx(presence: presence_actor)
+  let context = cursors_app.Context(presence: presence_actor)
 
   // Rate limiting for cursor events; the presence handle is required for
   // the app's presence effects to apply.
@@ -30,7 +30,9 @@ pub fn main() {
     beryl.start(
       config,
       init: cursors_app.standalone_init,
-      update: fn(model, ev) { cursors_app.standalone_update(ctx, model, ev) },
+      update: fn(model, ev) {
+        cursors_app.standalone_update(context, model, ev)
+      },
     )
 
   // Honor $PORT (Railway/PaaS) and $HOST/$BIND_ADDRESS; fall back to local defaults.
@@ -47,7 +49,7 @@ pub fn main() {
   io.println("")
 
   // Start the HTTP server.
-  let ctx_router =
+  let router_context =
     router.Context(channels:, presence: presence_actor, base_path: "")
 
   let assert Ok(_) =
@@ -56,7 +58,7 @@ pub fn main() {
         req,
         channels,
         mist_transport.default_config("/socket/websocket"),
-        fn() { router.handle_request(req, ctx_router) },
+        fn() { router.handle_request(req, router_context) },
       )
     }
     |> mist.new

--- a/examples/cursors/src/cursors/app.gleam
+++ b/examples/cursors/src/cursors/app.gleam
@@ -28,15 +28,15 @@ pub type Model {
 
 /// Dependencies the cursor logic reads (presence is written through
 /// effects; the handle is only needed for reads like `presence.list`).
-pub type Ctx {
-  Ctx(presence: Presence)
+pub type Context {
+  Context(presence: Presence)
 }
 
 const supported_reactions = ["👍", "❤️", "😂", "🎉", "🔥"]
 
 /// Handle a join for a `cursor:*` topic. Returns `None` when rejected.
 pub fn join(
-  _ctx: Ctx,
+  _context: Context,
   socket_id: String,
   topic: String,
   payload: Dynamic,
@@ -67,7 +67,7 @@ pub fn join(
 
 /// Handle a client message on a joined `cursor:*` topic.
 pub fn update(
-  _ctx: Ctx,
+  _context: Context,
   socket_id: String,
   topic: String,
   model: Model,
@@ -107,7 +107,7 @@ pub fn update(
 
 /// Handle the topic closing (leave, kick, crash, or disconnect).
 pub fn closed(
-  _ctx: Ctx,
+  _context: Context,
   _socket_id: String,
   topic: String,
   model: Model,
@@ -140,7 +140,7 @@ pub fn standalone_init(
 /// topic. Non-`cursor:*` joins are rejected (fail closed), mirroring the old
 /// `cursor:*` handler registration.
 pub fn standalone_update(
-  ctx: Ctx,
+  context: Context,
   model: Standalone,
   ev: socket.Input(Nil),
 ) -> socket.Next(Standalone, Nil) {
@@ -149,7 +149,7 @@ pub fn standalone_update(
       case topic {
         "cursor:" <> _ -> {
           let #(joined, effects) =
-            join(ctx, model.socket_id, topic, payload, ref)
+            join(context, model.socket_id, topic, payload, ref)
           case joined {
             Some(sub) ->
               socket.Next(
@@ -175,7 +175,7 @@ pub fn standalone_update(
       case dict.get(model.cursors, topic) {
         Ok(sub) -> {
           let #(sub, effects) =
-            update(ctx, model.socket_id, topic, sub, event_name, payload)
+            update(context, model.socket_id, topic, sub, event_name, payload)
           socket.Next(
             Standalone(..model, cursors: dict.insert(model.cursors, topic, sub)),
             effects,
@@ -189,7 +189,7 @@ pub fn standalone_update(
         Ok(sub) ->
           socket.Next(
             Standalone(..model, cursors: dict.delete(model.cursors, topic)),
-            closed(ctx, model.socket_id, topic, sub),
+            closed(context, model.socket_id, topic, sub),
           )
         Error(Nil) -> socket.Next(model, [])
       }

--- a/examples/cursors/src/cursors/router.gleam
+++ b/examples/cursors/src/cursors/router.gleam
@@ -16,19 +16,19 @@ pub type Context {
 
 pub fn handle_request(
   req: Request(Connection),
-  ctx: Context,
+  context: Context,
 ) -> Response(ResponseData) {
   case request.path_segments(req) {
     ["healthz"] -> healthz()
     _ -> {
-      use <- static.serve_static(
+      use <- static.serve_app_static(
         req,
-        under: ctx.base_path <> "/static",
-        from: static.priv_static("cursors"),
+        under: context.base_path <> "/static",
+        app: "cursors",
       )
 
-      case static.match_prefix(req, ctx.base_path) {
-        Ok([]) -> index_page(ctx)
+      case static.match_prefix(req, context.base_path) {
+        Ok([]) -> index_page(context)
         _ -> static.not_found()
       }
     }
@@ -41,8 +41,8 @@ fn healthz() -> Response(ResponseData) {
   |> response.set_body(mist.Bytes(bytes_tree.from_string("ok")))
 }
 
-fn index_page(ctx: Context) -> Response(ResponseData) {
-  let base = ctx.base_path
+fn index_page(context: Context) -> Response(ResponseData) {
+  let base = context.base_path
   let html = "<!DOCTYPE html>
 <html lang=\"en\">
 <head>

--- a/examples/cursors/test/cursors_app_test.gleam
+++ b/examples/cursors/test/cursors_app_test.gleam
@@ -6,10 +6,10 @@ import gleam/json
 import gleam/list
 import gleeunit/should
 
-fn context() -> app.Ctx {
+fn context() -> app.Context {
   let assert Ok(handle) =
     presence.start(presence.default_config("cursors-reaction-test"))
-  app.Ctx(presence: handle)
+  app.Context(presence: handle)
 }
 
 fn model() -> app.Model {

--- a/examples/example_helpers/src/example_helpers/static.gleam
+++ b/examples/example_helpers/src/example_helpers/static.gleam
@@ -98,20 +98,20 @@ pub fn match_prefix(
   req: Request(Connection),
   prefix: String,
 ) -> Result(List(String), Nil) {
-  let segs = request.path_segments(req)
-  let prefix_segs =
+  let segments = request.path_segments(req)
+  let prefix_segments =
     prefix
     |> drop_leading_slashes
     |> string.split("/")
-    |> list.filter(fn(s) { s != "" })
-  strip_prefix(segs, prefix_segs)
+    |> list.filter(fn(segment) { segment != "" })
+  strip_prefix(segments, prefix_segments)
 }
 
 fn strip_prefix(
-  segs: List(String),
+  segments: List(String),
   prefix: List(String),
 ) -> Result(List(String), Nil) {
-  case prefix, segs {
+  case prefix, segments {
     [], rest -> Ok(rest)
     [p, ..ps], [s, ..ss] if p == s -> strip_prefix(ss, ps)
     _, _ -> Error(Nil)
@@ -131,9 +131,25 @@ pub fn mime_type_for(path: String) -> String {
   }
 }
 
-/// Resolve `<priv>/static` for an OTP application. Crashes if the application
-/// isn't loaded — examples always have their own priv tree at runtime.
-pub fn priv_static(app_name: String) -> String {
-  let assert Ok(priv) = application.priv_directory(app_name)
-  priv <> "/static"
+/// Resolve `<priv>/static` for an OTP application. Errors if the application
+/// isn't loaded.
+pub fn priv_static(app_name: String) -> Result(String, Nil) {
+  application.priv_directory(app_name)
+  |> result.map(fn(priv) { priv <> "/static" })
+}
+
+/// Serve an application's `priv/static` files under the URL prefix `prefix`.
+/// Falls through to `handler` for non-GET requests, for paths that don't
+/// match, and when the application's priv directory is unavailable.
+pub fn serve_app_static(
+  req: Request(Connection),
+  under prefix: String,
+  app app_name: String,
+  next handler: fn() -> Response(ResponseData),
+) -> Response(ResponseData) {
+  case priv_static(app_name) {
+    Ok(directory) ->
+      serve_static(req, under: prefix, from: directory, next: handler)
+    Error(Nil) -> handler()
+  }
 }

--- a/examples/showcase/src/showcase.gleam
+++ b/examples/showcase/src/showcase.gleam
@@ -44,8 +44,12 @@ type Model {
 }
 
 /// Dependencies for the three embedded apps.
-type Ctx {
-  Ctx(cursors: cursors_app.Ctx, rooms: chat_app.Ctx, docs: docs_app.Ctx)
+type Context {
+  Context(
+    cursors: cursors_app.Context,
+    rooms: chat_app.Context,
+    docs: docs_app.Context,
+  )
 }
 
 pub fn main() {
@@ -65,11 +69,11 @@ pub fn main() {
   let docs_secret = docs_auth.new_secret()
   let assert Ok(docs_store) = doc_store.start()
 
-  let ctx =
-    Ctx(
-      cursors: cursors_app.Ctx(presence: presence_actor),
-      rooms: chat_app.Ctx(presence: presence_actor, groups: groups),
-      docs: docs_app.Ctx(store: docs_store, secret: docs_secret),
+  let context =
+    Context(
+      cursors: cursors_app.Context(presence: presence_actor),
+      rooms: chat_app.Context(presence: presence_actor, groups: groups),
+      docs: docs_app.Context(store: docs_store, secret: docs_secret),
     )
 
   // Per-topic-pattern rate limits replace the old single global
@@ -97,35 +101,35 @@ pub fn main() {
           [],
         )
       },
-      update: fn(model, ev) { update(ctx, model, ev) },
+      update: fn(model, ev) { update(context, model, ev) },
     )
 
   // Build per-example contexts pinned to their URL prefix.
-  let cursors_ctx =
+  let cursors_context =
     cursors_router.Context(
       channels:,
       presence: presence_actor,
       base_path: "/cursors",
     )
-  let chatrooms_ctx =
+  let chatrooms_context =
     chatrooms_router.Context(
       channels:,
       presence: presence_actor,
       groups:,
       base_path: "/chat",
     )
-  let collab_docs_ctx =
+  let collab_docs_context =
     collab_docs_router.Context(
       channels:,
       store: docs_store,
       secret: docs_secret,
       base_path: "/docs",
     )
-  let showcase_ctx =
+  let showcase_context =
     router.Context(
-      cursors: cursors_ctx,
-      chatrooms: chatrooms_ctx,
-      collab_docs: collab_docs_ctx,
+      cursors: cursors_context,
+      chatrooms: chatrooms_context,
+      collab_docs: collab_docs_context,
     )
 
   let port =
@@ -149,7 +153,7 @@ pub fn main() {
         req,
         channels,
         mist_transport.default_config("/socket/websocket"),
-        fn() { router.handle_request(req, showcase_ctx) },
+        fn() { router.handle_request(req, showcase_context) },
       )
     }
     |> mist.new
@@ -163,23 +167,29 @@ pub fn main() {
 /// The socket-wide router: dispatch every event to the embedded app that
 /// owns its topic namespace, threading that app's sub-model through the
 /// per-namespace `Dict`.
-fn update(ctx: Ctx, model: Model, ev: Input(Nil)) -> Next(Model, Nil) {
+fn update(context: Context, model: Model, ev: Input(Nil)) -> Next(Model, Nil) {
   case ev {
     socket.Join(topic, payload, ref) ->
       case topic {
         "cursor:" <> _ -> {
           let #(joined, effects) =
-            cursors_app.join(ctx.cursors, model.socket_id, topic, payload, ref)
+            cursors_app.join(
+              context.cursors,
+              model.socket_id,
+              topic,
+              payload,
+              ref,
+            )
           socket.Next(store_cursor(model, topic, joined), effects)
         }
         "room:" <> _ -> {
           let #(joined, effects) =
-            chat_app.join(ctx.rooms, model.socket_id, topic, payload, ref)
+            chat_app.join(context.rooms, model.socket_id, topic, payload, ref)
           socket.Next(store_room(model, topic, joined), effects)
         }
         "document:" <> _ -> {
           let #(joined, effects) =
-            docs_app.join(ctx.docs, model.socket_id, topic, payload, ref)
+            docs_app.join(context.docs, model.socket_id, topic, payload, ref)
           socket.Next(store_doc(model, topic, joined), effects)
         }
         _ ->
@@ -198,7 +208,7 @@ fn update(ctx: Ctx, model: Model, ev: Input(Nil)) -> Next(Model, Nil) {
             Ok(sub) -> {
               let #(sub, effects) =
                 cursors_app.update(
-                  ctx.cursors,
+                  context.cursors,
                   model.socket_id,
                   topic,
                   sub,
@@ -214,7 +224,7 @@ fn update(ctx: Ctx, model: Model, ev: Input(Nil)) -> Next(Model, Nil) {
             Ok(sub) -> {
               let #(sub, effects) =
                 chat_app.update(
-                  ctx.rooms,
+                  context.rooms,
                   model.socket_id,
                   topic,
                   sub,
@@ -231,7 +241,7 @@ fn update(ctx: Ctx, model: Model, ev: Input(Nil)) -> Next(Model, Nil) {
             Ok(sub) -> {
               let #(sub, effects) =
                 docs_app.update(
-                  ctx.docs,
+                  context.docs,
                   model.socket_id,
                   topic,
                   sub,
@@ -253,7 +263,7 @@ fn update(ctx: Ctx, model: Model, ev: Input(Nil)) -> Next(Model, Nil) {
             Ok(sub) ->
               socket.Next(
                 Model(..model, cursors: dict.delete(model.cursors, topic)),
-                cursors_app.closed(ctx.cursors, model.socket_id, topic, sub),
+                cursors_app.closed(context.cursors, model.socket_id, topic, sub),
               )
             Error(Nil) -> socket.Next(model, [])
           }
@@ -262,7 +272,7 @@ fn update(ctx: Ctx, model: Model, ev: Input(Nil)) -> Next(Model, Nil) {
             Ok(sub) ->
               socket.Next(
                 Model(..model, rooms: dict.delete(model.rooms, topic)),
-                chat_app.closed(ctx.rooms, model.socket_id, topic, sub),
+                chat_app.closed(context.rooms, model.socket_id, topic, sub),
               )
             Error(Nil) -> socket.Next(model, [])
           }
@@ -271,7 +281,7 @@ fn update(ctx: Ctx, model: Model, ev: Input(Nil)) -> Next(Model, Nil) {
             Ok(sub) ->
               socket.Next(
                 Model(..model, docs: dict.delete(model.docs, topic)),
-                docs_app.closed(ctx.docs, model.socket_id, topic, sub),
+                docs_app.closed(context.docs, model.socket_id, topic, sub),
               )
             Error(Nil) -> socket.Next(model, [])
           }

--- a/examples/showcase/src/showcase/router.gleam
+++ b/examples/showcase/src/showcase/router.gleam
@@ -21,17 +21,17 @@ pub type Context {
 
 pub fn handle_request(
   req: Request(Connection),
-  ctx: Context,
+  context: Context,
 ) -> Response(ResponseData) {
   case request.path_segments(req) {
     [] -> landing_page()
     ["healthz"] -> healthz()
-    ["cursors", ..] -> cursors_router.handle_request(req, ctx.cursors)
-    ["chat", ..] -> chatrooms_router.handle_request(req, ctx.chatrooms)
+    ["cursors", ..] -> cursors_router.handle_request(req, context.cursors)
+    ["chat", ..] -> chatrooms_router.handle_request(req, context.chatrooms)
     // TODO: re-enable the collab_docs demo. The handler is still
     // registered in showcase.main so reinstating the route + landing
     // card is a one-line change.
-    // ["docs", ..] -> collab_docs_router.handle_request(req, ctx.collab_docs)
+    // ["docs", ..] -> collab_docs_router.handle_request(req, context.collab_docs)
     _ -> static.not_found()
   }
 }

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -26,12 +26,12 @@
 ////
 //// pub fn main() {
 ////   // Optional: start PubSub for distributed messaging
-////   let ps = pubsub.start(pubsub.default_config())
+////   let bus = pubsub.start(pubsub.default_config())
 ////
 ////   // Start the system (with or without PubSub). The app supplies `init`
 ////   // (the per-socket model) and `update` (which routes every event by
 ////   // matching on its topic).
-////   let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
+////   let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(bus)
 ////   let assert Ok(sockets) =
 ////     beryl.start(
 ////       config,
@@ -261,8 +261,8 @@ pub fn with_presence_handle(
 }
 
 /// Add PubSub to a configuration for distributed broadcasts
-pub fn with_pubsub(config: Config, ps: PubSub(json.Json)) -> Config {
-  Config(..config, pubsub: Some(ps))
+pub fn with_pubsub(config: Config, pubsub: PubSub(json.Json)) -> Config {
+  Config(..config, pubsub: Some(pubsub))
 }
 
 /// Configure heartbeat timing.
@@ -1107,7 +1107,7 @@ fn runtime_start_error(error: runtime.StartError) -> actor.StartError {
 /// window or after `stop` degrades to a no-op instead of a crash.
 fn app_handle(
   subject: Subject(runtime.Msg(msg)),
-  ps: Option(PubSub(json.Json)),
+  bus: Option(PubSub(json.Json)),
 ) -> AppHandle {
   AppHandle(
     socket_connected: fn(socket_id, send, send_binary, seed) {
@@ -1135,12 +1135,12 @@ fn app_handle(
         subject,
         runtime.Broadcast(topic_name, event_name, payload, except),
       )
-      case ps, process.subject_owner(subject) {
-        Some(ps), Ok(runtime_pid) ->
+      case bus, process.subject_owner(subject) {
+        Some(bus), Ok(runtime_pid) ->
           case except {
             None ->
               pubsub.broadcast_from(
-                ps,
+                bus,
                 runtime_pid,
                 topic_name,
                 event_name,
@@ -1148,7 +1148,7 @@ fn app_handle(
               )
             Some(socket_id) ->
               pubsub.broadcast_from_socket(
-                ps,
+                bus,
                 runtime_pid,
                 socket_id,
                 topic_name,
@@ -1233,7 +1233,7 @@ fn internal_logging_config(logging: LoggingConfig) -> internal.LoggingConfig {
       DebugLevel -> internal.Debug
       InfoLevel -> internal.Info
       WarnLevel -> internal.Warn
-      ErrorLevel -> internal.Err
+      ErrorLevel -> internal.ErrorLevel
     },
     include_payloads: logging.include_payloads,
     payload_preview_bytes: logging.payload_preview_bytes,

--- a/packages/beryl/src/beryl/connection_limit.gleam
+++ b/packages/beryl/src/beryl/connection_limit.gleam
@@ -182,17 +182,6 @@ fn request(
   }
 }
 
-/// Start a connection limiter enforcing a per-IP ceiling and/or a node-wide
-/// ceiling. A ceiling of 0 disables that dimension.
-fn start(
-  max_per_ip: Int,
-  max_total: Int,
-) -> Result(ConnectionLimiter, actor.StartError) {
-  build(max_per_ip, max_total)
-  |> actor.start
-  |> result.map(fn(started) { ConnectionLimiter(subject: started.data) })
-}
-
 fn build(
   max_per_ip: Int,
   max_total: Int,
@@ -242,22 +231,12 @@ pub fn pid(limiter: ConnectionLimiter) -> Result(Pid, Nil) {
   process.subject_owner(limiter.subject)
 }
 
-/// Start a limiter only when at least one ceiling is positive.
+/// Whether at least one ceiling is positive and a limiter should run.
 ///
 /// `max_per_ip` caps concurrent connections from a single peer; `max_total`
 /// caps concurrent connections across the whole node. They compose: a
 /// connection is admitted only when it is under both configured ceilings. When
 /// both are 0 no limiter is started and every connection is admitted.
-@internal
-pub fn start_optional(
-  max_per_ip: Int,
-  max_total: Int,
-) -> Option(ConnectionLimiter) {
-  use <- bool.guard(when: !enabled(max_per_ip, max_total), return: None)
-  let assert Ok(limiter) = start(max_per_ip, max_total)
-  Some(limiter)
-}
-
 @internal
 pub fn enabled(max_per_ip: Int, max_total: Int) -> Bool {
   max_per_ip > 0 || max_total > 0

--- a/packages/beryl/src/beryl/error.gleam
+++ b/packages/beryl/src/beryl/error.gleam
@@ -2,6 +2,7 @@
 
 import gleam/erlang/process
 import gleam/otp/actor
+import gleam/string
 
 /// A stable description of an internal Beryl actor startup failure.
 ///
@@ -39,6 +40,7 @@ fn exit_reason(reason: process.ExitReason) -> String {
   case reason {
     process.Normal -> "normal"
     process.Killed -> "killed"
-    process.Abnormal(_) -> "abnormal"
+    // nolint: string_inspect -- abnormal exit reasons are arbitrary BEAM terms with no concrete type to serialize
+    process.Abnormal(detail) -> "abnormal: " <> string.inspect(detail)
   }
 }

--- a/packages/beryl/src/beryl/internal.gleam
+++ b/packages/beryl/src/beryl/internal.gleam
@@ -9,11 +9,14 @@ import palabres/level
 import palabres/options
 
 /// Logging verbosity for Beryl's internal helpers.
+///
+/// The error variant is named `ErrorLevel` so it cannot shadow the prelude's
+/// `Error` result constructor.
 pub type LogLevel {
   Debug
   Info
   Warn
-  Err
+  ErrorLevel
 }
 
 /// Logging configuration shared by internal Beryl modules.
@@ -40,7 +43,7 @@ fn to_palabres_level(log_level: LogLevel) -> level.Level {
     Debug -> level.Debug
     Info -> level.Info
     Warn -> level.Warning
-    Err -> level.Error
+    ErrorLevel -> level.Error
   }
 }
 

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -138,8 +138,8 @@ fn state_entries_to_presence_entries(
     #(
       topic,
       list.map(topic_entries, fn(topic_entry) {
-        let #(key, pid, meta) = topic_entry
-        PresenceEntry(session_id: pid, key: key, meta: meta)
+        let #(key, session_id, meta) = topic_entry
+        PresenceEntry(session_id: session_id, key: key, meta: meta)
       }),
     )
   })
@@ -192,12 +192,12 @@ pub opaque type Message {
   Track(
     topic: String,
     key: String,
-    pid: String,
+    session_id: String,
     meta: json.Json,
     reply: Subject(String),
   )
   Untrack(ref: String, reply: Subject(Nil))
-  UntrackAll(pid: String, reply: Subject(Nil))
+  UntrackAll(session_id: String, reply: Subject(Nil))
   List(topic: String, reply: Subject(List(PresenceEntry)))
   GetByKey(
     topic: String,
@@ -466,7 +466,11 @@ fn meta_with_phx_ref(meta: json.Json, ref: String) -> json.Json {
     fields
     |> dict.delete("phx_ref")
     |> dict.to_list
-    |> list.map(fn(field) { #(field.0, wire.dynamic_to_json(field.1)) })
+    // Meta fields come from decoded JSON, so conversion only fails for
+    // non-JSON terms smuggled into a meta object; store those as null.
+    |> list.map(fn(field) {
+      #(field.0, wire.dynamic_to_json(field.1) |> result.unwrap(json.null()))
+    })
     |> list.append([#("phx_ref", json.string(ref))])
     |> json.object
   })
@@ -541,26 +545,26 @@ fn handle_message(
 ) -> actor.Next(ActorState, Message) {
   let logger = internal.logger("beryl.presence")
   case message {
-    Track(topic, key, pid, meta, reply) -> {
+    Track(topic, key, session_id, meta, reply) -> {
       let ref = generate_ref()
       let meta = meta_with_phx_ref(meta, ref)
-      let new_crdt = state.join(actor_state.crdt, pid, topic, key, meta)
+      let new_crdt = state.join(actor_state.crdt, session_id, topic, key, meta)
       maybe_invoke_on_diff(
         actor_state.config,
-        single_join_diff(topic, key, pid, meta),
+        single_join_diff(topic, key, session_id, meta),
       )
       logger
       |> log.debug("Presence tracked", [
         #("topic", topic),
         #("key", key),
-        #("pid", pid),
+        #("session_id", session_id),
         #("ref", ref),
       ])
       let new_refs =
         dict.insert(
           actor_state.refs,
           ref,
-          TrackedPresence(topic: topic, key: key, session_id: pid),
+          TrackedPresence(topic: topic, key: key, session_id: session_id),
         )
       process.send(reply, ref)
       actor.continue(
@@ -583,7 +587,7 @@ fn handle_message(
           |> log.debug("Presence untracked", [
             #("topic", topic),
             #("key", key),
-            #("pid", session_id),
+            #("session_id", session_id),
             #("ref", ref),
           ])
           process.send(reply, Nil)
@@ -599,15 +603,15 @@ fn handle_message(
       }
     }
 
-    UntrackAll(pid, reply) -> {
-      let diff = leave_all_diff(actor_state.crdt, pid)
-      let new_crdt = state.leave_by_pid(actor_state.crdt, pid)
+    UntrackAll(session_id, reply) -> {
+      let diff = leave_all_diff(actor_state.crdt, session_id)
+      let new_crdt = state.leave_by_pid(actor_state.crdt, session_id)
       maybe_invoke_on_diff(actor_state.config, diff)
       // Drop any refs that pointed at the removed session so they cannot leak
       // or later leave presences they no longer own.
       let new_refs =
         dict.filter(actor_state.refs, fn(_ref, tracked) {
-          tracked.session_id != pid
+          tracked.session_id != session_id
         })
       process.send(reply, Nil)
       actor.continue(
@@ -658,13 +662,13 @@ fn handle_message(
 fn single_join_diff(
   topic: String,
   key: String,
-  pid: String,
+  session_id: String,
   meta: json.Json,
 ) -> Diff {
   Diff(
     joins: dict.from_list([
       #(topic, [
-        PresenceEntry(session_id: pid, key: key, meta: meta),
+        PresenceEntry(session_id: session_id, key: key, meta: meta),
       ]),
     ]),
     leaves: dict.new(),
@@ -675,11 +679,11 @@ fn leave_diff(
   crdt: state.State,
   topic: String,
   key: String,
-  pid: String,
+  session_id: String,
 ) -> Diff {
   let leaves =
     state.get_by_key(crdt, topic, key)
-    |> list.filter(fn(entry) { entry.0 == pid })
+    |> list.filter(fn(entry) { entry.0 == session_id })
     |> list.map(fn(entry) {
       PresenceEntry(session_id: entry.0, key: key, meta: entry.1)
     })
@@ -687,17 +691,17 @@ fn leave_diff(
   Diff(joins: dict.new(), leaves: topic_entries(topic, leaves))
 }
 
-fn leave_all_diff(crdt: State, pid: String) -> Diff {
+fn leave_all_diff(crdt: State, session_id: String) -> Diff {
   let leaves =
     state.online_list(crdt)
-    |> list.filter(fn(entry) { entry.0 == pid })
+    |> list.filter(fn(entry) { entry.0 == session_id })
     |> list.fold(dict.new(), fn(grouped, entry) {
       let #(_, topic, key, meta) = entry
       let existing =
         dict.get(grouped, topic)
         |> result.unwrap([])
       dict.insert(grouped, topic, [
-        PresenceEntry(session_id: pid, key: key, meta: meta),
+        PresenceEntry(session_id: session_id, key: key, meta: meta),
         ..existing
       ])
     })

--- a/packages/beryl/src/beryl/pubsub.gleam
+++ b/packages/beryl/src/beryl/pubsub.gleam
@@ -16,23 +16,23 @@
 //// ## Quick Start
 ////
 //// ```gleam
-//// let ps = pubsub.start(pubsub.default_config())
+//// let bus = pubsub.start(pubsub.default_config())
 ////
 //// // Sending: broadcast to all subscribers of a topic
-//// pubsub.broadcast(ps, "room:lobby", "new_msg", "hello")
+//// pubsub.broadcast(bus, "room:lobby", "new_msg", "hello")
 ////
 //// // Receiving: create a `subscriber`, join topics, and fold its
 //// // `selecting` into an actor's own `Selector`. `RemoteBroadcast` here is
 //// // the actor's own message constructor that wraps a `pubsub.Message`.
-//// let sub = pubsub.subscriber(ps)
-//// pubsub.join(sub, "room:lobby")
+//// let subscription = pubsub.subscriber(bus)
+//// pubsub.join(subscription, "room:lobby")
 //// let selector =
 ////   process.new_selector()
 ////   |> process.select(subject)
-////   |> pubsub.selecting(sub, RemoteBroadcast)
+////   |> pubsub.selecting(subscription, RemoteBroadcast)
 //// ```
 
-import gleam/dynamic.{type Dynamic}
+import gleam/erlang/atom.{type Atom}
 import gleam/erlang/process.{type Pid, type Selector, type Subject}
 import gleam/list
 
@@ -80,8 +80,8 @@ pub type PubSubFrom {
 /// scope representation can evolve without exposing record fields.
 pub opaque type PubSubConfig {
   PubSubConfig(
-    /// The pg scope name (atom). Different scopes are isolated.
-    scope: Dynamic,
+    /// The pg scope name. Different scopes are isolated.
+    scope: Atom,
   )
 }
 
@@ -91,35 +91,32 @@ pub opaque type PubSubConfig {
 /// depend on the runtime representation. `payload` fixes the Gleam type
 /// every `Message` broadcast through this instance carries.
 pub opaque type PubSub(payload) {
-  PubSub(scope: Dynamic)
+  PubSub(scope: Atom)
 }
 
 // ── FFI declarations ────────────────────────────────────────────────────────
 
 @external(erlang, "beryl_pubsub_ffi", "start_pg_scope")
-fn ffi_start_pg_scope(scope: Dynamic) -> Dynamic
+fn ffi_start_pg_scope(scope: Atom) -> Nil
 
 @external(erlang, "beryl_pubsub_ffi", "join_group")
-fn ffi_join_group(scope: Dynamic, group: String, pid: Pid) -> Dynamic
+fn ffi_join_group(scope: Atom, group: String, pid: Pid) -> Nil
 
 @external(erlang, "beryl_pubsub_ffi", "leave_group")
-fn ffi_leave_group(scope: Dynamic, group: String, pid: Pid) -> Dynamic
+fn ffi_leave_group(scope: Atom, group: String, pid: Pid) -> Nil
 
 @external(erlang, "beryl_pubsub_ffi", "get_members")
-fn ffi_get_members(scope: Dynamic, group: String) -> List(Pid)
+fn ffi_get_members(scope: Atom, group: String) -> List(Pid)
 
 @external(erlang, "beryl_pubsub_ffi", "get_local_members")
-fn ffi_get_local_members(scope: Dynamic, group: String) -> List(Pid)
-
-@external(erlang, "erlang", "binary_to_atom")
-fn binary_to_atom(name: String) -> Dynamic
+fn ffi_get_local_members(scope: Atom, group: String) -> List(Pid)
 
 /// The single, statically-known subject tag every PubSub broadcast is
 /// delivered under. Shared by every PubSub instance regardless of scope or
 /// payload type, so it never grows the atom table beyond this one entry, and
 /// identical on every node so cross-node sends and receives agree.
-fn pubsub_tag() -> Dynamic {
-  binary_to_atom("beryl_pubsub_message")
+fn pubsub_tag() -> Atom {
+  atom.create("beryl_pubsub_message")
 }
 
 /// Deliver a message to a subscriber pid through a typed `Subject`.
@@ -128,20 +125,23 @@ fn pubsub_tag() -> Dynamic {
 /// `pubsub_tag`, then sends with the ordinary typed `process.send`. This is
 /// the send counterpart of `selecting`: both sides agree on the tag and the
 /// `payload` type, so no value is ever coerced.
-fn deliver(pid: Pid, msg: Message(payload)) -> Nil {
-  process.send(process.unsafely_create_subject(pid, pubsub_tag()), msg)
+fn deliver(pid: Pid, message: Message(payload)) -> Nil {
+  process.send(
+    process.unsafely_create_subject(pid, atom.to_dynamic(pubsub_tag())),
+    message,
+  )
 }
 
 // ── Public API ──────────────────────────────────────────────────────────────
 
 /// Create a default PubSub configuration with scope `beryl_pubsub`
 pub fn default_config() -> PubSubConfig {
-  PubSubConfig(scope: binary_to_atom("beryl_pubsub"))
+  PubSubConfig(scope: atom.create("beryl_pubsub"))
 }
 
 /// Create a PubSub configuration with a custom scope name
 ///
-/// The scope name is converted to an Erlang atom via `binary_to_atom`.
+/// The scope name is converted to an Erlang atom.
 /// Atoms are never garbage-collected, so the scope name must be a
 /// **static, bounded deployment or configuration value** — never raw
 /// user-derived, per-request, per-tenant, database-derived, or otherwise
@@ -162,7 +162,7 @@ pub fn default_config() -> PubSubConfig {
 /// // pubsub.config_with_scope(database_row.name)
 /// ```
 pub fn config_with_scope(name: String) -> PubSubConfig {
-  PubSubConfig(scope: binary_to_atom(name))
+  PubSubConfig(scope: atom.create(name))
 }
 
 /// Start a PubSub instance
@@ -173,9 +173,7 @@ pub fn config_with_scope(name: String) -> PubSubConfig {
 /// `payload` is fixed by how the returned value is used (or annotated) at the
 /// call site — e.g. `pubsub.start(config) : PubSub(MySyncPayload)`.
 pub fn start(config: PubSubConfig) -> PubSub(payload) {
-  // pg:start returns {ok, Pid} or {error, {already_started, Pid}}
-  // Both are success cases for us
-  let _start_result = ffi_start_pg_scope(config.scope)
+  ffi_start_pg_scope(config.scope)
   PubSub(scope: config.scope)
 }
 
@@ -191,7 +189,7 @@ pub fn start(config: PubSubConfig) -> PubSub(payload) {
 /// Create it in the process that will receive (e.g. an actor's initialiser),
 /// since a `Subject` only delivers to its owner.
 pub opaque type Subscriber(payload) {
-  Subscriber(scope: Dynamic, subject: Subject(Message(payload)))
+  Subscriber(scope: Atom, subject: Subject(Message(payload)), owner: Pid)
 }
 
 /// Create a subscription handle owned by the current process.
@@ -204,10 +202,15 @@ pub opaque type Subscriber(payload) {
 /// **Important:** A single process should create only one `Subscriber` for a
 /// given `payload` type. Multiple subscribers in the same process would share
 /// the same subject tag and cannot multiplex different payload types safely.
-pub fn subscriber(ps: PubSub(payload)) -> Subscriber(payload) {
+pub fn subscriber(pubsub: PubSub(payload)) -> Subscriber(payload) {
+  let owner = process.self()
   Subscriber(
-    scope: ps.scope,
-    subject: process.unsafely_create_subject(process.self(), pubsub_tag()),
+    scope: pubsub.scope,
+    subject: process.unsafely_create_subject(
+      owner,
+      atom.to_dynamic(pubsub_tag()),
+    ),
+    owner: owner,
   )
 }
 
@@ -215,17 +218,13 @@ pub fn subscriber(ps: PubSub(payload)) -> Subscriber(payload) {
 ///
 /// A subscriber may join many topics; they all deliver through its one
 /// subject. Joining is idempotent per topic.
-pub fn join(sub: Subscriber(payload), topic: String) -> Nil {
-  let assert Ok(pid) = process.subject_owner(sub.subject)
-  let _join_result = ffi_join_group(sub.scope, topic, pid)
-  Nil
+pub fn join(subscriber: Subscriber(payload), topic: String) -> Nil {
+  ffi_join_group(subscriber.scope, topic, subscriber.owner)
 }
 
 /// Leave a topic previously joined with `join`.
-pub fn leave(sub: Subscriber(payload), topic: String) -> Nil {
-  let assert Ok(pid) = process.subject_owner(sub.subject)
-  let _leave_result = ffi_leave_group(sub.scope, topic, pid)
-  Nil
+pub fn leave(subscriber: Subscriber(payload), topic: String) -> Nil {
+  ffi_leave_group(subscriber.scope, topic, subscriber.owner)
 }
 
 /// Add a subscriber's PubSub message delivery to a `Selector`, alongside a
@@ -240,48 +239,49 @@ pub fn leave(sub: Subscriber(payload), topic: String) -> Nil {
 /// since the shared subject tag cannot safely multiplex different payload types.
 ///
 /// ```gleam
-/// let sub = pubsub.subscriber(ps)
-/// pubsub.join(sub, "room:lobby")
+/// let subscription = pubsub.subscriber(bus)
+/// pubsub.join(subscription, "room:lobby")
 /// let selector =
 ///   process.new_selector()
 ///   |> process.select(subject)
-///   |> pubsub.selecting(sub, RemoteBroadcast)
+///   |> pubsub.selecting(subscription, RemoteBroadcast)
 /// ```
 pub fn selecting(
   selector: Selector(message),
-  sub: Subscriber(payload),
+  subscriber: Subscriber(payload),
   transform: fn(Message(payload)) -> message,
 ) -> Selector(message) {
-  process.select_map(selector, sub.subject, transform)
+  process.select_map(selector, subscriber.subject, transform)
 }
 
 /// Broadcast a message to all subscribers of a topic (all nodes)
 pub fn broadcast(
-  ps: PubSub(payload),
+  pubsub: PubSub(payload),
   topic: String,
   event: String,
   payload: payload,
 ) -> Nil {
-  let msg = Message(topic: topic, event: event, payload: payload, from: System)
-  let members = ffi_get_members(ps.scope, topic)
-  list.each(members, fn(pid) { deliver(pid, msg) })
+  let message =
+    Message(topic: topic, event: event, payload: payload, from: System)
+  let members = ffi_get_members(pubsub.scope, topic)
+  list.each(members, fn(pid) { deliver(pid, message) })
 }
 
 /// Broadcast a message to all subscribers except those from a specific pid
 pub fn broadcast_from(
-  ps: PubSub(payload),
+  pubsub: PubSub(payload),
   from: Pid,
   topic: String,
   event: String,
   payload: payload,
 ) -> Nil {
-  let msg =
+  let message =
     Message(topic: topic, event: event, payload: payload, from: FromPid(from))
-  let members = ffi_get_members(ps.scope, topic)
+  let members = ffi_get_members(pubsub.scope, topic)
   list.each(members, fn(pid) {
     case pid == from {
       True -> Nil
-      False -> deliver(pid, msg)
+      False -> deliver(pid, message)
     }
   })
 }
@@ -289,25 +289,25 @@ pub fn broadcast_from(
 /// Broadcast a message to all subscribers except a process, preserving a socket
 /// ID that receiving runtimes should exclude locally.
 pub fn broadcast_from_socket(
-  ps: PubSub(payload),
+  pubsub: PubSub(payload),
   from: Pid,
   except_socket_id: String,
   topic: String,
   event: String,
   payload: payload,
 ) -> Nil {
-  let msg =
+  let message =
     Message(
       topic: topic,
       event: event,
       payload: payload,
       from: FromSocket(from, except_socket_id),
     )
-  let members = ffi_get_members(ps.scope, topic)
+  let members = ffi_get_members(pubsub.scope, topic)
   list.each(members, fn(pid) {
     case pid == from {
       True -> Nil
-      False -> deliver(pid, msg)
+      False -> deliver(pid, message)
     }
   })
 }
@@ -315,22 +315,23 @@ pub fn broadcast_from_socket(
 // nolint: unused_exports -- public PubSub API surface alongside broadcast/broadcast_from; intended for downstream consumers
 /// Broadcast a message to local subscribers only (current node)
 pub fn local_broadcast(
-  ps: PubSub(payload),
+  pubsub: PubSub(payload),
   topic: String,
   event: String,
   payload: payload,
 ) -> Nil {
-  let msg = Message(topic: topic, event: event, payload: payload, from: System)
-  let members = ffi_get_local_members(ps.scope, topic)
-  list.each(members, fn(pid) { deliver(pid, msg) })
+  let message =
+    Message(topic: topic, event: event, payload: payload, from: System)
+  let members = ffi_get_local_members(pubsub.scope, topic)
+  list.each(members, fn(pid) { deliver(pid, message) })
 }
 
 /// Get all subscribers for a topic (all nodes)
-pub fn subscribers(ps: PubSub(payload), topic: String) -> List(Pid) {
-  ffi_get_members(ps.scope, topic)
+pub fn subscribers(pubsub: PubSub(payload), topic: String) -> List(Pid) {
+  ffi_get_members(pubsub.scope, topic)
 }
 
 /// Get the number of subscribers for a topic (all nodes)
-pub fn subscriber_count(ps: PubSub(payload), topic: String) -> Int {
-  list.length(ffi_get_members(ps.scope, topic))
+pub fn subscriber_count(pubsub: PubSub(payload), topic: String) -> Int {
+  list.length(ffi_get_members(pubsub.scope, topic))
 }

--- a/packages/beryl/src/beryl/rate_limit.gleam
+++ b/packages/beryl/src/beryl/rate_limit.gleam
@@ -49,11 +49,11 @@ pub opaque type Bucket {
 const one_second_ns = 1_000_000_000
 
 /// Create a full bucket for the given config.
-pub fn new_bucket(cfg: RateLimitConfig) -> Bucket {
-  let ns_per_token = one_second_ns / int.max(cfg.per_second, 1)
+pub fn new_bucket(config: RateLimitConfig) -> Bucket {
+  let ns_per_token = one_second_ns / int.max(config.per_second, 1)
   Bucket(
-    tokens_ns: cfg.burst * ns_per_token,
-    max_tokens_ns: cfg.burst * ns_per_token,
+    tokens_ns: config.burst * ns_per_token,
+    max_tokens_ns: config.burst * ns_per_token,
     ns_per_token: ns_per_token,
     last_refill_ns: monotonic_time_ns(),
   )

--- a/packages/beryl/src/beryl/runtime.gleam
+++ b/packages/beryl/src/beryl/runtime.gleam
@@ -1189,7 +1189,7 @@ fn update_once(
           state.logger
           |> log.debug("Update stopped socket", [
             #("socket_id", socket_id),
-            #("reason", stop_reason_string(reason)),
+            #("reason", stop_reason_to_string(reason)),
           ])
           // A join answered with Stop is still unanswered on the wire:
           // fail it closed before the teardown frames.
@@ -1362,7 +1362,7 @@ fn close_topic(
           |> log.debug("Topic closed", [
             #("socket_id", socket_id),
             #("topic", topic_name),
-            #("reason", stop_reason_string(reason)),
+            #("reason", stop_reason_to_string(reason)),
           ])
           let close_join_ref = joined_ref(socket, topic_name)
           let socket =
@@ -1475,7 +1475,10 @@ fn teardown_socket(
       |> log.debug(
         "Socket teardown",
         list.append(
-          [#("socket_id", socket_id), #("reason", stop_reason_string(reason))],
+          [
+            #("socket_id", socket_id),
+            #("reason", stop_reason_to_string(reason)),
+          ],
           joined_topics_metadata(socket),
         ),
       )
@@ -2424,7 +2427,7 @@ fn send_frame_logged(
   send_result
 }
 
-fn stop_reason_string(reason: StopReason) -> String {
+fn stop_reason_to_string(reason: StopReason) -> String {
   case reason {
     sock.Normal -> "normal"
     sock.Shutdown -> "shutdown"

--- a/packages/beryl/src/beryl/socket.gleam
+++ b/packages/beryl/src/beryl/socket.gleam
@@ -81,8 +81,9 @@ pub fn ref_msg_ref(ref: Ref) -> Option(String) {
 
 /// Why a socket or topic is stopping.
 ///
-/// Delivered in `Closed` inputs and accepted by `Stop`. Match with a
-/// catch-all (`_`) arm: new stop reasons may be added in minor releases.
+/// Delivered in `Closed` inputs and accepted by `Stop`. This is a closed
+/// set: match it exhaustively. Adding a new stop reason is a breaking
+/// change and will be released as such.
 pub type StopReason {
   /// Normal shutdown (client left or disconnected cleanly).
   Normal

--- a/packages/beryl/src/beryl/wire.gleam
+++ b/packages/beryl/src/beryl/wire.gleam
@@ -112,7 +112,11 @@ fn validate_inbound_depth(msg: Inbound) -> Result(Inbound, DecodeError) {
 pub fn encode(msg: Inbound) -> String {
   let join_ref_json = option_to_json(codec.inbound_join_ref(msg))
   let ref_json = option_to_json(codec.inbound_ref(msg))
-  let payload_json = dynamic_to_json(codec.inbound_payload(msg))
+  // Inbound payloads come from decoded JSON, so conversion only fails for
+  // hand-built messages carrying non-JSON terms; encode those as null.
+  let payload_json =
+    dynamic_to_json(codec.inbound_payload(msg))
+    |> result.unwrap(json.null())
   let event = phoenix_event_name(codec.inbound_kind(msg))
 
   json.to_string(
@@ -152,9 +156,11 @@ fn phoenix_event_name(kind: InboundKind) -> String {
 }
 
 /// Convert a `Dynamic` (decoded from JSON) back into `json.Json`.
-pub fn dynamic_to_json(value: Dynamic) -> json.Json {
+///
+/// Errors when the value has no JSON representation (e.g. a raw binary) or
+/// nests deeper than the wire protocol's depth limit.
+pub fn dynamic_to_json(value: Dynamic) -> Result(json.Json, Nil) {
   dynamic_to_json_limited(value, max_json_nesting_depth)
-  |> result.unwrap(json.null())
 }
 
 fn dynamic_to_json_limited(

--- a/packages/beryl/src/beryl_pubsub_ffi.erl
+++ b/packages/beryl/src/beryl_pubsub_ffi.erl
@@ -2,9 +2,19 @@
 -export([start_pg_scope/1, join_group/3, leave_group/3,
          get_members/2, get_local_members/2]).
 
-start_pg_scope(Scope) -> pg:start(Scope).
+% pg:start returns {ok, Pid} or {error, {already_started, Pid}}; both are
+% success for us, so normalise to nil for the Gleam side.
+start_pg_scope(Scope) ->
+    _ = pg:start(Scope),
+    nil.
 
-join_group(Scope, Group, Pid) -> pg:join(Scope, Group, Pid).
-leave_group(Scope, Group, Pid) -> pg:leave(Scope, Group, Pid).
+join_group(Scope, Group, Pid) ->
+    ok = pg:join(Scope, Group, Pid),
+    nil.
+
+% pg:leave returns ok | not_joined; leaving an unjoined group is a no-op.
+leave_group(Scope, Group, Pid) ->
+    _ = pg:leave(Scope, Group, Pid),
+    nil.
 get_members(Scope, Group) -> pg:get_members(Scope, Group).
 get_local_members(Scope, Group) -> pg:get_local_members(Scope, Group).

--- a/packages/beryl/test/beryl_test.gleam
+++ b/packages/beryl/test/beryl_test.gleam
@@ -8,6 +8,7 @@ import beryl/wire
 import beryl/wire/codec
 import gleam/json
 import gleam/option
+import gleam/otp/actor
 import gleam/string
 import gleeunit
 import gleeunit/should
@@ -295,12 +296,8 @@ pub fn with_max_connections_per_ip_sets_limit_test() {
 // Wire protocol tests
 
 pub fn decode_valid_message_test() {
-  let result =
+  let assert Ok(msg) =
     wire.decode_message("[\"j1\",\"r1\",\"room:lobby\",\"phx_join\",{}]")
-
-  result |> should.be_ok
-
-  let assert Ok(msg) = result
   codec.inbound_join_ref(msg) |> should.equal(option.Some("j1"))
   codec.inbound_ref(msg) |> should.equal(option.Some("r1"))
   codec.inbound_topic(msg) |> should.equal("room:lobby")
@@ -439,97 +436,98 @@ pub fn format_decode_error_missing_field_test() {
 // Public config builder and topic helper coverage
 
 pub fn with_join_rate_sets_fields_test() {
-  let cfg =
+  let config =
     beryl.config(wire.phoenix_codec())
     |> beryl.with_join_rate(per_second: 5, burst: 10)
 
-  beryl.config_join_rate(cfg) |> should.equal(5)
-  beryl.config_join_burst(cfg) |> should.equal(10)
+  beryl.config_join_rate(config) |> should.equal(5)
+  beryl.config_join_burst(config) |> should.equal(10)
 }
 
 pub fn with_channel_rate_sets_fields_test() {
-  let cfg =
+  let config =
     beryl.config(wire.phoenix_codec())
     |> beryl.with_channel_rate(per_second: 7, burst: 14)
 
-  beryl.config_channel_rate(cfg) |> should.equal(7)
-  beryl.config_channel_burst(cfg) |> should.equal(14)
+  beryl.config_channel_rate(config) |> should.equal(7)
+  beryl.config_channel_burst(config) |> should.equal(14)
 }
 
 pub fn channel_rate_max_keys_defaults_to_1000_test() {
-  let cfg = beryl.config(wire.phoenix_codec())
+  let config = beryl.config(wire.phoenix_codec())
 
-  beryl.config_channel_rate_max_keys_per_socket(cfg) |> should.equal(1000)
+  beryl.config_channel_rate_max_keys_per_socket(config) |> should.equal(1000)
 }
 
 pub fn with_channel_rate_max_keys_per_socket_sets_field_test() {
-  let cfg =
+  let config =
     beryl.config(wire.phoenix_codec())
     |> beryl.with_channel_rate_max_keys_per_socket(max_keys: 42)
 
-  beryl.config_channel_rate_max_keys_per_socket(cfg) |> should.equal(42)
+  beryl.config_channel_rate_max_keys_per_socket(config) |> should.equal(42)
 }
 
 pub fn default_max_topic_length_is_256_test() {
-  let cfg = beryl.config(wire.phoenix_codec())
+  let config = beryl.config(wire.phoenix_codec())
 
-  beryl.config_max_topic_length(cfg) |> should.equal(256)
+  beryl.config_max_topic_length(config) |> should.equal(256)
 }
 
 pub fn with_max_topic_length_sets_field_test() {
-  let cfg =
+  let config =
     beryl.config(wire.phoenix_codec())
     |> beryl.with_max_topic_length(max_length: 128)
 
-  beryl.config_max_topic_length(cfg) |> should.equal(128)
+  beryl.config_max_topic_length(config) |> should.equal(128)
 }
 
 pub fn default_max_event_length_is_64_test() {
-  let cfg = beryl.config(wire.phoenix_codec())
+  let config = beryl.config(wire.phoenix_codec())
 
-  beryl.config_max_event_length(cfg) |> should.equal(64)
+  beryl.config_max_event_length(config) |> should.equal(64)
 }
 
 pub fn with_max_event_length_sets_field_test() {
-  let cfg =
+  let config =
     beryl.config(wire.phoenix_codec())
     |> beryl.with_max_event_length(max_length: 32)
 
-  beryl.config_max_event_length(cfg) |> should.equal(32)
+  beryl.config_max_event_length(config) |> should.equal(32)
 }
 
 pub fn default_max_inbound_frame_bytes_is_1mb_test() {
-  let cfg = beryl.config(wire.phoenix_codec())
+  let config = beryl.config(wire.phoenix_codec())
 
-  beryl.config_max_inbound_frame_bytes(cfg) |> should.equal(1_048_576)
+  beryl.config_max_inbound_frame_bytes(config) |> should.equal(1_048_576)
 }
 
 pub fn with_max_inbound_frame_bytes_sets_field_test() {
-  let cfg =
+  let config =
     beryl.config(wire.phoenix_codec())
     |> beryl.with_max_inbound_frame_bytes(max_bytes: 4096)
 
-  beryl.config_max_inbound_frame_bytes(cfg) |> should.equal(4096)
+  beryl.config_max_inbound_frame_bytes(config) |> should.equal(4096)
 }
 
 pub fn default_max_joined_topics_per_socket_is_1000_test() {
-  let cfg = beryl.config(wire.phoenix_codec())
+  let config = beryl.config(wire.phoenix_codec())
 
-  beryl.config_max_joined_topics_per_socket(cfg) |> should.equal(1000)
+  beryl.config_max_joined_topics_per_socket(config) |> should.equal(1000)
 }
 
 pub fn with_max_joined_topics_per_socket_sets_field_test() {
-  let cfg =
+  let config =
     beryl.config(wire.phoenix_codec())
     |> beryl.with_max_joined_topics_per_socket(max_topics: 12)
 
-  beryl.config_max_joined_topics_per_socket(cfg) |> should.equal(12)
+  beryl.config_max_joined_topics_per_socket(config) |> should.equal(12)
 }
 
 pub fn start_failure_description_is_public_test() {
-  let describe = beryl_error.describe_start_failure
-  should.be_true(True)
-  let _ = describe
+  actor.InitTimeout
+  |> beryl_error.from_actor_start_error
+  |> beryl_error.describe_start_failure
+  |> should.equal("actor init timed out")
 }
 
 pub fn topic_namespace_test() {

--- a/packages/beryl/test/bridge_test.gleam
+++ b/packages/beryl/test/bridge_test.gleam
@@ -3,7 +3,7 @@ import beryl/socket
 import gleam/erlang/process
 import gleam/string
 import gleeunit/should
-import test_helpers.{wait_until}
+import test_helpers
 
 /// Build a test `Sender` that forwards every notified value to a subject the
 /// test can receive on, standing in for a socket's real `update` delivery.
@@ -42,7 +42,7 @@ pub fn bridge_stop_tears_down_forwarder_test() {
 
   bridge.stop(b)
 
-  wait_until(fn() { !process.is_alive(pid) }, 1000, 10)
+  test_helpers.wait_until(fn() { !process.is_alive(pid) }, 1000, 10)
   process.is_alive(pid) |> should.be_false
 }
 
@@ -63,6 +63,6 @@ pub fn bridge_cleans_up_when_owner_dies_test() {
 
   let assert Ok(forwarder) = process.receive(pid_back, 1000)
 
-  wait_until(fn() { !process.is_alive(forwarder) }, 1000, 10)
+  test_helpers.wait_until(fn() { !process.is_alive(forwarder) }, 1000, 10)
   process.is_alive(forwarder) |> should.be_false
 }

--- a/packages/beryl/test/global_connection_limit_test.gleam
+++ b/packages/beryl/test/global_connection_limit_test.gleam
@@ -15,19 +15,6 @@ import gleam/int
 import gleam/list
 import gleeunit/should
 
-// Build the list [1, 2, ..., n] without depending on a specific stdlib
-// `list.range` availability.
-fn seq(n: Int) -> List(Int) {
-  seq_loop(n, [])
-}
-
-fn seq_loop(n: Int, acc: List(Int)) -> List(Int) {
-  case n <= 0 {
-    True -> acc
-    False -> seq_loop(n - 1, [n, ..acc])
-  }
-}
-
 fn start_with_global_limit(max_connections: Int) -> beryl.Sockets {
   let assert Ok(channels) =
     beryl.start(
@@ -180,8 +167,7 @@ pub fn concurrent_opens_do_not_exceed_global_ceiling_test() {
   let channels = start_with_global_limit(ceiling)
 
   let results = process.new_subject()
-  seq(attempts)
-  |> list.each(fn(i) {
+  int.range(from: 1, to: attempts + 1, with: Nil, run: fn(_, i) {
     process.spawn_unlinked(fn() {
       // Each attempt uses a unique IP so per-IP tracking cannot be what caps
       // the total — only the node-wide ceiling can.
@@ -203,8 +189,7 @@ pub fn concurrent_opens_do_not_exceed_global_ceiling_test() {
   })
 
   let successes =
-    seq(attempts)
-    |> list.fold(0, fn(acc, _) {
+    int.range(from: 1, to: attempts + 1, with: 0, run: fn(acc, _) {
       case process.receive(results, 1000) {
         Ok(True) -> acc + 1
         Ok(False) -> acc

--- a/packages/beryl/test/presence_replication_test.gleam
+++ b/packages/beryl/test/presence_replication_test.gleam
@@ -21,36 +21,42 @@ fn test_pubsub(name: String) -> pubsub.PubSub(presence.SyncPayload) {
 }
 
 fn test_config(
-  ps: pubsub.PubSub(presence.SyncPayload),
+  bus: pubsub.PubSub(presence.SyncPayload),
   replica: String,
   interval_ms: Int,
 ) -> presence.Config {
   presence.default_config(replica)
-  |> presence.with_pubsub(ps)
+  |> presence.with_pubsub(bus)
   |> presence.with_broadcast_interval(interval_ms)
 }
 
 // ── BroadcastTick sends state via PubSub ────────────────────────────
 
 pub fn broadcast_tick_sends_state_test() {
-  let ps = test_pubsub("bcast_tick")
+  let bus = test_pubsub("bcast_tick")
 
   // Start presence with a short broadcast interval
-  let config = test_config(ps, "node1", 50)
-  let assert Ok(p) = presence.start(config)
+  let config = test_config(bus, "node1", 50)
+  let assert Ok(replica) = presence.start(config)
 
   // Track an entry
   let _ =
-    presence.track(p, "room:lobby", "user:1", "socket-1", json.string("meta"))
+    presence.track(
+      replica,
+      "room:lobby",
+      "user:1",
+      "socket-1",
+      json.string("meta"),
+    )
 
   // Subscribe to the sync topic to observe broadcasts
-  let sub = pubsub.subscriber(ps)
-  pubsub.join(sub, "beryl:presence:sync")
+  let subscription = pubsub.subscriber(bus)
+  pubsub.join(subscription, "beryl:presence:sync")
 
   // Poll until a PubSub message arrives from the broadcast tick
   let selector =
     process.new_selector()
-    |> pubsub.selecting(sub, fn(_msg) { True })
+    |> pubsub.selecting(subscription, fn(_msg) { True })
 
   test_helpers.wait_until(
     fn() {
@@ -64,7 +70,7 @@ pub fn broadcast_tick_sends_state_test() {
   )
 
   // Clean up: leave to avoid polluting other tests
-  pubsub.leave(sub, "beryl:presence:sync")
+  pubsub.leave(subscription, "beryl:presence:sync")
 
   // Drain any remaining messages from the mailbox
   drain_mailbox()
@@ -73,31 +79,33 @@ pub fn broadcast_tick_sends_state_test() {
 // ── Two presence actors converge via PubSub ─────────────────────────
 
 pub fn two_replicas_converge_via_pubsub_test() {
-  let ps = test_pubsub("converge_2")
+  let bus = test_pubsub("converge_2")
 
-  let config1 = test_config(ps, "node1", 50)
-  let config2 = test_config(ps, "node2", 50)
+  let config1 = test_config(bus, "node1", 50)
+  let config2 = test_config(bus, "node2", 50)
 
-  let assert Ok(p1) = presence.start(config1)
-  let assert Ok(p2) = presence.start(config2)
+  let assert Ok(replica_one) = presence.start(config1)
+  let assert Ok(replica_two) = presence.start(config2)
 
-  let _ = presence.track(p1, "room:lobby", "user:1", "socket-1", json.null())
-  let _ = presence.track(p2, "room:lobby", "user:2", "socket-2", json.null())
+  let _ =
+    presence.track(replica_one, "room:lobby", "user:1", "socket-1", json.null())
+  let _ =
+    presence.track(replica_two, "room:lobby", "user:2", "socket-2", json.null())
 
   // Wait for broadcast ticks to fire and replicate
   test_helpers.wait_until(
-    fn() { list.length(presence.list(p1, "room:lobby")) == 2 },
+    fn() { list.length(presence.list(replica_one, "room:lobby")) == 2 },
     2000,
     20,
   )
   test_helpers.wait_until(
-    fn() { list.length(presence.list(p2, "room:lobby")) == 2 },
+    fn() { list.length(presence.list(replica_two, "room:lobby")) == 2 },
     2000,
     20,
   )
 
-  let entries1 = presence.list(p1, "room:lobby")
-  let entries2 = presence.list(p2, "room:lobby")
+  let entries1 = presence.list(replica_one, "room:lobby")
+  let entries2 = presence.list(replica_two, "room:lobby")
 
   list.length(entries1) |> should.equal(2)
   list.length(entries2) |> should.equal(2)
@@ -106,12 +114,13 @@ pub fn two_replicas_converge_via_pubsub_test() {
 // ── Self-broadcasts are ignored ─────────────────────────────────────
 
 pub fn self_broadcast_ignored_test() {
-  let ps = test_pubsub("self_bcast")
+  let bus = test_pubsub("self_bcast")
 
-  let config = test_config(ps, "node1", 50)
-  let assert Ok(p) = presence.start(config)
+  let config = test_config(bus, "node1", 50)
+  let assert Ok(replica) = presence.start(config)
 
-  let _ = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
+  let _ =
+    presence.track(replica, "room:lobby", "user:1", "socket-1", json.null())
 
   // Wait for several broadcast ticks to ensure self-broadcast doesn't duplicate.
   // This is a negative test (verifying something does NOT happen), so a sleep
@@ -119,38 +128,39 @@ pub fn self_broadcast_ignored_test() {
   process.sleep(200)
 
   // Should still only have 1 entry (self-broadcast doesn't duplicate)
-  let entries = presence.list(p, "room:lobby")
+  let entries = presence.list(replica, "room:lobby")
   list.length(entries) |> should.equal(1)
 }
 
 // ── Receiving remote state triggers merge ───────────────────────────
 
 pub fn remote_state_triggers_merge_via_pubsub_test() {
-  let ps = test_pubsub("remote_merge")
+  let bus = test_pubsub("remote_merge")
 
   // Node1 with broadcasting disabled (manual control)
   let config1 =
     presence.default_config("node1")
-    |> presence.with_pubsub(ps)
+    |> presence.with_pubsub(bus)
     |> presence.with_broadcast_interval(0)
-  let assert Ok(p1) = presence.start(config1)
+  let assert Ok(replica_one) = presence.start(config1)
 
   // Node2 with broadcasting enabled
-  let config2 = test_config(ps, "node2", 50)
-  let assert Ok(p2) = presence.start(config2)
+  let config2 = test_config(bus, "node2", 50)
+  let assert Ok(replica_two) = presence.start(config2)
 
   // Track on node2
-  let _ = presence.track(p2, "room:lobby", "user:2", "socket-2", json.null())
+  let _ =
+    presence.track(replica_two, "room:lobby", "user:2", "socket-2", json.null())
 
   // Wait for node2's broadcast to reach node1
   test_helpers.wait_until(
-    fn() { list.length(presence.list(p1, "room:lobby")) == 1 },
+    fn() { list.length(presence.list(replica_one, "room:lobby")) == 1 },
     2000,
     20,
   )
 
   // Node1 should now see node2's entry via PubSub replication
-  let entries = presence.list(p1, "room:lobby")
+  let entries = presence.list(replica_one, "room:lobby")
   list.length(entries) |> should.equal(1)
 
   let assert [entry] = entries
@@ -160,40 +170,49 @@ pub fn remote_state_triggers_merge_via_pubsub_test() {
 // ── Multi-replica convergence ───────────────────────────────────────
 
 pub fn three_replicas_converge_test() {
-  let ps = test_pubsub("converge_3")
+  let bus = test_pubsub("converge_3")
 
-  let config1 = test_config(ps, "node1", 50)
-  let config2 = test_config(ps, "node2", 50)
-  let config3 = test_config(ps, "node3", 50)
+  let config1 = test_config(bus, "node1", 50)
+  let config2 = test_config(bus, "node2", 50)
+  let config3 = test_config(bus, "node3", 50)
 
-  let assert Ok(p1) = presence.start(config1)
-  let assert Ok(p2) = presence.start(config2)
-  let assert Ok(p3) = presence.start(config3)
+  let assert Ok(replica_one) = presence.start(config1)
+  let assert Ok(replica_two) = presence.start(config2)
+  let assert Ok(replica_three) = presence.start(config3)
 
-  let _ = presence.track(p1, "room:lobby", "user:1", "socket-1", json.null())
-  let _ = presence.track(p2, "room:lobby", "user:2", "socket-2", json.null())
-  let _ = presence.track(p3, "room:lobby", "user:3", "socket-3", json.null())
+  let _ =
+    presence.track(replica_one, "room:lobby", "user:1", "socket-1", json.null())
+  let _ =
+    presence.track(replica_two, "room:lobby", "user:2", "socket-2", json.null())
+  let _ =
+    presence.track(
+      replica_three,
+      "room:lobby",
+      "user:3",
+      "socket-3",
+      json.null(),
+    )
 
   // Wait for convergence (all replicas see all 3 entries)
   test_helpers.wait_until(
-    fn() { list.length(presence.list(p1, "room:lobby")) == 3 },
+    fn() { list.length(presence.list(replica_one, "room:lobby")) == 3 },
     2000,
     20,
   )
   test_helpers.wait_until(
-    fn() { list.length(presence.list(p2, "room:lobby")) == 3 },
+    fn() { list.length(presence.list(replica_two, "room:lobby")) == 3 },
     2000,
     20,
   )
   test_helpers.wait_until(
-    fn() { list.length(presence.list(p3, "room:lobby")) == 3 },
+    fn() { list.length(presence.list(replica_three, "room:lobby")) == 3 },
     2000,
     20,
   )
 
-  let entries1 = presence.list(p1, "room:lobby")
-  let entries2 = presence.list(p2, "room:lobby")
-  let entries3 = presence.list(p3, "room:lobby")
+  let entries1 = presence.list(replica_one, "room:lobby")
+  let entries2 = presence.list(replica_two, "room:lobby")
+  let entries3 = presence.list(replica_three, "room:lobby")
 
   list.length(entries1) |> should.equal(3)
   list.length(entries2) |> should.equal(3)
@@ -204,47 +223,49 @@ pub fn three_replicas_converge_test() {
 
 pub fn presence_without_pubsub_still_works_test() {
   let config = presence.default_config("standalone")
-  let assert Ok(p) = presence.start(config)
+  let assert Ok(replica) = presence.start(config)
 
-  let _ = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
+  let _ =
+    presence.track(replica, "room:lobby", "user:1", "socket-1", json.null())
 
-  let entries = presence.list(p, "room:lobby")
+  let entries = presence.list(replica, "room:lobby")
   list.length(entries) |> should.equal(1)
 }
 
 // ── Untrack propagation via PubSub ───────────────────────────────────
 
 pub fn untrack_propagates_via_pubsub_test() {
-  let ps = test_pubsub("untrack_prop")
+  let bus = test_pubsub("untrack_prop")
 
-  let config1 = test_config(ps, "node1", 50)
-  let config2 = test_config(ps, "node2", 50)
+  let config1 = test_config(bus, "node1", 50)
+  let config2 = test_config(bus, "node2", 50)
 
-  let assert Ok(p1) = presence.start(config1)
-  let assert Ok(p2) = presence.start(config2)
+  let assert Ok(replica_one) = presence.start(config1)
+  let assert Ok(replica_two) = presence.start(config2)
 
   // Track on node1
-  let ref = presence.track(p1, "room:lobby", "user:1", "socket-1", json.null())
+  let ref =
+    presence.track(replica_one, "room:lobby", "user:1", "socket-1", json.null())
 
   // Wait for convergence -- both should see the entry
   test_helpers.wait_until(
-    fn() { list.length(presence.list(p2, "room:lobby")) == 1 },
+    fn() { list.length(presence.list(replica_two, "room:lobby")) == 1 },
     2000,
     20,
   )
 
   // Untrack on node1
-  presence.untrack(p1, ref)
+  presence.untrack(replica_one, ref)
 
   // Wait for the untrack to propagate via next broadcast tick
   test_helpers.wait_until(
-    fn() { presence.list(p2, "room:lobby") == [] },
+    fn() { presence.list(replica_two, "room:lobby") == [] },
     2000,
     20,
   )
 
   // Node2 should see the removal
-  list.length(presence.list(p2, "room:lobby")) |> should.equal(0)
+  list.length(presence.list(replica_two, "room:lobby")) |> should.equal(0)
 }
 
 // ── Resilience: malformed sync messages ──────────────────────────────
@@ -258,19 +279,19 @@ pub fn untrack_propagates_via_pubsub_test() {
 // rather than attempting to interpret.
 
 pub fn survives_unknown_envelope_version_test() {
-  let ps = test_pubsub("malform_version")
+  let bus = test_pubsub("malform_version")
   let config =
     presence.default_config("node1")
-    |> presence.with_pubsub(ps)
-  let assert Ok(p) = presence.start(config)
+    |> presence.with_pubsub(bus)
+  let assert Ok(replica) = presence.start(config)
 
   // Track an entry to prove the actor is alive
-  let _ = presence.track(p, "room:lobby", "user:1", "s1", json.null())
-  list.length(presence.list(p, "room:lobby")) |> should.equal(1)
+  let _ = presence.track(replica, "room:lobby", "user:1", "s1", json.null())
+  list.length(presence.list(replica, "room:lobby")) |> should.equal(1)
 
   // Send a sync envelope with a version this node does not understand
   pubsub.broadcast(
-    ps,
+    bus,
     "beryl:presence:sync",
     "presence_sync",
     presence.SyncPayload(
@@ -284,8 +305,8 @@ pub fn survives_unknown_envelope_version_test() {
   process.sleep(50)
 
   // Track another entry and verify the actor is still alive
-  let _ = presence.track(p, "room:lobby", "user:2", "s2", json.null())
-  list.length(presence.list(p, "room:lobby")) |> should.equal(2)
+  let _ = presence.track(replica, "room:lobby", "user:2", "s2", json.null())
+  list.length(presence.list(replica, "room:lobby")) |> should.equal(2)
 }
 
 // ── Resilience: exception raised inside the merge/processing path ─────
@@ -296,45 +317,63 @@ pub fn survives_unknown_envelope_version_test() {
 /// exception must be contained: the shared presence actor stays alive and its
 /// state is not partially mutated by the poisoned sync.
 pub fn survives_exception_in_processing_path_test() {
-  let ps = test_pubsub("processing_crash")
+  let bus = test_pubsub("processing_crash")
 
   // Node1's on_diff panics whenever a diff touches "room:poison". Diffs for
   // any other topic pass through untouched, so local tracking still works.
   let config1 =
     presence.default_config("node1")
-    |> presence.with_pubsub(ps)
+    |> presence.with_pubsub(bus)
     |> presence.with_on_diff(fn(diff) {
       case presence.diff_joins(diff, "room:poison") {
         [] -> Nil
         _ -> panic as "poisoned diff"
       }
     })
-  let assert Ok(p1) = presence.start(config1)
+  let assert Ok(replica_one) = presence.start(config1)
 
   // Prove the actor is alive and record its state before the poisoned sync.
   let _ =
-    presence.track(p1, "room:lobby", "user:safe", "socket-safe", json.null())
-  list.length(presence.list(p1, "room:lobby")) |> should.equal(1)
+    presence.track(
+      replica_one,
+      "room:lobby",
+      "user:safe",
+      "socket-safe",
+      json.null(),
+    )
+  list.length(presence.list(replica_one, "room:lobby")) |> should.equal(1)
 
   // Node2 broadcasts a *valid* sync that decodes cleanly but produces a diff
   // touching "room:poison", tripping node1's panicking callback inside the
   // merge/processing path.
-  let config2 = test_config(ps, "node2", 50)
-  let assert Ok(p2) = presence.start(config2)
+  let config2 = test_config(bus, "node2", 50)
+  let assert Ok(replica_two) = presence.start(config2)
   let _ =
-    presence.track(p2, "room:poison", "user:boom", "socket-boom", json.null())
+    presence.track(
+      replica_two,
+      "room:poison",
+      "user:boom",
+      "socket-boom",
+      json.null(),
+    )
 
   // Give node1 time to receive and reject several broadcasts of the poison.
   process.sleep(200)
 
   // The actor is still alive: a fresh local track succeeds.
   let _ =
-    presence.track(p1, "room:lobby", "user:safe2", "socket-safe2", json.null())
-  list.length(presence.list(p1, "room:lobby")) |> should.equal(2)
+    presence.track(
+      replica_one,
+      "room:lobby",
+      "user:safe2",
+      "socket-safe2",
+      json.null(),
+    )
+  list.length(presence.list(replica_one, "room:lobby")) |> should.equal(2)
 
   // State was not partially mutated: the poisoned sync never merged, so
   // "room:poison" remains empty on node1.
-  presence.list(p1, "room:poison") |> should.equal([])
+  presence.list(replica_one, "room:poison") |> should.equal([])
 }
 
 // ── Helper to drain stray messages ──────────────────────────────────
@@ -353,8 +392,8 @@ fn drain_mailbox() -> Nil {
 // ── Restart safety: incarnation-unique replicas ───────────────────────
 
 /// Kill a presence actor's process, simulating a crash without cleanup.
-fn kill_presence(p: presence.Presence) -> Nil {
-  let assert Ok(pid) = process.subject_owner(presence.subject(p))
+fn kill_presence(replica: presence.Presence) -> Nil {
+  let assert Ok(pid) = process.subject_owner(presence.subject(replica))
   // The actor is linked to this (test) process; unlink before killing so
   // the exit signal does not take the test runner down with it.
   process.unlink(pid)
@@ -365,60 +404,86 @@ fn kill_presence(p: presence.Presence) -> Nil {
 }
 
 pub fn restarted_node_presences_replicate_to_peers_test() {
-  let ps = test_pubsub("restart_join")
-  let assert Ok(p1) = presence.start(test_config(ps, "node1", 30))
-  let assert Ok(p2) = presence.start(test_config(ps, "node2", 30))
+  let bus = test_pubsub("restart_join")
+  let assert Ok(replica_one) = presence.start(test_config(bus, "node1", 30))
+  let assert Ok(replica_two) = presence.start(test_config(bus, "node2", 30))
 
   // Seed replication both ways so node2's context covers node1's clocks.
   let _ =
-    presence.track(p1, "room:lobby", "user:old", "socket-old", json.null())
+    presence.track(
+      replica_one,
+      "room:lobby",
+      "user:old",
+      "socket-old",
+      json.null(),
+    )
   test_helpers.wait_until(
-    fn() { list.length(presence.list(p2, "room:lobby")) == 1 },
+    fn() { list.length(presence.list(replica_two, "room:lobby")) == 1 },
     2000,
     10,
   )
 
   // Crash node1 and restart it under the same configured base name.
-  kill_presence(p1)
-  let assert Ok(p1b) = presence.start(test_config(ps, "node1", 30))
+  kill_presence(replica_one)
+  let assert Ok(replica_one_restarted) =
+    presence.start(test_config(bus, "node1", 30))
 
   // A presence tracked by the restarted incarnation must become visible on
   // node2. Without incarnation-unique replicas, node2's causal context
   // already covered the reused clocks and silently dropped this join.
   let _ =
-    presence.track(p1b, "room:lobby", "user:new", "socket-new", json.null())
+    presence.track(
+      replica_one_restarted,
+      "room:lobby",
+      "user:new",
+      "socket-new",
+      json.null(),
+    )
   test_helpers.wait_until(
     fn() {
-      presence.list(p2, "room:lobby")
+      presence.list(replica_two, "room:lobby")
       |> list.any(fn(entry) { entry.key == "user:new" })
     },
     2000,
     10,
   )
-  presence.list(p2, "room:lobby")
+  presence.list(replica_two, "room:lobby")
   |> list.any(fn(entry) { entry.key == "user:new" })
   |> should.be_true
 }
 
 pub fn restart_prunes_previous_incarnations_ghosts_test() {
-  let ps = test_pubsub("restart_ghosts")
-  let assert Ok(p1) = presence.start(test_config(ps, "node1", 30))
-  let assert Ok(p2) = presence.start(test_config(ps, "node2", 30))
+  let bus = test_pubsub("restart_ghosts")
+  let assert Ok(replica_one) = presence.start(test_config(bus, "node1", 30))
+  let assert Ok(replica_two) = presence.start(test_config(bus, "node2", 30))
 
   // node1 tracks a presence whose session dies with the node.
   let _ =
-    presence.track(p1, "room:lobby", "user:ghost", "socket-dead", json.null())
+    presence.track(
+      replica_one,
+      "room:lobby",
+      "user:ghost",
+      "socket-dead",
+      json.null(),
+    )
   test_helpers.wait_until(
-    fn() { list.length(presence.list(p2, "room:lobby")) == 1 },
+    fn() { list.length(presence.list(replica_two, "room:lobby")) == 1 },
     2000,
     10,
   )
 
-  kill_presence(p1)
-  let assert Ok(p1b) = presence.start(test_config(ps, "node1", 30))
+  kill_presence(replica_one)
+  let assert Ok(replica_one_restarted) =
+    presence.start(test_config(bus, "node1", 30))
   // Give the new incarnation something to gossip so peers observe it.
   let _ =
-    presence.track(p1b, "room:lobby", "user:live", "socket-live", json.null())
+    presence.track(
+      replica_one_restarted,
+      "room:lobby",
+      "user:live",
+      "socket-live",
+      json.null(),
+    )
 
   // The dead incarnation's entry disappears from the peer once it observes
   // the new incarnation, and it must not resurrect into the restarted node
@@ -426,18 +491,20 @@ pub fn restart_prunes_previous_incarnations_ghosts_test() {
   test_helpers.wait_until(
     fn() {
       let on_p2 =
-        presence.list(p2, "room:lobby") |> list.map(fn(entry) { entry.key })
+        presence.list(replica_two, "room:lobby")
+        |> list.map(fn(entry) { entry.key })
       let on_p1b =
-        presence.list(p1b, "room:lobby") |> list.map(fn(entry) { entry.key })
+        presence.list(replica_one_restarted, "room:lobby")
+        |> list.map(fn(entry) { entry.key })
       on_p2 == ["user:live"] && on_p1b == ["user:live"]
     },
     3000,
     10,
   )
-  presence.list(p2, "room:lobby")
+  presence.list(replica_two, "room:lobby")
   |> list.map(fn(entry) { entry.key })
   |> should.equal(["user:live"])
-  presence.list(p1b, "room:lobby")
+  presence.list(replica_one_restarted, "room:lobby")
   |> list.map(fn(entry) { entry.key })
   |> should.equal(["user:live"])
 }

--- a/packages/beryl/test/presence_test.gleam
+++ b/packages/beryl/test/presence_test.gleam
@@ -20,12 +20,12 @@ pub fn presence_start_test() {
 }
 
 pub fn presence_track_and_list_test() {
-  let assert Ok(p) = presence.start(test_config("node1"))
+  let assert Ok(tracker) = presence.start(test_config("node1"))
 
   let meta = json.object([#("status", json.string("online"))])
-  let _ref = presence.track(p, "room:lobby", "user:1", "socket-1", meta)
+  let _ref = presence.track(tracker, "room:lobby", "user:1", "socket-1", meta)
 
-  let entries = presence.list(p, "room:lobby")
+  let entries = presence.list(tracker, "room:lobby")
   list.length(entries) |> should.equal(1)
 
   let assert [entry] = entries
@@ -34,142 +34,168 @@ pub fn presence_track_and_list_test() {
 }
 
 pub fn presence_track_multiple_test() {
-  let assert Ok(p) = presence.start(test_config("node1"))
+  let assert Ok(tracker) = presence.start(test_config("node1"))
 
   let _ =
-    presence.track(p, "room:lobby", "user:1", "socket-1", json.string("meta1"))
+    presence.track(
+      tracker,
+      "room:lobby",
+      "user:1",
+      "socket-1",
+      json.string("meta1"),
+    )
   let _ =
-    presence.track(p, "room:lobby", "user:2", "socket-2", json.string("meta2"))
+    presence.track(
+      tracker,
+      "room:lobby",
+      "user:2",
+      "socket-2",
+      json.string("meta2"),
+    )
 
-  let entries = presence.list(p, "room:lobby")
+  let entries = presence.list(tracker, "room:lobby")
   list.length(entries) |> should.equal(2)
 }
 
 pub fn presence_untrack_test() {
-  let assert Ok(p) = presence.start(test_config("node1"))
+  let assert Ok(tracker) = presence.start(test_config("node1"))
 
-  let ref = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
-  presence.untrack(p, ref)
+  let ref =
+    presence.track(tracker, "room:lobby", "user:1", "socket-1", json.null())
+  presence.untrack(tracker, ref)
 
-  let entries = presence.list(p, "room:lobby")
+  let entries = presence.list(tracker, "room:lobby")
   list.length(entries) |> should.equal(0)
 }
 
 pub fn presence_track_returns_ref_distinct_from_pid_test() {
-  let assert Ok(p) = presence.start(test_config("node1"))
+  let assert Ok(tracker) = presence.start(test_config("node1"))
 
-  let ref = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
+  let ref =
+    presence.track(tracker, "room:lobby", "user:1", "socket-1", json.null())
 
   // The returned ref must be a server-generated handle, not the passed pid.
   ref |> should.not_equal("socket-1")
 }
 
 pub fn presence_track_yields_distinct_refs_test() {
-  let assert Ok(p) = presence.start(test_config("node1"))
+  let assert Ok(tracker) = presence.start(test_config("node1"))
 
-  let ref1 = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
-  let ref2 = presence.track(p, "room:lobby", "user:2", "socket-2", json.null())
+  let ref1 =
+    presence.track(tracker, "room:lobby", "user:1", "socket-1", json.null())
+  let ref2 =
+    presence.track(tracker, "room:lobby", "user:2", "socket-2", json.null())
 
   ref1 |> should.not_equal(ref2)
 }
 
 pub fn presence_untrack_removes_only_that_ref_test() {
-  let assert Ok(p) = presence.start(test_config("node1"))
+  let assert Ok(tracker) = presence.start(test_config("node1"))
 
-  let ref1 = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
-  let _ref2 = presence.track(p, "room:lobby", "user:2", "socket-2", json.null())
+  let ref1 =
+    presence.track(tracker, "room:lobby", "user:1", "socket-1", json.null())
+  let _ref2 =
+    presence.track(tracker, "room:lobby", "user:2", "socket-2", json.null())
 
   // Untracking ref1 removes exactly that presence, leaving ref2's intact.
-  presence.untrack(p, ref1)
+  presence.untrack(tracker, ref1)
 
-  let entries = presence.list(p, "room:lobby")
+  let entries = presence.list(tracker, "room:lobby")
   list.length(entries) |> should.equal(1)
   let assert [entry] = entries
   entry.session_id |> should.equal("socket-2")
 }
 
 pub fn presence_untrack_unknown_ref_is_noop_test() {
-  let assert Ok(p) = presence.start(test_config("node1"))
+  let assert Ok(tracker) = presence.start(test_config("node1"))
 
-  let _ = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
+  let _ =
+    presence.track(tracker, "room:lobby", "user:1", "socket-1", json.null())
   // An unknown/stale ref is a harmless no-op.
-  presence.untrack(p, "does-not-exist")
+  presence.untrack(tracker, "does-not-exist")
 
-  list.length(presence.list(p, "room:lobby")) |> should.equal(1)
+  list.length(presence.list(tracker, "room:lobby")) |> should.equal(1)
 }
 
 pub fn presence_untrack_all_test() {
-  let assert Ok(p) = presence.start(test_config("node1"))
+  let assert Ok(tracker) = presence.start(test_config("node1"))
 
-  let _ = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
-  let _ = presence.track(p, "room:general", "user:1", "socket-1", json.null())
+  let _ =
+    presence.track(tracker, "room:lobby", "user:1", "socket-1", json.null())
+  let _ =
+    presence.track(tracker, "room:general", "user:1", "socket-1", json.null())
 
   // Both topics have entries from socket-1
-  list.length(presence.list(p, "room:lobby")) |> should.equal(1)
-  list.length(presence.list(p, "room:general")) |> should.equal(1)
+  list.length(presence.list(tracker, "room:lobby")) |> should.equal(1)
+  list.length(presence.list(tracker, "room:general")) |> should.equal(1)
 
   // Untrack all for socket-1
-  presence.untrack_all(p, "socket-1")
+  presence.untrack_all(tracker, "socket-1")
 
-  list.length(presence.list(p, "room:lobby")) |> should.equal(0)
-  list.length(presence.list(p, "room:general")) |> should.equal(0)
+  list.length(presence.list(tracker, "room:lobby")) |> should.equal(0)
+  list.length(presence.list(tracker, "room:general")) |> should.equal(0)
 }
 
 pub fn presence_untrack_all_leaves_no_dangling_refs_test() {
-  let assert Ok(p) = presence.start(test_config("node1"))
+  let assert Ok(tracker) = presence.start(test_config("node1"))
 
-  let ref1 = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
+  let ref1 =
+    presence.track(tracker, "room:lobby", "user:1", "socket-1", json.null())
   let _ref2 =
-    presence.track(p, "room:general", "user:1", "socket-1", json.null())
+    presence.track(tracker, "room:general", "user:1", "socket-1", json.null())
 
-  presence.untrack_all(p, "socket-1")
+  presence.untrack_all(tracker, "socket-1")
 
   // A fresh track re-populates state.
-  let _ = presence.track(p, "room:lobby", "user:2", "socket-2", json.null())
-  list.length(presence.list(p, "room:lobby")) |> should.equal(1)
+  let _ =
+    presence.track(tracker, "room:lobby", "user:2", "socket-2", json.null())
+  list.length(presence.list(tracker, "room:lobby")) |> should.equal(1)
 
   // Replaying a ref that untrack_all should have dropped must be a no-op and
   // must not disturb the surviving presence.
-  presence.untrack(p, ref1)
-  list.length(presence.list(p, "room:lobby")) |> should.equal(1)
-  let assert [entry] = presence.list(p, "room:lobby")
+  presence.untrack(tracker, ref1)
+  list.length(presence.list(tracker, "room:lobby")) |> should.equal(1)
+  let assert [entry] = presence.list(tracker, "room:lobby")
   entry.session_id |> should.equal("socket-2")
 }
 
 pub fn presence_get_by_key_test() {
-  let assert Ok(p) = presence.start(test_config("node1"))
+  let assert Ok(tracker) = presence.start(test_config("node1"))
 
   let meta1 = json.object([#("device", json.string("desktop"))])
   let meta2 = json.object([#("device", json.string("mobile"))])
-  let _ = presence.track(p, "room:lobby", "user:1", "socket-1", meta1)
-  let _ = presence.track(p, "room:lobby", "user:1", "socket-2", meta2)
+  let _ = presence.track(tracker, "room:lobby", "user:1", "socket-1", meta1)
+  let _ = presence.track(tracker, "room:lobby", "user:1", "socket-2", meta2)
 
-  let entries = presence.get_by_key(p, "room:lobby", "user:1")
+  let entries = presence.get_by_key(tracker, "room:lobby", "user:1")
   list.length(entries) |> should.equal(2)
 }
 
 pub fn presence_different_topics_isolated_test() {
-  let assert Ok(p) = presence.start(test_config("node1"))
+  let assert Ok(tracker) = presence.start(test_config("node1"))
 
-  let _ = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
-  let _ = presence.track(p, "room:other", "user:2", "socket-2", json.null())
+  let _ =
+    presence.track(tracker, "room:lobby", "user:1", "socket-1", json.null())
+  let _ =
+    presence.track(tracker, "room:other", "user:2", "socket-2", json.null())
 
-  list.length(presence.list(p, "room:lobby")) |> should.equal(1)
-  list.length(presence.list(p, "room:other")) |> should.equal(1)
-  list.length(presence.list(p, "room:empty")) |> should.equal(0)
+  list.length(presence.list(tracker, "room:lobby")) |> should.equal(1)
+  list.length(presence.list(tracker, "room:other")) |> should.equal(1)
+  list.length(presence.list(tracker, "room:empty")) |> should.equal(0)
 }
 
 pub fn presence_empty_list_test() {
-  let assert Ok(p) = presence.start(test_config("node1"))
-  let entries = presence.list(p, "room:empty")
+  let assert Ok(tracker) = presence.start(test_config("node1"))
+  let entries = presence.list(tracker, "room:empty")
   list.length(entries) |> should.equal(0)
 }
 
 pub fn presence_default_config_test() {
-  let assert Ok(p) = presence.start(presence.default_config("my-node"))
-  let _ = presence.track(p, "room:default", "user:1", "socket-1", json.null())
+  let assert Ok(tracker) = presence.start(presence.default_config("my-node"))
+  let _ =
+    presence.track(tracker, "room:default", "user:1", "socket-1", json.null())
 
-  presence.list(p, "room:default")
+  presence.list(tracker, "room:default")
   |> list.length
   |> should.equal(1)
 }
@@ -191,11 +217,11 @@ pub fn on_diff_callback_receives_local_track_diff_test() {
     presence.default_config("node1")
     |> presence.with_on_diff(fn(diff) { process.send(diff_subject, diff) })
 
-  let assert Ok(p) = presence.start(config)
+  let assert Ok(tracker) = presence.start(config)
 
   let _ =
     presence.track(
-      p,
+      tracker,
       "room:lobby",
       "user:1",
       "socket-1",
@@ -226,10 +252,10 @@ pub fn on_diff_callback_receives_local_untrack_diff_test() {
     presence.default_config("node1")
     |> presence.with_on_diff(fn(diff) { process.send(diff_subject, diff) })
 
-  let assert Ok(p) = presence.start(config)
+  let assert Ok(tracker) = presence.start(config)
   let ref =
     presence.track(
-      p,
+      tracker,
       "room:lobby",
       "user:1",
       "socket-1",
@@ -237,7 +263,7 @@ pub fn on_diff_callback_receives_local_untrack_diff_test() {
     )
   let assert Ok(_) = process.receive(diff_subject, 1000)
 
-  presence.untrack(p, ref)
+  presence.untrack(tracker, ref)
 
   let assert Ok(diff) = process.receive(diff_subject, 1000)
   presence.diff_topics(diff)
@@ -263,10 +289,12 @@ pub fn on_diff_callback_receives_all_rapid_diffs_test() {
     presence.default_config("node1")
     |> presence.with_on_diff(fn(diff) { process.send(diff_subject, diff) })
 
-  let assert Ok(p) = presence.start(config)
+  let assert Ok(tracker) = presence.start(config)
 
-  let _ = presence.track(p, "room:lobby", "user:2", "socket-2", json.null())
-  let _ = presence.track(p, "room:lobby", "user:3", "socket-3", json.null())
+  let _ =
+    presence.track(tracker, "room:lobby", "user:2", "socket-2", json.null())
+  let _ =
+    presence.track(tracker, "room:lobby", "user:3", "socket-3", json.null())
 
   // Both diffs should have been delivered (no overwrite)
   let assert Ok(diff1) = process.receive(diff_subject, 1000)

--- a/packages/beryl/test/presence_wire_test.gleam
+++ b/packages/beryl/test/presence_wire_test.gleam
@@ -176,18 +176,18 @@ pub fn encode_state_groups_metas_by_presence_key_test() {
 }
 
 pub fn tracked_metas_carry_phx_ref_test() {
-  let assert Ok(p) = presence.start(presence.default_config("wire-node"))
+  let assert Ok(tracker) = presence.start(presence.default_config("wire-node"))
 
   let ref =
     presence.track(
-      p,
+      tracker,
       "room:lobby",
       "user:1",
       "socket-1",
       json.object([#("status", json.string("online"))]),
     )
 
-  let assert [entry] = presence.list(p, "room:lobby")
+  let assert [entry] = presence.list(tracker, "room:lobby")
 
   let phx_ref_decoder = {
     use phx_ref <- decode.field("phx_ref", decode.string)
@@ -207,16 +207,17 @@ pub fn tracked_metas_carry_phx_ref_test() {
 }
 
 pub fn tracked_multi_session_metas_have_distinct_phx_refs_test() {
-  let assert Ok(p) = presence.start(presence.default_config("wire-node-2"))
+  let assert Ok(tracker) =
+    presence.start(presence.default_config("wire-node-2"))
 
   let ref1 =
-    presence.track(p, "room:lobby", "user:1", "socket-1", json.object([]))
+    presence.track(tracker, "room:lobby", "user:1", "socket-1", json.object([]))
   let ref2 =
-    presence.track(p, "room:lobby", "user:1", "socket-2", json.object([]))
+    presence.track(tracker, "room:lobby", "user:1", "socket-2", json.object([]))
 
   { ref1 != ref2 } |> should.be_true
 
-  let entries = presence.list(p, "room:lobby")
+  let entries = presence.list(tracker, "room:lobby")
   entries |> list.length |> should.equal(2)
 
   let phx_ref_decoder = {
@@ -233,11 +234,18 @@ pub fn tracked_multi_session_metas_have_distinct_phx_refs_test() {
 }
 
 pub fn non_object_meta_is_stored_unchanged_test() {
-  let assert Ok(p) = presence.start(presence.default_config("wire-node-3"))
+  let assert Ok(tracker) =
+    presence.start(presence.default_config("wire-node-3"))
 
   let _ref =
-    presence.track(p, "room:lobby", "user:1", "socket-1", json.string("plain"))
+    presence.track(
+      tracker,
+      "room:lobby",
+      "user:1",
+      "socket-1",
+      json.string("plain"),
+    )
 
-  let assert [entry] = presence.list(p, "room:lobby")
+  let assert [entry] = presence.list(tracker, "room:lobby")
   json.to_string(entry.meta) |> should.equal("\"plain\"")
 }

--- a/packages/beryl/test/pubsub_test.gleam
+++ b/packages/beryl/test/pubsub_test.gleam
@@ -9,64 +9,65 @@ pub fn main() {
 
 pub fn pubsub_start_test() {
   let config = pubsub.config_with_scope("test_pubsub_start")
-  let _ps: pubsub.PubSub(String) = pubsub.start(config)
-  should.be_true(True)
+  let bus: pubsub.PubSub(String) = pubsub.start(config)
+  // A fresh scope has no subscribers for any topic.
+  pubsub.subscriber_count(bus, "room:lobby") |> should.equal(0)
 }
 
 pub fn pubsub_start_default_config_test() {
-  let _ps: pubsub.PubSub(String) = pubsub.start(pubsub.default_config())
-  should.be_true(True)
+  let bus: pubsub.PubSub(String) = pubsub.start(pubsub.default_config())
+  pubsub.subscriber_count(bus, "room:lobby") |> should.equal(0)
 }
 
 pub fn pubsub_subscribe_and_count_test() {
   let config = pubsub.config_with_scope("test_pubsub_sub")
-  let ps: pubsub.PubSub(String) = pubsub.start(config)
+  let bus: pubsub.PubSub(String) = pubsub.start(config)
 
-  let sub = pubsub.subscriber(ps)
-  pubsub.join(sub, "room:lobby")
-  pubsub.subscriber_count(ps, "room:lobby") |> should.equal(1)
+  let subscription = pubsub.subscriber(bus)
+  pubsub.join(subscription, "room:lobby")
+  pubsub.subscriber_count(bus, "room:lobby") |> should.equal(1)
 
   // Cleanup
-  pubsub.leave(sub, "room:lobby")
+  pubsub.leave(subscription, "room:lobby")
 }
 
 pub fn pubsub_unsubscribe_test() {
   let config = pubsub.config_with_scope("test_pubsub_unsub")
-  let ps: pubsub.PubSub(String) = pubsub.start(config)
+  let bus: pubsub.PubSub(String) = pubsub.start(config)
 
-  let sub = pubsub.subscriber(ps)
-  pubsub.join(sub, "room:lobby")
-  pubsub.subscriber_count(ps, "room:lobby") |> should.equal(1)
+  let subscription = pubsub.subscriber(bus)
+  pubsub.join(subscription, "room:lobby")
+  pubsub.subscriber_count(bus, "room:lobby") |> should.equal(1)
 
-  pubsub.leave(sub, "room:lobby")
-  pubsub.subscriber_count(ps, "room:lobby") |> should.equal(0)
+  pubsub.leave(subscription, "room:lobby")
+  pubsub.subscriber_count(bus, "room:lobby") |> should.equal(0)
 }
 
 pub fn pubsub_subscribers_returns_pids_test() {
   let config = pubsub.config_with_scope("test_pubsub_pids")
-  let ps: pubsub.PubSub(String) = pubsub.start(config)
+  let bus: pubsub.PubSub(String) = pubsub.start(config)
 
-  let sub = pubsub.subscriber(ps)
-  pubsub.join(sub, "room:lobby")
-  let subs = pubsub.subscribers(ps, "room:lobby")
-  should.equal(subs, [process.self()])
+  let subscription = pubsub.subscriber(bus)
+  pubsub.join(subscription, "room:lobby")
+  let member_pids = pubsub.subscribers(bus, "room:lobby")
+  should.equal(member_pids, [process.self()])
 
   // Cleanup
-  pubsub.leave(sub, "room:lobby")
+  pubsub.leave(subscription, "room:lobby")
 }
 
 pub fn pubsub_broadcast_delivers_message_test() {
   let config = pubsub.config_with_scope("test_pubsub_bcast")
-  let ps: pubsub.PubSub(String) = pubsub.start(config)
+  let bus: pubsub.PubSub(String) = pubsub.start(config)
 
-  let sub = pubsub.subscriber(ps)
-  pubsub.join(sub, "room:lobby")
+  let subscription = pubsub.subscriber(bus)
+  pubsub.join(subscription, "room:lobby")
 
-  pubsub.broadcast(ps, "room:lobby", "new_msg", "hello")
+  pubsub.broadcast(bus, "room:lobby", "new_msg", "hello")
 
   let selector =
     process.new_selector()
-    |> pubsub.selecting(sub, fn(msg) { msg })
+    |> pubsub.selecting(subscription, fn(message) { message })
 
   let assert Ok(message) = process.selector_receive(from: selector, within: 100)
   message.topic |> should.equal("room:lobby")
@@ -75,72 +76,72 @@ pub fn pubsub_broadcast_delivers_message_test() {
   message.from |> should.equal(pubsub.System)
 
   // Cleanup
-  pubsub.leave(sub, "room:lobby")
+  pubsub.leave(subscription, "room:lobby")
 }
 
 pub fn pubsub_broadcast_from_excludes_sender_test() {
   let config = pubsub.config_with_scope("test_pubsub_bcast_from")
-  let ps: pubsub.PubSub(String) = pubsub.start(config)
+  let bus: pubsub.PubSub(String) = pubsub.start(config)
 
-  let sub = pubsub.subscriber(ps)
-  pubsub.join(sub, "room:lobby")
+  let subscription = pubsub.subscriber(bus)
+  pubsub.join(subscription, "room:lobby")
 
   // Broadcast from self - should NOT receive it
-  pubsub.broadcast_from(ps, process.self(), "room:lobby", "typing", "")
+  pubsub.broadcast_from(bus, process.self(), "room:lobby", "typing", "")
 
   let selector =
     process.new_selector()
-    |> pubsub.selecting(sub, fn(msg) { msg })
+    |> pubsub.selecting(subscription, fn(message) { message })
 
   // Should time out since we excluded ourselves
   let result = process.selector_receive(from: selector, within: 50)
   should.be_error(result)
 
   // Cleanup
-  pubsub.leave(sub, "room:lobby")
+  pubsub.leave(subscription, "room:lobby")
 }
 
 pub fn pubsub_no_subscribers_is_noop_test() {
   let config = pubsub.config_with_scope("test_pubsub_nosubs")
-  let ps: pubsub.PubSub(String) = pubsub.start(config)
+  let bus: pubsub.PubSub(String) = pubsub.start(config)
 
   // Broadcast to topic with no subscribers - should not crash
-  pubsub.broadcast(ps, "room:empty", "event", "")
-  pubsub.subscriber_count(ps, "room:empty") |> should.equal(0)
+  pubsub.broadcast(bus, "room:empty", "event", "")
+  pubsub.subscriber_count(bus, "room:empty") |> should.equal(0)
 }
 
 pub fn pubsub_multiple_topics_test() {
   let config = pubsub.config_with_scope("test_pubsub_multi")
-  let ps: pubsub.PubSub(String) = pubsub.start(config)
+  let bus: pubsub.PubSub(String) = pubsub.start(config)
 
-  let sub = pubsub.subscriber(ps)
-  pubsub.join(sub, "room:lobby")
-  pubsub.join(sub, "room:private")
+  let subscription = pubsub.subscriber(bus)
+  pubsub.join(subscription, "room:lobby")
+  pubsub.join(subscription, "room:private")
 
-  pubsub.subscriber_count(ps, "room:lobby") |> should.equal(1)
-  pubsub.subscriber_count(ps, "room:private") |> should.equal(1)
+  pubsub.subscriber_count(bus, "room:lobby") |> should.equal(1)
+  pubsub.subscriber_count(bus, "room:private") |> should.equal(1)
 
   // Cleanup
-  pubsub.leave(sub, "room:lobby")
-  pubsub.leave(sub, "room:private")
+  pubsub.leave(subscription, "room:lobby")
+  pubsub.leave(subscription, "room:private")
 }
 
 pub fn pubsub_one_subscriber_receives_from_multiple_topics_test() {
   let config = pubsub.config_with_scope("test_pubsub_multi_recv")
-  let ps: pubsub.PubSub(String) = pubsub.start(config)
+  let bus: pubsub.PubSub(String) = pubsub.start(config)
 
   // A single subscriber joined to two topics receives both topics' messages
   // through its one typed subject — no per-topic subject bookkeeping.
-  let sub = pubsub.subscriber(ps)
-  pubsub.join(sub, "room:lobby")
-  pubsub.join(sub, "room:private")
+  let subscription = pubsub.subscriber(bus)
+  pubsub.join(subscription, "room:lobby")
+  pubsub.join(subscription, "room:private")
 
   let selector =
     process.new_selector()
-    |> pubsub.selecting(sub, fn(msg) { msg })
+    |> pubsub.selecting(subscription, fn(message) { message })
 
-  pubsub.broadcast(ps, "room:lobby", "a", "one")
-  pubsub.broadcast(ps, "room:private", "b", "two")
+  pubsub.broadcast(bus, "room:lobby", "a", "one")
+  pubsub.broadcast(bus, "room:private", "b", "two")
 
   let assert Ok(first) = process.selector_receive(from: selector, within: 100)
   let assert Ok(second) = process.selector_receive(from: selector, within: 100)
@@ -151,6 +152,6 @@ pub fn pubsub_one_subscriber_receives_from_multiple_topics_test() {
   |> should.equal(["one", "two"])
 
   // Cleanup
-  pubsub.leave(sub, "room:lobby")
-  pubsub.leave(sub, "room:private")
+  pubsub.leave(subscription, "room:lobby")
+  pubsub.leave(subscription, "room:private")
 }

--- a/packages/beryl_mist/test/client_contract_test.gleam
+++ b/packages/beryl_mist/test/client_contract_test.gleam
@@ -6,6 +6,7 @@ import beryl/socket
 import beryl/wire
 import beryl_mist as mist_transport
 import gleam/bytes_tree
+import gleam/dynamic
 import gleam/dynamic/decode
 import gleam/erlang/process
 import gleam/http/response
@@ -301,7 +302,7 @@ fn echo_update() -> fn(Nil, socket.Input(Nil)) -> socket.Next(Nil, Nil) {
   }
 }
 
-fn decode_body(payload) -> Result(String, Nil) {
+fn decode_body(payload: dynamic.Dynamic) -> Result(String, Nil) {
   let decoder = {
     use body <- decode.subfield(["response", "body"], decode.string)
     decode.success(body)
@@ -311,7 +312,7 @@ fn decode_body(payload) -> Result(String, Nil) {
   |> result.map_error(fn(_) { Nil })
 }
 
-fn decode_n(payload) -> Result(Int, Nil) {
+fn decode_n(payload: dynamic.Dynamic) -> Result(Int, Nil) {
   let decoder = {
     use n <- decode.field("n", decode.int)
     decode.success(n)

--- a/packages/beryl_mist/test/phoenix_contract_test.gleam
+++ b/packages/beryl_mist/test/phoenix_contract_test.gleam
@@ -126,21 +126,14 @@ fn decode_json_frame(raw: String) -> Result(Frame, Nil) {
   }
 
   json.parse(from: raw, using: decoder)
-  |> result_nil
-}
-
-fn result_nil(result: Result(a, b)) -> Result(a, Nil) {
-  case result {
-    Ok(value) -> Ok(value)
-    Error(_) -> Error(Nil)
-  }
+  |> result.replace_error(Nil)
 }
 
 fn assert_json_string(
   payload: dynamic.Dynamic,
   field: String,
   expected: String,
-) {
+) -> Nil {
   let decoder = {
     use actual <- decode.field(field, decode.string)
     decode.success(actual)
@@ -149,7 +142,11 @@ fn assert_json_string(
   actual |> should.equal(expected)
 }
 
-fn assert_json_bool(payload: dynamic.Dynamic, field: String, expected: Bool) {
+fn assert_json_bool(
+  payload: dynamic.Dynamic,
+  field: String,
+  expected: Bool,
+) -> Nil {
   let decoder = {
     use actual <- decode.field(field, decode.bool)
     decode.success(actual)
@@ -188,14 +185,14 @@ fn latest_text_message(client: WebsocketClient) -> String {
   message
 }
 
-fn drain_text_messages(client: WebsocketClient) {
+fn drain_text_messages(client: WebsocketClient) -> Nil {
   case receive_text(client, 10) {
     Ok(_) -> drain_text_messages(client)
     Error(_) -> Nil
   }
 }
 
-fn assert_no_text_message(client: WebsocketClient) {
+fn assert_no_text_message(client: WebsocketClient) -> Nil {
   receive_text(client, 50)
   |> should.equal(Error(Nil))
 }
@@ -234,7 +231,7 @@ fn contract_update(
           socket.BroadcastFrom(
             topic,
             "broadcasted",
-            wire.dynamic_to_json(payload),
+            wire.dynamic_to_json(payload) |> result.unwrap(json.null()),
           ),
         ])
       socket.Closed(_topic, reason) -> {
@@ -272,12 +269,15 @@ fn start_mist_server(channels: beryl.Sockets) -> #(Int, process.Pid) {
   #(port, server.pid)
 }
 
-fn connect_client(port: Int) {
+fn connect_client(port: Int) -> WebsocketClient {
   let assert Ok(client) = connect_websocket(port, "/socket/websocket")
   client
 }
 
-fn join_client(serializer: Serializer, client: WebsocketClient) {
+fn join_client(
+  serializer: Serializer,
+  client: WebsocketClient,
+) -> WebsocketClient {
   let assert Ok(client) =
     send_text(
       client,
@@ -421,7 +421,10 @@ pub fn json_contract_join_custom_broadcast_heartbeat_leave_test() {
 
 // Socket-level connect/auth hook (on_connect) — issue #93
 
-fn auth_query(req, name: String) -> Result(String, Nil) {
+fn auth_query(
+  req: request.Request(mist.Connection),
+  name: String,
+) -> Result(String, Nil) {
   case request.get_query(req) {
     Ok(params) ->
       list.find(params, fn(pair) { pair.0 == name })


### PR DESCRIPTION
Fixes the style-review findings that survive #220, stacked on that branch so the combined result is clean. Targets `docs/propose-app-side-dispatch`; retarget to `main` if #220 merges first (the diff stays the same).

## Library source (`packages/beryl/src`)

- **`wire.dynamic_to_json` returns `Result(Json, Nil)`** instead of silently encoding unconvertible payloads as `null`; the two internal callers choose the `null` fallback explicitly. Changelog fragment included.
- **PubSub pg scope is typed `Atom` end to end** — no more `Dynamic` in config/handle/FFI signatures; the Erlang shims normalise returns to `nil`; `binary_to_atom` external replaced with `atom.create`. `Subscriber` stores its owner pid, removing the `let assert`s in `join`/`leave`.
- **Deleted dead `connection_limit.start`/`start_optional`** (the last `let assert` in library src — the limiter already starts supervised via `start_named`).
- **`socket.StopReason` is documented as a closed set**: match exhaustively; new reasons are a breaking change (replaces the "match with a catch-all" guidance).
- `error.exit_reason` carries the abnormal exit detail instead of the constant `"abnormal"`.
- Naming: `internal.Err` → `ErrorLevel`, presence `pid` → `session_id` throughout, `rate_limit` `cfg` → `config`, `runtime.stop_reason_string` → `stop_reason_to_string`, `ps` → `pubsub`/`bus` in `beryl.gleam`.

## Tests

- Qualified `test_helpers` import in `bridge_test`; removed a check-then-assert in `beryl_test`; vacuous `should.be_true(True)` tests in `beryl_test`/`pubsub_test` now assert real behavior.
- Hand-rolled `seq` replaced with `int.range` (`list.range` no longer exists in gleam_stdlib v2); `result_nil` replaced with `result.replace_error`.
- Missing parameter/return annotations added in `beryl_mist` test helpers; `cfg`/`coord`/`ps`/`p` renamed to full words.

## Examples

- `example_helpers` static serving returns `Result` instead of `let assert`-panicking; callers updated.
- `Ctx`/`ctx` → `Context`/`context` across all apps; `sys_payload`/`msg_payload` spelled out; `segs` → `segments`.
- collab_docs client: stringly errors replaced with a `DocumentError` type carrying the underlying decode/merge errors; CRDT matches are exhaustive over all 8 `lattice_maps/crdt` variants.

## Verification

- `just format-check`, `just check`: all packages ok
- Tests: beryl 252, beryl_mist 41, beryl_ewe 33, collab_docs 15, collab_docs client 13, chatrooms 9, cursors 4 — all passing
- glinter: exactly at the base branch's pre-existing 65 errors; none introduced here