### PR TITLE
feat(load): add reusable k6 Phoenix V2 client

### DIFF
--- a/docs/sprint-6/done.md
+++ b/docs/sprint-6/done.md
@@ -1,0 +1,32 @@
+# Sprint 6 handoff
+
+## Completed
+
+- Reusable Phoenix V2 text protocol encoder/decoder and monotonic ref generator.
+- Validated, transport-neutral k6 environment configuration.
+- `k6/websockets` client with join state, correlated replies, heartbeats,
+  operation timeouts, graceful leave/close, and timer cleanup.
+- Observable client, protocol, decode, unmatched-ref, timeout, rejection, and
+  socket errors.
+- Shared Trend, Counter, Rate, and Gauge metrics tagged by transport.
+- Framework-free pure-helper checks runnable with Node.
+
+## Validation
+
+```sh
+node --check load/k6/lib/config.js
+node --check load/k6/lib/protocol.js
+node --check load/k6/lib/metrics.js
+node --check load/k6/lib/phoenix.js
+node load/k6/check-helpers.mjs
+git diff --check
+```
+
+All commands pass. k6 is not installed locally, so k6-only imports and live
+socket behavior were syntax-checked but not exercised against a server.
+
+## Follow-up
+
+The scenario-profiles todo owns executable smoke, throughput, fan-out, presence,
+mixed, and guardrail scenarios. No Beryl Gleam package files were changed by
+this work.

--- a/docs/sprint-6/progress.md
+++ b/docs/sprint-6/progress.md
@@ -9,3 +9,24 @@
 - No blocking GitHub issue applies to this isolated load-client work.
 - `PROJECT_BRIEF.md` and an in-repository sprint plan are not present; the
   Producer-provided saved plan is the source of scope.
+
+## Phase 2: k6 client lifecycle and metrics
+
+- Added a `k6/websockets` client with correlated joins, pushes, replies, leaves,
+  and graceful shutdown.
+- Added heartbeat scheduling and reply tracking, operation timeouts, and
+  complete interval/timeout cleanup on leave or close.
+- Added observable decode, protocol, unmatched-ref, rejection, timeout, socket,
+  and callback errors.
+- Added tagged k6 Trend, Counter, Rate, and Gauge metrics without target-specific
+  behavior or remote imports.
+
+## Telemetry foundation
+
+- Added the Erlang `telemetry` runtime dependency through Gleam tooling.
+- Added disabled-by-default public `beryl.with_telemetry` configuration and
+  propagated the flag into coordinator configuration without instrumenting
+  coordinator or transport paths.
+- Added typed internal event helpers, closed metadata vocabularies, monotonic
+  duration and mailbox helpers, and the Erlang `telemetry:execute/3` FFI.
+- Added focused config, helper, enabled-emission, and disabled-emission tests.

--- a/docs/sprint-6/progress.md
+++ b/docs/sprint-6/progress.md
@@ -21,6 +21,16 @@
 - Added tagged k6 Trend, Counter, Rate, and Gauge metrics without target-specific
   behavior or remote imports.
 
+## Phase 3: validation and handoff
+
+- Node syntax checks pass for all pure and k6-only modules.
+- Framework-free helper checks cover config, URL construction, refs, frames,
+  replies, malformed input, and heartbeat timeout validation.
+- k6 is not installed in the development environment, so no live WebSocket
+  smoke run was possible in this phase.
+- The full smoke and load scenario matrix remains intentionally deferred to the
+  later scenario-profiles todo.
+
 ## Telemetry foundation
 
 - Added the Erlang `telemetry` runtime dependency through Gleam tooling.

--- a/docs/sprint-6/progress.md
+++ b/docs/sprint-6/progress.md
@@ -1,0 +1,11 @@
+# Sprint 6 progress
+
+## Phase 1: protocol and configuration helpers
+
+- Added strict Phoenix V2 five-element text frame encoding and decoding.
+- Added monotonically increasing, per-client message refs.
+- Added environment configuration validation and URL construction.
+- Added framework-free Node checks for k6-independent helpers.
+- No blocking GitHub issue applies to this isolated load-client work.
+- `PROJECT_BRIEF.md` and an in-repository sprint plan are not present; the
+  Producer-provided saved plan is the source of scope.

--- a/load/k6/check-helpers.mjs
+++ b/load/k6/check-helpers.mjs
@@ -41,6 +41,19 @@ assert.deepEqual(
   { value: 42 },
 );
 assert.throws(() => decodeFrame('["too","short"]'), ProtocolError);
