### PR TITLE
docs: correct stale and false claims in public doc comments

### DIFF
--- a/.changes/unreleased/beryl-2.toml
+++ b/.changes/unreleased/beryl-2.toml
@@ -1,0 +1,3 @@
+project = "beryl"
+kind = "Fixed"
+body = "Corrected stale and false doc comments across the public API: removed references to the deleted start function, documented the real max_topic_length behavior (joins get an error reply; other frames naming an invalid topic are dropped), replaced the beryl/bridge example with the working closure form, removed a false module-shadowing warning from the channel docs, and standardized wildcard terminology to prefix/segment wildcards. Presence debug logs now use the session_id metadata key instead of pid."

--- a/.changes/unreleased/beryl_mist-1.toml
+++ b/.changes/unreleased/beryl_mist-1.toml
@@ -1,0 +1,3 @@
+project = "beryl_mist"
+kind = "Fixed"
+body = "Clarified transport doc comments: removed the incorrect pre-1.0 reference from with_allow_all_origins and showed the import alias used by the upgrade and handler examples."

--- a/README.md
+++ b/README.md
@@ -177,8 +177,10 @@ updates that need to be pushed to each joined socket. The `beryl/bridge` module
 removes the per-socket forwarder boilerplate: start a bridge in `join`, subscribe
 your actor to the bridge's `Subject`, and stop it in `terminate`. Each value the
 actor emits is translated and delivered to the channel's `handle_info` callback
-via `beryl.send_info`. The forwarder also monitors the channel process, so it is
-cleaned up automatically if that process dies — no leaked processes.
+via `beryl.send_info`. Calling `bridge.stop` in `terminate` is required:
+channels are dispatched by a shared coordinator, so the forwarder's monitor
+only fires if the coordinator itself dies — it does not detect an individual
+channel ending.
 
 ```gleam
 import beryl.{type RegisteredChannel}

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -24,7 +24,6 @@
 ////
 //// ```gleam
 //// import beryl
-//// import beryl/channel
 //// import beryl/group
 //// import beryl/presence
 //// import beryl/pubsub
