### PR TITLE
refactor(beryl)!: remove the unsupervised start path

### DIFF
--- a/.changes/unreleased/beryl-supervised-only.toml
+++ b/.changes/unreleased/beryl-supervised-only.toml
@@ -1,0 +1,3 @@
+project = "beryl"
+kind = "Removed"
+body = "`beryl.start`, `beryl.stop`, and `beryl.StartError` are no longer public. Starting a channel system without supervision left a coordinator crash unrecoverable and every connected socket stranded, so the API no longer offers it as a choice. Applications start beryl through `beryl/supervisor`, which returns a child specification for their own OTP supervision tree — the pattern already used throughout the guides and examples."

--- a/.changes/unreleased/beryl_mist-origin-anchor.toml
+++ b/.changes/unreleased/beryl_mist-origin-anchor.toml
@@ -1,0 +1,3 @@
+project = "beryl_mist"
+kind = "Fixed"
+body = "Fixed broken `#OriginPolicy` anchor links in the generated API reference for `TransportConfig`, `with_allowed_origins`, and `with_allow_all_origins`. Rendered heading slugs are lowercased, so the links resolved to nothing."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,9 @@
 ## Project Summary
 
 Beryl is a Gleam library for type-safe real-time channels and presence on the
-Erlang/BEAM runtime. It's a trellis-managed monorepo with three publishable
-packages, runnable examples, and an Astro/Starlight documentation website.
+Erlang/BEAM runtime. It's a trellis-managed monorepo with three packages — two
+of them currently publishable, since `beryl_ewe` is release-excluded — plus
+runnable examples and an Astro/Starlight documentation website.
 
 ## Essential Commands
 
@@ -81,10 +82,13 @@ A transport implementation must follow this lifecycle:
 
 ### Wire Protocol
 
-The default codec (`wire.phoenix_codec()`) implements the Phoenix wire format:
+The built-in codec (`wire.phoenix_codec()`) implements the Phoenix wire format.
+`beryl.config` takes the codec as a required argument — there is no implicit
+default.
 - Text frames: `[join_ref, ref, topic, event, payload]` JSON arrays
 - Binary frames: Phoenix V2 binary framing
-- Heartbeats: `phx_heartbeat` event with `null` payload
+- Heartbeats: topic `"phoenix"`, event `"heartbeat"`; replied to with
+  `phx_reply` on the same topic
 
 ### PubSub Wire Contract
 
@@ -178,11 +182,15 @@ untracked artifacts — clean before staging.
 
 ### Tool Versions
 
-`.tool-versions` is the source of truth for CI:
+`.tool-versions` sets the floor and is what CI's version-file resolution uses:
 - Erlang 27.2.1, Gleam 1.16.0, just 1.50.0
 