+assert.throws(
+  () => decodeReply(["1", "2", "bench:one", "phx_reply", { response: {} }]),
+  ProtocolError,
+);
 assert.throws(() => loadConfig({ TARGET_URL: "https://example.invalid" }));
+assert.throws(
+  () =>
+    loadConfig({
+      TARGET_URL: "ws://example.invalid",
+      HEARTBEAT_INTERVAL_MS: "1000",
+      HEARTBEAT_TIMEOUT_MS: "1000",
+    }),
+  /HEARTBEAT_TIMEOUT_MS/,
+);
 
 console.log("k6 pure helper checks passed");

--- a/load/k6/check-helpers.mjs
+++ b/load/k6/check-helpers.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+
+import { buildWebSocketUrl, loadConfig } from "./lib/config.js";
+import {
+  ProtocolError,
+  RefGenerator,
+  decodeFrame,
+  decodeReply,
+  encodeFrame,
+} from "./lib/protocol.js";
+
+const config = loadConfig({
+  TARGET_URL: "wss://example.invalid/socket?vsn=2.0.0",
+  TOKEN: "a token",
+  TOPICS: "bench:one, bench:two",
+  HEARTBEAT_INTERVAL_MS: "10000",
+  HEARTBEAT_TIMEOUT_MS: "1000",
+});
+assert.equal(
+  buildWebSocketUrl(config),
+  "wss://example.invalid/socket?vsn=2.0.0&token=a%20token",
+);
+assert.deepEqual(config.topics, ["bench:one", "bench:two"]);
+
+const refs = new RefGenerator();
+assert.deepEqual([refs.next(), refs.next(), refs.next()], ["1", "2", "3"]);
+
+const encoded = encodeFrame("1", "2", "bench:one", "echo", { value: 42 });
+assert.deepEqual(decodeFrame(encoded), {
+  joinRef: "1",
+  ref: "2",
+  topic: "bench:one",
+  event: "echo",
+  payload: { value: 42 },
+});
+assert.deepEqual(
+  decodeReply(["1", "2", "bench:one", "phx_reply", {
+    status: "ok",
+    response: { value: 42 },
+  }]).response,
+  { value: 42 },
+);
+assert.throws(() => decodeFrame('["too","short"]'), ProtocolError);
+assert.throws(() => loadConfig({ TARGET_URL: "https://example.invalid" }));
+
+console.log("k6 pure helper checks passed");