@@ -159,7 +158,7 @@ pub fn logging_payload_preview_bytes(logging: LoggingConfig) -> Int {
 pub opaque type Config {
   Config(
     /// Wire codec used to decode inbound text and encode replies/pushes.
-    /// Use `wire.phoenix_codec()` for the historical Phoenix array format.
+    /// Use `wire.phoenix_codec()` for the Phoenix array format.
     codec: codec.Codec,
     /// Client-advisory heartbeat interval in milliseconds (default: 30000).
     /// The server does not read this value; it is the interval clients should
@@ -191,8 +190,9 @@ pub opaque type Config {
     /// Values <= 0 disable the cap.
     channel_rate_max_keys_per_socket: Int,
     /// Maximum byte length for client-supplied topic strings (default: 256).
-    /// Topics exceeding this limit are rejected with a `phx_reply` error before
-    /// reaching a channel handler.
+    /// Joins to longer topics are rejected with an error reply (a `phx_reply`
+    /// under the Phoenix codec) before reaching a channel handler; other
+    /// frames naming them are dropped.
     max_topic_length: Int,
     /// Maximum byte length for client-supplied event name strings (default: 64).
     /// Events exceeding this limit are dropped before reaching a channel handler.
@@ -226,9 +226,9 @@ pub fn logging_config(
 
 /// Build a configuration with sensible defaults.
 ///
-/// A `codec` is required — beryl no longer ships an implicit Phoenix
-/// default. Pass `wire.phoenix_codec()` to keep Phoenix wire compatibility,
-/// or your own `Codec` for a custom framing.
+/// A `codec` is required — there is no implicit default. Pass
+/// `wire.phoenix_codec()` for Phoenix wire compatibility, or your own
+/// `Codec` for a custom framing.
 pub fn config(codec: codec.Codec) -> Config {
   Config(
     codec: codec,
@@ -267,9 +267,9 @@ pub fn with_pubsub(config: Config, ps: PubSub(json.Json)) -> Config {
 /// `timeout_ms` is the server-side staleness window — a socket that sends no
 /// heartbeat within this window is evicted. The server derives its internal
 /// check interval as `timeout_ms / 2` (integer division), so `timeout_ms` must
-/// be at least 2; smaller values are rejected by `start` with
-/// `InvalidHeartbeatTimeout` because a check interval of 0 would disable
-/// eviction. The defaults are 30000 ms and 60000 ms respectively.
+/// be at least 2; with smaller values `supervisor.start`'s child specification
+/// fails to start, because a check interval of 0 would disable eviction. The
+/// defaults are 30000 ms and 60000 ms respectively.
 pub fn with_heartbeat(
   config: Config,
   interval_ms interval_ms: Int,
@@ -419,9 +419,10 @@ pub fn with_channel_rate_max_keys_per_socket(
 /// Configure the maximum allowed byte length for client-supplied topic
 /// strings.
 ///
-/// Topics longer than `max_length` bytes are rejected with a `phx_reply`
-/// error before reaching a channel handler, bounding the size of keys stored
-/// in the coordinator's topic registry. The default is 256.
+/// Joins to topics longer than `max_length` bytes are rejected with an error
+/// reply (a `phx_reply` under the Phoenix codec) before reaching a channel
+/// handler, and other frames naming them are dropped — bounding the size of
+/// keys stored in the coordinator's topic registry. The default is 256.
 pub fn with_max_topic_length(
   config: Config,
   max_length max_length: Int,
@@ -443,7 +444,7 @@ pub fn with_max_event_length(
 
 /// Configure the maximum allowed inbound WebSocket frame size in bytes.
 ///
-/// The limit is enforced **post-assembly**: the transport (Mist/gramps)
+/// The limit is enforced **post-assembly**: the transport's WebSocket layer
 /// buffers and assembles a complete frame first, and only then does beryl
 /// measure it and close the connection if it exceeds `max_bytes`. This bounds
 /// per-message processing cost (decode, routing, rate-limit accounting), but
@@ -457,7 +458,7 @@ pub fn with_max_event_length(
 /// balancer in front of beryl and configure a WebSocket frame-size limit
 /// there (and a matching request/body size limit). beryl's per-IP connection
 /// limit and per-socket message-rate limit do not mitigate this vector. See
-/// the "Security & deployment" section of the README and
+/// the "Security" section of the README and
 /// `docs/security/frame-buffering-followup.md` for details.
 ///
 /// Values <= 0 disable the cap. The default is 1 MiB.
@@ -559,7 +560,8 @@ pub fn config_max_joined_topics_per_socket(config: Config) -> Int {
 /// beryl ships with rate and connection limits off (like Phoenix) because
 /// no default is right for every deployment — but running that way in
 /// production leaves the server open to trivial floods, so the choice
-/// should be a visible one. Called by both `start` and `supervisor.start`.
+/// should be a visible one. Called by `supervisor.start` and the internal
+/// unsupervised start path.
 @internal
 pub fn warn_if_unprotected(config: Config) -> Nil {
   let unprotected =
@@ -629,8 +631,8 @@ pub fn to_coordinator_config(config: Config) -> coordinator.CoordinatorConfig {
 
 /// Channels system handle.
 ///
-/// This opaque handle is returned by `start` and passed to registration,
-/// broadcast, bridge, group, supervisor, and transport functions. Its internal
+/// This opaque handle is obtained from `supervisor.channels` and passed to
+/// registration, broadcast, bridge, group, and transport functions. Its internal
 /// actor protocol is intentionally hidden so beryl can evolve coordinator
 /// internals without breaking application code.
 pub opaque type Channels {
@@ -778,7 +780,7 @@ pub fn channels_registry(channels: Channels) -> Option(coordinator.Registry) {
 
 /// Register a channel handler for a topic pattern
 ///
-/// Patterns can be exact matches like "room:lobby", legacy prefix wildcards
+/// Patterns can be exact matches like "room:lobby", prefix wildcards
 /// like "room:*" which match any topic starting with "room:", or segment
 /// wildcards like "document:*:ops" where "*" matches one complete segment.
 /// The bare pattern "*" is a catch-all that matches every topic.
@@ -803,13 +805,13 @@ pub fn channels_registry(channels: Channels) -> Option(coordinator.Registry) {
 ///   channel.NoReply(socket)
 /// })
 ///
-/// // Register it with a legacy prefix wildcard
+/// // Register it with a prefix wildcard
 /// let assert Ok(chat) = beryl.register(channels, "chat:*", chat_channel)
 ///
 /// // Exact topic
 /// let assert Ok(lobby) = beryl.register(channels, "room:lobby", lobby_channel)
 ///
-/// // Segment-aware wildcard
+/// // Segment wildcard
 /// let assert Ok(ops) = beryl.register(channels, "document:*:ops", ops_channel)
 /// ```
 pub fn register(
@@ -857,9 +859,10 @@ fn map_register_error(error: coordinator.RegisterError) -> RegisterError {
   }
 }
 
-/// Broadcast a message to all subscribers of a topic
+/// Broadcast a message to all sockets subscribed to a topic.
 ///
-/// This sends the message to all sockets subscribed to the topic.
+/// When the channels system was configured with PubSub, the broadcast also
+/// fans out to subscribers on other nodes in the cluster.
 ///
 /// ## Example
 ///

--- a/packages/beryl/src/beryl/bridge.gleam
+++ b/packages/beryl/src/beryl/bridge.gleam
@@ -20,10 +20,12 @@
 //// ## Example
 ////
 //// ```gleam
-//// import beryl
+//// import beryl.{type RegisteredChannel}
 //// import beryl/bridge.{type Bridge}
-//// import beryl/channel
+//// import beryl/channel.{type Channel}
 //// import beryl/socket
+//// import gleam/option.{None}
+//// import my_app/doc
 ////
 //// // Messages emitted by your domain actor.
 //// pub type DocEvent {
@@ -34,22 +36,27 @@
 ////   Assigns(bridge: Bridge(DocEvent))
 //// }
 ////
-//// fn join(registered_channel, doc_actor, topic, _payload, socket) {
-////   // Forward each DocEvent to this socket's `handle_info` callback.
-////   let b =
-////     bridge.start(
-////       channel: registered_channel,
-////       socket_id: socket.id(socket),
-////       topic: topic,
-////       with: fn(event) { event },
-////     )
-////   // Subscribe the domain actor to the bridge's subject.
-////   doc.subscribe(doc_actor, bridge.subject(b))
-////   channel.JoinOk(reply: None, socket: socket.set_assigns(socket, Assigns(b)))
-//// }
-////
-//// fn terminate(_reason, socket) {
-////   bridge.stop(socket.get_assigns(socket).bridge)
+//// // `registered_channel` is the handle returned by `beryl.register`.
+//// fn new_channel(
+////   registered_channel: RegisteredChannel(Assigns, DocEvent),
+////   doc_actor,
+//// ) -> Channel(Assigns, DocEvent) {
+////   channel.new(fn(topic, _payload, socket) {
+////     // Forward each DocEvent to this socket's `handle_info` callback.
+////     let b =
+////       bridge.start(
+////         channel: registered_channel,
+////         socket_id: socket.id(socket),
+////         topic: topic,
+////         with: fn(event) { event },
+////       )
+////     // Subscribe the domain actor to the bridge's subject.
+////     doc.subscribe(doc_actor, bridge.subject(b))
+////     channel.JoinOk(reply: None, socket: socket.set_assigns(socket, Assigns(b)))
+////   })
+////   |> channel.with_terminate(fn(_reason, socket) {
+////     bridge.stop(socket.get_assigns(socket).bridge)
+////   })
 //// }
 //// ```
 

--- a/packages/beryl/src/beryl/channel.gleam
+++ b/packages/beryl/src/beryl/channel.gleam
@@ -16,9 +16,7 @@
 ////   |> channel.with_terminate(terminate)
 //// }
 ////
-//// // Name the first argument something other than `topic`: a local binding
-//// // named `topic` shadows the `beryl/topic` module if you import it.
-//// fn join(topic_name, payload, socket) {
+//// fn join(topic, payload, socket) {
 ////   let assigns = RoomAssigns(user_id: "...", room_id: "...")
 ////   channel.JoinOk(reply: None, socket: socket.set_assigns(socket, assigns))
 //// }

--- a/packages/beryl/src/beryl/group.gleam
+++ b/packages/beryl/src/beryl/group.gleam
@@ -4,6 +4,10 @@
 //// Useful for scenarios like broadcasting to all channels in a "team" or
 //// sending a system-wide notification.
 ////
+//// When running beryl under `beryl/supervisor`, enable groups with
+//// `supervisor.with_groups` and obtain the handle from `supervisor.groups`
+//// instead of calling `start` directly.
+////
 //// ## Example
 ////
 //// ```gleam

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -6,6 +6,10 @@
 //// - Receives remote state from PubSub and merges it internally
 //// - Invokes `on_diff` callback when merges produce non-empty diffs
 ////
+//// When running beryl under `beryl/supervisor`, enable presence with
+//// `supervisor.with_presence` and obtain the handle from
+//// `supervisor.presence` instead of calling `start` directly.
+////
 //// ## Example
 ////
 //// ```gleam
@@ -552,7 +556,7 @@ fn handle_message(
       |> log.debug("Presence tracked", [
         #("topic", topic),
         #("key", key),
-        #("pid", pid),
+        #("session_id", pid),
         #("ref", ref),
       ])
       let new_refs =
@@ -582,7 +586,7 @@ fn handle_message(
           |> log.debug("Presence untracked", [
             #("topic", topic),
             #("key", key),
-            #("pid", session_id),
+            #("session_id", session_id),
             #("ref", ref),
           ])
           process.send(reply, Nil)

--- a/packages/beryl/src/beryl/topic.gleam
+++ b/packages/beryl/src/beryl/topic.gleam
@@ -2,8 +2,8 @@
 ////
 //// Topics are string identifiers that clients join (e.g., "room:lobby").
 //// Patterns define how topics are routed to channel handlers. Patterns can be
-//// exact, legacy trailing prefix wildcards, or segment-aware wildcards where
-//// "*" occupies a complete colon-delimited segment.
+//// exact, prefix wildcards, or segment wildcards where "*" occupies a
+//// complete colon-delimited segment.
 
 import gleam/bool
 import gleam/list
@@ -14,7 +14,7 @@ import gleam/string
 pub type TopicPattern {
   /// Exact match: "room:lobby" only matches "room:lobby"
   Exact(String)
-  /// Wildcard suffix: "room:*" matches "room:lobby", "room:123", etc.
+  /// Prefix wildcard: "room:*" matches "room:lobby", "room:123", etc.
   Wildcard(prefix: String)
   /// Segment wildcard: "document:*:ops" matches the same number of ":"
   /// segments where "*" occupies one complete segment.
@@ -143,7 +143,7 @@ pub fn extract_id(
 
 /// Extract values captured by wildcard segments.
 ///
-/// For legacy prefix wildcards, returns the suffix as a single value.
+/// For prefix wildcards, returns the suffix as a single value.
 /// For segment wildcards, returns each topic segment matched by "*".
 ///
 /// ## Examples

--- a/packages/beryl/src/beryl/wire.gleam
+++ b/packages/beryl/src/beryl/wire.gleam
@@ -30,7 +30,7 @@ const expected_array_message = "Expected array of 5 elements [join_ref, ref, top
 
 const max_json_nesting_depth = 64
 
-/// The canonical Phoenix wire codec. Pass to `beryl.config/1`.
+/// The canonical Phoenix wire codec. Pass to `beryl.config`.
 ///
 /// Handles both the JSON array framing on text frames and the Phoenix V2
 /// binary framing on binary frames (see `decode_binary_message`). Binary

--- a/packages/beryl_ewe/src/beryl_ewe.gleam
+++ b/packages/beryl_ewe/src/beryl_ewe.gleam
@@ -1,7 +1,7 @@
 //// Ewe WebSocket Transport - Direct Ewe integration for beryl
 ////
-//// This module provides the bridge between Ewe's native WebSocket handling
-//// and the beryl coordinator using Ewe request and response types directly.
+//// Bridges Ewe's native WebSocket handling to the beryl coordinator, using
+//// Ewe request and response types directly.
 ////
 //// It mirrors the `beryl_mist` package: the two transports expose the same
 //// config-builder and handler API, so an integrator can run beryl channels on
@@ -153,7 +153,7 @@ pub fn with_allowed_origins(
 /// Disable `Origin` checking, allowing WebSocket upgrades from any origin.
 ///
 /// This is an explicit opt-out of the default [`SameOrigin`](#originpolicy)
-/// CSWSH protection and restores the pre-1.0 allow-all behaviour. Only use it
+/// CSWSH protection. Only use it
 /// for sockets that do not rely on ambient browser credentials (cookies,
 /// sessions) for authorization, or that authenticate every message
 /// independently. For cookie/session-authenticated apps, prefer the default
@@ -197,6 +197,8 @@ type SendRequest {
 ///
 /// Usage in your Ewe handler:
 /// ```gleam
+/// import beryl_ewe as ewe_transport
+///
 /// fn handle_request(req: Request(Connection), channels: Channels) -> Response(ResponseBody) {
 ///   use <- ewe_transport.upgrade(req, channels, ewe_transport.default_config("/socket"))
 ///   // Fall through to regular HTTP routing
@@ -411,6 +413,8 @@ pub fn is_websocket_request(request: Request(Connection)) -> Bool {
 /// by hand:
 ///
 /// ```gleam
+/// import beryl_ewe as ewe_transport
+///
 /// ewe_transport.handler(channels, ewe_transport.default_config("/socket"), http_handler)
 /// |> ewe.new
 /// |> ewe.listening(port: 8000)

--- a/packages/beryl_mist/src/beryl_mist.gleam
+++ b/packages/beryl_mist/src/beryl_mist.gleam
@@ -1,7 +1,7 @@
 //// Mist WebSocket Transport - Direct Mist integration for beryl
 ////
-//// This module provides the bridge between Mist's native WebSocket handling
-//// and the beryl coordinator using Mist request and response types directly.
+//// Bridges Mist's native WebSocket handling to the beryl coordinator, using
+//// Mist request and response types directly.
 ////
 //// The `beryl_ewe` package mirrors it: the two transports expose the same
 //// config-builder and handler API, so an integrator can run beryl channels on
@@ -154,7 +154,7 @@ pub fn with_allowed_origins(
 /// Disable `Origin` checking, allowing WebSocket upgrades from any origin.
 ///
 /// This is an explicit opt-out of the default [`SameOrigin`](#originpolicy)
-/// CSWSH protection and restores the pre-1.0 allow-all behaviour. Only use it
+/// CSWSH protection. Only use it
 /// for sockets that do not rely on ambient browser credentials (cookies,
 /// sessions) for authorization, or that authenticate every message
 /// independently. For cookie/session-authenticated apps, prefer the default
@@ -198,6 +198,8 @@ type SendRequest {
 ///
 /// Usage in your Mist handler:
 /// ```gleam
+/// import beryl_mist as mist_transport
+///
 /// fn handle_request(req: Request(Connection), channels: Channels) -> Response(ResponseData) {
 ///   use <- mist_transport.upgrade(req, channels, mist_transport.default_config("/socket"))
 ///   // Fall through to regular HTTP routing
@@ -412,6 +414,8 @@ pub fn is_websocket_request(request: Request(Connection)) -> Bool {
 /// by hand:
 ///
 /// ```gleam
+/// import beryl_mist as mist_transport
+///
 /// mist_transport.handler(channels, mist_transport.default_config("/socket"), http_handler)
 /// |> mist.new
 /// |> mist.port(8000)

--- a/website/src/content/docs/guides/channels.md
+++ b/website/src/content/docs/guides/channels.md
@@ -8,7 +8,7 @@ Two words recur throughout these docs and are not interchangeable: a **channel h
 
 ## Topics and patterns
 
-Topics are colon-delimited string identifiers. Patterns can be exact matches, legacy trailing prefix wildcards, or segment-aware wildcards:
+Topics are colon-delimited string identifiers. Patterns can be exact matches, prefix wildcards, or segment wildcards:
 
 ```gleam
 import beryl/topic
@@ -46,7 +46,7 @@ topic.segments("room:lobby")  // -> ["room", "lobby"]
 topic.namespace("room:lobby")  // -> Ok("room")
 ```
 
-Use `document:tenant-a:*` to route all documents for one tenant while keeping the existing trailing-wildcard prefix semantics. Use `document:*:*` when a callback needs to extract both tenant and document IDs from a topic with the exact shape `document:{tenant_id}:{document_id}`:
+Use `document:tenant-a:*` to route all documents for one tenant while keeping prefix-wildcard semantics. Use `document:*:*` when a callback needs to extract both tenant and document IDs from a topic with the exact shape `document:{tenant_id}:{document_id}`:
 
 ```gleam
 let pattern = topic.parse_pattern("document:*:*")

--- a/website/src/content/docs/reference/api/beryl-bridge.md
+++ b/website/src/content/docs/reference/api/beryl-bridge.md
@@ -31,10 +31,12 @@ Bridge - Forward an external OTP actor's message stream to a socket channel.
  ## Example
 
  ```gleam
- import beryl
+ import beryl.{type RegisteredChannel}
  import beryl/bridge.{type Bridge}
- import beryl/channel
+ import beryl/channel.{type Channel}
  import beryl/socket
+ import gleam/option.{None}
+ import my_app/doc
 
  // Messages emitted by your domain actor.
  pub type DocEvent {
@@ -45,22 +47,27 @@ Bridge - Forward an external OTP actor's message stream to a socket channel.
    Assigns(bridge: Bridge(DocEvent))
  }
 
- fn join(registered_channel, doc_actor, topic, _payload, socket) {
-   // Forward each DocEvent to this socket's `handle_info` callback.
-   let b =
-     bridge.start(
-       channel: registered_channel,
-       socket_id: socket.id(socket),
-       topic: topic,
-       with: fn(event) { event },
-     )
-   // Subscribe the domain actor to the bridge's subject.
-   doc.subscribe(doc_actor, bridge.subject(b))
-   channel.JoinOk(reply: None, socket: socket.set_assigns(socket, Assigns(b)))
- }
-
- fn terminate(_reason, socket) {
-   bridge.stop(socket.get_assigns(socket).bridge)
+ // `registered_channel` is the handle returned by `beryl.register`.
+ fn new_channel(
+   registered_channel: RegisteredChannel(Assigns, DocEvent),
+   doc_actor,
+ ) -> Channel(Assigns, DocEvent) {
+   channel.new(fn(topic, _payload, socket) {
+     // Forward each DocEvent to this socket's `handle_info` callback.
+     let b =
+       bridge.start(
+         channel: registered_channel,
+         socket_id: socket.id(socket),
+         topic: topic,
+         with: fn(event) { event },
+       )
+     // Subscribe the domain actor to the bridge's subject.
+     doc.subscribe(doc_actor, bridge.subject(b))
+     channel.JoinOk(reply: None, socket: socket.set_assigns(socket, Assigns(b)))
+   })
+   |> channel.with_terminate(fn(_reason, socket) {
+     bridge.stop(socket.get_assigns(socket).bridge)
+   })
  }
  ```
 

--- a/website/src/content/docs/reference/api/beryl-channel.md
+++ b/website/src/content/docs/reference/api/beryl-channel.md
@@ -27,9 +27,7 @@ Channel - Topic-based message callbacks
    |> channel.with_terminate(terminate)
  }
 
- // Name the first argument something other than `topic`: a local binding
- // named `topic` shadows the `beryl/topic` module if you import it.
- fn join(topic_name, payload, socket) {
+ fn join(topic, payload, socket) {
    let assigns = RoomAssigns(user_id: "...", room_id: "...")
    channel.JoinOk(reply: None, socket: socket.set_assigns(socket, assigns))
  }

--- a/website/src/content/docs/reference/api/beryl-group.md
+++ b/website/src/content/docs/reference/api/beryl-group.md
@@ -15,6 +15,10 @@ Channel Groups - Named collections of topics for multi-topic broadcasting
  Useful for scenarios like broadcasting to all channels in a "team" or
  sending a system-wide notification.
 
+ When running beryl under `beryl/supervisor`, enable groups with
+ `supervisor.with_groups` and obtain the handle from `supervisor.groups`
+ instead of calling `start` directly.
+
  ## Example
 
  ```gleam

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -17,6 +17,10 @@ Presence - Distributed presence tracking backed by a CRDT
  - Receives remote state from PubSub and merges it internally
  - Invokes `on_diff` callback when merges produce non-empty diffs
 
+ When running beryl under `beryl/supervisor`, enable presence with
+ `supervisor.with_presence` and obtain the handle from
+ `supervisor.presence` instead of calling `start` directly.
+
  ## Example
 
  ```gleam

--- a/website/src/content/docs/reference/api/beryl-topic.md
+++ b/website/src/content/docs/reference/api/beryl-topic.md
@@ -13,8 +13,8 @@ Topic - Pattern matching for channel routing
 
  Topics are string identifiers that clients join (e.g., "room:lobby").
  Patterns define how topics are routed to channel handlers. Patterns can be
- exact, legacy trailing prefix wildcards, or segment-aware wildcards where
- "*" occupies a complete colon-delimited segment.
+ exact, prefix wildcards, or segment wildcards where "*" occupies a
+ complete colon-delimited segment.
 
 ## Types
 
@@ -91,7 +91,7 @@ Exact match: "room:lobby" only matches "room:lobby"
 
 ##### `Wildcard(prefix: String)`
 
-Wildcard suffix: "room:*" matches "room:lobby", "room:123", etc.
+Prefix wildcard: "room:*" matches "room:lobby", "room:123", etc.
 
 ##### `SegmentWildcard(segments: List(String))`
 
@@ -124,7 +124,7 @@ pub fn extract_id(
 
 Extract values captured by wildcard segments.
 
- For legacy prefix wildcards, returns the suffix as a single value.
+ For prefix wildcards, returns the suffix as a single value.
  For segment wildcards, returns each topic segment matched by "*".
 
  ## Examples

--- a/website/src/content/docs/reference/api/beryl-wire.md
+++ b/website/src/content/docs/reference/api/beryl-wire.md
@@ -154,7 +154,7 @@ pub fn heartbeat_reply(option.Option(String)) -> codec.Frame
 
 ### `phoenix_codec`
 
-The canonical Phoenix wire codec. Pass to `beryl.config/1`.
+The canonical Phoenix wire codec. Pass to `beryl.config`.
 
  Handles both the JSON array framing on text frames and the Phoenix V2
  binary framing on binary frames (see `decode_binary_message`). Binary

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -35,7 +35,6 @@ beryl - Type-safe real-time communication
 
  ```gleam
  import beryl
- import beryl/channel
  import beryl/group
  import beryl/presence
  import beryl/pubsub
@@ -80,8 +79,8 @@ beryl - Type-safe real-time communication
 
 Channels system handle.
 
- This opaque handle is returned by `start` and passed to registration,
- broadcast, bridge, group, supervisor, and transport functions. Its internal
+ This opaque handle is obtained from `supervisor.channels` and passed to
+ registration, broadcast, bridge, group, and transport functions. Its internal
  actor protocol is intentionally hidden so beryl can evolve coordinator
  internals without breaking application code.
 
@@ -218,9 +217,10 @@ pub fn bind_connection_slot(ConnectionPermit) -> Nil
 
 ### `broadcast`
 
-Broadcast a message to all subscribers of a topic
+Broadcast a message to all sockets subscribed to a topic.
 
- This sends the message to all sockets subscribed to the topic.
+ When the channels system was configured with PubSub, the broadcast also
+ fans out to subscribers on other nodes in the cluster.
 
  ## Example
 
@@ -302,9 +302,9 @@ pub fn broadcast_presence_diff(
 
 Build a configuration with sensible defaults.
 
- A `codec` is required — beryl no longer ships an implicit Phoenix
- default. Pass `wire.phoenix_codec()` to keep Phoenix wire compatibility,
- or your own `Codec` for a custom framing.
+ A `codec` is required — there is no implicit default. Pass
+ `wire.phoenix_codec()` for Phoenix wire compatibility, or your own
+ `Codec` for a custom framing.
 
 ```gleam
 pub fn config(codec.Codec) -> Config
@@ -337,7 +337,7 @@ pub fn max_inbound_frame_bytes(Channels) -> Int
 
 Register a channel handler for a topic pattern
 
- Patterns can be exact matches like "room:lobby", legacy prefix wildcards
+ Patterns can be exact matches like "room:lobby", prefix wildcards
  like "room:*" which match any topic starting with "room:", or segment
  wildcards like "document:*:ops" where "*" matches one complete segment.
  The bare pattern "*" is a catch-all that matches every topic.
@@ -362,13 +362,13 @@ Register a channel handler for a topic pattern
    channel.NoReply(socket)
  })
 
- // Register it with a legacy prefix wildcard
+ // Register it with a prefix wildcard
  let assert Ok(chat) = beryl.register(channels, "chat:*", chat_channel)
 
  // Exact topic
  let assert Ok(lobby) = beryl.register(channels, "room:lobby", lobby_channel)
 
- // Segment-aware wildcard
+ // Segment wildcard
  let assert Ok(ops) = beryl.register(channels, "document:*:ops", ops_channel)
  ```
 
@@ -452,9 +452,9 @@ Configure heartbeat timing.
  `timeout_ms` is the server-side staleness window — a socket that sends no
  heartbeat within this window is evicted. The server derives its internal
  check interval as `timeout_ms / 2` (integer division), so `timeout_ms` must
- be at least 2; smaller values are rejected by `start` with
- `InvalidHeartbeatTimeout` because a check interval of 0 would disable
- eviction. The defaults are 30000 ms and 60000 ms respectively.
+ be at least 2; with smaller values `supervisor.start`'s child specification
+ fails to start, because a check interval of 0 would disable eviction. The
+ defaults are 30000 ms and 60000 ms respectively.
 
 ```gleam
 pub fn with_heartbeat(
@@ -575,7 +575,7 @@ pub fn with_max_event_length(
 
 Configure the maximum allowed inbound WebSocket frame size in bytes.
 
- The limit is enforced **post-assembly**: the transport (Mist/gramps)
+ The limit is enforced **post-assembly**: the transport's WebSocket layer
  buffers and assembles a complete frame first, and only then does beryl
  measure it and close the connection if it exceeds `max_bytes`. This bounds
  per-message processing cost (decode, routing, rate-limit accounting), but
@@ -589,7 +589,7 @@ Configure the maximum allowed inbound WebSocket frame size in bytes.
  balancer in front of beryl and configure a WebSocket frame-size limit
  there (and a matching request/body size limit). beryl's per-IP connection
  limit and per-socket message-rate limit do not mitigate this vector. See
- the "Security & deployment" section of the README and
+ the "Security" section of the README and
  `docs/security/frame-buffering-followup.md` for details.
 
  Values <= 0 disable the cap. The default is 1 MiB.
@@ -619,9 +619,10 @@ pub fn with_max_joined_topics_per_socket(
 Configure the maximum allowed byte length for client-supplied topic
  strings.
 
- Topics longer than `max_length` bytes are rejected with a `phx_reply`
- error before reaching a channel handler, bounding the size of keys stored
- in the coordinator's topic registry. The default is 256.
+ Joins to topics longer than `max_length` bytes are rejected with an error
+ reply (a `phx_reply` under the Phoenix codec) before reaching a channel
+ handler, and other frames naming them are dropped — bounding the size of
+ keys stored in the coordinator's topic registry. The default is 256.
 
 ```gleam
 pub fn with_max_topic_length(

--- a/website/src/content/docs/reference/api/beryl_ewe.md
+++ b/website/src/content/docs/reference/api/beryl_ewe.md
@@ -11,8 +11,8 @@ description: Ewe WebSocket Transport - Direct Ewe integration for beryl
 
 Ewe WebSocket Transport - Direct Ewe integration for beryl
 
- This module provides the bridge between Ewe's native WebSocket handling
- and the beryl coordinator using Ewe request and response types directly.
+ Bridges Ewe's native WebSocket handling to the beryl coordinator, using
+ Ewe request and response types directly.
 
  It mirrors the `beryl_mist` package: the two transports expose the same
  config-builder and handler API, so an integrator can run beryl channels on
@@ -140,6 +140,8 @@ Build a combined request handler that serves both WebSocket channels and
  by hand:
 
  ```gleam
+ import beryl_ewe as ewe_transport
+
  ewe_transport.handler(channels, ewe_transport.default_config("/socket"), http_handler)
  |> ewe.new
  |> ewe.listening(port: 8000)
@@ -160,6 +162,8 @@ Upgrade a request to WebSocket if it matches the configured path
 
  Usage in your Ewe handler:
  ```gleam
+ import beryl_ewe as ewe_transport
+
  fn handle_request(req: Request(Connection), channels: Channels) -> Response(ResponseBody) {
    use <- ewe_transport.upgrade(req, channels, ewe_transport.default_config("/socket"))
    // Fall through to regular HTTP routing
@@ -229,7 +233,7 @@ pub fn upgrade_connection(
 Disable `Origin` checking, allowing WebSocket upgrades from any origin.
 
  This is an explicit opt-out of the default [`SameOrigin`](#originpolicy)
- CSWSH protection and restores the pre-1.0 allow-all behaviour. Only use it
+ CSWSH protection. Only use it
  for sockets that do not rely on ambient browser credentials (cookies,
  sessions) for authorization, or that authenticate every message
  independently. For cookie/session-authenticated apps, prefer the default

--- a/website/src/content/docs/reference/api/beryl_mist.md
+++ b/website/src/content/docs/reference/api/beryl_mist.md
@@ -11,8 +11,8 @@ description: Mist WebSocket Transport - Direct Mist integration for beryl
 
 Mist WebSocket Transport - Direct Mist integration for beryl
 
- This module provides the bridge between Mist's native WebSocket handling
- and the beryl coordinator using Mist request and response types directly.
+ Bridges Mist's native WebSocket handling to the beryl coordinator, using
+ Mist request and response types directly.
 
  The `beryl_ewe` package mirrors it: the two transports expose the same
  config-builder and handler API, so an integrator can run beryl channels on
@@ -140,6 +140,8 @@ Build a combined request handler that serves both WebSocket channels and
  by hand:
 
  ```gleam
+ import beryl_mist as mist_transport
+
  mist_transport.handler(channels, mist_transport.default_config("/socket"), http_handler)
  |> mist.new
  |> mist.port(8000)
@@ -160,6 +162,8 @@ Upgrade a request to WebSocket if it matches the configured path
 
  Usage in your Mist handler:
  ```gleam
+ import beryl_mist as mist_transport
+
  fn handle_request(req: Request(Connection), channels: Channels) -> Response(ResponseData) {
    use <- mist_transport.upgrade(req, channels, mist_transport.default_config("/socket"))
    // Fall through to regular HTTP routing
@@ -229,7 +233,7 @@ pub fn upgrade_connection(
 Disable `Origin` checking, allowing WebSocket upgrades from any origin.
 
  This is an explicit opt-out of the default [`SameOrigin`](#originpolicy)
- CSWSH protection and restores the pre-1.0 allow-all behaviour. Only use it
+ CSWSH protection. Only use it
  for sockets that do not rely on ambient browser credentials (cookies,
  sessions) for authorization, or that authenticate every message
  independently. For cookie/session-authenticated apps, prefer the default


### PR DESCRIPTION
Copy review of the user-facing doc comments across `beryl`, `beryl_mist`, and `beryl_ewe`, with every claim verified against the code before editing. Fixes the defects found, applies a terminology census, and regenerates the website API reference.

## Defects fixed

- **Stale `beryl.start` references** (removed in #234): `with_heartbeat` claimed small timeouts are "rejected by `start` with `InvalidHeartbeatTimeout`" (now an internal constructor; the real behavior is `supervisor.start`'s child spec failing), and the `Channels` doc said the handle is "returned by `start`" (it comes from `supervisor.channels`).
- **False shadowing claim in `beryl/channel`**: the module example warned that a binding named `topic` shadows the `beryl/topic` module. Verified empirically that it compiles fine; removed the warning.
- **Overbroad `max_topic_length` claim**: docs said over-long topics are "rejected with a `phx_reply` error". Verified in the coordinator: only joins get an error reply (and only the Phoenix codec calls it `phx_reply`); other frames naming an invalid topic are dropped. Docs now say so, codec-agnostically.
- **Broken `beryl/bridge` example**: its `join` took five arguments and couldn't be passed to `channel.new`. Replaced with the canonical closure form from the README recipe. Also fixed the README recipe's wrong claim that the forwarder's monitor cleans up per-channel — it only fires on coordinator death (see #238 for the underlying API gap).
- **Stale pointers/archaeology**: README section renamed "Security & deployment" → "Security"; "(Mist/gramps)" aside; "restores the pre-1.0 allow-all behaviour" (the packages are 0.0.1); "historical default" phrasing; Erlang-style `beryl.config/1`.

## Terminology

Census found four names for `Wildcard(prefix:)` ("legacy prefix wildcard", "trailing prefix wildcard", "wildcard suffix", "prefix wildcard") and two for `SegmentWildcard`. Standardized on **prefix wildcard** / **segment wildcard** (the constructor field is literally `prefix`; plain "prefix wildcard" already dominated the guides). Losing-word count after: 0 across source, website, and README. Prose-only; no shipped identifier changed.

Presence debug logs now use the `session_id` metadata key instead of `pid`, matching the public API vocabulary (no tests assert on the key). This is the one behavior-adjacent change.

## Copy improvements

- `beryl.broadcast`: cut the tautological line, added the missing fact that PubSub fans the broadcast across the cluster.
- `group`/`presence` module docs point at the supervised path before the standalone `start` examples.
- Transport `upgrade`/`handler` examples show the `import beryl_mist as mist_transport` / `import beryl_ewe as ewe_transport` aliases they rely on.
- Front-loaded transport module docs; removed an unused import from the quick-start example.

## Verification

`just check`, `just test`, and `just format-check` all green after the edits; `just docs` regenerated the 17 reference pages (included in the diff, as the docs CI job requires); terminology and stale-reference greps re-run from final file state with zero survivors. Changelog fragments added for `beryl` and `beryl_mist` (`beryl_ewe` is release-excluded); `trellis changelog check` and `trellis doctor` pass locally.