-`.mise.toml` pins trellis (>= 0.4.1) and rebar for local development only.
-Keep `.mise.toml` limited to mise-only helper tools.
+CI additionally matrix-tests Erlang **27 and 28** (see `.github/workflows/ci.yml`).
+
+`.mise.toml` pins trellis (0.4.1) and rebar for local development, and
+deliberately pins `erlang = "28"` so local dev runs on the newer of the two
+matrix versions. That pin intentionally overrides `.tool-versions` for mise
+users; keep everything else in `.mise.toml` limited to mise-only helper tools.
 
 ### Dependency Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,8 @@
 
 Type-safe real-time channels and presence for Gleam, targeting the Erlang
 (BEAM) runtime. The repository is a [trellis](https://trellis.tylerbutler.com)-managed
-monorepo with three publishable packages:
+monorepo with three packages (two currently publishable — `beryl_ewe` is
+excluded from release via the `@release` key in the root `gleam.toml`):
 
 - **`packages/beryl`** — core channels library (channels, presence, PubSub,
   wire protocol, abuse controls, transport SPI)
@@ -139,12 +140,16 @@ cd packages/beryl && gleam test   # Directly
 
 ## Tool Versions
 
-Managed via `.tool-versions` (source of truth for CI):
+Managed via `.tool-versions` (the floor, and what CI's version-file
+resolution uses):
 - Erlang 27.2.1
 - Gleam 1.16.0
 - just 1.50.0
 
-trellis (>= 0.3.0) is pinned in `.mise.toml` for local development and
+CI matrix-tests Erlang 27 and 28. `.mise.toml` pins `erlang = "28"` for local
+development, deliberately overriding `.tool-versions` for mise users.
+
+trellis (0.4.1) is pinned in `.mise.toml` for local development and
 installed in CI via `.github/actions/install-trellis`.
 
 ## CI/CD

--- a/DEV.md
+++ b/DEV.md
@@ -11,14 +11,16 @@ Ensure you have the following installed:
 | Erlang/OTP | 27.2.1+ | BEAM runtime |
 | Gleam | 1.16.0+ | Compiler and tooling |
 | just | 1.50.0+ | Task runner |
-| [trellis](https://trellis.tylerbutler.com) | 0.3.0+ | Gleam workspace manager (tasks, versions, publishing) |
+| [trellis](https://trellis.tylerbutler.com) | 0.4.1+ | Gleam workspace manager (tasks, versions, publishing) |
 
-**Recommended:** Use [mise](https://mise.jdx.dev/) or [asdf](https://asdf-vm.com/) with the provided `.tool-versions` file. trellis is pinned in `.mise.toml` (mise's GitHub backend); it can also be installed via its shell installer or Homebrew.
+**Recommended:** Use [mise](https://mise.jdx.dev/) or [asdf](https://asdf-vm.com/) with the provided `.tool-versions` file. trellis is pinned in `.mise.toml` (mise's GitHub backend); it can also be installed via its shell installer or Homebrew. Note that `.mise.toml` also pins `erlang = "28"`, so mise users build on Erlang 28 while `.tool-versions` sets the 27.2.1 floor; CI matrix-tests both.
 
-This repository is a trellis-managed workspace: the publishable packages live
-in `packages/beryl` and `packages/beryl_mist`, runnable examples in
-`examples/`, and the root `gleam.toml` holds only the `[tools.trellis]`
-configuration. `just` recipes fan out across the workspace through
+This repository is a trellis-managed workspace: three packages live under
+`packages/` — `beryl`, `beryl_mist`, and `beryl_ewe` — with runnable examples
+in `examples/` and a root `gleam.toml` holding only the `[tools.trellis]`
+configuration. `beryl_ewe` is built, tested, and linted but excluded from
+release via the `@release` key, so only `beryl` and `beryl_mist` are
+publishable today. `just` recipes fan out across the workspace through
 `trellis run`.
 
 ```bash
@@ -206,9 +208,10 @@ Releases are driven by trellis changelog fragments (TOML files in
 4. After merge, the release workflow runs `trellis release pr`, which batches
    fragments into a release PR (branch `release/pending`) bumping versions
    and regenerating each package's CHANGELOG.md
-5. Merging the release PR publishes every untagged package to Hex in
-   dependency order and creates per-package tags (`beryl-v1.2.3`) and GitHub
-   releases
+5. Merging the release PR creates per-package tags (`beryl-v1.2.3`) and GitHub
+   releases. Hex.pm publishing is temporarily disabled — `trellis publish` is
+   not run; see the header comment in `.github/workflows/publish.yml` for how
+   to resume it
 
 Useful commands: `just version-plan` previews the next versions;
 `just doctor` validates workspace invariants.
@@ -217,8 +220,14 @@ Useful commands: `just version-plan` previews the next versions;
 
 One-time steps to perform in the same PR that tags `v1.0.0`:
 
-- Remove (or rewrite) the "beryl is not yet 1.0 / API is unstable" callout at
-  the top of `README.md`.
+- Remove (or rewrite) the "beryl is not yet 1.0 / API is unstable" callout.
+  The wording is identical everywhere it appears, so one find-and-replace
+  covers all of them:
+  - `README.md`, `packages/beryl/README.md`, `packages/beryl_mist/README.md`,
+    `packages/beryl_ewe/README.md`
+  - `website/src/content/docs/`: `introduction.md`, `installation.md`,
+    `quick-start.mdx`, `examples.mdx`, `reference/index.md` (the last one
+    keeps its trailing "See the Stability policy" pointer)
 - Confirm the documented Gleam version requirement in `README.md` and
   `website/src/content/docs/installation.md`. Note that the documented
   requirement (1.18+) is deliberately higher than the `gleam` constraint in each

--- a/DEV.md
+++ b/DEV.md
@@ -220,7 +220,12 @@ One-time steps to perform in the same PR that tags `v1.0.0`:
 - Remove (or rewrite) the "beryl is not yet 1.0 / API is unstable" callout at
   the top of `README.md`.
 - Confirm the documented Gleam version requirement in `README.md` and
-  `website/src/content/docs/installation.md` still matches `gleam.toml`.
+  `website/src/content/docs/installation.md`. Note that the documented
+  requirement (1.18+) is deliberately higher than the `gleam` constraint in each
+  package's `gleam.toml` (1.13+): 1.18 is what *consumers* need for the
+  `path` field on git dependencies, not what beryl needs to compile. If beryl is
+  published to Hex, that consumer-side requirement goes away and the docs should
+  drop back to the manifest constraint.
 - Verify the publish tarball with `gleam export hex-tarball` before tagging.
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -10,15 +10,30 @@
 
 ## Install
 
-```sh
-gleam add beryl beryl_mist
+beryl is not yet published to Hex, so add it as a git dependency in your
+`gleam.toml`:
+
+```toml
+[dependencies]
+beryl = { git = "https://github.com/tylerbutler/beryl.git", ref = "v0.0", path = "packages/beryl" }
+beryl_mist = { git = "https://github.com/tylerbutler/beryl.git", ref = "v0.0", path = "packages/beryl_mist" }
 ```
+
+> [!IMPORTANT]
+> **This requires Gleam 1.18 or later.** beryl's packages live in
+> subdirectories of this repository, and the `path` field that points a git
+> dependency at a subdirectory was added in Gleam 1.18. There is no way to
+> depend on beryl from an earlier Gleam version.
+
+`gleam add` only handles Hex packages, so edit `gleam.toml` by hand and then run
+`gleam deps download`.
 
 `beryl` is the core channels library; `beryl_mist` is the [Mist](https://hex.pm/packages/mist)
 WebSocket transport. An [Ewe](https://hex.pm/packages/ewe) transport is also
-available as `beryl_ewe` (`gleam add beryl beryl_ewe`) and mirrors the
-`beryl_mist` API. All live in this repository (a [trellis](https://trellis.tylerbutler.com)-managed
-workspace under `packages/`).
+available as `beryl_ewe` (same git dependency with
+`path = "packages/beryl_ewe"`) and mirrors the `beryl_mist` API. All live in
+this repository (a [trellis](https://trellis.tylerbutler.com)-managed workspace
+under `packages/`).
 
 beryl targets the **Erlang/BEAM** runtime only. It does not support the JavaScript target.
 
@@ -292,7 +307,8 @@ and the changelog is managed with [changie](https://changie.dev/).
 ### Prerequisites
 
 - [Erlang](https://www.erlang.org/) 27+
-- [Gleam](https://gleam.run/) 1.13+
+- [Gleam](https://gleam.run/) 1.16+ (see `.tool-versions`; consuming beryl as a
+  dependency requires 1.18+)
 - [just](https://github.com/casey/just) (task runner)
 
 Install tools via [mise](https://mise.jdx.dev/) or [asdf](https://asdf-vm.com/):

--- a/README.md
+++ b/README.md
@@ -41,14 +41,13 @@ beryl targets the **Erlang/BEAM** runtime only. It does not support the JavaScri
 
 ```gleam
 import beryl
-import beryl/channel.{type Channel, type HandleResult, type JoinResult}
-import beryl/socket.{type Socket}
+import beryl/channel.{type Channel}
+import beryl/socket
 import beryl/supervisor
-import beryl_mist as mist_transport
 import beryl/wire
+import beryl_mist as mist_transport
 import gleam/dynamic/decode
 import gleam/erlang/process
-import gleam/json
 import gleam/option.{None}
 import gleam/otp/static_supervisor
 import mist
@@ -73,8 +72,8 @@ fn new_channel() -> Channel(RoomAssigns, info) {
 }
 
 pub fn main() {
-  // beryl doesn't start an unmanaged process; add its child specification to
-  // your own application supervisor.
+  // beryl has no unsupervised start; add its child specification to your own
+  // application supervisor so a coordinator crash restarts just that subtree.
   let beryl_config = supervisor.config(beryl.config(wire.phoenix_codec()))
 
   let assert Ok(_root) =
@@ -110,7 +109,10 @@ For a complete end-to-end walkthrough including Phoenix JS client code, see the
 ## Documentation
 
 - **Website & guides**: <https://beryl.tylerbutler.com>
-- **Generated API docs**: <https://hexdocs.pm/beryl/>
+- **Generated API reference**: <https://beryl.tylerbutler.com/reference/api/>
+
+beryl is not on Hex yet, so there is no `hexdocs.pm` listing; the reference
+above is generated from the same Gleam docs metadata.
 
 ## Ecosystem
 
@@ -185,6 +187,7 @@ import beryl/channel.{type Channel}
 import beryl/socket
 import gleam/json
 import gleam/option.{None}
+import my_app/doc
 
 // Messages emitted by your domain actor.
 pub type DocEvent {
@@ -261,46 +264,23 @@ see the [Production Hardening guide](https://beryl.tylerbutler.com/guides/produc
 
 ### Required: an edge proxy frame-size limit
 
-Beryl's `with_max_inbound_frame_bytes` limit is enforced **post-assembly** —
-the WebSocket transport (Mist/gramps) buffers and reassembles a complete frame
-*before* Beryl measures it and rejects oversized frames. This bounds
-per-message processing cost, but it does **not** bound transport memory.
+`with_max_inbound_frame_bytes` is enforced **post-assembly** — the transport
+buffers and reassembles a complete frame before Beryl measures it. That bounds
+per-message processing cost but **not** transport memory: a hostile client can
+grow the receive buffer without limit on a single connection by declaring a huge
+payload length and streaming slowly, or by sending a long run of fragmented
+continuation frames. Neither `with_max_connections_per_ip` nor
+`with_message_rate` mitigates this — the buffer grows before any message reaches
+a channel.
 
-A hostile client can therefore exhaust node memory with a single connection by
-either:
+So in production you **must** put an edge proxy or load balancer in front of
+Beryl and set a maximum WebSocket frame/message size at or below your
+`with_max_inbound_frame_bytes` value, plus a matching body-size limit on the
+initial HTTP upgrade. Treat Beryl's in-process limit as defense-in-depth for
+per-message cost, not as a memory bound.
 
-- declaring a huge payload length in a frame header and streaming the body
-  slowly, or
-- sending a long run of fragmented continuation frames that the transport
-  aggregates into one buffer.
-
-In both cases the transport's receive buffer grows unbounded *before* Beryl's
-frame-size check ever runs. **Beryl's per-IP connection limit
-(`with_max_connections_per_ip`) and per-socket message-rate limit
-(`with_message_rate`) do not mitigate this vector** — the buffer grows within a
-single admitted connection and before any message is emitted to a channel.
-
-To bound transport memory in production you **must** place an edge proxy or
-load balancer (e.g. nginx, HAProxy, Envoy, or your cloud LB) in front of Beryl
-and configure:
-
-- a **maximum WebSocket frame/message size** at or below your chosen
-  `with_max_inbound_frame_bytes` value, and
-- a matching **request/body size limit** for the initial HTTP upgrade.
-
-Set the proxy limit to reject oversized frames at the edge, before they are
-buffered by the BEAM node. Beryl's in-process limit should be treated as
-defense-in-depth for per-message cost, not as a memory bound.
-
-The upstream work needed to enforce a size cap *before* buffering (in
-gramps/mist) is tracked in
+Upstream work to cap size *before* buffering is tracked in
 [`docs/security/frame-buffering-followup.md`](docs/security/frame-buffering-followup.md).
-
-## Releases & changelog
-
-See the [GitHub Releases](https://github.com/tylerbutler/beryl/releases) page for
-release notes. Releases follow [Conventional Commits](https://www.conventionalcommits.org/)
-and the changelog is managed with [changie](https://changie.dev/).
 
 ## Development
 

--- a/docs/talks/beryl-interview/deck.md
+++ b/docs/talks/beryl-interview/deck.md
@@ -316,7 +316,14 @@ on Elixir, use Phoenix.
 
 ```gleam
 pub fn main() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let beryl_config = supervisor.config(beryl.config(wire.phoenix_codec()))
+
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(supervisor.start(beryl_config))
+    |> static_supervisor.start()
+
+  let channels = supervisor.channels(beryl_config)
   let assert Ok(_) = beryl.register(channels, "room:*", new_channel())
 
   let assert Ok(_) =
@@ -336,10 +343,11 @@ pub fn main() {
 <!--
 Walk it line by line — this is the whole server, not an excerpt:
 
-1. `beryl.start(beryl.config(wire.phoenix_codec()))` — boots the channel
-   runtime and returns a handle. The config takes a CODEC: Phoenix JSON
-   framing ships in the box, but it's an interface — custom binary
-   framing is a config change, not a fork.
+1. `supervisor.config(beryl.config(wire.phoenix_codec()))` — describes the
+   channel runtime as a child spec for YOUR supervision tree; there is no
+   unsupervised start. The config takes a CODEC: Phoenix JSON framing ships
+   in the box, but it's an interface — custom binary framing is a config
+   change, not a fork.
 2. `beryl.register(channels, "room:*", new_channel())` — binds a topic
    pattern to a channel definition. Call it as many times as you have
    channel types; patterns can be exact, prefix (`room:*`), or

--- a/packages/beryl/README.md
+++ b/packages/beryl/README.md
@@ -13,11 +13,19 @@ PubSub for multi-node fan-out, and built-in abuse controls (rate limits,
 connection ceilings, heartbeat eviction).
 
 To serve channels over WebSockets, pair it with a transport package such as
-[`beryl_mist`](https://hex.pm/packages/beryl_mist):
+`beryl_mist`. beryl is not yet on Hex, so add both as git dependencies in your
+`gleam.toml`:
 
-```sh
-gleam add beryl beryl_mist
+```toml
+[dependencies]
+beryl = { git = "https://github.com/tylerbutler/beryl.git", ref = "v0.0", path = "packages/beryl" }
+beryl_mist = { git = "https://github.com/tylerbutler/beryl.git", ref = "v0.0", path = "packages/beryl_mist" }
 ```
+
+> [!IMPORTANT]
+> **Gleam 1.18 or later is required.** These packages live in subdirectories of
+> the beryl monorepo, and the `path` field for git dependencies was added in
+> Gleam 1.18.
 
 beryl targets the **Erlang/BEAM** runtime only. It does not support the
 JavaScript target.

--- a/packages/beryl/README.md
+++ b/packages/beryl/README.md
@@ -32,8 +32,8 @@ JavaScript target.
 
 ## Documentation
 
-- Guides and API reference: <https://beryl.tylerbutler.com>
-- Package docs: <https://hexdocs.pm/beryl>
+- Guides: <https://beryl.tylerbutler.com>
+- API reference: <https://beryl.tylerbutler.com/reference/api/>
 - Repository: <https://github.com/tylerbutler/beryl> (monorepo; this package
   lives in `packages/beryl`)
 
@@ -41,8 +41,9 @@ JavaScript target.
 
 The `beryl/transport` module is the public SPI for transport authors: socket
 lifecycle announcements, inbound routing, codec access, and per-connection
-rate limiting. `beryl_mist` is the reference implementation.
+rate limiting. `beryl_mist` is the reference implementation; `beryl_ewe`
+mirrors it against the same SPI.
 
-## Licence
+## License
 
 MIT

--- a/packages/beryl/gleam.toml
+++ b/packages/beryl/gleam.toml
@@ -9,6 +9,7 @@ internal_modules = [
   "beryl/connection_limit",
   "beryl/coordinator",
   "beryl/internal",
+  "beryl/internal/unsupervised",
   "beryl/log",
   "beryl/rate_limit",
 ]

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -64,7 +64,6 @@
 import beryl/channel.{type Channel}
 import beryl/connection_limit
 import beryl/coordinator
-import beryl/error as beryl_error
 import beryl/internal
 import beryl/log
 import beryl/presence.{type Diff}
@@ -761,118 +760,18 @@ pub fn max_inbound_frame_bytes(channels: Channels) -> Int {
   channels.config.max_inbound_frame_bytes
 }
 
-/// Errors when starting channels
-pub type StartError {
-  /// The coordinator actor failed to start.
-  CoordinatorStartFailed(beryl_error.StartFailure)
-  /// `heartbeat_timeout_ms` must be at least 2. The server derives its staleness
-  /// check interval as `heartbeat_timeout_ms / 2` (integer division), so a
-  /// timeout of 1 would round down to a check interval of 0 — which disables
-  /// heartbeat eviction entirely. `start` rejects such a config loudly rather
-  /// than silently turning eviction off.
-  InvalidHeartbeatTimeout
+// nolint: unused_exports -- package-internal accessor for beryl/internal/unsupervised; hidden from public docs with @internal
+@internal
+pub fn channels_connection_limiter(
+  channels: Channels,
+) -> Option(connection_limit.ConnectionLimiter) {
+  channels.connection_limiter
 }
 
-/// Start the channels system
-///
-/// Call once at application startup. Returns a handle that can be passed
-/// to the WebSocket transport and used for broadcasting.
-///
-/// Heartbeat eviction is configured via `heartbeat_timeout_ms` in the Config.
-/// The coordinator evicts any socket that has not sent a heartbeat within that
-/// window, checking for stale sockets at a server-derived interval of
-/// `heartbeat_timeout_ms / 2`. `heartbeat_interval_ms` is client-advisory only
-/// (see `with_heartbeat`) and does not schedule anything on the server.
-///
-/// Returns `Error(InvalidHeartbeatTimeout)` if `heartbeat_timeout_ms` is less
-/// than 2.
-///
-/// ## Example
-///
-/// ```gleam
-/// pub fn main() {
-///   let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
-///   // Use channels...
-/// }
-/// ```
-pub fn start(config: Config) -> Result(Channels, StartError) {
-  use <- bool.guard(
-    when: config.heartbeat_timeout_ms < 2,
-    return: internal.result_error(InvalidHeartbeatTimeout),
-  )
-  warn_if_unprotected(config)
-  // Registrations live in a registry that outlives the coordinator, so a
-  // supervised restart (or manual coordinator replacement) can re-seed
-  // them.
-  use registry <- result.try(
-    coordinator.start_registry()
-    |> result.map_error(fn(error) {
-      CoordinatorStartFailed(beryl_error.from_actor_start_error(error))
-    }),
-  )
-  let coord_config =
-    coordinator.CoordinatorConfig(
-      ..to_coordinator_config(config),
-      registry: Some(registry),
-    )
-
-  let coordinator_result = case config.pubsub {
-    Some(ps) -> coordinator.start_with_config_and_pubsub(coord_config, ps)
-    None -> coordinator.start_with_config(coord_config)
-  }
-
-  case coordinator_result {
-    Ok(coord) ->
-      Ok(channels_from_coordinator(
-        coordinator: coord,
-        config: config,
-        registry: Some(registry),
-      ))
-    error_result -> {
-      case
-        result.unwrap_error(
-          error_result,
-          or: coordinator.InvalidHeartbeatTimeout,
-        )
-      {
-        coordinator.ActorStartFailed(error) ->
-          internal.result_error(
-            CoordinatorStartFailed(beryl_error.from_actor_start_error(error)),
-          )
-        coordinator.InvalidHeartbeatTimeout ->
-          internal.result_error(InvalidHeartbeatTimeout)
-      }
-    }
-  }
-}
-
-/// Stop an unsupervised channels system.
-///
-/// This shuts down the coordinator actor started by `start` and any auxiliary
-/// limiter actors owned by the `Channels` handle. Joined channel handlers
-/// receive `channel.Shutdown` in their `terminate` callback before the
-/// coordinator exits. After this call the `Channels` handle should no longer be
-/// used.
-pub fn stop(channels: Channels) -> Nil {
-  stop_coordinator(channels.coordinator)
-  connection_limit.stop_optional(channels.connection_limiter)
-  case channels.registry {
-    Some(registry) -> coordinator.stop_registry(registry)
-    None -> Nil
-  }
-}
-
-fn stop_coordinator(coordinator: Subject(coordinator.Message)) -> Nil {
-  let should_send = case process.subject_owner(coordinator) {
-    Ok(pid) -> process.is_alive(pid)
-    _ -> False
-  }
-
-  use <- bool.guard(when: !should_send, return: Nil)
-  let reply = process.new_subject()
-  process.send(coordinator, coordinator.Stop(reply))
-  let _stop_result = process.receive(reply, 5000)
-  Nil
+// nolint: unused_exports -- package-internal accessor for beryl/internal/unsupervised; hidden from public docs with @internal
+@internal
+pub fn channels_registry(channels: Channels) -> Option(coordinator.Registry) {
+  channels.registry
 }
 
 /// Register a channel handler for a topic pattern

--- a/packages/beryl/src/beryl/internal/unsupervised.gleam
+++ b/packages/beryl/src/beryl/internal/unsupervised.gleam
@@ -1,0 +1,120 @@
+//// Unsupervised channel-system startup.
+////
+//// This module is **package-internal**: it is listed in `internal_modules`,
+//// so it is excluded from generated documentation and from beryl's published
+//// API. It exists purely so beryl's own tests can drive a bare coordinator
+//// without standing up a supervision tree.
+////
+//// Like beryl's other internal modules (`beryl/coordinator`, `beryl/log`,
+//// `beryl/rate_limit`), the boundary is not enforced by the compiler for
+//// path dependencies inside this workspace — it is a project rule. Nothing
+//// outside `packages/beryl/test` may import this module.
+////
+//// Applications must start beryl through `beryl/supervisor`, which returns a
+//// child specification for their own OTP supervision tree. A channel system
+//// started here has nothing watching it: if the coordinator crashes, the
+//// system stays down and every connected socket is stranded.
+
+import beryl
+import beryl/connection_limit
+import beryl/coordinator
+import beryl/error as beryl_error
+import beryl/internal
+import gleam/bool
+import gleam/erlang/process
+import gleam/option.{None, Some}
+import gleam/result
+
+/// Errors when starting an unsupervised channels system.
+pub type StartError {
+  /// The coordinator actor failed to start.
+  CoordinatorStartFailed(beryl_error.StartFailure)
+  /// `heartbeat_timeout_ms` must be at least 2. The server derives its
+  /// staleness check interval as `heartbeat_timeout_ms / 2` (integer
+  /// division), so a timeout of 1 would round down to a check interval of 0 —
+  /// which disables heartbeat eviction entirely. `start` rejects such a config
+  /// loudly rather than silently turning eviction off.
+  InvalidHeartbeatTimeout
+}
+
+/// Start an unsupervised channels system.
+///
+/// Test-only. Production code uses `beryl/supervisor` so OTP can restart the
+/// subtree; see this module's documentation.
+pub fn start(config: beryl.Config) -> Result(beryl.Channels, StartError) {
+  use <- bool.guard(
+    when: beryl.config_heartbeat_timeout_ms(config) < 2,
+    return: internal.result_error(InvalidHeartbeatTimeout),
+  )
+  beryl.warn_if_unprotected(config)
+  // Registrations live in a registry that outlives the coordinator, so a
+  // supervised restart (or manual coordinator replacement) can re-seed them.
+  use registry <- result.try(
+    coordinator.start_registry()
+    |> result.map_error(fn(error) {
+      CoordinatorStartFailed(beryl_error.from_actor_start_error(error))
+    }),
+  )
+  let coord_config =
+    coordinator.CoordinatorConfig(
+      ..beryl.to_coordinator_config(config),
+      registry: Some(registry),
+    )
+
+  let coordinator_result = case beryl.config_pubsub(config) {
+    Some(ps) -> coordinator.start_with_config_and_pubsub(coord_config, ps)
+    None -> coordinator.start_with_config(coord_config)
+  }
+
+  case coordinator_result {
+    Ok(coord) ->
+      Ok(beryl.channels_from_coordinator(
+        coordinator: coord,
+        config: config,
+        registry: Some(registry),
+      ))
+    error_result -> {
+      case
+        result.unwrap_error(
+          error_result,
+          or: coordinator.InvalidHeartbeatTimeout,
+        )
+      {
+        coordinator.ActorStartFailed(error) ->
+          internal.result_error(
+            CoordinatorStartFailed(beryl_error.from_actor_start_error(error)),
+          )
+        coordinator.InvalidHeartbeatTimeout ->
+          internal.result_error(InvalidHeartbeatTimeout)
+      }
+    }
+  }
+}
+
+/// Stop an unsupervised channels system.
+///
+/// Shuts down the coordinator actor started by `start` and any auxiliary
+/// limiter actors owned by the `Channels` handle. Joined channel handlers
+/// receive `channel.Shutdown` in their `terminate` callback before the
+/// coordinator exits. After this call the `Channels` handle must not be used.
+pub fn stop(channels: beryl.Channels) -> Nil {
+  stop_coordinator(beryl.coordinator_subject(channels))
+  connection_limit.stop_optional(beryl.channels_connection_limiter(channels))
+  case beryl.channels_registry(channels) {
+    Some(registry) -> coordinator.stop_registry(registry)
+    None -> Nil
+  }
+}
+
+fn stop_coordinator(coordinator: process.Subject(coordinator.Message)) -> Nil {
+  let should_send = case process.subject_owner(coordinator) {
+    Ok(pid) -> process.is_alive(pid)
+    _ -> False
+  }
+
+  use <- bool.guard(when: !should_send, return: Nil)
+  let reply = process.new_subject()
+  process.send(coordinator, coordinator.Stop(reply))
+  let _stop_result = process.receive(reply, 5000)
+  Nil
+}

--- a/packages/beryl/test/beryl_test.gleam
+++ b/packages/beryl/test/beryl_test.gleam
@@ -3,6 +3,7 @@ import beryl/channel
 import beryl/coordinator
 import beryl/error as beryl_error
 import beryl/group
+import beryl/internal/unsupervised
 import beryl/socket
 import beryl/topic
 import beryl/wire
@@ -280,7 +281,8 @@ pub fn sanitize_for_log_test() {
 }
 
 pub fn join_with_control_character_topic_gets_error_reply_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let sent_messages = process.new_subject()
 
   process.send(
@@ -318,7 +320,7 @@ pub fn join_with_control_character_topic_gets_error_reply_test() {
 pub fn join_with_too_long_topic_gets_error_reply_test() {
   let long_topic = "room:" <> string.repeat("a", 300)
   let assert Ok(channels) =
-    beryl.start(
+    unsupervised.start(
       beryl.config(wire.phoenix_codec())
       |> beryl.with_max_topic_length(max_length: 64),
     )
@@ -361,7 +363,7 @@ pub fn join_topic_over_byte_limit_but_under_grapheme_limit_gets_error_reply_test
   // max_topic_length is a byte limit, so this must be rejected.
   let multibyte_topic = "room:" <> string.repeat("€", 32)
   let assert Ok(channels) =
-    beryl.start(
+    unsupervised.start(
       beryl.config(wire.phoenix_codec())
       |> beryl.with_max_topic_length(max_length: 64),
     )
@@ -400,7 +402,7 @@ pub fn join_topic_over_byte_limit_but_under_grapheme_limit_gets_error_reply_test
 
 pub fn event_over_byte_limit_but_under_grapheme_limit_is_dropped_test() {
   let assert Ok(channels) =
-    beryl.start(
+    unsupervised.start(
       beryl.config(wire.phoenix_codec())
       |> beryl.with_max_event_length(max_length: 16),
     )
@@ -459,7 +461,8 @@ pub fn event_over_byte_limit_but_under_grapheme_limit_is_dropped_test() {
 }
 
 pub fn register_rejects_empty_pattern_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let handler =
     channel.new(fn(_topic_name, _payload, socket) {
       channel.JoinOk(reply: option.None, socket: socket)
@@ -470,7 +473,8 @@ pub fn register_rejects_empty_pattern_test() {
 }
 
 pub fn register_rejects_control_character_pattern_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let handler =
     channel.new(fn(_topic_name, _payload, socket) {
       channel.JoinOk(reply: option.None, socket: socket)
@@ -481,7 +485,8 @@ pub fn register_rejects_control_character_pattern_test() {
 }
 
 pub fn register_accepts_bare_catch_all_pattern_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let handler =
     channel.new(fn(_topic_name, _payload, socket) {
       channel.JoinOk(reply: option.None, socket: socket)
@@ -492,7 +497,7 @@ pub fn register_accepts_bare_catch_all_pattern_test() {
 
 pub fn socket_cannot_join_more_than_configured_topic_cap_test() {
   let assert Ok(channels) =
-    beryl.start(
+    unsupervised.start(
       beryl.config(wire.phoenix_codec())
       |> beryl.with_max_joined_topics_per_socket(max_topics: 1),
     )
@@ -536,7 +541,8 @@ pub fn socket_cannot_join_more_than_configured_topic_cap_test() {
 }
 
 pub fn segment_wildcard_registered_channel_routes_matching_topic_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let sent_messages = process.new_subject()
 
   process.send(
@@ -578,7 +584,8 @@ pub fn segment_wildcard_registered_channel_routes_matching_topic_test() {
 }
 
 pub fn segment_wildcard_registered_channel_rejects_wrong_segment_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let sent_messages = process.new_subject()
 
   process.send(
@@ -649,7 +656,8 @@ pub fn with_max_connections_per_ip_sets_limit_test() {
 }
 
 pub fn send_info_routes_message_to_joined_channel_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let sent_messages = process.new_subject()
 
   process.send(
@@ -709,7 +717,8 @@ type Notification {
 }
 
 pub fn send_info_typed_message_round_trips_without_cast_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let sent_messages = process.new_subject()
 
   process.send(
@@ -767,7 +776,8 @@ pub fn send_info_typed_message_round_trips_without_cast_test() {
 }
 
 pub fn send_info_reply_result_pushes_message_to_client_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let sent_messages = process.new_subject()
 
   process.send(
@@ -817,7 +827,8 @@ pub fn send_info_reply_result_pushes_message_to_client_test() {
 // Connect-hook (on_connect) assigns seeding tests
 
 pub fn connect_assigns_visible_in_channel_join_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let sent_messages = process.new_subject()
 
   // Seed socket-level assigns as if produced by the transport on_connect hook.
@@ -861,7 +872,8 @@ pub fn connect_assigns_visible_in_channel_join_test() {
 // the same socket/topic: the coordinator threads channel state between
 // dispatches.
 pub fn assigns_threaded_across_handle_in_calls_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let sent_messages = process.new_subject()
 
   process.send(
@@ -1210,7 +1222,8 @@ pub fn start_failure_description_is_public_test() {
 }
 
 pub fn channels_handle_remains_usable_after_start_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
 
   let handler =
     channel.new(fn(_topic, _payload, socket) {
@@ -1227,7 +1240,7 @@ pub fn stop_shuts_down_unsupervised_coordinator_test() {
     |> beryl.with_message_rate(per_second: 10, burst: 10)
     |> beryl.with_join_rate(per_second: 10, burst: 10)
     |> beryl.with_channel_rate(per_second: 10, burst: 10)
-  let assert Ok(channels) = beryl.start(config)
+  let assert Ok(channels) = unsupervised.start(config)
   let assert Ok(coordinator_pid) =
     process.subject_owner(beryl.coordinator_subject(channels))
   let sent_messages = process.new_subject()
@@ -1262,13 +1275,13 @@ pub fn stop_shuts_down_unsupervised_coordinator_test() {
   )
   let assert Ok(_) = process.receive(sent_messages, 500)
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
   let assert Ok(reason) = process.receive(terminated, 500)
   reason |> should.equal(channel.Shutdown)
   wait_until(fn() { !process.is_alive(coordinator_pid) }, 1000, 10)
 
   process.is_alive(coordinator_pid) |> should.be_false
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }
 
 pub fn topic_namespace_test() {
@@ -1277,7 +1290,8 @@ pub fn topic_namespace_test() {
 }
 
 pub fn group_broadcast_is_fire_and_forget_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let assert Ok(groups) = group.start()
   let assert Ok(Nil) = group.create(groups, "team:eng")
   let assert Ok(Nil) = group.add(groups, "team:eng", "room:lobby")

--- a/packages/beryl/test/binary_codec_test.gleam
+++ b/packages/beryl/test/binary_codec_test.gleam
@@ -1,6 +1,7 @@
 import beryl
 import beryl/channel
 import beryl/coordinator
+import beryl/internal/unsupervised
 import beryl/wire
 import beryl/wire/codec
 import gleam/bit_array
@@ -154,7 +155,8 @@ fn ref_to_string(ref: Option(String)) -> String {
 pub fn binary_codec_routes_join_message_and_reply_over_binary_test() {
   let sent_text = process.new_subject()
   let sent_binary = process.new_subject()
-  let assert Ok(channels) = beryl.start(beryl.config(binary_test_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(binary_test_codec()))
 
   process.send(
     beryl.coordinator_subject(channels),
@@ -229,7 +231,7 @@ pub fn binary_codec_event_consumes_one_message_rate_token_test() {
   let config =
     beryl.config(binary_test_codec())
     |> beryl.with_message_rate(per_second: 100, burst: 2)
-  let assert Ok(channels) = beryl.start(config)
+  let assert Ok(channels) = unsupervised.start(config)
 
   process.send(
     beryl.coordinator_subject(channels),
@@ -284,7 +286,8 @@ pub fn binary_codec_event_consumes_one_message_rate_token_test() {
 pub fn binary_codec_broadcast_uses_binary_send_test() {
   let sent_text = process.new_subject()
   let sent_binary = process.new_subject()
-  let assert Ok(channels) = beryl.start(beryl.config(binary_test_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(binary_test_codec()))
 
   process.send(
     beryl.coordinator_subject(channels),
@@ -343,7 +346,7 @@ pub fn codec_without_binary_decoder_preserves_raw_binary_handler_test() {
       encode_push: wire.push,
       encode_heartbeat_reply: wire.heartbeat_reply,
     )
-  let assert Ok(channels) = beryl.start(beryl.config(text_only))
+  let assert Ok(channels) = unsupervised.start(beryl.config(text_only))
 
   process.send(
     beryl.coordinator_subject(channels),

--- a/packages/beryl/test/bridge_test.gleam
+++ b/packages/beryl/test/bridge_test.gleam
@@ -2,6 +2,7 @@ import beryl
 import beryl/bridge
 import beryl/channel
 import beryl/coordinator
+import beryl/internal/unsupervised
 import beryl/wire
 import gleam/dynamic
 import gleam/erlang/process
@@ -14,7 +15,8 @@ import test_helpers.{wait_until}
 fn start_channels_with_socket(
   socket_id: String,
 ) -> #(beryl.Channels, process.Subject(String)) {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let sent_messages = process.new_subject()
 
   process.send(

--- a/packages/beryl/test/broadcast_test.gleam
+++ b/packages/beryl/test/broadcast_test.gleam
@@ -1,5 +1,6 @@
 import beryl
 import beryl/coordinator
+import beryl/internal/unsupervised
 import beryl/presence
 import beryl/pubsub
 import beryl/topic
@@ -104,7 +105,8 @@ fn presence_diff() -> presence.Diff {
 }
 
 pub fn broadcast_from_local_only_excludes_socket_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   register_test_channel(channels)
 
   let sender = connect_socket(channels, "sender-socket")
@@ -134,8 +136,8 @@ pub fn broadcast_from_local_only_excludes_socket_test() {
 pub fn broadcast_from_with_pubsub_excludes_socket_on_remote_coordinator_test() {
   let ps = pubsub.start(pubsub.config_with_scope("test_broadcast_from_pubsub"))
   let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
-  let assert Ok(origin_channels) = beryl.start(config)
-  let assert Ok(remote_channels) = beryl.start(config)
+  let assert Ok(origin_channels) = unsupervised.start(config)
+  let assert Ok(remote_channels) = unsupervised.start(config)
   register_test_channel(origin_channels)
   register_test_channel(remote_channels)
 
@@ -164,7 +166,8 @@ pub fn broadcast_from_with_pubsub_excludes_socket_on_remote_coordinator_test() {
 }
 
 pub fn broadcast_presence_diff_local_delivers_phoenix_event_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   register_test_channel(channels)
 
   let socket = connect_socket(channels, "socket-1")
@@ -186,7 +189,8 @@ pub fn broadcast_presence_diff_local_delivers_phoenix_event_test() {
 }
 
 pub fn presence_track_can_broadcast_presence_diff_to_joined_socket_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   register_test_channel(channels)
 
   let socket = connect_socket(channels, "socket-1")
@@ -224,8 +228,8 @@ pub fn presence_track_can_broadcast_presence_diff_to_joined_socket_test() {
 pub fn broadcast_presence_diff_with_pubsub_delivers_to_remote_coordinator_test() {
   let ps = pubsub.start(pubsub.config_with_scope("test_presence_diff_pubsub"))
   let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
-  let assert Ok(origin_channels) = beryl.start(config)
-  let assert Ok(remote_channels) = beryl.start(config)
+  let assert Ok(origin_channels) = unsupervised.start(config)
+  let assert Ok(remote_channels) = unsupervised.start(config)
   register_test_channel(origin_channels)
   register_test_channel(remote_channels)
 

--- a/packages/beryl/test/callback_crash_test.gleam
+++ b/packages/beryl/test/callback_crash_test.gleam
@@ -4,6 +4,7 @@
 import beryl
 import beryl/channel
 import beryl/coordinator
+import beryl/internal/unsupervised
 import beryl/topic
 import beryl/wire
 import gleam/dynamic
@@ -125,7 +126,8 @@ fn crashing_handle_in_handler(
 }
 
 pub fn handle_in_crash_terminates_channel_but_not_coordinator_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let terminated = process.new_subject()
   let _id = register_channel(channels, crashing_handle_in_handler(terminated))
 
@@ -164,7 +166,8 @@ pub fn handle_in_crash_terminates_channel_but_not_coordinator_test() {
 }
 
 pub fn join_crash_sends_error_reply_and_coordinator_survives_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let handler =
     coordinator.ChannelHandler(
       id: 0,
@@ -209,7 +212,8 @@ fn crashing_terminate_instance() -> coordinator.JoinedChannel {
 }
 
 pub fn terminate_crash_does_not_kill_coordinator_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let handler =
     coordinator.ChannelHandler(
       id: 0,
@@ -249,7 +253,8 @@ pub fn terminate_crash_does_not_kill_coordinator_test() {
 }
 
 pub fn handle_info_crash_terminates_channel_not_coordinator_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let terminated = process.new_subject()
   let id = register_channel(channels, crashing_handle_in_handler(terminated))
 

--- a/packages/beryl/test/channel_close_test.gleam
+++ b/packages/beryl/test/channel_close_test.gleam
@@ -5,6 +5,7 @@
 import beryl
 import beryl/channel
 import beryl/coordinator
+import beryl/internal/unsupervised
 import beryl/topic
 import beryl/wire
 import gleam/dynamic
@@ -106,7 +107,8 @@ fn join_topic(
 }
 
 pub fn leave_sends_reply_then_phx_close_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   register_stopping_channel(channels, channel.Normal)
 
   let socket = connect_socket(channels, "socket-1")
@@ -133,7 +135,8 @@ pub fn leave_sends_reply_then_phx_close_test() {
 }
 
 pub fn stop_with_error_sends_phx_error_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   register_stopping_channel(channels, channel.Errored("boom"))
 
   let socket = connect_socket(channels, "socket-1")
@@ -155,7 +158,8 @@ pub fn stop_with_error_sends_phx_error_test() {
 }
 
 pub fn stop_with_normal_sends_phx_close_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   register_stopping_channel(channels, channel.Normal)
 
   let socket = connect_socket(channels, "socket-1")

--- a/packages/beryl/test/connection_limit_test.gleam
+++ b/packages/beryl/test/connection_limit_test.gleam
@@ -6,13 +6,14 @@
 //// real socket peer IP.
 
 import beryl
+import beryl/internal/unsupervised
 import beryl/wire
 import gleam/erlang/process
 import gleeunit/should
 
 fn start_with_limit(max_connections: Int) -> beryl.Channels {
   let assert Ok(channels) =
-    beryl.start(
+    unsupervised.start(
       beryl.config(wire.phoenix_codec())
       |> beryl.with_max_connections_per_ip(max_connections: max_connections),
     )
@@ -31,7 +32,7 @@ pub fn zero_means_unlimited_test() {
   beryl.release_connection_slot(first)
   |> should.equal(Nil)
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }
 
 // Connections at or below the configured limit are admitted.
@@ -41,7 +42,7 @@ pub fn admits_connections_under_limit_test() {
   should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.1"))
   should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.1"))
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }
 
 // The connection that would exceed the limit is rejected.
@@ -52,7 +53,7 @@ pub fn rejects_connection_over_limit_test() {
   beryl.acquire_connection_slot(channels, "10.0.0.2")
   |> should.equal(Error(Nil))
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }
 
 // Releasing a slot frees capacity so a subsequent connection from that IP
@@ -69,7 +70,7 @@ pub fn releasing_slot_frees_capacity_test() {
   beryl.release_connection_slot(permit)
   should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.3"))
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }
 
 // The limit is tracked independently per IP.
@@ -85,7 +86,7 @@ pub fn limit_is_per_ip_test() {
   beryl.acquire_connection_slot(channels, "10.0.0.5")
   |> should.equal(Error(Nil))
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }
 
 // A slot is reclaimed when its holder process dies without releasing —
@@ -107,7 +108,7 @@ pub fn slot_reclaimed_when_holder_dies_without_release_test() {
   process.sleep(50)
 
   should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.7"))
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }
 
 // A permit obtained under a limit can be released explicitly.
@@ -117,5 +118,5 @@ pub fn permit_can_be_released_test() {
   let assert Ok(permit) = beryl.acquire_connection_slot(channels, "10.0.0.6")
   beryl.release_connection_slot(permit)
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }

--- a/packages/beryl/test/duplicate_join_test.gleam
+++ b/packages/beryl/test/duplicate_join_test.gleam
@@ -5,6 +5,7 @@
 import beryl
 import beryl/channel
 import beryl/coordinator
+import beryl/internal/unsupervised
 import beryl/topic
 import beryl/wire
 import gleam/dynamic
@@ -106,7 +107,8 @@ fn join_with_ref(
 }
 
 pub fn duplicate_join_terminates_previous_instance_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let terminated = process.new_subject()
   register_channel(channels, terminated)
 
@@ -133,7 +135,8 @@ pub fn duplicate_join_terminates_previous_instance_test() {
 }
 
 pub fn stale_join_ref_messages_are_dropped_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let terminated = process.new_subject()
   register_channel(channels, terminated)
 
@@ -167,7 +170,8 @@ pub fn stale_join_ref_messages_are_dropped_test() {
 }
 
 pub fn stale_join_ref_leave_is_ignored_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let terminated = process.new_subject()
   register_channel(channels, terminated)
 

--- a/packages/beryl/test/error_reply_test.gleam
+++ b/packages/beryl/test/error_reply_test.gleam
@@ -5,6 +5,7 @@
 import beryl
 import beryl/channel
 import beryl/coordinator
+import beryl/internal/unsupervised
 import beryl/wire
 import gleam/dynamic
 import gleam/erlang/process
@@ -18,7 +19,8 @@ pub fn main() {
 }
 
 fn start_with_error_channel() -> beryl.Channels {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let handler =
     channel.new(fn(_topic, _payload, socket) {
       channel.JoinOk(reply: None, socket: socket)

--- a/packages/beryl/test/global_connection_limit_test.gleam
+++ b/packages/beryl/test/global_connection_limit_test.gleam
@@ -8,6 +8,7 @@
 //// limit alone cannot enforce against distributed/rotating addresses.
 
 import beryl
+import beryl/internal/unsupervised
 import beryl/wire
 import gleam/erlang/process
 import gleam/int
@@ -29,7 +30,7 @@ fn seq_loop(n: Int, acc: List(Int)) -> List(Int) {
 
 fn start_with_global_limit(max_connections: Int) -> beryl.Channels {
   let assert Ok(channels) =
-    beryl.start(
+    unsupervised.start(
       beryl.config(wire.phoenix_codec())
       |> beryl.with_max_connections(max_connections: max_connections),
     )
@@ -41,7 +42,7 @@ fn start_with_both_limits(
   max_connections: Int,
 ) -> beryl.Channels {
   let assert Ok(channels) =
-    beryl.start(
+    unsupervised.start(
       beryl.config(wire.phoenix_codec())
       |> beryl.with_max_connections_per_ip(max_connections: max_per_ip)
       |> beryl.with_max_connections(max_connections: max_connections),
@@ -61,7 +62,7 @@ pub fn global_zero_means_unlimited_test() {
   beryl.release_connection_slot(first)
   |> should.equal(Nil)
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }
 
 // Connections at or below the node-wide limit are admitted regardless of which
@@ -73,7 +74,7 @@ pub fn admits_connections_under_global_limit_test() {
   should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.2"))
   should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.3"))
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }
 
 // A connection that would exceed the node-wide limit is rejected even though it
@@ -89,7 +90,7 @@ pub fn rejects_connection_over_global_limit_test() {
   beryl.acquire_connection_slot(channels, "10.0.1.3")
   |> should.equal(Error(Nil))
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }
 
 // Releasing a slot frees node-wide capacity so a subsequent connection (from
@@ -106,7 +107,7 @@ pub fn releasing_slot_frees_global_capacity_test() {
   beryl.release_connection_slot(permit)
   should.be_ok(beryl.acquire_connection_slot(channels, "10.0.2.2"))
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }
 
 // A global slot is reclaimed when its holder process dies without releasing —
@@ -133,7 +134,7 @@ pub fn global_slot_reclaimed_when_holder_dies_without_release_test() {
   // The reclaimed slot admits a connection from a *different* IP, proving the
   // global count (not just the per-IP count) was decremented.
   should.be_ok(beryl.acquire_connection_slot(channels, "10.0.3.2"))
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }
 
 // The per-IP and node-wide ceilings compose: a connection must be under both.
@@ -148,7 +149,7 @@ pub fn per_ip_and_global_compose_test() {
   beryl.acquire_connection_slot(channels, "10.0.4.2")
   |> should.equal(Error(Nil))
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }
 
 // The per-IP limit still bites under a generous node-wide ceiling: a single IP
@@ -163,7 +164,7 @@ pub fn per_ip_limit_still_enforced_under_global_test() {
   // A different IP is admitted (node still under its global ceiling).
   should.be_ok(beryl.acquire_connection_slot(channels, "10.0.5.2"))
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }
 
 // Concurrent opens cannot race past the node-wide ceiling. Many processes
@@ -210,5 +211,5 @@ pub fn concurrent_opens_do_not_exceed_global_ceiling_test() {
   successes
   |> should.equal(ceiling)
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
 }

--- a/packages/beryl/test/heartbeat_test.gleam
+++ b/packages/beryl/test/heartbeat_test.gleam
@@ -1,6 +1,7 @@
 import beryl
 import beryl/channel
 import beryl/coordinator
+import beryl/internal/unsupervised
 import beryl/topic
 import beryl/wire
 import gleam/dynamic
@@ -297,7 +298,7 @@ pub fn positive_timeout_with_checking_enabled_is_ok_test() {
 // `heartbeat_timeout_ms` drives the server's staleness check interval, which
 // is derived as `timeout_ms / 2`. A timeout of 1 integer-divides to a check
 // interval of 0, which the scheduler treats as "disabled" — silently turning
-// off heartbeat eviction. `beryl.start` must reject any timeout below 2 loudly
+// off heartbeat eviction. `unsupervised.start` must reject any timeout below 2 loudly
 // rather than accepting a config that disables eviction.
 
 pub fn beryl_start_rejects_timeout_of_one_test() {
@@ -305,9 +306,9 @@ pub fn beryl_start_rejects_timeout_of_one_test() {
     beryl.config(wire.phoenix_codec())
     |> beryl.with_heartbeat(interval_ms: 30_000, timeout_ms: 1)
 
-  beryl.start(config)
+  unsupervised.start(config)
   |> should.be_error
-  |> should.equal(beryl.InvalidHeartbeatTimeout)
+  |> should.equal(unsupervised.InvalidHeartbeatTimeout)
 }
 
 pub fn beryl_start_rejects_zero_timeout_test() {
@@ -315,9 +316,9 @@ pub fn beryl_start_rejects_zero_timeout_test() {
     beryl.config(wire.phoenix_codec())
     |> beryl.with_heartbeat(interval_ms: 30_000, timeout_ms: 0)
 
-  beryl.start(config)
+  unsupervised.start(config)
   |> should.be_error
-  |> should.equal(beryl.InvalidHeartbeatTimeout)
+  |> should.equal(unsupervised.InvalidHeartbeatTimeout)
 }
 
 pub fn beryl_start_rejects_negative_timeout_test() {
@@ -325,9 +326,9 @@ pub fn beryl_start_rejects_negative_timeout_test() {
     beryl.config(wire.phoenix_codec())
     |> beryl.with_heartbeat(interval_ms: 30_000, timeout_ms: -5)
 
-  beryl.start(config)
+  unsupervised.start(config)
   |> should.be_error
-  |> should.equal(beryl.InvalidHeartbeatTimeout)
+  |> should.equal(unsupervised.InvalidHeartbeatTimeout)
 }
 
 pub fn beryl_start_accepts_timeout_of_two_test() {
@@ -337,13 +338,14 @@ pub fn beryl_start_accepts_timeout_of_two_test() {
     beryl.config(wire.phoenix_codec())
     |> beryl.with_heartbeat(interval_ms: 30_000, timeout_ms: 2)
 
-  let assert Ok(channels) = beryl.start(config)
-  beryl.stop(channels)
+  let assert Ok(channels) = unsupervised.start(config)
+  unsupervised.stop(channels)
 }
 
 pub fn beryl_start_accepts_default_timeout_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
-  beryl.stop(channels)
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
+  unsupervised.stop(channels)
 }
 
 pub fn start_named_validates_heartbeat_timeout_test() {

--- a/packages/beryl/test/logging_test.gleam
+++ b/packages/beryl/test/logging_test.gleam
@@ -2,6 +2,7 @@ import beryl
 import beryl/channel
 import beryl/coordinator
 import beryl/internal
+import beryl/internal/unsupervised
 import beryl/wire
 import gleam/dict
 import gleam/dynamic
@@ -105,7 +106,7 @@ pub fn channels_start_accepts_debug_logging_config_test() {
       include_payloads: False,
     ))
 
-  beryl.start(config)
+  unsupervised.start(config)
   |> should.be_ok
 }
 
@@ -166,7 +167,7 @@ pub fn debug_decode_log_omits_frame_preview_by_default_test() {
       level: beryl.DebugLevel,
       include_payloads: False,
     ))
-  let assert Ok(channels) = beryl.start(config)
+  let assert Ok(channels) = unsupervised.start(config)
 
   process.send(
     beryl.coordinator_subject(channels),
@@ -210,7 +211,7 @@ pub fn debug_join_missing_handler_logs_routing_and_send_test() {
       level: beryl.DebugLevel,
       include_payloads: False,
     ))
-  let assert Ok(channels) = beryl.start(config)
+  let assert Ok(channels) = unsupervised.start(config)
 
   process.send(
     beryl.coordinator_subject(channels),
@@ -253,7 +254,7 @@ pub fn debug_channel_callback_logs_push_result_test() {
       level: beryl.DebugLevel,
       include_payloads: False,
     ))
-  let assert Ok(channels) = beryl.start(config)
+  let assert Ok(channels) = unsupervised.start(config)
   let handler =
     channel.new(fn(_, _, socket) { channel.JoinOk(reply: None, socket: socket) })
     |> channel.with_handle_in(fn(_, _, socket) {
@@ -300,12 +301,13 @@ pub fn debug_channel_callback_logs_push_result_test() {
 pub fn start_warns_when_no_abuse_controls_configured_test() {
   let selector = begin_capture()
 
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
 
   receive_log(selector, "No abuse controls configured", 10)
   |> should.be_ok
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
   stop_capture()
 }
 
@@ -313,7 +315,7 @@ pub fn start_does_not_warn_when_a_limit_is_configured_test() {
   let selector = begin_capture()
 
   let assert Ok(channels) =
-    beryl.start(
+    unsupervised.start(
       beryl.config(wire.phoenix_codec())
       |> beryl.with_message_rate(per_second: 100, burst: 200),
     )
@@ -321,7 +323,7 @@ pub fn start_does_not_warn_when_a_limit_is_configured_test() {
   receive_log(selector, "No abuse controls configured", 2)
   |> should.be_error
 
-  beryl.stop(channels)
+  unsupervised.stop(channels)
   stop_capture()
 }
 

--- a/packages/beryl/test/phoenix_binary_test.gleam
+++ b/packages/beryl/test/phoenix_binary_test.gleam
@@ -4,6 +4,7 @@
 import beryl
 import beryl/channel
 import beryl/coordinator
+import beryl/internal/unsupervised
 import beryl/wire
 import beryl/wire/codec
 import gleam/dynamic
@@ -157,7 +158,8 @@ pub fn binary_encoders_reject_oversized_components_test() {
 // === End-to-end through the coordinator ===
 
 pub fn phoenix_binary_push_routes_to_handle_in_with_reply_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let seen = process.new_subject()
 
   let handler =
@@ -221,7 +223,8 @@ pub fn phoenix_binary_push_routes_to_handle_in_with_reply_test() {
 }
 
 pub fn phoenix_malformed_binary_frame_is_dropped_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let seen_binary = process.new_subject()
 
   let handler =

--- a/packages/beryl/test/topic_fallback_test.gleam
+++ b/packages/beryl/test/topic_fallback_test.gleam
@@ -1,6 +1,7 @@
 import beryl
 import beryl/channel
 import beryl/coordinator
+import beryl/internal/unsupervised
 import beryl/wire
 import beryl/wire/codec
 import gleam/dynamic
@@ -14,7 +15,7 @@ fn start_with_socket(socket_id) {
   // Empty-topic fallback is an explicit codec capability for topicless
   // framings; the plain Phoenix codec drops empty-topic events instead.
   let topicless = wire.phoenix_codec() |> codec.with_topicless_events()
-  let assert Ok(channels) = beryl.start(beryl.config(topicless))
+  let assert Ok(channels) = unsupervised.start(beryl.config(topicless))
   let sent = process.new_subject()
   process.send(
     beryl.coordinator_subject(channels),
@@ -64,7 +65,8 @@ pub fn topicless_event_routes_to_single_join_test() {
 // The plain Phoenix codec never guesses: an empty-topic event is dropped
 // even when the socket has exactly one join, matching Phoenix.
 pub fn phoenix_codec_drops_topicless_events_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) =
+    unsupervised.start(beryl.config(wire.phoenix_codec()))
   let sent = process.new_subject()
   process.send(
     beryl.coordinator_subject(channels),

--- a/packages/beryl_ewe/README.md
+++ b/packages/beryl_ewe/README.md
@@ -5,7 +5,8 @@
 
 > [!IMPORTANT]
 > beryl is not yet 1.0. The API is unstable, features may be removed in minor
-> releases, and quality should not be considered production-ready.
+> releases, and quality should not be considered production-ready. We welcome
+> usage and feedback in the meantime!
 
 beryl is not yet on Hex. Add it and this transport as git dependencies in your
 `gleam.toml`:
@@ -47,7 +48,7 @@ pub fn main() {
   let assert Ok(_) =
     ewe_transport.handler(
       channels,
-      ewe_transport.default_config("/socket"),
+      ewe_transport.default_config("/socket/websocket"),
       http_fallback,
     )
     |> ewe.new
@@ -68,11 +69,11 @@ channels on either web server by choosing the matching transport package.
 
 ## Documentation
 
-- Guides and API reference: <https://beryl.tylerbutler.com>
-- Package docs: <https://hexdocs.pm/beryl_ewe>
+- Guides: <https://beryl.tylerbutler.com>
+- API reference: <https://beryl.tylerbutler.com/reference/api/>
 - Repository: <https://github.com/tylerbutler/beryl> (monorepo; this package
   lives in `packages/beryl_ewe`)
 
-## Licence
+## License
 
 MIT

--- a/packages/beryl_ewe/README.md
+++ b/packages/beryl_ewe/README.md
@@ -1,15 +1,25 @@
 # beryl_ewe
 
 [Ewe](https://hex.pm/packages/ewe) WebSocket transport for
-[beryl](https://hex.pm/packages/beryl) real-time channels.
+[beryl](https://github.com/tylerbutler/beryl) real-time channels.
 
 > [!IMPORTANT]
 > beryl is not yet 1.0. The API is unstable, features may be removed in minor
 > releases, and quality should not be considered production-ready.
 
-```sh
-gleam add beryl beryl_ewe
+beryl is not yet on Hex. Add it and this transport as git dependencies in your
+`gleam.toml`:
+
+```toml
+[dependencies]
+beryl = { git = "https://github.com/tylerbutler/beryl.git", ref = "v0.0", path = "packages/beryl" }
+beryl_ewe = { git = "https://github.com/tylerbutler/beryl.git", ref = "v0.0", path = "packages/beryl_ewe" }
 ```
+
+> [!IMPORTANT]
+> **Gleam 1.18 or later is required.** These packages live in subdirectories of
+> the beryl monorepo, and the `path` field for git dependencies was added in
+> Gleam 1.18.
 
 ## Usage
 
@@ -52,7 +62,7 @@ upgrade, validates the `Origin` header (same-origin by default, allow-list,
 or allow-all), and enforces beryl's frame-size, message-rate, and connection
 limits at the edge.
 
-It mirrors the [`beryl_mist`](https://hex.pm/packages/beryl_mist) package: both
+It mirrors the [`beryl_mist`](https://github.com/tylerbutler/beryl/tree/main/packages/beryl_mist) package: both
 transports expose the same config-builder and handler API, so you can run beryl
 channels on either web server by choosing the matching transport package.
 

--- a/packages/beryl_ewe/src/beryl_ewe.gleam
+++ b/packages/beryl_ewe/src/beryl_ewe.gleam
@@ -42,7 +42,7 @@ pub opaque type TransportConfig(assigns) {
     /// and assigns start empty (`Nil`).
     on_connect: Option(fn(Request(Connection)) -> Result(assigns, ConnectError)),
     /// Policy applied to the request `Origin` header before the WebSocket
-    /// handshake. Defaults to [`SameOrigin`](#OriginPolicy).
+    /// handshake. Defaults to [`SameOrigin`](#originpolicy).
     origin_policy: OriginPolicy,
   )
 }
@@ -66,7 +66,7 @@ pub type ConnectError {
 /// always send `Origin` on WebSocket handshakes, so an absent header signals a
 /// non-browser client (native app, server-to-server, CLI) that is not subject
 /// to the browser same-origin model and cannot be tricked into a cross-site
-/// upgrade. The one exception is [`AllowList`](#OriginPolicy), which requires a
+/// upgrade. The one exception is [`AllowList`](#originpolicy), which requires a
 /// matching `Origin` and therefore rejects absent ones.
 pub type OriginPolicy {
   /// Allow an upgrade only when the request `Origin` authority (host plus any
@@ -79,7 +79,7 @@ pub type OriginPolicy {
   ///
   /// Behind a reverse proxy this compares against the `Host` header as the app
   /// sees it: ensure the proxy forwards the public `Host` unchanged, or use
-  /// [`AllowList`](#OriginPolicy) with the public origins instead. Forwarded
+  /// [`AllowList`](#originpolicy) with the public origins instead. Forwarded
   /// headers such as `X-Forwarded-Host` are not trusted, because clients can
   /// spoof them.
   SameOrigin
@@ -97,7 +97,7 @@ pub type OriginPolicy {
 /// Create a default transport config with no connect hook.
 ///
 /// The resulting config seeds `Nil` assigns and applies the
-/// [`SameOrigin`](#OriginPolicy) origin policy, which rejects cross-site
+/// [`SameOrigin`](#originpolicy) origin policy, which rejects cross-site
 /// WebSocket upgrades before the handshake (CSWSH protection). Same-origin
 /// upgrades and non-browser clients (no `Origin` header) are admitted without
 /// configuration.
@@ -130,8 +130,8 @@ pub fn with_on_connect(
 /// Restrict WebSocket upgrades to requests whose `Origin` header exactly
 /// matches one of the given values.
 ///
-/// This replaces the default [`SameOrigin`](#OriginPolicy) policy with an
-/// [`AllowList`](#OriginPolicy). Values are matched exactly against the full
+/// This replaces the default [`SameOrigin`](#originpolicy) policy with an
+/// [`AllowList`](#originpolicy). Values are matched exactly against the full
 /// `Origin` header, including scheme and host (and port when present), such as
 /// `"https://app.example.com"`. Missing or non-matching origins are rejected
 /// with `403 Forbidden` before the WebSocket handshake.
@@ -152,7 +152,7 @@ pub fn with_allowed_origins(
 
 /// Disable `Origin` checking, allowing WebSocket upgrades from any origin.
 ///
-/// This is an explicit opt-out of the default [`SameOrigin`](#OriginPolicy)
+/// This is an explicit opt-out of the default [`SameOrigin`](#originpolicy)
 /// CSWSH protection and restores the pre-1.0 allow-all behaviour. Only use it
 /// for sockets that do not rely on ambient browser credentials (cookies,
 /// sessions) for authorization, or that authenticate every message

--- a/packages/beryl_ewe/test/ewe_handler_test.gleam
+++ b/packages/beryl_ewe/test/ewe_handler_test.gleam
@@ -5,12 +5,16 @@
 //// server-agnostic raw-TCP WebSocket client FFI.
 
 import beryl
+import beryl/supervisor
 import beryl/wire
 import beryl_ewe as ewe_transport
 import ewe
 import gleam/erlang/process
 import gleam/http/response
 import gleam/int
+import gleam/otp/actor
+import gleam/otp/static_supervisor
+import gleam/result
 import gleam/string
 import gleeunit/should
 
@@ -84,7 +88,7 @@ fn start_server_with_config(
 
 fn start_limited_server() -> #(Int, process.Pid) {
   let assert Ok(channels) =
-    beryl.start(
+    start_supervised(
       beryl.config(wire.phoenix_codec())
       |> beryl.with_max_connections_per_ip(max_connections: 1),
     )
@@ -93,7 +97,7 @@ fn start_limited_server() -> #(Int, process.Pid) {
 
 fn start_frame_limited_server() -> #(Int, process.Pid) {
   let assert Ok(channels) =
-    beryl.start(
+    start_supervised(
       beryl.config(wire.phoenix_codec())
       |> beryl.with_max_inbound_frame_bytes(max_bytes: 32),
     )
@@ -101,7 +105,7 @@ fn start_frame_limited_server() -> #(Int, process.Pid) {
 }
 
 fn start_channels() -> beryl.Channels {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) = start_supervised(beryl.config(wire.phoenix_codec()))
   channels
 }
 
@@ -279,7 +283,7 @@ pub fn handler_allows_unlimited_connections_when_limit_is_zero_test() {
 
 pub fn handler_sheds_message_flood_at_the_edge_test() {
   let assert Ok(channels) =
-    beryl.start(
+    start_supervised(
       beryl.config(wire.phoenix_codec())
       |> beryl.with_message_rate(per_second: 1, burst: 2),
     )
@@ -327,4 +331,20 @@ pub fn handler_closes_socket_on_oversized_text_frame_test() {
 
   close(client)
   stop_supervisor(server_pid)
+}
+
+/// Start a supervised channel system for tests.
+///
+/// beryl exposes no public unsupervised start, so tests stand up a real
+/// supervision tree the way an application would.
+fn start_supervised(
+  config: beryl.Config,
+) -> Result(beryl.Channels, actor.StartError) {
+  let supervised = supervisor.config(config)
+  use _root <- result.map(
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(supervisor.start(supervised))
+    |> static_supervisor.start(),
+  )
+  supervisor.channels(supervised)
 }

--- a/packages/beryl_mist/README.md
+++ b/packages/beryl_mist/README.md
@@ -5,7 +5,8 @@
 
 > [!IMPORTANT]
 > beryl is not yet 1.0. The API is unstable, features may be removed in minor
-> releases, and quality should not be considered production-ready.
+> releases, and quality should not be considered production-ready. We welcome
+> usage and feedback in the meantime!
 
 beryl is not yet on Hex. Add it and this transport as git dependencies in your
 `gleam.toml`:
@@ -47,7 +48,7 @@ pub fn main() {
   let assert Ok(_) =
     mist_transport.handler(
       channels,
-      mist_transport.default_config("/socket"),
+      mist_transport.default_config("/socket/websocket"),
       http_fallback,
     )
     |> mist.new
@@ -62,13 +63,17 @@ upgrade, validates the `Origin` header (same-origin by default, allow-list,
 or allow-all), and enforces beryl's frame-size, message-rate, and connection
 limits at the edge.
 
+If you serve HTTP with [Ewe](https://hex.pm/packages/ewe) rather than Mist, use
+[`beryl_ewe`](https://github.com/tylerbutler/beryl/tree/main/packages/beryl_ewe)
+instead — it exposes the same config-builder and handler API.
+
 ## Documentation
 
-- Guides and API reference: <https://beryl.tylerbutler.com>
-- Package docs: <https://hexdocs.pm/beryl_mist>
+- Guides: <https://beryl.tylerbutler.com>
+- API reference: <https://beryl.tylerbutler.com/reference/api/>
 - Repository: <https://github.com/tylerbutler/beryl> (monorepo; this package
   lives in `packages/beryl_mist`)
 
-## Licence
+## License
 
 MIT

--- a/packages/beryl_mist/README.md
+++ b/packages/beryl_mist/README.md
@@ -1,15 +1,25 @@
 # beryl_mist
 
 [Mist](https://hex.pm/packages/mist) WebSocket transport for
-[beryl](https://hex.pm/packages/beryl) real-time channels.
+[beryl](https://github.com/tylerbutler/beryl) real-time channels.
 
 > [!IMPORTANT]
 > beryl is not yet 1.0. The API is unstable, features may be removed in minor
 > releases, and quality should not be considered production-ready.
 
-```sh
-gleam add beryl beryl_mist
+beryl is not yet on Hex. Add it and this transport as git dependencies in your
+`gleam.toml`:
+
+```toml
+[dependencies]
+beryl = { git = "https://github.com/tylerbutler/beryl.git", ref = "v0.0", path = "packages/beryl" }
+beryl_mist = { git = "https://github.com/tylerbutler/beryl.git", ref = "v0.0", path = "packages/beryl_mist" }
 ```
+
+> [!IMPORTANT]
+> **Gleam 1.18 or later is required.** These packages live in subdirectories of
+> the beryl monorepo, and the `path` field for git dependencies was added in
+> Gleam 1.18.
 
 ## Usage
 

--- a/packages/beryl_mist/src/beryl_mist.gleam
+++ b/packages/beryl_mist/src/beryl_mist.gleam
@@ -38,7 +38,7 @@ pub opaque type TransportConfig(assigns) {
     /// and assigns start empty (`Nil`).
     on_connect: Option(fn(Request(Connection)) -> Result(assigns, ConnectError)),
     /// Policy applied to the request `Origin` header before the WebSocket
-    /// handshake. Defaults to [`SameOrigin`](#OriginPolicy).
+    /// handshake. Defaults to [`SameOrigin`](#originpolicy).
     origin_policy: OriginPolicy,
   )
 }
@@ -62,7 +62,7 @@ pub type ConnectError {
 /// always send `Origin` on WebSocket handshakes, so an absent header signals a
 /// non-browser client (native app, server-to-server, CLI) that is not subject
 /// to the browser same-origin model and cannot be tricked into a cross-site
-/// upgrade. The one exception is [`AllowList`](#OriginPolicy), which requires a
+/// upgrade. The one exception is [`AllowList`](#originpolicy), which requires a
 /// matching `Origin` and therefore rejects absent ones.
 pub type OriginPolicy {
   /// Allow an upgrade only when the request `Origin` authority (host plus any
@@ -75,7 +75,7 @@ pub type OriginPolicy {
   ///
   /// Behind a reverse proxy this compares against the `Host` header as the app
   /// sees it: ensure the proxy forwards the public `Host` unchanged, or use
-  /// [`AllowList`](#OriginPolicy) with the public origins instead. Forwarded
+  /// [`AllowList`](#originpolicy) with the public origins instead. Forwarded
   /// headers such as `X-Forwarded-Host` are not trusted, because clients can
   /// spoof them.
   SameOrigin
@@ -93,7 +93,7 @@ pub type OriginPolicy {
 /// Create a default transport config with no connect hook.
 ///
 /// The resulting config seeds `Nil` assigns and applies the
-/// [`SameOrigin`](#OriginPolicy) origin policy, which rejects cross-site
+/// [`SameOrigin`](#originpolicy) origin policy, which rejects cross-site
 /// WebSocket upgrades before the handshake (CSWSH protection). Same-origin
 /// upgrades and non-browser clients (no `Origin` header) are admitted without
 /// configuration.
@@ -126,8 +126,8 @@ pub fn with_on_connect(
 /// Restrict WebSocket upgrades to requests whose `Origin` header exactly
 /// matches one of the given values.
 ///
-/// This replaces the default [`SameOrigin`](#OriginPolicy) policy with an
-/// [`AllowList`](#OriginPolicy). Values are matched exactly against the full
+/// This replaces the default [`SameOrigin`](#originpolicy) policy with an
+/// [`AllowList`](#originpolicy). Values are matched exactly against the full
 /// `Origin` header, including scheme and host (and port when present), such as
 /// `"https://app.example.com"`. Missing or non-matching origins are rejected
 /// with `403 Forbidden` before the WebSocket handshake.
@@ -148,7 +148,7 @@ pub fn with_allowed_origins(
 
 /// Disable `Origin` checking, allowing WebSocket upgrades from any origin.
 ///
-/// This is an explicit opt-out of the default [`SameOrigin`](#OriginPolicy)
+/// This is an explicit opt-out of the default [`SameOrigin`](#originpolicy)
 /// CSWSH protection and restores the pre-1.0 allow-all behaviour. Only use it
 /// for sockets that do not rely on ambient browser credentials (cookies,
 /// sessions) for authorization, or that authenticate every message

--- a/packages/beryl_mist/test/client_contract_test.gleam
+++ b/packages/beryl_mist/test/client_contract_test.gleam
@@ -3,6 +3,7 @@ import aquamarine/error as aquamarine_error
 import aquamarine/phoenix
 import beryl
 import beryl/channel as bchannel
+import beryl/supervisor
 import beryl/wire
 import beryl_mist as mist_transport
 import gleam/bytes_tree
@@ -72,7 +73,7 @@ fn start_test_server(
   register: fn(beryl.Channels, process.Subject(TestEvent)) -> Nil,
   events: process.Subject(TestEvent),
 ) -> Result(TestServer, Nil) {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) = start_supervised(beryl.config(wire.phoenix_codec()))
   register(channels, events)
   let port_subject = process.new_subject()
 
@@ -332,4 +333,20 @@ fn receive_terminated(
       Ok(reason)
     _ -> Error(Nil)
   }
+}
+
+/// Start a supervised channel system for tests.
+///
+/// beryl exposes no public unsupervised start, so tests stand up a real
+/// supervision tree the way an application would.
+fn start_supervised(
+  config: beryl.Config,
+) -> Result(beryl.Channels, actor.StartError) {
+  let supervised = supervisor.config(config)
+  use _root <- result.map(
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(supervisor.start(supervised))
+    |> static_supervisor.start(),
+  )
+  supervisor.channels(supervised)
 }

--- a/packages/beryl_mist/test/mist_handler_test.gleam
+++ b/packages/beryl_mist/test/mist_handler_test.gleam
@@ -4,12 +4,16 @@
 //// handler routes WebSocket upgrades versus plain HTTP requests.
 
 import beryl
+import beryl/supervisor
 import beryl/wire
 import beryl_mist as mist_transport
 import gleam/bytes_tree
 import gleam/erlang/process
 import gleam/http/response
 import gleam/int
+import gleam/otp/actor
+import gleam/otp/static_supervisor
+import gleam/result
 import gleam/string
 import gleeunit/should
 import mist
@@ -84,7 +88,7 @@ fn start_server_with_config(
 
 fn start_limited_server() -> #(Int, process.Pid) {
   let assert Ok(channels) =
-    beryl.start(
+    start_supervised(
       beryl.config(wire.phoenix_codec())
       |> beryl.with_max_connections_per_ip(max_connections: 1),
     )
@@ -93,7 +97,7 @@ fn start_limited_server() -> #(Int, process.Pid) {
 
 fn start_frame_limited_server() -> #(Int, process.Pid) {
   let assert Ok(channels) =
-    beryl.start(
+    start_supervised(
       beryl.config(wire.phoenix_codec())
       |> beryl.with_max_inbound_frame_bytes(max_bytes: 32),
     )
@@ -101,7 +105,7 @@ fn start_frame_limited_server() -> #(Int, process.Pid) {
 }
 
 fn start_channels() -> beryl.Channels {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) = start_supervised(beryl.config(wire.phoenix_codec()))
   channels
 }
 
@@ -279,7 +283,7 @@ pub fn handler_allows_unlimited_connections_when_limit_is_zero_test() {
 
 pub fn handler_sheds_message_flood_at_the_edge_test() {
   let assert Ok(channels) =
-    beryl.start(
+    start_supervised(
       beryl.config(wire.phoenix_codec())
       |> beryl.with_message_rate(per_second: 1, burst: 2),
     )
@@ -327,4 +331,20 @@ pub fn handler_closes_socket_on_oversized_text_frame_test() {
 
   close(client)
   stop_supervisor(server_pid)
+}
+
+/// Start a supervised channel system for tests.
+///
+/// beryl exposes no public unsupervised start, so tests stand up a real
+/// supervision tree the way an application would.
+fn start_supervised(
+  config: beryl.Config,
+) -> Result(beryl.Channels, actor.StartError) {
+  let supervised = supervisor.config(config)
+  use _root <- result.map(
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(supervisor.start(supervised))
+    |> static_supervisor.start(),
+  )
+  supervisor.channels(supervised)
 }

--- a/packages/beryl_mist/test/phoenix_contract_test.gleam
+++ b/packages/beryl_mist/test/phoenix_contract_test.gleam
@@ -1,6 +1,7 @@
 import beryl
 import beryl/channel
 import beryl/socket
+import beryl/supervisor
 import beryl/wire
 import beryl_mist as mist_transport
 import gleam/bytes_tree
@@ -12,6 +13,8 @@ import gleam/http/response
 import gleam/json.{type Json}
 import gleam/list
 import gleam/option.{type Option, None, Some}
+import gleam/otp/actor
+import gleam/otp/static_supervisor
 import gleam/result
 import gleeunit
 import gleeunit/should
@@ -296,7 +299,7 @@ fn join_client(serializer: Serializer, client: WebsocketClient) {
 
 pub fn json_contract_join_custom_broadcast_heartbeat_leave_test() {
   let serializer = json_serializer()
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) = start_supervised(beryl.config(wire.phoenix_codec()))
   let terminated = process.new_subject()
   let assert Ok(_) =
     beryl.register(channels, "room:*", contract_channel(channels, terminated))
@@ -449,7 +452,7 @@ fn start_auth_server(
 }
 
 pub fn on_connect_rejects_connection_without_token_test() {
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) = start_supervised(beryl.config(wire.phoenix_codec()))
   let config =
     mist_transport.default_config("/socket/websocket")
     |> mist_transport.with_on_connect(fn(req) {
@@ -473,7 +476,7 @@ pub fn on_connect_rejects_connection_without_token_test() {
 
 pub fn on_connect_seeds_assigns_visible_at_join_test() {
   let serializer = json_serializer()
-  let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+  let assert Ok(channels) = start_supervised(beryl.config(wire.phoenix_codec()))
 
   // The channel's assigns is the connect-seeded user id; join echoes it back
   // without re-authenticating.
@@ -509,4 +512,20 @@ pub fn on_connect_seeds_assigns_visible_at_join_test() {
   assert_json_string(response, "user", "alice")
   close(client)
   stop_supervisor(server_pid)
+}
+
+/// Start a supervised channel system for tests.
+///
+/// beryl exposes no public unsupervised start, so tests stand up a real
+/// supervision tree the way an application would.
+fn start_supervised(
+  config: beryl.Config,
+) -> Result(beryl.Channels, actor.StartError) {
+  let supervised = supervisor.config(config)
+  use _root <- result.map(
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(supervisor.start(supervised))
+    |> static_supervisor.start(),
+  )
+  supervisor.channels(supervised)
 }

--- a/website/scripts/generate-reference.mjs
+++ b/website/scripts/generate-reference.mjs
@@ -157,6 +157,13 @@ function code(value) {
 	return `\`${String(value).replaceAll("`", "\\`")}\``;
 }
 
+/** Join items as prose: "a", "a and b", "a, b, and c". */
+function formatList(items) {
+	if (items.length <= 1) return items.join("");
+	if (items.length === 2) return `${items[0]} and ${items[1]}`;
+	return `${items.slice(0, -1).join(", ")}, and ${items.at(-1)}`;
+}
+
 function variableSymbol(id) {
 	return String.fromCharCode("a".charCodeAt(0) + (Number.isInteger(id) ? id : 0));
 }
@@ -284,24 +291,19 @@ ${moduleRows}`;
 		})
 		.join("\n\n");
 
-	const hexDocsLinks = packages
-		.map(
-			(packageInterface) =>
-				`[${packageInterface.name}](https://hexdocs.pm/${packageInterface.name}/)`,
-		)
-		.join(", ");
+	const packageList = formatList(
+		packages.map((packageInterface) => code(packageInterface.name)),
+	);
 
 	return `---
 title: API Reference
 description: Generated API reference from Gleam docs metadata.
 ---
 
-This reference is generated from Gleam's docs metadata for ${packages
-		.map((packageInterface) => code(packageInterface.name))
-		.join(" and ")}.
+This reference is generated from Gleam's docs metadata for ${packageList}.
 
 :::note[Generated content]
-Pages under \`${referenceBasePath}/\` are generated from Gleam's docs metadata and reflect every public type, function, and constant. The canonical, hosted API docs live on HexDocs: ${hexDocsLinks}.
+Pages under \`${referenceBasePath}/\` are generated from Gleam's docs metadata and reflect every public type, function, and constant. This is beryl's canonical API reference — beryl is not published to Hex yet, so there is no \`hexdocs.pm\` listing.
 :::
 
 ${packageSections}

--- a/website/scripts/generate-reference.test.mjs
+++ b/website/scripts/generate-reference.test.mjs
@@ -191,7 +191,12 @@ test("merges multiple packages into one grouped reference", async () => {
 		assert.match(index, /## `beryl` `9\.9\.9`/);
 		assert.match(index, /## `beryl_mist` `1\.2\.3`/);
 		assert.ok(index.indexOf("## `beryl`") < index.indexOf("## `beryl_mist`"));
-		assert.match(index, /hexdocs\.pm\/beryl_mist/);
+		// beryl is not on Hex, so the index must not link out to hexdocs
+		// (it may still mention hexdocs.pm to explain the absence).
+		assert.doesNotMatch(index, /https:\/\/hexdocs\.pm/);
+		assert.match(index, /canonical API reference/);
+		// Package names read as prose: "`beryl` and `beryl_mist`".
+		assert.match(index, /for `beryl` and `beryl_mist`\./);
 
 		const page = await readFile(path.join(outputDir, "beryl_mist.md"), "utf8");
 		assert.match(page, /Mist WebSocket transport\./);

--- a/website/src/content/docs/architecture/coordinator.md
+++ b/website/src/content/docs/architecture/coordinator.md
@@ -41,7 +41,7 @@ The registry lookup for topic matching uses `topic.matches`, which supports exac
 
 ## Heartbeat enforcement
 
-When `heartbeat_check_interval_ms` is greater than zero in `CoordinatorConfig`, the coordinator schedules a recurring self-message (`CheckHeartbeats`) at that interval. On each check it iterates all tracked sockets, compares the current monotonic time to `last_heartbeat`, and evicts any socket whose elapsed time exceeds `heartbeat_timeout_ms`. Eviction calls each joined topic's `terminate` callback, sends a disconnect notification over the socket's send function, then removes the socket from all state. By default `beryl.start` sets the check interval to half the timeout.
+When `heartbeat_check_interval_ms` is greater than zero in `CoordinatorConfig`, the coordinator schedules a recurring self-message (`CheckHeartbeats`) at that interval. On each check it iterates all tracked sockets, compares the current monotonic time to `last_heartbeat`, and evicts any socket whose elapsed time exceeds `heartbeat_timeout_ms`. Eviction calls each joined topic's `terminate` callback, sends a disconnect notification over the socket's send function, then removes the socket from all state. The supervised startup path sets the check interval to half the timeout.
 
 ## Supervision tree
 
@@ -76,5 +76,5 @@ PubSub is **not** part of this tree; it is backed by Erlang's `pg` module, which
 
 ## Where this lives
 
-- `src/beryl/coordinator.gleam` — `ChannelHandler`, `SocketContext`, `JoinResultErased`, `HandleResultErased`, `route_message`, `route_decoded`, `route_binary`, heartbeat timer.
-- `src/beryl/supervisor.gleam` — `SupervisedConfig`, stable named handles, and the `start` child specification; one-for-one isolation around a rest-for-one channel subtree.
+- `packages/beryl/src/beryl/coordinator.gleam` — `ChannelHandler`, `SocketContext`, `JoinResultErased`, `HandleResultErased`, `route_message`, `route_decoded`, `route_binary`, heartbeat timer.
+- `packages/beryl/src/beryl/supervisor.gleam` — `SupervisedConfig`, stable named handles, and the `start` child specification; one-for-one isolation around a rest-for-one channel subtree.

--- a/website/src/content/docs/architecture/message-lifecycle.md
+++ b/website/src/content/docs/architecture/message-lifecycle.md
@@ -108,6 +108,6 @@ The coordinator is a single OTP actor processing its mailbox sequentially; broad
 ## Where this lives
 
 - `packages/beryl_mist/src/beryl_mist.gleam` — connect/close, frame routing
-- `src/beryl/coordinator.gleam` — `route_message`, `route_decoded`, `route_binary`, heartbeat timer
-- `src/beryl/wire.gleam`, `src/beryl/wire/codec.gleam` — decode/encode frames
-- `src/beryl/pubsub.gleam` — fan-out
+- `packages/beryl/src/beryl/coordinator.gleam` — `route_message`, `route_decoded`, `route_binary`, heartbeat timer
+- `packages/beryl/src/beryl/wire.gleam`, `packages/beryl/src/beryl/wire/codec.gleam` — decode/encode frames
+- `packages/beryl/src/beryl/pubsub.gleam` — fan-out

--- a/website/src/content/docs/architecture/overview.md
+++ b/website/src/content/docs/architecture/overview.md
@@ -11,17 +11,17 @@ PubSub is the only cross-node primitive; everything else is local to a node.
 
 Each subsystem page covers one slice of the stack end-to-end and ends with a **"Where this lives"** pointer back to the relevant source files.
 
-- [Message Lifecycle](/architecture/message-lifecycle) — how a frame travels from WebSocket to channel handler and back
-- [Coordinator & Supervision](/architecture/coordinator) — OTP actor lifecycle, handler registry, and the supervision tree
-- [PubSub & Distribution](/architecture/pubsub-and-distribution) — Erlang `pg` groups, broadcast semantics, and cross-node delivery
-- [Presence](/architecture/presence) — CRDT-backed presence tracking, diffs, and replication
-- [Wire & Transport](/architecture/wire-and-transport) — codec contract, Phoenix framing, and the Mist WebSocket adapter
+- [Message Lifecycle](/architecture/message-lifecycle/) — how a frame travels from WebSocket to channel handler and back
+- [Coordinator & Supervision](/architecture/coordinator/) — OTP actor lifecycle, handler registry, and the supervision tree
+- [PubSub & Distribution](/architecture/pubsub-and-distribution/) — Erlang `pg` groups, broadcast semantics, and cross-node delivery
+- [Presence](/architecture/presence/) — CRDT-backed presence tracking, diffs, and replication
+- [Wire & Transport](/architecture/wire-and-transport/) — codec contract, Phoenix framing, and the WebSocket transport adapters
 
 ## The layer stack
 
 ```mermaid
 flowchart TB
-  T["WebSocket Transport<br/>beryl_mist"]
+  T["WebSocket Transport<br/>beryl_mist · beryl_ewe"]
   W["Wire Protocol<br/>beryl/wire · beryl/wire/codec"]
   subgraph Domain["Channel domain"]
     C["Channels<br/>beryl/channel"]
@@ -38,18 +38,19 @@ flowchart TB
 | Module | Responsibility | Page |
 |---|---|---|
 | `beryl` | Public entry-point: `config/1`, `start/1`, `register/3`, `broadcast/4`, `send_info/4` | — |
-| `beryl/coordinator` | Central OTP actor: handler registry, socket tracking, message routing, heartbeat enforcement | [Coordinator](/architecture/coordinator) |
-| `beryl/pubsub` | Distributed pub-sub via Erlang `pg`; subscribe, broadcast, and broadcast_from | [PubSub & Distribution](/architecture/pubsub-and-distribution) |
-| `beryl/presence` | OTP actor wrapping an add-wins OR-set CRDT; track/untrack, cross-node diff broadcast, `on_diff` callbacks | [Presence](/architecture/presence) |
-| `beryl/presence/wire` | Phoenix-compatible JSON encoding for presence diffs (`joins`/`leaves` maps) | [Presence](/architecture/presence) |
-| `beryl/wire` | Pluggable codec surface; ships `phoenix_codec()` for `[join_ref, ref, topic, event, payload]` framing | [Wire & Transport](/architecture/wire-and-transport) |
-| `beryl/wire/codec` | `Codec` type contract: `decode_text`, `decode_binary`, `encode_*` — lets you swap framing | [Wire & Transport](/architecture/wire-and-transport) |
-| `beryl_mist` | Mist WebSocket adapter: assigns socket IDs, registers send functions, routes frames to coordinator | [Wire & Transport](/architecture/wire-and-transport) |
-| `beryl/supervisor` | one-for-one supervision tree isolating an optional connection limiter from a nested rest-for-one channel subtree (registry → coordinator → presence → groups); returns a child specification via `start/1` | [Coordinator](/architecture/coordinator) |
+| `beryl/coordinator` | Central OTP actor: handler registry, socket tracking, message routing, heartbeat enforcement | [Coordinator](/architecture/coordinator/) |
+| `beryl/pubsub` | Distributed pub-sub via Erlang `pg`; subscribe, broadcast, and broadcast_from | [PubSub & Distribution](/architecture/pubsub-and-distribution/) |
+| `beryl/presence` | OTP actor wrapping an add-wins OR-set CRDT; track/untrack, cross-node diff broadcast, `on_diff` callbacks | [Presence](/architecture/presence/) |
+| `beryl/presence/wire` | Phoenix-compatible JSON encoding for presence diffs (`joins`/`leaves` maps) | [Presence](/architecture/presence/) |
+| `beryl/wire` | Pluggable codec surface; ships `phoenix_codec()` for `[join_ref, ref, topic, event, payload]` framing | [Wire & Transport](/architecture/wire-and-transport/) |
+| `beryl/wire/codec` | `Codec` type contract: `decode_text`, `decode_binary`, `encode_*` — lets you swap framing | [Wire & Transport](/architecture/wire-and-transport/) |
+| `beryl_mist` | Mist WebSocket adapter: assigns socket IDs, registers send functions, routes frames to coordinator | [Wire & Transport](/architecture/wire-and-transport/) |
+| `beryl_ewe` | Ewe WebSocket adapter; mirrors the `beryl_mist` API against the same `beryl/transport` SPI | [Wire & Transport](/architecture/wire-and-transport/) |
+| `beryl/supervisor` | one-for-one supervision tree isolating an optional connection limiter from a nested rest-for-one channel subtree (registry → coordinator → presence → groups); returns a child specification via `start/1` | [Coordinator](/architecture/coordinator/) |
 | `beryl/group` | Named topic collections managed by an OTP actor; supports grouped broadcast | — |
 | `beryl/topic` | Topic pattern matching: exact strings, `"ns:*"` prefix wildcards, and segment wildcards (`"document:*:ops"`) | — |
 | `beryl/socket` | Opaque connected-client type with typed assigns; `id`, `get_assigns`, `set_assigns`, `map_assigns` | — |
-| `beryl/channel` | Builder API for user-defined message handlers parameterized by an `assigns` type | [Message Lifecycle](/architecture/message-lifecycle) |
+| `beryl/channel` | Builder API for user-defined message handlers parameterized by an `assigns` type | [Message Lifecycle](/architecture/message-lifecycle/) |
 | `beryl/error` | Opaque `StartFailure` type that hides OTP's `actor.StartError` from public APIs | — |
 | `beryl/rate_limit` | Token-bucket rate limiter backed by an OTP registry actor; keyed by socket ID or topic | — |
 | `beryl/bridge` | Forwards an external OTP actor's message stream into a socket channel; avoids per-socket forwarder boilerplate | — |
@@ -73,7 +74,7 @@ flowchart TB
 
 ## Where things live
 
-All source files live under `src/beryl/`.
-The coordinator and supervisor are the entry points for understanding runtime behaviour — start with [Coordinator & Supervision](/architecture/coordinator).
-For how a message actually moves through the system, see [Message Lifecycle](/architecture/message-lifecycle).
-For cross-node concerns, see [PubSub & Distribution](/architecture/pubsub-and-distribution).
+beryl is a monorepo. Core library sources live under `packages/beryl/src/`, and each transport is its own package (`packages/beryl_mist/src/`, `packages/beryl_ewe/src/`).
+The coordinator and supervisor are the entry points for understanding runtime behaviour — start with [Coordinator & Supervision](/architecture/coordinator/).
+For how a message actually moves through the system, see [Message Lifecycle](/architecture/message-lifecycle/).
+For cross-node concerns, see [PubSub & Distribution](/architecture/pubsub-and-distribution/).

--- a/website/src/content/docs/architecture/presence.md
+++ b/website/src/content/docs/architecture/presence.md
@@ -84,5 +84,5 @@ sequenceDiagram
 
 | File | Role |
 |---|---|
-| `src/beryl/presence.gleam` | OTP actor, public API, CRDT wiring, PubSub subscription and broadcast |
-| `src/beryl/presence/wire.gleam` | Wire helpers for encoding and decoding presence diffs over the channel protocol |
+| `packages/beryl/src/beryl/presence.gleam` | OTP actor, public API, CRDT wiring, PubSub subscription and broadcast |
+| `packages/beryl/src/beryl/presence/wire.gleam` | Wire helpers for encoding and decoding presence diffs over the channel protocol |

--- a/website/src/content/docs/architecture/pubsub-and-distribution.md
+++ b/website/src/content/docs/architecture/pubsub-and-distribution.md
@@ -12,7 +12,7 @@ Each PubSub instance is isolated by a **scope** (an Erlang atom). The default sc
 
 ## The FFI Boundary
 
-The Gleam module `beryl/pubsub` delegates all low-level pg operations to `src/beryl_pubsub_ffi.erl` via `@external` declarations. The FFI file is intentionally minimal — it is a thin wrapper that maps Gleam calls directly to `pg` BIFs.
+The Gleam module `beryl/pubsub` delegates all low-level pg operations to `packages/beryl/src/beryl_pubsub_ffi.erl` via `@external` declarations. The FFI file is intentionally minimal — it is a thin wrapper that maps Gleam calls directly to `pg` BIFs.
 
 **Public surface of `beryl/pubsub`:**
 
@@ -93,5 +93,5 @@ distribution, EPMD port restrictions, and cluster isolation).
 
 | File | Role |
 |---|---|
-| `src/beryl/pubsub.gleam` | Public Gleam API — types, config, and all broadcast functions |
-| `src/beryl_pubsub_ffi.erl` | Erlang FFI — thin `pg` wrappers called via `@external` |
+| `packages/beryl/src/beryl/pubsub.gleam` | Public Gleam API — types, config, and all broadcast functions |
+| `packages/beryl/src/beryl_pubsub_ffi.erl` | Erlang FFI — thin `pg` wrappers called via `@external` |

--- a/website/src/content/docs/architecture/wire-and-transport.md
+++ b/website/src/content/docs/architecture/wire-and-transport.md
@@ -9,7 +9,7 @@ The wire and transport layer sits between raw WebSocket frames and the coordinat
 A `Codec` is a plain data value that pairs a decoder with a set of encoders. The coordinator is framing-agnostic: it only ever sees `Inbound` values and emits `Frame` values; the codec performs every translation.
 
 ```
-src/beryl/wire/codec.gleam
+packages/beryl/src/beryl/wire/codec.gleam
 ```
 
 The `Codec` type carries five fields:
@@ -22,7 +22,7 @@ The `Codec` type carries five fields:
 | `encode_push` | Encode a server-initiated push |
 | `encode_heartbeat_reply` | Encode the heartbeat acknowledgement |
 
-The built-in `phoenix_codec()` (from `src/beryl/wire.gleam`) wires the Phoenix JSON framing into all five slots and is the default codec. Pass it to `beryl.config/1` to use it:
+The built-in `phoenix_codec()` (from `packages/beryl/src/beryl/wire.gleam`) wires the Phoenix JSON framing into all five slots. `beryl.config/1` takes the codec as a required argument — there is no implicit default — so pass it explicitly:
 
 ```gleam
 beryl.config(wire.phoenix_codec())
@@ -92,6 +92,6 @@ flowchart LR
 
 | Module | Path |
 |---|---|
-| Codec abstraction | `src/beryl/wire/codec.gleam` |
-| Phoenix wire helpers | `src/beryl/wire.gleam` |
+| Codec abstraction | `packages/beryl/src/beryl/wire/codec.gleam` |
+| Phoenix wire helpers | `packages/beryl/src/beryl/wire.gleam` |
 | Mist transport | `packages/beryl_mist/src/beryl_mist.gleam` |

--- a/website/src/content/docs/examples.mdx
+++ b/website/src/content/docs/examples.mdx
@@ -11,7 +11,7 @@ directory. They use a Gleam/BEAM backend with browser frontends that exercise
 different realtime collaboration patterns.
 
 <Aside type="caution" title="Pre-1.0 Software">
-beryl is not yet 1.0. The API is unstable and features may be removed in minor releases.
+beryl is not yet 1.0. The API is unstable, features may be removed in minor releases, and quality should not be considered production-ready. We welcome usage and feedback in the meantime!
 </Aside>
 
 ## Collaborative Cursors

--- a/website/src/content/docs/guides/authentication.md
+++ b/website/src/content/docs/guides/authentication.md
@@ -9,7 +9,7 @@ from the handshake, verify it into typed **claims**, seed those claims as the
 socket's initial assigns, and then authorize individual topic joins.
 
 For the mechanics of `with_on_connect` and rejection behavior, see the
-[WebSocket Transport guide](/guides/websocket#authentication). This page focuses
+[WebSocket Transport guide](/guides/websocket/#authentication). This page focuses
 on wiring *real* auth end to end.
 
 ## 1. Model your claims
@@ -138,6 +138,6 @@ fn has_role(claims: Claims, role: String) -> Bool {
 - **Cookie sessions need origin checks.** If you authenticate from a cookie
   instead of a token, always pair it with `with_allowed_origins` to prevent
   Cross-Site WebSocket Hijacking. See
-  [Origin validation and CSWSH](/guides/websocket#origin-validation-and-cswsh).
+  [Origin validation and CSWSH](/guides/websocket/#origin-validation-and-cswsh).
 - **Rejection shape.** For the client-visible error when a join or connection is
-  refused, see [Error Handling](/guides/error-handling#connection-level-authentication-rejection).
+  refused, see [Error Handling](/guides/error-handling/#connection-level-authentication-rejection).

--- a/website/src/content/docs/guides/backend-integration.md
+++ b/website/src/content/docs/guides/backend-integration.md
@@ -12,7 +12,7 @@ connected sockets.
 This guide wires up that split:
 
 1. The existing backend authenticates users and issues a token.
-2. beryl verifies that token at connect (see [Authentication](/guides/authentication)).
+2. beryl verifies that token at connect (see [Authentication](/guides/authentication/)).
 3. When domain data changes, the backend calls an **internal publish endpoint**
    on the beryl service, which forwards the change with `beryl.broadcast`.
 
@@ -157,8 +157,8 @@ fn not_found() -> Response(mist.ResponseData) {
 - **Push from anywhere.** Any backend process — an HTTP handler, a background job,
   a webhook consumer — can publish by POSTing to the internal endpoint.
 - **Distributed fan-out for free.** If beryl runs as a cluster, use the
-  [PubSub layer](/guides/pubsub) so a broadcast on one node reaches subscribers on
+  [PubSub layer](/guides/pubsub/) so a broadcast on one node reaches subscribers on
   every node.
 
 For the connect-time verification of the tokens your backend issues, see the
-[Authentication guide](/guides/authentication).
+[Authentication guide](/guides/authentication/).

--- a/website/src/content/docs/guides/channels.md
+++ b/website/src/content/docs/guides/channels.md
@@ -89,15 +89,19 @@ pub fn new() -> Channel(RoomAssigns, info) {
 
 Called when a client sends a `phx_join` message. Return `JoinOk` to accept or `JoinError` to reject:
 
+The callback's first argument is the topic string. Name it something other than
+`topic` if you also import the `beryl/topic` module — a local binding named
+`topic` shadows the module and its functions become unreachable:
+
 ```gleam
 fn join(
-  topic: String,
+  topic_name: String,
   payload: Dynamic,
   socket: Socket(RoomAssigns),
 ) -> JoinResult(RoomAssigns) {
   // Extract room ID from topic pattern
   let assert Ok(room_id) =
-    topic.extract_id(topic.Wildcard("room:"), topic)
+    topic.extract_id(topic.Wildcard("room:"), topic_name)
 
   let assigns = RoomAssigns(user_id: "user_123", room_id: room_id)
   let socket = socket.set_assigns(socket, assigns)
@@ -114,8 +118,10 @@ If every topic needs the same per-socket auth (e.g. the same JWT), validate it
 check in every `join`. `on_connect` runs once per socket, can reject the whole
 connection before any join, and can seed initial assigns that this `join`
 callback reads via `socket.get_assigns`. See
-[WebSocket Transport → Authentication](/guides/websocket#authentication).
+[WebSocket Transport → Authentication](/guides/websocket/#authentication).
 :::
+
+### Message handler
 
 Called for each incoming text message. The `event` string identifies the message type:
 
@@ -207,7 +213,7 @@ The handler receives the **typed** message you sent — there is no `Dynamic` an
 
 ```gleam
 type ServerMessage {
-  Tick(at: Int)
+  Tick(sequence: Int)
   Notify(text: String)
 }
 
@@ -216,10 +222,10 @@ fn handle_info(
   socket: Socket(RoomAssigns),
 ) -> HandleResult(RoomAssigns) {
   case message {
-    Tick(at) ->
+    Tick(sequence) ->
       channel.Push(
         "tick",
-        json.object([#("at", json.int(at))]),
+        json.object([#("sequence", json.int(sequence))]),
         socket,
       )
     Notify(text) ->
@@ -254,29 +260,50 @@ If the socket is not connected, the topic is not joined, or no `handle_info` is 
 
 A common use case is scheduling periodic pushes to a specific client. Spawn a process when the client joins and cancel it in `terminate`:
 
+The channel needs a `beryl.Channels` handle to send to itself, so capture one
+when you build the channel and close over it in the join callback:
+
 ```gleam
+import beryl
 import gleam/erlang/process
 
-fn join(topic, _payload, socket) -> JoinResult(RoomAssigns) {
+pub fn new(channels: beryl.Channels) -> Channel(RoomAssigns, ServerMessage) {
+  channel.new(fn(topic_name, _payload, socket) {
+    join(channels, topic_name, socket)
+  })
+  |> channel.with_handle_info(handle_info)
+}
+
+fn join(
+  channels: beryl.Channels,
+  topic_name: String,
+  socket: Socket(RoomAssigns),
+) -> JoinResult(RoomAssigns) {
   let socket_id = socket.id(socket)
 
-  // Spawn a timer process that sends a tick every 5 seconds
-  let _pid = process.spawn(fn() {
-    let rec = process.new_subject()
-    timer_loop(channels, socket_id, topic, rec)
-  })
+  // Spawn a timer process that sends a tick every 5 seconds. Spawn it
+  // unlinked so the timer dying cannot take the coordinator down with it.
+  let _pid =
+    process.spawn_unlinked(fn() {
+      timer_loop(channels, socket_id, topic_name, 0)
+    })
 
   channel.JoinOk(reply: None, socket: socket)
 }
 
-fn timer_loop(channels, socket_id, topic, _self) {
+fn timer_loop(
+  channels: beryl.Channels,
+  socket_id: String,
+  topic_name: String,
+  sequence: Int,
+) -> Nil {
   process.sleep(5000)
-  beryl.send_info(channels, socket_id, topic, Tick(erlang.system_time(erlang.Millisecond)))
-  timer_loop(channels, socket_id, topic, _self)
+  beryl.send_info(channels, socket_id, topic_name, Tick(sequence))
+  timer_loop(channels, socket_id, topic_name, sequence + 1)
 }
 ```
 
-For production use, prefer OTP-based timers (e.g., Erlang's `:timer.send_interval`) over bare recursion, and track the timer PID in assigns so you can cancel it in `terminate`.
+This loop runs until the process is killed. For production use, prefer OTP-based timers (e.g. Erlang's `timer:send_interval`) over bare recursion, and keep the timer's PID in assigns so `terminate` can cancel it — otherwise the loop outlives the socket and `send_info` keeps firing into a topic nobody has joined.
 
 ## Registering channels
 
@@ -284,15 +311,28 @@ Register channels with the beryl system using topic patterns:
 
 ```gleam
 import beryl
+import beryl/supervisor
 import beryl/wire
+import gleam/otp/static_supervisor
 
-let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
+let beryl_config = supervisor.config(beryl.config(wire.phoenix_codec()))
+
+let assert Ok(_root) =
+  static_supervisor.new(static_supervisor.OneForOne)
+  |> static_supervisor.add(supervisor.start(beryl_config))
+  |> static_supervisor.start()
+
+let channels = supervisor.channels(beryl_config)
 
 // Register handlers for different topic patterns
 let assert Ok(_) = beryl.register(channels, "room:*", room_channel.new())
 let assert Ok(_) = beryl.register(channels, "user:*", user_channel.new())
 let assert Ok(_) = beryl.register(channels, "system", system_channel.new())
 ```
+
+Register channels after the root supervisor is running — `supervisor.channels`
+resolves a stable named subject, so the handle keeps routing to replacement
+processes after a restart. See the [Supervision guide](/guides/supervision/).
 
 ## Broadcasting
 

--- a/website/src/content/docs/guides/groups.md
+++ b/website/src/content/docs/guides/groups.md
@@ -95,10 +95,17 @@ This is equivalent to calling `beryl.broadcast` on each topic in the group in se
 
 ## Error reference
 
-| Error | When |
+Group operations return `GroupError`:
+
+| `GroupError` | When |
 |-------|------|
 | `GroupAlreadyExists` | `create` called for a name already in use |
 | `GroupNotFound` | `delete`, `add`, `remove`, or `topics` called for an unknown group name |
+
+Startup has its own separate type, `GroupStartError`:
+
+| `GroupStartError` | When |
+|-------|------|
 | `GroupActorStartFailed` | `group.start()` — the internal group actor failed to initialize |
 
 ## Full example: team rooms
@@ -136,6 +143,7 @@ When using `beryl/supervisor`, enable groups in the supervised configuration, ad
 
 ```gleam
 import beryl
+import beryl/group
 import beryl/supervisor
 import beryl/wire
 import gleam/option.{None, Some}
@@ -157,4 +165,4 @@ case supervisor.groups(beryl) {
 }
 ```
 
-See the [Supervision guide](/guides/supervision) for details on the supervised startup pattern.
+See the [Supervision guide](/guides/supervision/) for details on the supervised startup pattern.

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -42,16 +42,18 @@ import gleam/json
 let ref = presence.track(
   p,
   "room:lobby",   // topic
-  "user:alice",    // key (groups multiple connections)
-  socket_id,       // pid (unique per connection)
-  json.object([    // metadata
+  "user:alice",   // key (groups multiple connections)
+  socket_id,      // session id (unique per connection)
+  json.object([   // metadata
     #("status", json.string("online")),
     #("joined_at", json.int(1234567890)),
   ]),
 )
 ```
 
-The **key** groups multiple connections from the same user. The **pid** uniquely identifies each connection (typically the socket ID).
+The **key** groups multiple connections from the same user — every browser tab
+signed in as `alice` shares one key. The **session id** identifies a single
+connection; pass the socket ID, which is what `untrack_all` expects later.
 
 ## Untracking
 

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -173,6 +173,8 @@ for the full trust-boundary and distribution-hardening reference.
   sheds oversized frames and (when configured) rate-limited traffic before
   it, but extreme fan-out workloads may want multiple channels systems
   sharded by topic space.
-- If beryl is embedded in your own supervision tree via
-  `supervisor.start`, restarts of the beryl subtree are bounded by a
-  rest-for-one strategy with an intensity of 3 restarts per 5 seconds.
+- If beryl is embedded in your own supervision tree via `supervisor.start`,
+  the subtree has a one-for-one parent wrapping a rest-for-one channel
+  supervisor, and restarts are bounded at 3 per 5 seconds before the beryl
+  supervisor shuts down and defers to its parent. See the
+  [Supervision guide](/guides/supervision/) for the full tree.

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -4,6 +4,8 @@ title: PubSub
 
 beryl's PubSub layer provides distributed publish/subscribe messaging built on Erlang's `pg` (process groups) module.
 
+PubSub is generic over its payload type: a `PubSub(payload)` carries values of whatever type you choose, and every broadcast and subscribe function is typed against it. beryl's own channel broadcasts use `PubSub(json.Json)`.
+
 ## Starting PubSub
 
 ```gleam
@@ -14,6 +16,12 @@ let ps = pubsub.start(pubsub.default_config())
 
 // Custom scope (isolates process groups)
 let ps = pubsub.start(pubsub.config_with_scope("my_app_pubsub"))
+```
+
+The payload type is inferred from how you use `ps`. Annotate it when you want it pinned explicitly:
+
+```gleam
+let ps: pubsub.PubSub(json.Json) = pubsub.start(pubsub.default_config())
 ```
 
 The scope maps to a `pg` scope atom. Different scopes are completely isolated from each other.
@@ -41,14 +49,14 @@ pubsub.unsubscribe(ps, "room:lobby")
 
 ## Messages
 
-Subscribers receive `Message` records:
+Subscribers receive `Message(payload)` records:
 
 ```gleam
-pub type Message {
+pub type Message(payload) {
   Message(
     topic: String,
     event: String,
-    payload: json.Json,
+    payload: payload,
     from: PubSubFrom,
   )
 }
@@ -61,6 +69,35 @@ pub type PubSubFrom {
 ```
 
 `FromSocket` carries both the sending process PID and a socket ID to exclude. Receiving coordinators use this to suppress delivery to the named socket, so that `beryl.broadcast_from` correctly excludes the sender across cluster nodes.
+
+### Receiving messages with `selecting`
+
+`pg` tracks bare `Pid`s, so a broadcast arrives as a **raw process message** rather than through a typed `Subject`. Use `pubsub.selecting` to recover it — it is the only supported way to turn that raw shape back into a `Message(payload)`:
+
+```gleam
+import gleam/erlang/process
+
+pub type AppMessage {
+  RemoteBroadcast(pubsub.Message(json.Json))
+}
+
+let selector =
+  process.new_selector()
+  |> process.select(my_subject)
+  |> pubsub.selecting(RemoteBroadcast)
+```
+
+:::danger[Never match on the raw message yourself]
+Do not build your own `select_record` matcher for `Message` or coerce the raw
+term. `selecting` is the one place that knows the record's runtime shape; going
+around it means a change to that shape becomes a silent mis-parse in your code.
+:::
+
+### The frozen wire contract
+
+`Message` is sent **raw between nodes** via `pg`, so for any given `payload` type its runtime shape — the record tag and its four fields, in order — is a frozen wire contract, not just a source-level API. A rolling cluster upgrade must never mis-parse a frame from an older node. The same applies to `PubSubFrom`.
+
+Because payloads travel as native BEAM terms rather than a self-describing format like JSON, evolving the shape of *your own* `payload` type is also a wire change. Version it yourself (for example with an explicit `v` field) if it has to change across a rolling upgrade.
 
 ## Broadcasting
 
@@ -115,11 +152,21 @@ The channel system uses PubSub internally for distributed broadcasts when config
 
 ```gleam
 import beryl
+import beryl/supervisor
 import beryl/wire
+import gleam/otp/static_supervisor
 
 let ps = pubsub.start(pubsub.default_config())
-let config = beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps)
-let assert Ok(channels) = beryl.start(config)
+
+let beryl_config =
+  supervisor.config(beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(ps))
+
+let assert Ok(_root) =
+  static_supervisor.new(static_supervisor.OneForOne)
+  |> static_supervisor.add(supervisor.start(beryl_config))
+  |> static_supervisor.start()
+
+let channels = supervisor.channels(beryl_config)
 
 // beryl.broadcast() now sends to all nodes automatically
 beryl.broadcast(channels, "room:lobby", "event", payload)

--- a/website/src/content/docs/guides/supervision.md
+++ b/website/src/content/docs/guides/supervision.md
@@ -2,7 +2,9 @@
 title: Supervision
 ---
 
-`beryl/supervisor` integrates Beryl into your application's OTP supervision tree. It does not expose a separate function that starts an unmanaged Beryl process. Instead, `supervisor.start` returns a supervisor child specification for your root supervisor.
+`beryl/supervisor` integrates Beryl into your application's OTP supervision tree. `supervisor.start` returns a supervisor child specification that you add to your own root supervisor, rather than starting a process itself.
+
+This is the only way to start Beryl. There is deliberately no unsupervised entry point: a channel system with nothing watching it stays down after a coordinator crash, stranding every connected socket, so the API does not offer that as a choice.
 
 ## Add Beryl to your application supervisor
 

--- a/website/src/content/docs/guides/websocket.md
+++ b/website/src/content/docs/guides/websocket.md
@@ -2,21 +2,64 @@
 title: WebSocket Transport
 ---
 
-beryl provides a WebSocket transport layer that integrates directly with [Mist](https://hexdocs.pm/mist/) for handling browser client connections.
+beryl serves channels over WebSockets through a transport package. Two are
+available and expose the same API:
+
+| Package | Web server |
+|---|---|
+| `beryl_mist` | [Mist](https://hexdocs.pm/mist/) |
+| `beryl_ewe` | [Ewe](https://hexdocs.pm/ewe/) |
+
+This guide uses `beryl_mist`. Every example applies to `beryl_ewe` with
+`ewe_transport` substituted for `mist_transport` — the config builders,
+`on_connect` hook, origin validation, and handler functions are identical.
 
 ## Basic setup
 
-The simplest way to add WebSocket support is with `mist_transport.upgrade`:
+`mist_transport.handler` composes the WebSocket upgrade and your regular HTTP
+handler into a single request handler, so it is the shortest path to a working
+server:
 
 ```gleam
 import beryl
 import beryl_mist as mist_transport
 import gleam/bytes_tree
-import gleam/http/request
 import gleam/http/request.{type Request}
 import gleam/http/response
 import mist
 
+pub fn start(channels: beryl.Channels) {
+  mist_transport.handler(
+    channels,
+    mist_transport.default_config("/socket/websocket"),
+    handle_http,
+  )
+  |> mist.new
+  |> mist.port(8000)
+  |> mist.start
+}
+
+fn handle_http(
+  req: Request(mist.Connection),
+) -> response.Response(mist.ResponseData) {
+  case request.path_segments(req) {
+    [] -> response.new(200) |> response.set_body(mist.Bytes(bytes_tree.new()))
+    _ -> response.new(404) |> response.set_body(mist.Bytes(bytes_tree.new()))
+  }
+}
+```
+
+WebSocket upgrades on the configured path go to beryl; everything else falls
+through to `handle_http`.
+
+### Driving the upgrade yourself
+
+When you need the upgrade decision inside your own routing — to run middleware
+first, or to mount the socket conditionally — use `mist_transport.upgrade`
+directly. It matches the request path, performs the upgrade, and calls the
+continuation when the path does not match:
+
+```gleam
 fn handle_request(
   req: Request(mist.Connection),
   channels: beryl.Channels,
@@ -29,14 +72,9 @@ fn handle_request(
   )
 
   // Non-WebSocket requests fall through here
-  case request.path_segments(req) {
-    [] -> response.new(200) |> response.set_body(mist.Bytes(bytes_tree.new()))
-    _ -> response.new(404) |> response.set_body(mist.Bytes(bytes_tree.new()))
-  }
+  handle_http(req)
 }
 ```
-
-The `upgrade` function checks if the request path matches, performs the WebSocket upgrade, and wires the connection to the beryl coordinator.
 
 :::tip[Phoenix JS clients]
 The Phoenix JS client (`new Socket("/socket", ...)`) connects to `/socket/websocket` by default — it appends `/websocket` to the path you pass. Configure the transport path to match:
@@ -69,7 +107,7 @@ let config =
 use <- mist_transport.upgrade(req, channels, config)
 ```
 
-Returning `Error(mist_transport.ConnectRejected)` sends an HTTP 403 before the WebSocket upgrade. See [Connection-level authentication rejection](/guides/error-handling#connection-level-authentication-rejection) for the client-visible error shape and [Authentication failures](/troubleshooting#authentication-failures) for diagnosis steps.
+Returning `Error(mist_transport.ConnectRejected)` sends an HTTP 403 before the WebSocket upgrade. See [Connection-level authentication rejection](/guides/error-handling/#connection-level-authentication-rejection) for the client-visible error shape and [Authentication failures](/troubleshooting/#authentication-failures) for diagnosis steps.
 
 ### Origin validation and CSWSH
 
@@ -146,7 +184,7 @@ fn handle_request(req, channels) -> response.Response(mist.ResponseData) {
 Note: `upgrade_connection` does not invoke the `on_connect` callback. Run your own auth check before calling it.
 
 :::tip[Troubleshooting connections]
-If clients cannot connect, see [Clients cannot connect at all](/troubleshooting#clients-cannot-connect-at-all) for path mismatch, reverse proxy, and upgrade header checks.
+If clients cannot connect, see [Clients cannot connect at all](/troubleshooting/#clients-cannot-connect-at-all) for path mismatch, reverse proxy, and upgrade header checks.
 :::
 
 ## Wire protocol

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -97,7 +97,7 @@ import { Aside } from '@astrojs/starlight/components';
 		</li>
 		<li>
 			<h3>See it running</h3>
-			<p>Browse complete, runnable examples, then go deeper in the <a href="/guides/channels/">guides</a> or the <a href="https://hexdocs.pm/beryl/">API reference</a>.</p>
+			<p>Browse complete, runnable examples, then go deeper in the <a href="/guides/channels/">guides</a> or the <a href="/reference/api/">API reference</a>.</p>
 			<a class="beryl-path__go" href="/examples/">View examples →</a>
 		</li>
 	</ol>

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -74,17 +74,6 @@ import { Aside } from '@astrojs/starlight/components';
     color: var(--sl-color-gray-2);
     text-wrap: pretty;
   }
-  .beryl-path .beryl-path__cmd {
-    margin: 0.7rem 0 0.2rem;
-  }
-  .beryl-path .beryl-path__cmd code {
-    font-size: 0.95em;
-    background: var(--beryl-surface);
-    border: 1px solid var(--beryl-hairline);
-    color: var(--sl-color-white);
-    padding: 0.4em 0.75em;
-    border-radius: 8px;
-  }
   .beryl-path__go {
     display: inline-block;
     margin-top: 0.75rem;
@@ -98,8 +87,7 @@ import { Aside } from '@astrojs/starlight/components';
 	<ol>
 		<li>
 			<h3>Install beryl</h3>
-			<p>Add beryl and its BEAM dependencies to your Gleam project.</p>
-			<p class="beryl-path__cmd"><code>gleam add beryl</code></p>
+			<p>Add beryl and its BEAM dependencies to your Gleam project. beryl installs as a git dependency, which needs <strong>Gleam 1.18+</strong>.</p>
 			<a class="beryl-path__go" href="/installation/">Installation guide →</a>
 		</li>
 		<li>

--- a/website/src/content/docs/installation.md
+++ b/website/src/content/docs/installation.md
@@ -3,7 +3,7 @@ title: Installation
 ---
 
 :::caution[Pre-1.0 Software]
-beryl is not yet 1.0. The API is unstable and features may be removed in minor releases.
+beryl is not yet 1.0. The API is unstable, features may be removed in minor releases, and quality should not be considered production-ready. We welcome usage and feedback in the meantime!
 :::
 
 beryl is not yet published to Hex. Add it to your Gleam project as a git

--- a/website/src/content/docs/installation.md
+++ b/website/src/content/docs/installation.md
@@ -6,19 +6,54 @@ title: Installation
 beryl is not yet 1.0. The API is unstable and features may be removed in minor releases.
 :::
 
-Add beryl to your Gleam project:
+beryl is not yet published to Hex. Add it to your Gleam project as a git
+dependency by editing `gleam.toml`:
 
-```bash
-gleam add beryl
+```toml
+[dependencies]
+beryl = { git = "https://github.com/tylerbutler/beryl.git", ref = "v0.0", path = "packages/beryl" }
+beryl_mist = { git = "https://github.com/tylerbutler/beryl.git", ref = "v0.0", path = "packages/beryl_mist" }
 ```
 
-This adds beryl to your `gleam.toml` dependencies. beryl targets the **Erlang (BEAM)** runtime — it does not support the JavaScript target.
+Then download the dependencies:
+
+```bash
+gleam deps download
+```
+
+`gleam add` only works with Hex packages, so the dependency has to be written by
+hand.
+
+`beryl` is the core channels library. `beryl_mist` is the
+[Mist](https://hex.pm/packages/mist) WebSocket transport; if you prefer
+[Ewe](https://hex.pm/packages/ewe), use `path = "packages/beryl_ewe"` instead.
+Both transports live in the same repository, so they share the `git` and `ref`
+values.
+
+beryl targets the **Erlang (BEAM)** runtime — it does not support the JavaScript target.
 
 ## Requirements
 
-- **Gleam** >= 1.13.0
+- **Gleam** >= 1.18.0
 - **Erlang/OTP** >= 26 (recommended: 27+)
 - **Target**: Erlang only
+
+### Why Gleam 1.18?
+
+beryl is a monorepo: the packages live in subdirectories (`packages/beryl`,
+`packages/beryl_mist`, `packages/beryl_ewe`) rather than at the repository root.
+Pointing a git dependency at a subdirectory needs the `path` field, which Gleam
+added in 1.18. Gleam 1.17 and earlier have no way to point a git dependency at
+anything but the repository root, so beryl cannot be used as a dependency from
+those versions.
+
+## Choosing a ref
+
+The `ref` above pins the [`v0.0`](https://github.com/tylerbutler/beryl/releases)
+tag. Pin a tag rather than a branch: git dependencies are resolved at the exact
+ref you name, and beryl is pre-1.0, so tracking `main` can pull in breaking
+changes without warning. Use the same `ref` for `beryl` and its transport
+package — mixing versions across the two is unsupported.
 
 ## Dependencies
 

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -56,7 +56,7 @@ beryl uses the same JSON array wire format as Phoenix channels (`[join_ref, ref,
 ## Next steps
 
 - [Quick Start](/quick-start/) — get a working server in minutes
-- [Channels guide](/guides/channels) — topics, callbacks, and broadcasting
-- [Supervision guide](/guides/supervision) — production startup with OTP supervision
-- [Error Handling guide](/guides/error-handling) — rejected joins, rate limits, and more
-- [Troubleshooting](/troubleshooting) — symptom-first diagnostics
+- [Channels guide](/guides/channels/) — topics, callbacks, and broadcasting
+- [Supervision guide](/guides/supervision/) — production startup with OTP supervision
+- [Error Handling guide](/guides/error-handling/) — rejected joins, rate limits, and more
+- [Troubleshooting](/troubleshooting/) — symptom-first diagnostics

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -6,7 +6,7 @@ description: Build your first beryl channel end-to-end — server callbacks, Web
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
 <Aside type="caution" title="Pre-1.0 Software">
-beryl is not yet 1.0. The API is unstable and features may be removed in minor releases.
+beryl is not yet 1.0. The API is unstable, features may be removed in minor releases, and quality should not be considered production-ready. We welcome usage and feedback in the meantime!
 </Aside>
 
 This guide walks you through building a working real-time channel from scratch:
@@ -47,7 +47,7 @@ import beryl/socket.{type Socket}
 import gleam/dynamic.{type Dynamic}
 import gleam/dynamic/decode
 import gleam/json
-import gleam/option.{None, Some}
+import gleam/option.{Some}
 
 /// Per-socket state for this channel.
 pub type RoomAssigns {
@@ -176,17 +176,15 @@ pub fn main() {
   let assert Ok(_) =
     beryl.register(channels, "room:*", room_channel.new(channels))
 
-  // Start the HTTP + WebSocket server.
+  // Start the HTTP + WebSocket server. `handler` composes the WebSocket
+  // upgrade with your HTTP handler: upgrades on the configured path go to
+  // beryl, everything else falls through to `handle_http`.
   let assert Ok(_) =
-    fn(req) {
-      // Upgrade WebSocket requests first; fall through to HTTP for everything else.
-      mist_transport.upgrade(
-        req,
-        channels,
-        mist_transport.default_config("/socket/websocket"),
-        fn() { handle_http(req) },
-      )
-    }
+    mist_transport.handler(
+      channels,
+      mist_transport.default_config("/socket/websocket"),
+      handle_http,
+    )
     |> mist.new
     |> mist.port(8000)
     |> mist.start
@@ -322,7 +320,7 @@ The client receives an `"error"` reply on its `.join()` call.
 
 ## Next steps
 
-- Explore the full [examples](/examples/) — two runnable demos with HTML frontends
+- Explore the full [examples](/examples/) — three runnable demos with HTML frontends
 - Learn about [Channels](/guides/channels/) in depth — topic patterns, handle_out, terminate
 - Add [Presence tracking](/guides/presence/) to see who's online
 - Set up [PubSub](/guides/pubsub/) for distributed messaging

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -19,8 +19,20 @@ runnable application with HTML, static assets, and end-to-end tests, see the
 
 ## Prerequisites
 
+- **Gleam 1.18 or later** — beryl is installed as a git dependency pointing at a
+  subdirectory of its monorepo, and the `path` field that makes that possible
+  was added in Gleam 1.18
 - Gleam project targeting **Erlang** (`gleam new my_app`)
-- `gleam add beryl beryl_mist` adds beryl, the Mist WebSocket transport, and all their dependencies
+- beryl and the Mist WebSocket transport in your `gleam.toml`:
+
+  ```toml
+  [dependencies]
+  beryl = { git = "https://github.com/tylerbutler/beryl.git", ref = "v0.0", path = "packages/beryl" }
+  beryl_mist = { git = "https://github.com/tylerbutler/beryl.git", ref = "v0.0", path = "packages/beryl_mist" }
+  ```
+
+  Run `gleam deps download` to fetch them and their transitive dependencies. See
+  the [installation guide](/installation/) for details.
 
 ## 1. Define a channel
 

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -173,31 +173,6 @@ A handler is already registered for this exact topic pattern.
 The topic pattern is invalid. Patterns must be non-empty and must not
  contain control characters (codepoints 0–31 or 127).
 
-### `StartError`
-
-Errors when starting channels
-
-```gleam
-pub type StartError {
-  CoordinatorStartFailed(error.StartFailure)
-  InvalidHeartbeatTimeout
-}
-```
-
-#### Constructors
-
-##### `CoordinatorStartFailed(error.StartFailure)`
-
-The coordinator actor failed to start.
-
-##### `InvalidHeartbeatTimeout`
-
-`heartbeat_timeout_ms` must be at least 2. The server derives its staleness
- check interval as `heartbeat_timeout_ms / 2` (integer division), so a
- timeout of 1 would round down to a check interval of 0 — which disables
- heartbeat eviction entirely. `start` rejects such a config loudly rather
- than silently turning eviction off.
-
 ## Functions
 
 ### `acquire_connection_slot`
@@ -426,49 +401,6 @@ pub fn send_info(
   String,
   b
 ) -> Nil
-```
-
-### `start`
-
-Start the channels system
-
- Call once at application startup. Returns a handle that can be passed
- to the WebSocket transport and used for broadcasting.
-
- Heartbeat eviction is configured via `heartbeat_timeout_ms` in the Config.
- The coordinator evicts any socket that has not sent a heartbeat within that
- window, checking for stale sockets at a server-derived interval of
- `heartbeat_timeout_ms / 2`. `heartbeat_interval_ms` is client-advisory only
- (see `with_heartbeat`) and does not schedule anything on the server.
-
- Returns `Error(InvalidHeartbeatTimeout)` if `heartbeat_timeout_ms` is less
- than 2.
-
- ## Example
-
- ```gleam
- pub fn main() {
-   let assert Ok(channels) = beryl.start(beryl.config(wire.phoenix_codec()))
-   // Use channels...
- }
- ```
-
-```gleam
-pub fn start(Config) -> Result(Channels, StartError)
-```
-
-### `stop`
-
-Stop an unsupervised channels system.
-
- This shuts down the coordinator actor started by `start` and any auxiliary
- limiter actors owned by the `Channels` handle. Joined channel handlers
- receive `channel.Shutdown` in their `terminate` callback before the
- coordinator exits. After this call the `Channels` handle should no longer be
- used.
-
-```gleam
-pub fn stop(Channels) -> Nil
 ```
 
 ### `with_channel_rate`

--- a/website/src/content/docs/reference/api/beryl_ewe.md
+++ b/website/src/content/docs/reference/api/beryl_ewe.md
@@ -46,7 +46,7 @@ Policy for validating the browser `Origin` header before a WebSocket
  always send `Origin` on WebSocket handshakes, so an absent header signals a
  non-browser client (native app, server-to-server, CLI) that is not subject
  to the browser same-origin model and cannot be tricked into a cross-site
- upgrade. The one exception is [`AllowList`](#OriginPolicy), which requires a
+ upgrade. The one exception is [`AllowList`](#originpolicy), which requires a
  matching `Origin` and therefore rejects absent ones.
 
 ```gleam
@@ -71,7 +71,7 @@ Allow an upgrade only when the request `Origin` authority (host plus any
 
  Behind a reverse proxy this compares against the `Host` header as the app
  sees it: ensure the proxy forwards the public `Host` unchanged, or use
- [`AllowList`](#OriginPolicy) with the public origins instead. Forwarded
+ [`AllowList`](#originpolicy) with the public origins instead. Forwarded
  headers such as `X-Forwarded-Host` are not trusted, because clients can
  spoof them.
 
@@ -106,7 +106,7 @@ pub type TransportConfig(a)
 Create a default transport config with no connect hook.
 
  The resulting config seeds `Nil` assigns and applies the
- [`SameOrigin`](#OriginPolicy) origin policy, which rejects cross-site
+ [`SameOrigin`](#originpolicy) origin policy, which rejects cross-site
  WebSocket upgrades before the handshake (CSWSH protection). Same-origin
  upgrades and non-browser clients (no `Origin` header) are admitted without
  configuration.
@@ -222,7 +222,7 @@ pub fn upgrade_connection(
 
 Disable `Origin` checking, allowing WebSocket upgrades from any origin.
 
- This is an explicit opt-out of the default [`SameOrigin`](#OriginPolicy)
+ This is an explicit opt-out of the default [`SameOrigin`](#originpolicy)
  CSWSH protection and restores the pre-1.0 allow-all behaviour. Only use it
  for sockets that do not rely on ambient browser credentials (cookies,
  sessions) for authorization, or that authenticate every message
@@ -238,8 +238,8 @@ pub fn with_allow_all_origins(TransportConfig(a)) -> TransportConfig(a)
 Restrict WebSocket upgrades to requests whose `Origin` header exactly
  matches one of the given values.
 
- This replaces the default [`SameOrigin`](#OriginPolicy) policy with an
- [`AllowList`](#OriginPolicy). Values are matched exactly against the full
+ This replaces the default [`SameOrigin`](#originpolicy) policy with an
+ [`AllowList`](#originpolicy). Values are matched exactly against the full
  `Origin` header, including scheme and host (and port when present), such as
  `"https://app.example.com"`. Missing or non-matching origins are rejected
  with `403 Forbidden` before the WebSocket handshake.

--- a/website/src/content/docs/reference/api/beryl_mist.md
+++ b/website/src/content/docs/reference/api/beryl_mist.md
@@ -41,7 +41,7 @@ Policy for validating the browser `Origin` header before a WebSocket
  always send `Origin` on WebSocket handshakes, so an absent header signals a
  non-browser client (native app, server-to-server, CLI) that is not subject
  to the browser same-origin model and cannot be tricked into a cross-site
- upgrade. The one exception is [`AllowList`](#OriginPolicy), which requires a
+ upgrade. The one exception is [`AllowList`](#originpolicy), which requires a
  matching `Origin` and therefore rejects absent ones.
 
 ```gleam
@@ -66,7 +66,7 @@ Allow an upgrade only when the request `Origin` authority (host plus any
 
  Behind a reverse proxy this compares against the `Host` header as the app
  sees it: ensure the proxy forwards the public `Host` unchanged, or use
- [`AllowList`](#OriginPolicy) with the public origins instead. Forwarded
+ [`AllowList`](#originpolicy) with the public origins instead. Forwarded
  headers such as `X-Forwarded-Host` are not trusted, because clients can
  spoof them.
 
@@ -101,7 +101,7 @@ pub type TransportConfig(a)
 Create a default transport config with no connect hook.
 
  The resulting config seeds `Nil` assigns and applies the
- [`SameOrigin`](#OriginPolicy) origin policy, which rejects cross-site
+ [`SameOrigin`](#originpolicy) origin policy, which rejects cross-site
  WebSocket upgrades before the handshake (CSWSH protection). Same-origin
  upgrades and non-browser clients (no `Origin` header) are admitted without
  configuration.
@@ -217,7 +217,7 @@ pub fn upgrade_connection(
 
 Disable `Origin` checking, allowing WebSocket upgrades from any origin.
 
- This is an explicit opt-out of the default [`SameOrigin`](#OriginPolicy)
+ This is an explicit opt-out of the default [`SameOrigin`](#originpolicy)
  CSWSH protection and restores the pre-1.0 allow-all behaviour. Only use it
  for sockets that do not rely on ambient browser credentials (cookies,
  sessions) for authorization, or that authenticate every message
@@ -233,8 +233,8 @@ pub fn with_allow_all_origins(TransportConfig(a)) -> TransportConfig(a)
 Restrict WebSocket upgrades to requests whose `Origin` header exactly
  matches one of the given values.
 
- This replaces the default [`SameOrigin`](#OriginPolicy) policy with an
- [`AllowList`](#OriginPolicy). Values are matched exactly against the full
+ This replaces the default [`SameOrigin`](#originpolicy) policy with an
+ [`AllowList`](#originpolicy). Values are matched exactly against the full
  `Origin` header, including scheme and host (and port when present), such as
  `"https://app.example.com"`. Missing or non-matching origins are rejected
  with `403 Forbidden` before the WebSocket handshake.

--- a/website/src/content/docs/reference/api/index.md
+++ b/website/src/content/docs/reference/api/index.md
@@ -3,10 +3,10 @@ title: API Reference
 description: Generated API reference from Gleam docs metadata.
 ---
 
-This reference is generated from Gleam's docs metadata for `beryl` and `beryl_ewe` and `beryl_mist`.
+This reference is generated from Gleam's docs metadata for `beryl`, `beryl_ewe`, and `beryl_mist`.
 
 :::note[Generated content]
-Pages under `/reference/api/` are generated from Gleam's docs metadata and reflect every public type, function, and constant. The canonical, hosted API docs live on HexDocs: [beryl](https://hexdocs.pm/beryl/), [beryl_ewe](https://hexdocs.pm/beryl_ewe/), [beryl_mist](https://hexdocs.pm/beryl_mist/).
+Pages under `/reference/api/` are generated from Gleam's docs metadata and reflect every public type, function, and constant. This is beryl's canonical API reference — beryl is not published to Hex yet, so there is no `hexdocs.pm` listing.
 :::
 
 ## `beryl` `0.0.1`

--- a/website/src/content/docs/reference/index.md
+++ b/website/src/content/docs/reference/index.md
@@ -4,12 +4,14 @@ description: Module map, wire protocol, broadcast cheatsheet, and client compati
 ---
 
 :::caution[Pre-1.0 Software]
-beryl is not yet 1.0. The API is unstable and may change in minor releases. See the [Stability policy](#pre-10-stability-policy) section below.
+beryl is not yet 1.0. The API is unstable, features may be removed in minor releases, and quality should not be considered production-ready. We welcome usage and feedback in the meantime! See the [Stability policy](#pre-10-stability-policy) section below.
 :::
 
-The canonical function-level API reference is the generated Gleam documentation hosted on HexDocs:
+The canonical function-level API reference is generated from Gleam's docs metadata and published here:
 
-**[https://hexdocs.pm/beryl/](https://hexdocs.pm/beryl/)**
+**[API Reference](/reference/api/)**
+
+beryl is not on Hex yet, so there is no `hexdocs.pm` listing.
 
 This page provides a module map, broadcast cheatsheet, Phoenix wire protocol reference, and client compatibility notes.
 
@@ -19,17 +21,21 @@ This page provides a module map, broadcast cheatsheet, Phoenix wire protocol ref
 
 | Module | What it does | When to use it |
 |---|---|---|
-| `beryl` | Top-level API: start the registry, register channels, broadcast | Entry point for all applications |
+| `beryl` | Top-level API: register channels, broadcast, `send_info` | Entry point for all applications |
+| `beryl/supervisor` | Supervised startup: builds beryl's child specification and resolves stable subsystem handles | Starting beryl — this is the only entry point |
 | `beryl/channel` | Channel builder, callback types, `HandleResult` | Defining channel behaviour |
 | `beryl/socket` | Socket abstraction, assigns helpers | Inside channel callbacks |
 | `beryl/topic` | Topic parsing, wildcard matching, segment extraction | Dynamic routing, multi-tenant patterns |
-| `beryl/pubsub` | Distributed PubSub backed by Erlang `pg` | Multi-node fan-out, cluster broadcasts |
+| `beryl/pubsub` | Distributed PubSub backed by Erlang `pg`, generic over payload type | Multi-node fan-out, cluster broadcasts |
 | `beryl/presence` | OTP actor wrapping the presence CRDT, plus opaque `Diff` accessors | Tracking who is online |
 | `beryl/group` | Named sets of topics for bulk broadcast | Rooms with multiple sub-topics |
+| `beryl/bridge` | Forwards an external OTP actor's stream to a socket channel | Pushing a domain actor's updates to clients |
+| `beryl/error` | Opaque `StartFailure` type returned by subsystem start functions | Handling startup errors |
 | `beryl/wire` | Phoenix-compatible codec and JSON helpers | Phoenix clients, custom transports, protocol debugging |
 | `beryl/wire/codec` | Pluggable codec contract for text and binary frames | Custom wire formats |
 | `beryl/transport` | Transport SPI: socket lifecycle, inbound routing, edge rate limiting | Writing a custom WebSocket transport |
-| `beryl_mist` | Mist WebSocket upgrade and dispatch (separate `beryl_mist` package) | Wiring beryl to an HTTP server |
+| `beryl_mist` | Mist WebSocket upgrade and dispatch (separate `beryl_mist` package) | Wiring beryl to a Mist server |
+| `beryl_ewe` | Ewe WebSocket upgrade and dispatch (separate `beryl_ewe` package); mirrors the `beryl_mist` API | Wiring beryl to an Ewe server |
 
 ---
 
@@ -40,10 +46,10 @@ This page provides a module map, broadcast cheatsheet, Phoenix wire protocol ref
 | Reply to an incoming message | `channel.Reply(event, payload, socket)` from `handle_in` | Sends `phx_reply`; the `event` arg is ignored on the wire — reply is keyed by ref |
 | Push to the current socket only | `channel.Push(event, payload, socket)` from `handle_in` or `handle_info` | Server-originated push on this socket's topic |
 | No response | `channel.NoReply(socket)` | Use when the handler has no output |
-| Broadcast to all sockets on a topic | `beryl.broadcast(registry, topic, event, payload)` | All subscribers including the sender |
+| Broadcast to all sockets on a topic | `beryl.broadcast(channels, topic, event, payload)` | All subscribers including the sender |
 | Broadcast, excluding sender | `beryl.broadcast_from(channels, socket.id(socket), topic, event, payload)` | Second arg is `except_socket_id: String`; use `socket.id/1` to extract it when you have a `Socket` value. Skips the originating socket; works across PubSub nodes |
 | Send an OTP message to a joined channel context | `beryl.send_info(channels, socket_id, topic_name, message)` | Delivers the typed message to `handle_info`; the callback receives the concrete `info` value — no `Dynamic` decode and no unsafe cast required |
-| Broadcast presence diff | `beryl.broadcast_presence_diff(registry, topic, diff)` | Encodes Phoenix-shaped `joins`/`leaves`; only named topic entries are included |
+| Broadcast presence diff | `beryl.broadcast_presence_diff(channels, topic, diff)` | Encodes Phoenix-shaped `joins`/`leaves`; only named topic entries are included |
 
 ---
 
@@ -130,7 +136,7 @@ When started with `wire.phoenix_codec()`, beryl uses the standard Phoenix wire f
 | Phoenix Swift / Kotlin clients | Community Phoenix clients; wire-compatible |
 | Plain WebSocket | Use the JSON array format directly; no reconnect logic |
 
-The WebSocket upgrade path is caller-provided — there is no default. Pass the path when constructing your transport config with `mist_transport.default_config(path)`. The Phoenix JS client appends `/websocket` to the socket endpoint, so if you configure the client with `"/socket"`, mount your handler at `"/socket/websocket"`. See the [WebSocket Transport guide](/guides/websocket) for details.
+The WebSocket upgrade path is caller-provided — there is no default. Pass the path when constructing your transport config with `mist_transport.default_config(path)`. The Phoenix JS client appends `/websocket` to the socket endpoint, so if you configure the client with `"/socket"`, mount your handler at `"/socket/websocket"`. See the [WebSocket Transport guide](/guides/websocket/) for details.
 
 ---
 
@@ -141,6 +147,6 @@ beryl follows [Semantic Versioning](https://semver.org/) but is **not yet 1.0**.
 - **Minor version bumps** (`0.x → 0.x+1`) may include breaking changes to the public API.
 - **Patch version bumps** (`0.x.y → 0.x.y+1`) fix bugs without intentional breakage.
 - Public API is defined as the exports of the modules listed in the module map above.
-- Coordinator, rate-limit, and internal helper modules are intentionally hidden from downstream packages. Transports integrate through the public `beryl/transport` SPI; `beryl_mist` is the supported WebSocket transport.
+- Coordinator, rate-limit, and internal helper modules are intentionally hidden from downstream packages. Transports integrate through the public `beryl/transport` SPI; `beryl_mist` and `beryl_ewe` are the supported WebSocket transports.
 
 Check [GitHub releases](https://github.com/tylerbutler/beryl/releases) before upgrading to a new minor version.

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -4,13 +4,15 @@ title: Troubleshooting
 
 This page lists common symptoms with targeted diagnosis steps. Start from your symptom and follow the checks in order.
 
+Examples use `beryl_mist`. `beryl_ewe` exposes the same config-builder and handler API, so every check applies with `ewe_transport` substituted for `mist_transport`.
+
 ## Clients cannot connect at all
 
 **Symptoms:** Browser WebSocket error, `net::ERR_CONNECTION_REFUSED`, or immediate close before any Phoenix messages.
 
 **Checks:**
 
-1. **Is Mist listening?** Confirm your HTTP server started without error. `mist.serve` or `mist.serve_ssl` returns a `Result` — make sure you handle `Error`.
+1. **Is the HTTP server listening?** Confirm it started without error — `mist.start` (and the Ewe equivalent) returns a `Result`, so make sure you handle `Error` rather than discarding it.
 
 2. **Path mismatch.** The Phoenix JS client appends `/websocket` to the socket path you pass:
    ```js
@@ -125,9 +127,9 @@ let logging =
 
 2. **Cross-node sync.** If running multiple nodes, each node must be configured with the same PubSub instance and each presence actor needs a unique replica ID. The CRDT merges state over PubSub; without PubSub, nodes have independent state.
 
-3. **`on_diff` not broadcasting.** If clients rely on receiving `presence_diff` events, confirm `on_diff` is configured and calls `beryl.broadcast_presence_diff`. See the [Presence guide](/guides/presence).
+3. **`on_diff` not broadcasting.** If clients rely on receiving `presence_diff` events, confirm `on_diff` is configured and calls `beryl.broadcast_presence_diff`. See the [Presence guide](/guides/presence/).
 
-4. **CRDT compaction.** The CRDT can accumulate causal history. Call `presence.compact` (on the state layer) if memory usage grows unexpectedly over a long uptime.
+4. **Long-lived causal history.** The CRDT retains causal context for tracked entries. beryl exposes no public compaction hook, so if presence memory grows over a long uptime the cause is almost always check 1 — entries that are never untracked — rather than unbounded CRDT metadata.
 
 ---
 
@@ -141,7 +143,7 @@ let logging =
 
 2. **Token validation error.** Check that your token validation logic handles expired or malformed tokens gracefully and returns `Error(Nil)` rather than panicking.
 
-3. **Join handler returning JoinError for all.** Log the `payload` argument in `join` to confirm the client is sending the expected shape. `payload` arrives as `gleam/json.Json` (already decoded from the raw frame).
+3. **Join handler returning JoinError for all.** Log the `payload` argument in `join` to confirm the client is sending the expected shape. `payload` arrives as `Dynamic` — decode it with `channel.decode_payload` and a `gleam/dynamic/decode` decoder, and check that a failed decode is not falling through to a rejection.
 
 ---
 


### PR DESCRIPTION
Documents the Gleam 1.18+ requirement for installing beryl as a git dependency, then follows a full review of the documentation against the source — which surfaced a breaking API change worth making.

## Breaking: supervision is now mandatory

`beryl.start`, `beryl.stop`, and `beryl.StartError` are no longer public. An unsupervised channel system left a coordinator crash unrecoverable and every connected socket stranded, so the API no longer offers it as a choice. Applications start beryl through `beryl/supervisor`, which returns a child specification for their own OTP supervision tree — the pattern already used throughout the guides and examples.

Nothing in production code or the examples used the removed functions; they were reachable only from tests. The implementation moves to `beryl/internal/unsupervised`, listed in `internal_modules` so it is excluded from generated docs and the published API. beryl's own tests import it directly. The transport suites now stand up a real supervision tree, so they exercise the production path.

Worth knowing for future boundary work: neither `@internal` nor `internal_modules` is enforced by the compiler for path dependencies — `beryl_mist` can already import `beryl/coordinator` without complaint. The boundary is a project rule, not a hard error, and that limitation is now stated on the module rather than implied away.

## Documentation corrections

Every hand-written doc was checked against the source. The factual errors:

- The README carried two contradictory "Releases & changelog" sections, one naming trellis and one naming changie.
- Troubleshooting claimed payloads arrive as `json.Json` — they are `Dynamic` — and recommended a `presence.compact` that does not exist.
- `AGENTS.md` documented a `phx_heartbeat` event that appears nowhere in the codebase; the wire uses topic `"phoenix"` / event `"heartbeat"`.
- `DEV.md` said merging the release PR publishes to Hex, which is currently disabled.
- The PubSub guide predated the generic-payload change and omitted `pubsub.selecting`, the only safe way to receive a broadcast.
- Architecture pages used pre-monorepo `src/beryl/` paths.
- Production hardening described the supervision tree as rest-for-one at the top; it is one-for-one wrapping a rest-for-one channel subtree.
- Snippets that would not compile: a duplicated `gleam/http/request` import, a `topic` parameter shadowing the `topic` module, and a timer example referencing out-of-scope bindings.
- The `handle_in` section had lost its heading, so the most important callback was missing from the page TOC.

Consistency work: `beryl_ewe` is now visible in the transport guide, module map, and architecture pages instead of Mist-only; `handler` is the recommended entry point everywhere rather than split with `upgrade`; package READMEs use the `/socket/websocket` path Phoenix JS clients actually need; internal link trailing slashes and pre-1.0 notice wording are uniform, with the 1.0 checklist naming every file that carries the notice.

The `.mise.toml` Erlang 28 pin turned out to be deliberate — CI matrix-tests 27 and 28 — so that intent is documented rather than "fixed". Package counts and the trellis version pin are corrected across `DEV.md`, `AGENTS.md`, and `CLAUDE.md`.

## Generated reference

Twelve `#OriginPolicy` anchor links in the generated transport pages resolved to nothing, because rendered heading slugs are lowercased. With those fixed the site reports **all internal links valid**; it had twelve broken before this branch.

The reference index also linked to `hexdocs.pm`, which 404s since beryl is unpublished, while the real canonical reference is the generated site itself. Those links now point inward.