--- a/load/k6/lib/config.js
+++ b/load/k6/lib/config.js
@@ -1,0 +1,136 @@
+const DEFAULTS = Object.freeze({
+  path: "",
+  token: "",
+  tokenParam: "token",
+  topics: ["bench:default"],
+  transport: "unknown",
+  connectTimeoutMs: 10_000,
+  replyTimeoutMs: 5_000,
+  leaveTimeoutMs: 2_000,
+  heartbeatIntervalMs: 30_000,
+  heartbeatTimeoutMs: 5_000,
+});
+
+function integer(env, name, fallback, minimum) {
+  const raw = env[name];
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`${name} must be an integer`);
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    throw new Error(`${name} must be at least ${minimum}`);
+  }
+  return parsed;
+}
+
+function text(env, name, fallback) {
+  const value = env[name];
+  return value === undefined ? fallback : value.trim();
+}
+
+function targetUrl(value) {
+  const url = value.trim();
+  if (!/^wss?:\/\/[^/\s]+(?:[/?#].*)?$/i.test(url)) {
+    throw new Error("TARGET_URL must be an absolute ws:// or wss:// URL");
+  }
+  if (url.includes("#")) {
+    throw new Error("TARGET_URL must not contain a URL fragment");
+  }
+  return url;
+}
+
+function path(value) {
+  if (value === "") {
+    return "";
+  }
+  if (!value.startsWith("/") || value.includes("?") || value.includes("#")) {
+    throw new Error("WS_PATH must start with / and contain no query or fragment");
+  }
+  return value;
+}
+
+function topics(value) {
+  const parsed = value
+    .split(",")
+    .map((topic) => topic.trim())
+    .filter(Boolean);
+  if (parsed.length === 0) {
+    throw new Error("TOPICS must contain at least one topic");
+  }
+  return parsed;
+}
+
+export function buildWebSocketUrl(config) {
+  let url = config.targetUrl;
+  if (config.path) {
+    const queryIndex = url.indexOf("?");
+    const base = queryIndex === -1 ? url : url.slice(0, queryIndex);
+    const query = queryIndex === -1 ? "" : url.slice(queryIndex);
+    url = `${base.replace(/\/+$/, "")}${config.path}${query}`;
+  }
+  if (config.token) {
+    const separator = url.includes("?") ? "&" : "?";
+    url += `${separator}${encodeURIComponent(config.tokenParam)}=${encodeURIComponent(
+      config.token,
+    )}`;
+  }
+  return url;
+}
+
+export function loadConfig(env = globalThis.__ENV ?? {}) {
+  const rawTarget = text(env, "TARGET_URL", "");
+  if (rawTarget === "") {
+    throw new Error("TARGET_URL is required");
+  }
+
+  const config = {
+    targetUrl: targetUrl(rawTarget),
+    path: path(text(env, "WS_PATH", DEFAULTS.path)),
+    token: text(env, "TOKEN", DEFAULTS.token),
+    tokenParam: text(env, "TOKEN_PARAM", DEFAULTS.tokenParam),
+    topics: topics(text(env, "TOPICS", DEFAULTS.topics.join(","))),
+    transport: text(env, "TRANSPORT", DEFAULTS.transport),
+    connectTimeoutMs: integer(
+      env,
+      "CONNECT_TIMEOUT_MS",
+      DEFAULTS.connectTimeoutMs,
+      1,
+    ),
+    replyTimeoutMs: integer(env, "REPLY_TIMEOUT_MS", DEFAULTS.replyTimeoutMs, 1),
+    leaveTimeoutMs: integer(env, "LEAVE_TIMEOUT_MS", DEFAULTS.leaveTimeoutMs, 1),
+    heartbeatIntervalMs: integer(
+      env,
+      "HEARTBEAT_INTERVAL_MS",
+      DEFAULTS.heartbeatIntervalMs,
+      0,
+    ),
+    heartbeatTimeoutMs: integer(
+      env,
+      "HEARTBEAT_TIMEOUT_MS",
+      DEFAULTS.heartbeatTimeoutMs,
+      1,
+    ),
+  };
+
+  if (!config.tokenParam) {
+    throw new Error("TOKEN_PARAM must not be empty");
+  }
+  if (!config.transport) {
+    throw new Error("TRANSPORT must not be empty");
+  }
+  if (
+    config.heartbeatIntervalMs > 0 &&
+    config.heartbeatTimeoutMs >= config.heartbeatIntervalMs
+  ) {
+    throw new Error(
+      "HEARTBEAT_TIMEOUT_MS must be less than HEARTBEAT_INTERVAL_MS",
+    );
+  }
+
+  return Object.freeze({ ...config, topics: Object.freeze(config.topics) });
+}
+
+export { DEFAULTS };

--- a/load/k6/lib/config.js
+++ b/load/k6/lib/config.js
@@ -2,7 +2,7 @@ const DEFAULTS = Object.freeze({
   path: "",
   token: "",
   tokenParam: "token",
-  topics: ["bench:default"],
+  topics: [],
   transport: "unknown",
   connectTimeoutMs: 10_000,
   replyTimeoutMs: 5_000,
@@ -53,6 +53,9 @@ function path(value) {
 }
 
 function topics(value) {
+  if (value.trim() === "") {
+    return [];
+  }
   const parsed = value
     .split(",")
     .map((topic) => topic.trim())
@@ -91,7 +94,7 @@ export function loadConfig(env = globalThis.__ENV ?? {}) {
     path: path(text(env, "WS_PATH", DEFAULTS.path)),
     token: text(env, "TOKEN", DEFAULTS.token),
     tokenParam: text(env, "TOKEN_PARAM", DEFAULTS.tokenParam),
-    topics: topics(text(env, "TOPICS", DEFAULTS.topics.join(","))),
+    topics: topics(text(env, "TOPICS", "")),
     transport: text(env, "TRANSPORT", DEFAULTS.transport),
     connectTimeoutMs: integer(
       env,

--- a/load/k6/lib/metrics.js
+++ b/load/k6/lib/metrics.js
@@ -1,0 +1,100 @@
+import { Counter, Gauge, Rate, Trend } from "k6/metrics";
+
+export const websocketEstablishDuration = new Trend(
+  "phoenix_ws_establish_duration",
+  true,
+);
+export const joinDuration = new Trend("phoenix_join_duration", true);
+export const pushReplyDuration = new Trend("phoenix_push_reply_duration", true);
+export const heartbeatReplyDuration = new Trend(
+  "phoenix_heartbeat_reply_duration",
+  true,
+);
+
+export const sessionsActive = new Gauge("phoenix_sessions_active");
+export const sessionsOpened = new Counter("phoenix_sessions_opened");
+export const sessionsClosed = new Counter("phoenix_sessions_closed");
+export const repliesReceived = new Counter("phoenix_replies_received");
+export const clientErrors = new Counter("phoenix_client_errors");
+export const protocolErrors = new Counter("phoenix_protocol_errors");
+export const decodeErrors = new Counter("phoenix_decode_errors");
+export const unmatchedReplies = new Counter("phoenix_unmatched_replies");
+export const pushTimeouts = new Counter("phoenix_push_timeouts");
+export const heartbeatTimeouts = new Counter("phoenix_heartbeat_timeouts");
+
+export const websocketFailureRate = new Rate("phoenix_ws_failure_rate");
+export const joinRejectionRate = new Rate("phoenix_join_rejection_rate");
+export const pushTimeoutRate = new Rate("phoenix_push_timeout_rate");
+export const heartbeatTimeoutRate = new Rate("phoenix_heartbeat_timeout_rate");
+
+function add(metric, value, tags) {
+  metric.add(value, tags);
+}
+
+export const clientMetrics = Object.freeze({
+  connected(durationMs, tags) {
+    add(websocketEstablishDuration, durationMs, tags);
+    add(websocketFailureRate, false, tags);
+    add(sessionsOpened, 1, tags);
+    add(sessionsActive, 1, tags);
+  },
+
+  connectFailed(durationMs, tags) {
+    add(websocketEstablishDuration, durationMs, tags);
+    add(websocketFailureRate, true, tags);
+  },
+
+  closed(tags) {
+    add(sessionsClosed, 1, tags);
+    add(sessionsActive, 0, tags);
+  },
+
+  reply(kind, durationMs, tags) {
+    add(repliesReceived, 1, tags);
+    if (kind === "join") {
+      add(joinDuration, durationMs, tags);
+      add(joinRejectionRate, false, tags);
+    } else if (kind === "heartbeat") {
+      add(heartbeatReplyDuration, durationMs, tags);
+      add(heartbeatTimeoutRate, false, tags);
+    } else {
+      add(pushReplyDuration, durationMs, tags);
+      add(pushTimeoutRate, false, tags);
+    }
+  },
+
+  rejected(kind, durationMs, tags) {
+    if (kind === "join") {
+      add(joinDuration, durationMs, tags);
+      add(joinRejectionRate, true, tags);
+    } else {
+      add(pushReplyDuration, durationMs, tags);
+    }
+  },
+
+  timeout(kind, tags) {
+    if (kind === "heartbeat") {
+      add(heartbeatTimeouts, 1, tags);
+      add(heartbeatTimeoutRate, true, tags);
+    } else {
+      add(pushTimeouts, 1, tags);
+      add(pushTimeoutRate, true, tags);
+    }
+  },
+
+  decodeError(tags) {
+    add(decodeErrors, 1, tags);
+  },
+
+  error(type, tags) {
+    add(clientErrors, 1, { ...tags, error_type: type });
+  },
+
+  protocolError(type, tags) {
+    add(protocolErrors, 1, { ...tags, error_type: type });
+  },
+
+  unmatchedReply(tags) {
+    add(unmatchedReplies, 1, tags);
+  },
+});

--- a/load/k6/lib/phoenix.js
+++ b/load/k6/lib/phoenix.js
@@ -1,0 +1,525 @@
+import { WebSocket } from "k6/websockets";
+
+import { buildWebSocketUrl } from "./config.js";
+import {
+  ProtocolError,
+  RefGenerator,
+  decodeFrame,
+  decodeReply,
+  encodeFrame,
+} from "./protocol.js";
+import { clientMetrics } from "./metrics.js";
+
+const OPEN = 1;
+const NORMAL_CLOSE = 1000;
+
+export class PhoenixReplyError extends Error {
+  constructor(topic, event, status, response) {
+    super(`Phoenix ${event} on ${topic} returned status ${status}`);
+    this.name = "PhoenixReplyError";
+    this.topic = topic;
+    this.event = event;
+    this.status = status;
+    this.response = response;
+  }
+}
+
+export class PhoenixTimeoutError extends Error {
+  constructor(topic, event, timeoutMs) {
+    super(`Phoenix ${event} on ${topic} timed out after ${timeoutMs}ms`);
+    this.name = "PhoenixTimeoutError";
+    this.topic = topic;
+    this.event = event;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+function sameRef(left, right) {
+  if (left === null || right === null) {
+    return left === right;
+  }
+  return String(left) === String(right);
+}
+
+export class PhoenixClient {
+  constructor(config, options = {}) {
+    this.config = config;
+    this.url = buildWebSocketUrl(config);
+    this.tags = Object.freeze({
+      transport: config.transport,
+      ...(options.tags ?? {}),
+    });
+    this.protocols = options.protocols ?? [];
+    this.metricSink = options.metrics ?? clientMetrics;
+    this.refs = new RefGenerator();
+    this.socket = null;
+    this.state = "idle";
+    this.channels = new Map();
+    this.pending = new Map();
+    this.messageHandlers = new Set();
+    this.errorHandlers = new Set();
+    this.connectTimer = null;
+    this.heartbeatTimer = null;
+    this.heartbeatPending = false;
+    this.closeWaiters = [];
+    this.wasOpened = false;
+  }
+
+  onMessage(handler) {
+    this.messageHandlers.add(handler);
+    return () => this.messageHandlers.delete(handler);
+  }
+
+  onError(handler) {
+    this.errorHandlers.add(handler);
+    return () => this.errorHandlers.delete(handler);
+  }
+
+  connect() {
+    if (this.state !== "idle" && this.state !== "closed") {
+      return Promise.reject(new Error(`cannot connect while client is ${this.state}`));
+    }
+
+    this.state = "connecting";
+    this.wasOpened = false;
+    const startedAt = Date.now();
+
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const fail = (error, type) => {
+        if (settled) return;
+        settled = true;
+        this._clearConnectTimer();
+        this.state = "closed";
+        this.metricSink.connectFailed(Date.now() - startedAt, this.tags);
+        this._observeError(error, type);
+        reject(error);
+      };
+
+      this.connectTimer = setTimeout(() => {
+        const error = new PhoenixTimeoutError(
+          "websocket",
+          "connect",
+          this.config.connectTimeoutMs,
+        );
+        fail(error, "connect_timeout");
+        this._closeSocket(NORMAL_CLOSE, "connect timeout");
+      }, this.config.connectTimeoutMs);
+
+      try {
+        this.socket = new WebSocket(this.url, this.protocols, { tags: this.tags });
+      } catch (error) {
+        fail(error, "connect");
+        return;
+      }
+
+      this.socket.addEventListener("open", () => {
+        if (settled) {
+          this._closeSocket(NORMAL_CLOSE, "late open");
+          return;
+        }
+        settled = true;
+        this._clearConnectTimer();
+        this.state = "open";
+        this.wasOpened = true;
+        this.metricSink.connected(Date.now() - startedAt, this.tags);
+        this._startHeartbeat();
+        resolve(this);
+      });
+
+      this.socket.addEventListener("message", (event) => {
+        this._handleMessage(event.data);
+      });
+
+      this.socket.addEventListener("error", (event) => {
+        const error =
+          event?.error instanceof Error
+            ? event.error
+            : new Error(event?.message || "WebSocket error");
+        if (!settled) {
+          fail(error, "connect");
+        } else {
+          this._observeError(error, "websocket");
+        }
+      });
+
+      this.socket.addEventListener("close", (event) => {
+        const opened = this.wasOpened;
+        if (!settled) {
+          fail(
+            new Error(`WebSocket closed during connect (code ${event.code})`),
+            "connect_close",
+          );
+        }
+        if (opened) {
+          this._handleClose(event);
+        } else {
+          this._cleanup(new Error("WebSocket closed during connect"));
+        }
+      });
+    });
+  }
+
+  async join(topic, payload = {}, timeoutMs = this.config.replyTimeoutMs) {
+    if (this.channels.has(topic)) {
+      throw new Error(`already joined or joining ${topic}`);
+    }
+    this._requireOpen();
+
+    const joinRef = this.refs.next();
+    this.channels.set(topic, { joinRef, state: "joining" });
+    try {
+      const response = await this._request(
+        joinRef,
+        joinRef,
+        topic,
+        "phx_join",
+        payload,
+        timeoutMs,
+        "join",
+      );
+      this.channels.set(topic, { joinRef, state: "joined" });
+      return response;
+    } catch (error) {
+      this.channels.delete(topic);
+      throw error;
+    }
+  }
+
+  push(topic, event, payload = {}, timeoutMs = this.config.replyTimeoutMs) {
+    if (event === "phx_join" || event === "phx_leave") {
+      return Promise.reject(new Error(`${event} must use the lifecycle API`));
+    }
+    const channel = this.channels.get(topic);
+    if (channel?.state !== "joined") {
+      return Promise.reject(new Error(`cannot push before joining ${topic}`));
+    }
+    return this._request(
+      channel.joinRef,
+      this.refs.next(),
+      topic,
+      event,
+      payload,
+      timeoutMs,
+      "push",
+    );
+  }
+
+  async leave(topic, timeoutMs = this.config.leaveTimeoutMs) {
+    const channel = this.channels.get(topic);
+    if (channel?.state !== "joined") {
+      throw new Error(`cannot leave unjoined topic ${topic}`);
+    }
+    channel.state = "leaving";
+    try {
+      const response = await this._request(
+        channel.joinRef,
+        this.refs.next(),
+        topic,
+        "phx_leave",
+        {},
+        timeoutMs,
+        "leave",
+      );
+      this.channels.delete(topic);
+      return response;
+    } catch (error) {
+      channel.state = "joined";
+      throw error;
+    }
+  }
+
+  async leaveAll(timeoutMs = this.config.leaveTimeoutMs) {
+    const topics = [...this.channels.entries()]
+      .filter(([, channel]) => channel.state === "joined")
+      .map(([topic]) => topic);
+    const errors = [];
+    for (const topic of topics) {
+      try {
+        await this.leave(topic, timeoutMs);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length > 0) {
+      const error = new Error("one or more Phoenix leaves failed");
+      error.errors = errors;
+      throw error;
+    }
+  }
+
+  close(code = NORMAL_CLOSE, reason = "normal", timeoutMs = this.config.leaveTimeoutMs) {
+    if (this.state === "idle" || this.state === "closed") {
+      this._cleanup(new Error("client closed"));
+      return Promise.resolve();
+    }
+    if (this.state === "closing") {
+      return new Promise((resolve, reject) => {
+        this._addCloseWaiter(resolve, reject, timeoutMs);
+      });
+    }
+
+    this.state = "closing";
+    this._stopHeartbeat();
+    return new Promise((resolve, reject) => {
+      this._addCloseWaiter(resolve, reject, timeoutMs);
+      this._closeSocket(code, reason);
+    });
+  }
+
+  async shutdown() {
+    let leaveError = null;
+    try {
+      await this.leaveAll();
+    } catch (error) {
+      leaveError = error;
+      this._observeError(error, "leave");
+    }
+    await this.close();
+    if (leaveError) {
+      throw leaveError;
+    }
+  }
+
+  _request(joinRef, ref, topic, event, payload, timeoutMs, kind) {
+    try {
+      this._requireOpen();
+    } catch (error) {
+      return Promise.reject(error);
+    }
+
+    return new Promise((resolve, reject) => {
+      const startedAt = Date.now();
+      const key = String(ref);
+      const timer = setTimeout(() => {
+        this.pending.delete(key);
+        const error = new PhoenixTimeoutError(topic, event, timeoutMs);
+        this.metricSink.timeout(kind, this.tags);
+        this._observeError(error, `${kind}_timeout`);
+        reject(error);
+      }, timeoutMs);
+
+      this.pending.set(key, {
+        joinRef,
+        topic,
+        event,
+        kind,
+        startedAt,
+        timer,
+        resolve,
+        reject,
+      });
+
+      try {
+        this.socket.send(encodeFrame(joinRef, ref, topic, event, payload));
+      } catch (error) {
+        clearTimeout(timer);
+        this.pending.delete(key);
+        this._observeError(error, "send");
+        reject(error);
+      }
+    });
+  }
+
+  _handleMessage(data) {
+    let frame;
+    try {
+      frame = decodeFrame(data);
+    } catch (error) {
+      this.metricSink.decodeError(this.tags);
+      this._observeError(error, "decode");
+      return;
+    }
+
+    if (frame.event !== "phx_reply") {
+      const channel = this.channels.get(frame.topic);
+      if (channel && sameRef(channel.joinRef, frame.joinRef)) {
+        if (frame.event === "phx_close") {
+          this.channels.delete(frame.topic);
+        } else if (frame.event === "phx_error") {
+          this.channels.delete(frame.topic);
+          this._observeError(
+            new Error(`Phoenix channel errored on ${frame.topic}`),
+            "channel_error",
+          );
+        }
+      }
+      this._dispatchMessage(frame);
+      return;
+    }
+
+    const key = frame.ref === null ? "" : String(frame.ref);
+    const pending = this.pending.get(key);
+    if (!pending) {
+      this.metricSink.unmatchedReply(this.tags);
+      this.metricSink.protocolError("unmatched_ref", this.tags);
+      this._observeError(
+        new ProtocolError(`received phx_reply with unmatched ref ${key || "null"}`),
+        "unmatched_ref",
+      );
+      return;
+    }
+
+    clearTimeout(pending.timer);
+    this.pending.delete(key);
+    const durationMs = Date.now() - pending.startedAt;
+
+    let reply;
+    try {
+      reply = decodeReply(frame);
+      if (reply.topic !== pending.topic || !sameRef(reply.joinRef, pending.joinRef)) {
+        throw new ProtocolError("phx_reply topic or join_ref did not match its push");
+      }
+    } catch (error) {
+      this.metricSink.protocolError("invalid_reply", this.tags);
+      this._observeError(error, "invalid_reply");
+      pending.reject(error);
+      return;
+    }
+
+    if (reply.status !== "ok") {
+      const error = new PhoenixReplyError(
+        pending.topic,
+        pending.event,
+        reply.status,
+        reply.response,
+      );
+      this.metricSink.rejected(pending.kind, durationMs, this.tags);
+      this._observeError(error, `${pending.kind}_rejected`);
+      pending.reject(error);
+      return;
+    }
+
+    this.metricSink.reply(pending.kind, durationMs, this.tags);
+    pending.resolve(reply.response);
+  }
+
+  _dispatchMessage(frame) {
+    for (const handler of this.messageHandlers) {
+      try {
+        handler(frame);
+      } catch (error) {
+        this._observeError(error, "message_handler");
+      }
+    }
+  }
+
+  _startHeartbeat() {
+    if (this.config.heartbeatIntervalMs === 0) return;
+    this.heartbeatTimer = setInterval(() => {
+      if (this.state !== "open" || this.heartbeatPending) return;
+      this.heartbeatPending = true;
+      this._request(
+        null,
+        this.refs.next(),
+        "phoenix",
+        "heartbeat",
+        {},
+        this.config.heartbeatTimeoutMs,
+        "heartbeat",
+      ).then(
+        () => {
+          this.heartbeatPending = false;
+        },
+        () => {
+          this.heartbeatPending = false;
+        },
+      );
+    }, this.config.heartbeatIntervalMs);
+  }
+
+  _stopHeartbeat() {
+    if (this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    this.heartbeatPending = false;
+  }
+
+  _handleClose(event) {
+    const error =
+      this.state === "closing"
+        ? new Error("client closed")
+        : new Error(`WebSocket closed unexpectedly (code ${event.code})`);
+    const unexpected = this.state !== "closing";
+    this._cleanup(error);
+    if (unexpected) {
+      this._observeError(error, "unexpected_close");
+    }
+    for (const waiter of this.closeWaiters.splice(0)) {
+      if (waiter.timer !== null) clearTimeout(waiter.timer);
+      waiter.resolve();
+    }
+  }
+
+  _addCloseWaiter(resolve, reject, timeoutMs) {
+    const waiter = { resolve, reject, timer: null };
+    waiter.timer = setTimeout(() => {
+      const error = new PhoenixTimeoutError("websocket", "close", timeoutMs);
+      this._observeError(error, "close_timeout");
+      this._cleanup(error);
+      for (const closeWaiter of this.closeWaiters.splice(0)) {
+        if (closeWaiter.timer !== null) clearTimeout(closeWaiter.timer);
+        closeWaiter.reject(error);
+      }
+    }, timeoutMs);
+    this.closeWaiters.push(waiter);
+  }
+
+  _cleanup(error) {
+    this._clearConnectTimer();
+    this._stopHeartbeat();
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+    this.channels.clear();
+    this.state = "closed";
+    this.socket = null;
+    if (this.wasOpened) {
+      this.metricSink.closed(this.tags);
+      this.wasOpened = false;
+    }
+  }
+
+  _clearConnectTimer() {
+    if (this.connectTimer !== null) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
+  }
+
+  _closeSocket(code, reason) {
+    if (this.socket && this.socket.readyState <= OPEN) {
+      try {
+        this.socket.close(code, reason);
+      } catch (error) {
+        this._observeError(error, "close");
+      }
+    }
+  }
+
+  _requireOpen() {
+    if (this.state !== "open" || !this.socket || this.socket.readyState !== OPEN) {
+      throw new Error(`Phoenix client is not open (state: ${this.state})`);
+    }
+  }
+
+  _observeError(error, type) {
+    this.metricSink.error(type, this.tags);
+    if (this.errorHandlers.size === 0) {
+      console.error(`[phoenix:${type}] ${error.message || String(error)}`);
+      return;
+    }
+    for (const handler of this.errorHandlers) {
+      try {
+        handler(error, type);
+      } catch (handlerError) {
+        console.error(
+          `[phoenix:error_handler] ${handlerError.message || String(handlerError)}`,
+        );
+      }
+    }
+  }
+}

--- a/load/k6/lib/protocol.js
+++ b/load/k6/lib/protocol.js
@@ -1,0 +1,103 @@
+const FRAME_LENGTH = 5;
+const PHOENIX_REPLY = "phx_reply";
+
+export class ProtocolError extends Error {
+  constructor(message, cause) {
+    super(message);
+    this.name = "ProtocolError";
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
+  }
+}
+
+export class RefGenerator {
+  constructor(initialRef = 0) {
+    if (!Number.isSafeInteger(initialRef) || initialRef < 0) {
+      throw new TypeError("initialRef must be a non-negative safe integer");
+    }
+    this.current = initialRef;
+  }
+
+  next() {
+    if (this.current === Number.MAX_SAFE_INTEGER) {
+      throw new RangeError("Phoenix message ref space exhausted");
+    }
+    this.current += 1;
+    return String(this.current);
+  }
+}
+
+function isRef(value) {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    (typeof value === "number" && Number.isSafeInteger(value))
+  );
+}
+
+function isPayload(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function validateFrame(frame) {
+  if (!Array.isArray(frame) || frame.length !== FRAME_LENGTH) {
+    throw new ProtocolError("Phoenix V2 frames must be five-element arrays");
+  }
+
+  const [joinRef, ref, topic, event, payload] = frame;
+  if (!isRef(joinRef)) {
+    throw new ProtocolError("frame join_ref must be null, a string, or an integer");
+  }
+  if (!isRef(ref)) {
+    throw new ProtocolError("frame ref must be null, a string, or an integer");
+  }
+  if (typeof topic !== "string" || topic.length === 0) {
+    throw new ProtocolError("frame topic must be a non-empty string");
+  }
+  if (typeof event !== "string" || event.length === 0) {
+    throw new ProtocolError("frame event must be a non-empty string");
+  }
+  if (!isPayload(payload)) {
+    throw new ProtocolError("frame payload must be an object");
+  }
+
+  return { joinRef, ref, topic, event, payload };
+}
+
+export function encodeFrame(joinRef, ref, topic, event, payload = {}) {
+  const frame = [joinRef, ref, topic, event, payload];
+  validateFrame(frame);
+  return JSON.stringify(frame);
+}
+
+export function decodeFrame(data) {
+  if (typeof data !== "string") {
+    throw new ProtocolError("expected a Phoenix V2 text frame");
+  }
+
+  let frame;
+  try {
+    frame = JSON.parse(data);
+  } catch (error) {
+    throw new ProtocolError("received invalid JSON", error);
+  }
+  return validateFrame(frame);
+}
+
+export function decodeReply(frame) {
+  const decoded = Array.isArray(frame) ? validateFrame(frame) : frame;
+  if (decoded.event !== PHOENIX_REPLY) {
+    throw new ProtocolError(`expected phx_reply, received ${decoded.event}`);
+  }
+
+  const { status, response } = decoded.payload;
+  if (typeof status !== "string" || status.length === 0) {
+    throw new ProtocolError("phx_reply payload must contain a status string");
+  }
+  if (!Object.prototype.hasOwnProperty.call(decoded.payload, "response")) {
+    throw new ProtocolError("phx_reply payload must contain a response");
+  }
+
+  return { ...decoded, status, response };
+}

--- a/load/k6/package.json
+++ b/load/k6/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}


### PR DESCRIPTION
## Summary
- add strict Phoenix V2 frame/config helpers and monotonic refs
- add k6/websockets lifecycle client with reply correlation, heartbeat, timeouts, and cleanup
- add custom metrics and framework-free Node helper checks

## Validation
- node --check load/k6/lib/{config,protocol,metrics,phoenix}.js
- node load/k6/check-helpers.mjs
- git diff --check

## Notes
- k6 is unavailable locally, so live socket validation is deferred to the scenario-profile todo.