### PR TITLE
feat: add telemetry foundation and k6 client

### DIFF
--- a/.changes/unreleased/beryl-3.toml
+++ b/.changes/unreleased/beryl-3.toml
@@ -1,0 +1,3 @@
+project = "beryl"
+kind = "Added"
+body = "Add opt-in telemetry configuration and typed internal event foundations."

--- a/docs/sprint-6/done.md
+++ b/docs/sprint-6/done.md
@@ -1,0 +1,32 @@
+# Sprint 6 handoff
+
+## Completed
+
+- Reusable Phoenix V2 text protocol encoder/decoder and monotonic ref generator.
+- Validated, transport-neutral k6 environment configuration.
+- `k6/websockets` client with join state, correlated replies, heartbeats,
+  operation timeouts, graceful leave/close, and timer cleanup.
+- Observable client, protocol, decode, unmatched-ref, timeout, rejection, and
+  socket errors.
+- Shared Trend, Counter, Rate, and Gauge metrics tagged by transport.
+- Framework-free pure-helper checks runnable with Node.
+
+## Validation
+
+```sh
+node --check load/k6/lib/config.js
+node --check load/k6/lib/protocol.js
+node --check load/k6/lib/metrics.js
+node --check load/k6/lib/phoenix.js
+node load/k6/check-helpers.mjs
+git diff --check
+```
+
+All commands pass. k6 is not installed locally, so k6-only imports and live
+socket behavior were syntax-checked but not exercised against a server.
+
+## Follow-up
+
+The scenario-profiles todo owns executable smoke, throughput, fan-out, presence,
+mixed, and guardrail scenarios. No Beryl Gleam package files were changed by
+this work.

--- a/docs/sprint-6/progress.md
+++ b/docs/sprint-6/progress.md
@@ -9,3 +9,24 @@
 - No blocking GitHub issue applies to this isolated load-client work.
 - `PROJECT_BRIEF.md` and an in-repository sprint plan are not present; the
   Producer-provided saved plan is the source of scope.
+
+## Phase 2: k6 client lifecycle and metrics
+
+- Added a `k6/websockets` client with correlated joins, pushes, replies, leaves,
+  and graceful shutdown.
+- Added heartbeat scheduling and reply tracking, operation timeouts, and
+  complete interval/timeout cleanup on leave or close.
+- Added observable decode, protocol, unmatched-ref, rejection, timeout, socket,
+  and callback errors.
+- Added tagged k6 Trend, Counter, Rate, and Gauge metrics without target-specific
+  behavior or remote imports.
+
+## Telemetry foundation
+
+- Added the Erlang `telemetry` runtime dependency through Gleam tooling.
+- Added disabled-by-default public `beryl.with_telemetry` configuration and
+  propagated the flag into coordinator configuration without instrumenting
+  coordinator or transport paths.
+- Added typed internal event helpers, closed metadata vocabularies, monotonic
+  duration and mailbox helpers, and the Erlang `telemetry:execute/3` FFI.
+- Added focused config, helper, enabled-emission, and disabled-emission tests.

--- a/docs/sprint-6/progress.md
+++ b/docs/sprint-6/progress.md
@@ -21,6 +21,16 @@
 - Added tagged k6 Trend, Counter, Rate, and Gauge metrics without target-specific
   behavior or remote imports.
 
+## Phase 3: validation and handoff
+
+- Node syntax checks pass for all pure and k6-only modules.
+- Framework-free helper checks cover config, URL construction, refs, frames,
+  replies, malformed input, and heartbeat timeout validation.
+- k6 is not installed in the development environment, so no live WebSocket
+  smoke run was possible in this phase.
+- The full smoke and load scenario matrix remains intentionally deferred to the
+  later scenario-profiles todo.
+
 ## Telemetry foundation
 
 - Added the Erlang `telemetry` runtime dependency through Gleam tooling.

--- a/docs/sprint-6/progress.md
+++ b/docs/sprint-6/progress.md
@@ -1,0 +1,11 @@
+# Sprint 6 progress
+
+## Phase 1: protocol and configuration helpers
+
+- Added strict Phoenix V2 five-element text frame encoding and decoding.
+- Added monotonically increasing, per-client message refs.
+- Added environment configuration validation and URL construction.
+- Added framework-free Node checks for k6-independent helpers.
+- No blocking GitHub issue applies to this isolated load-client work.
+- `PROJECT_BRIEF.md` and an in-repository sprint plan are not present; the
+  Producer-provided saved plan is the source of scope.

--- a/examples/chatrooms/manifest.toml
+++ b/examples/chatrooms/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "beryl", version = "0.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres"], source = "local", path = "../../packages/beryl" },
+  { name = "beryl", version = "0.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
   { name = "beryl_mist", version = "0.0.1", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
   { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
@@ -21,6 +21,7 @@ packages = [
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
+  { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
 ]
 
 [requirements]

--- a/examples/collab_docs/manifest.toml
+++ b/examples/collab_docs/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "beryl", version = "0.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres"], source = "local", path = "../../packages/beryl" },
+  { name = "beryl", version = "0.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
   { name = "beryl_mist", version = "0.0.1", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
   { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
@@ -26,6 +26,7 @@ packages = [
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
+  { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
 ]
 
 [requirements]

--- a/examples/cursors/manifest.toml
+++ b/examples/cursors/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "beryl", version = "0.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres"], source = "local", path = "../../packages/beryl" },
+  { name = "beryl", version = "0.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
   { name = "beryl_mist", version = "0.0.1", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
   { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
@@ -21,6 +21,7 @@ packages = [
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
+  { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
 ]
 
 [requirements]

--- a/examples/example_helpers/manifest.toml
+++ b/examples/example_helpers/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "beryl", version = "0.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres"], source = "local", path = "../../packages/beryl" },
+  { name = "beryl", version = "0.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
   { name = "exception", version = "2.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "6BDEA95248093599391C3B5DF1835C5C6A86C353C2F99CE539B450E3432FE117" },
   { name = "gleam_crypto", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "2DE9E4EF53CF6FEE049D4F765731F7178F7A11AEFAE00EEE63BF7536B354AD3F" },
@@ -18,6 +18,7 @@ packages = [
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
+  { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
 ]
 
 [requirements]

--- a/examples/showcase/manifest.toml
+++ b/examples/showcase/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "beryl", version = "0.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres"], source = "local", path = "../../packages/beryl" },
+  { name = "beryl", version = "0.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
   { name = "beryl_mist", version = "0.0.1", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "chatrooms", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "beryl_mist", "example_helpers", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../chatrooms" },
   { name = "collab_docs", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "beryl_mist", "example_helpers", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_core", "lattice_maps", "mist"], source = "local", path = "../collab_docs" },
@@ -29,6 +29,7 @@ packages = [
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
+  { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
 ]
 
 [requirements]

--- a/load/k6/check-helpers.mjs
+++ b/load/k6/check-helpers.mjs
@@ -41,6 +41,19 @@ assert.deepEqual(
   { value: 42 },
 );
 assert.throws(() => decodeFrame('["too","short"]'), ProtocolError);
+assert.throws(
+  () => decodeReply(["1", "2", "bench:one", "phx_reply", { response: {} }]),
+  ProtocolError,
+);
 assert.throws(() => loadConfig({ TARGET_URL: "https://example.invalid" }));
+assert.throws(
+  () =>
+    loadConfig({
+      TARGET_URL: "ws://example.invalid",
+      HEARTBEAT_INTERVAL_MS: "1000",
+      HEARTBEAT_TIMEOUT_MS: "1000",
+    }),
+  /HEARTBEAT_TIMEOUT_MS/,
+);
 
 console.log("k6 pure helper checks passed");

--- a/load/k6/check-helpers.mjs
+++ b/load/k6/check-helpers.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+
+import { buildWebSocketUrl, loadConfig } from "./lib/config.js";
+import {
+  ProtocolError,
+  RefGenerator,
+  decodeFrame,
+  decodeReply,
+  encodeFrame,
+} from "./lib/protocol.js";
+
+const config = loadConfig({
+  TARGET_URL: "wss://example.invalid/socket?vsn=2.0.0",
+  TOKEN: "a token",
+  TOPICS: "bench:one, bench:two",
+  HEARTBEAT_INTERVAL_MS: "10000",
+  HEARTBEAT_TIMEOUT_MS: "1000",
+});
+assert.equal(
+  buildWebSocketUrl(config),
+  "wss://example.invalid/socket?vsn=2.0.0&token=a%20token",
+);
+assert.deepEqual(config.topics, ["bench:one", "bench:two"]);
+
+const refs = new RefGenerator();
+assert.deepEqual([refs.next(), refs.next(), refs.next()], ["1", "2", "3"]);
+
+const encoded = encodeFrame("1", "2", "bench:one", "echo", { value: 42 });
+assert.deepEqual(decodeFrame(encoded), {
+  joinRef: "1",
+  ref: "2",
+  topic: "bench:one",
+  event: "echo",
+  payload: { value: 42 },
+});
+assert.deepEqual(
+  decodeReply(["1", "2", "bench:one", "phx_reply", {
+    status: "ok",
+    response: { value: 42 },
+  }]).response,
+  { value: 42 },
+);
+assert.throws(() => decodeFrame('["too","short"]'), ProtocolError);
+assert.throws(() => loadConfig({ TARGET_URL: "https://example.invalid" }));
+
+console.log("k6 pure helper checks passed");

--- a/load/k6/lib/config.js
+++ b/load/k6/lib/config.js
@@ -1,0 +1,136 @@
+const DEFAULTS = Object.freeze({
+  path: "",
+  token: "",
+  tokenParam: "token",
+  topics: ["bench:default"],
+  transport: "unknown",
+  connectTimeoutMs: 10_000,
+  replyTimeoutMs: 5_000,
+  leaveTimeoutMs: 2_000,
+  heartbeatIntervalMs: 30_000,
+  heartbeatTimeoutMs: 5_000,
+});
+
+function integer(env, name, fallback, minimum) {
+  const raw = env[name];
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`${name} must be an integer`);
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    throw new Error(`${name} must be at least ${minimum}`);
+  }
+  return parsed;
+}
+
+function text(env, name, fallback) {
+  const value = env[name];
+  return value === undefined ? fallback : value.trim();
+}
+
+function targetUrl(value) {
+  const url = value.trim();
+  if (!/^wss?:\/\/[^/\s]+(?:[/?#].*)?$/i.test(url)) {
+    throw new Error("TARGET_URL must be an absolute ws:// or wss:// URL");
+  }
+  if (url.includes("#")) {
+    throw new Error("TARGET_URL must not contain a URL fragment");
+  }
+  return url;
+}
+
+function path(value) {
+  if (value === "") {
+    return "";
+  }
+  if (!value.startsWith("/") || value.includes("?") || value.includes("#")) {
+    throw new Error("WS_PATH must start with / and contain no query or fragment");
+  }
+  return value;
+}
+
+function topics(value) {
+  const parsed = value
+    .split(",")
+    .map((topic) => topic.trim())
+    .filter(Boolean);
+  if (parsed.length === 0) {
+    throw new Error("TOPICS must contain at least one topic");
+  }
+  return parsed;
+}
+
+export function buildWebSocketUrl(config) {
+  let url = config.targetUrl;
+  if (config.path) {
+    const queryIndex = url.indexOf("?");
+    const base = queryIndex === -1 ? url : url.slice(0, queryIndex);
+    const query = queryIndex === -1 ? "" : url.slice(queryIndex);
+    url = `${base.replace(/\/+$/, "")}${config.path}${query}`;
+  }
+  if (config.token) {
+    const separator = url.includes("?") ? "&" : "?";
+    url += `${separator}${encodeURIComponent(config.tokenParam)}=${encodeURIComponent(
+      config.token,
+    )}`;
+  }
+  return url;
+}
+
+export function loadConfig(env = globalThis.__ENV ?? {}) {
+  const rawTarget = text(env, "TARGET_URL", "");
+  if (rawTarget === "") {
+    throw new Error("TARGET_URL is required");
+  }
+
+  const config = {
+    targetUrl: targetUrl(rawTarget),
+    path: path(text(env, "WS_PATH", DEFAULTS.path)),
+    token: text(env, "TOKEN", DEFAULTS.token),
+    tokenParam: text(env, "TOKEN_PARAM", DEFAULTS.tokenParam),
+    topics: topics(text(env, "TOPICS", DEFAULTS.topics.join(","))),
+    transport: text(env, "TRANSPORT", DEFAULTS.transport),
+    connectTimeoutMs: integer(
+      env,
+      "CONNECT_TIMEOUT_MS",
+      DEFAULTS.connectTimeoutMs,
+      1,
+    ),
+    replyTimeoutMs: integer(env, "REPLY_TIMEOUT_MS", DEFAULTS.replyTimeoutMs, 1),
+    leaveTimeoutMs: integer(env, "LEAVE_TIMEOUT_MS", DEFAULTS.leaveTimeoutMs, 1),
+    heartbeatIntervalMs: integer(
+      env,
+      "HEARTBEAT_INTERVAL_MS",
+      DEFAULTS.heartbeatIntervalMs,
+      0,
+    ),
+    heartbeatTimeoutMs: integer(
+      env,
+      "HEARTBEAT_TIMEOUT_MS",
+      DEFAULTS.heartbeatTimeoutMs,
+      1,
+    ),
+  };
+
+  if (!config.tokenParam) {
+    throw new Error("TOKEN_PARAM must not be empty");
+  }
+  if (!config.transport) {
+    throw new Error("TRANSPORT must not be empty");
+  }
+  if (
+    config.heartbeatIntervalMs > 0 &&
+    config.heartbeatTimeoutMs >= config.heartbeatIntervalMs
+  ) {
+    throw new Error(
+      "HEARTBEAT_TIMEOUT_MS must be less than HEARTBEAT_INTERVAL_MS",
+    );
+  }
+
+  return Object.freeze({ ...config, topics: Object.freeze(config.topics) });
+}
+
+export { DEFAULTS };

--- a/load/k6/lib/config.js
+++ b/load/k6/lib/config.js
@@ -2,7 +2,7 @@ const DEFAULTS = Object.freeze({
   path: "",
   token: "",
   tokenParam: "token",
-  topics: ["bench:default"],
+  topics: [],
   transport: "unknown",
   connectTimeoutMs: 10_000,
   replyTimeoutMs: 5_000,
@@ -53,6 +53,9 @@ function path(value) {
 }
 
 function topics(value) {
+  if (value.trim() === "") {
+    return [];
+  }
   const parsed = value
     .split(",")
     .map((topic) => topic.trim())
@@ -91,7 +94,7 @@ export function loadConfig(env = globalThis.__ENV ?? {}) {
     path: path(text(env, "WS_PATH", DEFAULTS.path)),
     token: text(env, "TOKEN", DEFAULTS.token),
     tokenParam: text(env, "TOKEN_PARAM", DEFAULTS.tokenParam),
-    topics: topics(text(env, "TOPICS", DEFAULTS.topics.join(","))),
+    topics: topics(text(env, "TOPICS", "")),
     transport: text(env, "TRANSPORT", DEFAULTS.transport),
     connectTimeoutMs: integer(
       env,

--- a/load/k6/lib/metrics.js
+++ b/load/k6/lib/metrics.js
@@ -1,0 +1,100 @@
+import { Counter, Gauge, Rate, Trend } from "k6/metrics";
+
+export const websocketEstablishDuration = new Trend(
+  "phoenix_ws_establish_duration",
+  true,
+);
+export const joinDuration = new Trend("phoenix_join_duration", true);
+export const pushReplyDuration = new Trend("phoenix_push_reply_duration", true);
+export const heartbeatReplyDuration = new Trend(
+  "phoenix_heartbeat_reply_duration",
+  true,
+);
+
+export const sessionsActive = new Gauge("phoenix_sessions_active");
+export const sessionsOpened = new Counter("phoenix_sessions_opened");
+export const sessionsClosed = new Counter("phoenix_sessions_closed");
+export const repliesReceived = new Counter("phoenix_replies_received");
+export const clientErrors = new Counter("phoenix_client_errors");
+export const protocolErrors = new Counter("phoenix_protocol_errors");
+export const decodeErrors = new Counter("phoenix_decode_errors");
+export const unmatchedReplies = new Counter("phoenix_unmatched_replies");
+export const pushTimeouts = new Counter("phoenix_push_timeouts");
+export const heartbeatTimeouts = new Counter("phoenix_heartbeat_timeouts");
+
+export const websocketFailureRate = new Rate("phoenix_ws_failure_rate");
+export const joinRejectionRate = new Rate("phoenix_join_rejection_rate");
+export const pushTimeoutRate = new Rate("phoenix_push_timeout_rate");
+export const heartbeatTimeoutRate = new Rate("phoenix_heartbeat_timeout_rate");
+
+function add(metric, value, tags) {
+  metric.add(value, tags);
+}
+
+export const clientMetrics = Object.freeze({
+  connected(durationMs, tags) {
+    add(websocketEstablishDuration, durationMs, tags);
+    add(websocketFailureRate, false, tags);
+    add(sessionsOpened, 1, tags);
+    add(sessionsActive, 1, tags);
+  },
+
+  connectFailed(durationMs, tags) {
+    add(websocketEstablishDuration, durationMs, tags);
+    add(websocketFailureRate, true, tags);
+  },
+
+  closed(tags) {
+    add(sessionsClosed, 1, tags);
+    add(sessionsActive, 0, tags);
+  },
+
+  reply(kind, durationMs, tags) {
+    add(repliesReceived, 1, tags);
+    if (kind === "join") {
+      add(joinDuration, durationMs, tags);
+      add(joinRejectionRate, false, tags);
+    } else if (kind === "heartbeat") {
+      add(heartbeatReplyDuration, durationMs, tags);
+      add(heartbeatTimeoutRate, false, tags);
+    } else {
+      add(pushReplyDuration, durationMs, tags);
+      add(pushTimeoutRate, false, tags);
+    }
+  },
+
+  rejected(kind, durationMs, tags) {
+    if (kind === "join") {
+      add(joinDuration, durationMs, tags);
+      add(joinRejectionRate, true, tags);
+    } else {
+      add(pushReplyDuration, durationMs, tags);
+    }
+  },
+
+  timeout(kind, tags) {
+    if (kind === "heartbeat") {
+      add(heartbeatTimeouts, 1, tags);
+      add(heartbeatTimeoutRate, true, tags);
+    } else {
+      add(pushTimeouts, 1, tags);
+      add(pushTimeoutRate, true, tags);
+    }
+  },
+
+  decodeError(tags) {
+    add(decodeErrors, 1, tags);
+  },
+
+  error(type, tags) {
+    add(clientErrors, 1, { ...tags, error_type: type });
+  },
+
+  protocolError(type, tags) {
+    add(protocolErrors, 1, { ...tags, error_type: type });
+  },
+
+  unmatchedReply(tags) {
+    add(unmatchedReplies, 1, tags);
+  },
+});

--- a/load/k6/lib/phoenix.js
+++ b/load/k6/lib/phoenix.js
@@ -1,0 +1,525 @@
+import { WebSocket } from "k6/websockets";
+
+import { buildWebSocketUrl } from "./config.js";
+import {
+  ProtocolError,
+  RefGenerator,
+  decodeFrame,
+  decodeReply,
+  encodeFrame,
+} from "./protocol.js";
+import { clientMetrics } from "./metrics.js";
+
+const OPEN = 1;
+const NORMAL_CLOSE = 1000;
+
+export class PhoenixReplyError extends Error {
+  constructor(topic, event, status, response) {
+    super(`Phoenix ${event} on ${topic} returned status ${status}`);
+    this.name = "PhoenixReplyError";
+    this.topic = topic;
+    this.event = event;
+    this.status = status;
+    this.response = response;
+  }
+}
+
+export class PhoenixTimeoutError extends Error {
+  constructor(topic, event, timeoutMs) {
+    super(`Phoenix ${event} on ${topic} timed out after ${timeoutMs}ms`);
+    this.name = "PhoenixTimeoutError";
+    this.topic = topic;
+    this.event = event;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+function sameRef(left, right) {
+  if (left === null || right === null) {
+    return left === right;
+  }
+  return String(left) === String(right);
+}
+
+export class PhoenixClient {
+  constructor(config, options = {}) {
+    this.config = config;
+    this.url = buildWebSocketUrl(config);
+    this.tags = Object.freeze({
+      transport: config.transport,
+      ...(options.tags ?? {}),
+    });
+    this.protocols = options.protocols ?? [];
+    this.metricSink = options.metrics ?? clientMetrics;
+    this.refs = new RefGenerator();
+    this.socket = null;
+    this.state = "idle";
+    this.channels = new Map();
+    this.pending = new Map();
+    this.messageHandlers = new Set();
+    this.errorHandlers = new Set();
+    this.connectTimer = null;
+    this.heartbeatTimer = null;
+    this.heartbeatPending = false;
+    this.closeWaiters = [];
+    this.wasOpened = false;
+  }
+
+  onMessage(handler) {
+    this.messageHandlers.add(handler);
+    return () => this.messageHandlers.delete(handler);
+  }
+
+  onError(handler) {
+    this.errorHandlers.add(handler);
+    return () => this.errorHandlers.delete(handler);
+  }
+
+  connect() {
+    if (this.state !== "idle" && this.state !== "closed") {
+      return Promise.reject(new Error(`cannot connect while client is ${this.state}`));
+    }
+
+    this.state = "connecting";
+    this.wasOpened = false;
+    const startedAt = Date.now();
+
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const fail = (error, type) => {
+        if (settled) return;
+        settled = true;
+        this._clearConnectTimer();
+        this.state = "closed";
+        this.metricSink.connectFailed(Date.now() - startedAt, this.tags);
+        this._observeError(error, type);
+        reject(error);
+      };
+
+      this.connectTimer = setTimeout(() => {
+        const error = new PhoenixTimeoutError(
+          "websocket",
+          "connect",
+          this.config.connectTimeoutMs,
+        );
+        fail(error, "connect_timeout");
+        this._closeSocket(NORMAL_CLOSE, "connect timeout");
+      }, this.config.connectTimeoutMs);
+
+      try {
+        this.socket = new WebSocket(this.url, this.protocols, { tags: this.tags });
+      } catch (error) {
+        fail(error, "connect");
+        return;
+      }
+
+      this.socket.addEventListener("open", () => {
+        if (settled) {
+          this._closeSocket(NORMAL_CLOSE, "late open");
+          return;
+        }
+        settled = true;
+        this._clearConnectTimer();
+        this.state = "open";
+        this.wasOpened = true;
+        this.metricSink.connected(Date.now() - startedAt, this.tags);
+        this._startHeartbeat();
+        resolve(this);
+      });
+
+      this.socket.addEventListener("message", (event) => {
+        this._handleMessage(event.data);
+      });
+
+      this.socket.addEventListener("error", (event) => {
+        const error =
+          event?.error instanceof Error
+            ? event.error
+            : new Error(event?.message || "WebSocket error");
+        if (!settled) {
+          fail(error, "connect");
+        } else {
+          this._observeError(error, "websocket");
+        }
+      });
+
+      this.socket.addEventListener("close", (event) => {
+        const opened = this.wasOpened;
+        if (!settled) {
+          fail(
+            new Error(`WebSocket closed during connect (code ${event.code})`),
+            "connect_close",
+          );
+        }
+        if (opened) {
+          this._handleClose(event);
+        } else {
+          this._cleanup(new Error("WebSocket closed during connect"));
+        }
+      });
+    });
+  }
+
+  async join(topic, payload = {}, timeoutMs = this.config.replyTimeoutMs) {
+    if (this.channels.has(topic)) {
+      throw new Error(`already joined or joining ${topic}`);
+    }
+    this._requireOpen();
+
+    const joinRef = this.refs.next();
+    this.channels.set(topic, { joinRef, state: "joining" });
+    try {
+      const response = await this._request(
+        joinRef,
+        joinRef,
+        topic,
+        "phx_join",
+        payload,
+        timeoutMs,
+        "join",
+      );
+      this.channels.set(topic, { joinRef, state: "joined" });
+      return response;
+    } catch (error) {
+      this.channels.delete(topic);
+      throw error;
+    }
+  }
+
+  push(topic, event, payload = {}, timeoutMs = this.config.replyTimeoutMs) {
+    if (event === "phx_join" || event === "phx_leave") {
+      return Promise.reject(new Error(`${event} must use the lifecycle API`));
+    }
+    const channel = this.channels.get(topic);
+    if (channel?.state !== "joined") {
+      return Promise.reject(new Error(`cannot push before joining ${topic}`));
+    }
+    return this._request(
+      channel.joinRef,
+      this.refs.next(),
+      topic,
+      event,
+      payload,
+      timeoutMs,
+      "push",
+    );
+  }
+
+  async leave(topic, timeoutMs = this.config.leaveTimeoutMs) {
+    const channel = this.channels.get(topic);
+    if (channel?.state !== "joined") {
+      throw new Error(`cannot leave unjoined topic ${topic}`);
+    }
+    channel.state = "leaving";
+    try {
+      const response = await this._request(
+        channel.joinRef,
+        this.refs.next(),
+        topic,
+        "phx_leave",
+        {},
+        timeoutMs,
+        "leave",
+      );
+      this.channels.delete(topic);
+      return response;
+    } catch (error) {
+      channel.state = "joined";
+      throw error;
+    }
+  }
+
+  async leaveAll(timeoutMs = this.config.leaveTimeoutMs) {
+    const topics = [...this.channels.entries()]
+      .filter(([, channel]) => channel.state === "joined")
+      .map(([topic]) => topic);
+    const errors = [];
+    for (const topic of topics) {
+      try {
+        await this.leave(topic, timeoutMs);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length > 0) {
+      const error = new Error("one or more Phoenix leaves failed");
+      error.errors = errors;
+      throw error;
+    }
+  }
+
+  close(code = NORMAL_CLOSE, reason = "normal", timeoutMs = this.config.leaveTimeoutMs) {
+    if (this.state === "idle" || this.state === "closed") {
+      this._cleanup(new Error("client closed"));
+      return Promise.resolve();
+    }
+    if (this.state === "closing") {
+      return new Promise((resolve, reject) => {
+        this._addCloseWaiter(resolve, reject, timeoutMs);
+      });
+    }
+
+    this.state = "closing";
+    this._stopHeartbeat();
+    return new Promise((resolve, reject) => {
+      this._addCloseWaiter(resolve, reject, timeoutMs);
+      this._closeSocket(code, reason);
+    });
+  }
+
+  async shutdown() {
+    let leaveError = null;
+    try {
+      await this.leaveAll();
+    } catch (error) {
+      leaveError = error;
+      this._observeError(error, "leave");
+    }
+    await this.close();
+    if (leaveError) {
+      throw leaveError;
+    }
+  }
+
+  _request(joinRef, ref, topic, event, payload, timeoutMs, kind) {
+    try {
+      this._requireOpen();
+    } catch (error) {
+      return Promise.reject(error);
+    }
+
+    return new Promise((resolve, reject) => {
+      const startedAt = Date.now();
+      const key = String(ref);
+      const timer = setTimeout(() => {
+        this.pending.delete(key);
+        const error = new PhoenixTimeoutError(topic, event, timeoutMs);
+        this.metricSink.timeout(kind, this.tags);
+        this._observeError(error, `${kind}_timeout`);
+        reject(error);
+      }, timeoutMs);
+
+      this.pending.set(key, {
+        joinRef,
+        topic,
+        event,
+        kind,
+        startedAt,
+        timer,
+        resolve,
+        reject,
+      });
+
+      try {
+        this.socket.send(encodeFrame(joinRef, ref, topic, event, payload));
+      } catch (error) {
+        clearTimeout(timer);
+        this.pending.delete(key);
+        this._observeError(error, "send");
+        reject(error);
+      }
+    });
+  }
+
+  _handleMessage(data) {
+    let frame;
+    try {
+      frame = decodeFrame(data);
+    } catch (error) {
+      this.metricSink.decodeError(this.tags);
+      this._observeError(error, "decode");
+      return;
+    }
+
+    if (frame.event !== "phx_reply") {
+      const channel = this.channels.get(frame.topic);
+      if (channel && sameRef(channel.joinRef, frame.joinRef)) {
+        if (frame.event === "phx_close") {
+          this.channels.delete(frame.topic);
+        } else if (frame.event === "phx_error") {
+          this.channels.delete(frame.topic);
+          this._observeError(
+            new Error(`Phoenix channel errored on ${frame.topic}`),
+            "channel_error",
+          );
+        }
+      }
+      this._dispatchMessage(frame);
+      return;
+    }
+
+    const key = frame.ref === null ? "" : String(frame.ref);
+    const pending = this.pending.get(key);
+    if (!pending) {
+      this.metricSink.unmatchedReply(this.tags);
+      this.metricSink.protocolError("unmatched_ref", this.tags);
+      this._observeError(
+        new ProtocolError(`received phx_reply with unmatched ref ${key || "null"}`),
+        "unmatched_ref",
+      );
+      return;
+    }
+
+    clearTimeout(pending.timer);
+    this.pending.delete(key);
+    const durationMs = Date.now() - pending.startedAt;
+
+    let reply;
+    try {
+      reply = decodeReply(frame);
+      if (reply.topic !== pending.topic || !sameRef(reply.joinRef, pending.joinRef)) {
+        throw new ProtocolError("phx_reply topic or join_ref did not match its push");
+      }
+    } catch (error) {
+      this.metricSink.protocolError("invalid_reply", this.tags);
+      this._observeError(error, "invalid_reply");
+      pending.reject(error);
+      return;
+    }
+
+    if (reply.status !== "ok") {
+      const error = new PhoenixReplyError(
+        pending.topic,
+        pending.event,
+        reply.status,
+        reply.response,
+      );
+      this.metricSink.rejected(pending.kind, durationMs, this.tags);
+      this._observeError(error, `${pending.kind}_rejected`);
+      pending.reject(error);
+      return;
+    }
+
+    this.metricSink.reply(pending.kind, durationMs, this.tags);
+    pending.resolve(reply.response);
+  }
+
+  _dispatchMessage(frame) {
+    for (const handler of this.messageHandlers) {
+      try {
+        handler(frame);
+      } catch (error) {
+        this._observeError(error, "message_handler");
+      }
+    }
+  }
+
+  _startHeartbeat() {
+    if (this.config.heartbeatIntervalMs === 0) return;
+    this.heartbeatTimer = setInterval(() => {
+      if (this.state !== "open" || this.heartbeatPending) return;
+      this.heartbeatPending = true;
+      this._request(
+        null,
+        this.refs.next(),
+        "phoenix",
+        "heartbeat",
+        {},
+        this.config.heartbeatTimeoutMs,
+        "heartbeat",
+      ).then(
+        () => {
+          this.heartbeatPending = false;
+        },
+        () => {
+          this.heartbeatPending = false;
+        },
+      );
+    }, this.config.heartbeatIntervalMs);
+  }
+
+  _stopHeartbeat() {
+    if (this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    this.heartbeatPending = false;
+  }
+
+  _handleClose(event) {
+    const error =
+      this.state === "closing"
+        ? new Error("client closed")
+        : new Error(`WebSocket closed unexpectedly (code ${event.code})`);
+    const unexpected = this.state !== "closing";
+    this._cleanup(error);
+    if (unexpected) {
+      this._observeError(error, "unexpected_close");
+    }
+    for (const waiter of this.closeWaiters.splice(0)) {
+      if (waiter.timer !== null) clearTimeout(waiter.timer);
+      waiter.resolve();
+    }
+  }
+
+  _addCloseWaiter(resolve, reject, timeoutMs) {
+    const waiter = { resolve, reject, timer: null };
+    waiter.timer = setTimeout(() => {
+      const error = new PhoenixTimeoutError("websocket", "close", timeoutMs);
+      this._observeError(error, "close_timeout");
+      this._cleanup(error);
+      for (const closeWaiter of this.closeWaiters.splice(0)) {
+        if (closeWaiter.timer !== null) clearTimeout(closeWaiter.timer);
+        closeWaiter.reject(error);
+      }
+    }, timeoutMs);
+    this.closeWaiters.push(waiter);
+  }
+
+  _cleanup(error) {
+    this._clearConnectTimer();
+    this._stopHeartbeat();
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+    this.channels.clear();
+    this.state = "closed";
+    this.socket = null;
+    if (this.wasOpened) {
+      this.metricSink.closed(this.tags);
+      this.wasOpened = false;
+    }
+  }
+
+  _clearConnectTimer() {
+    if (this.connectTimer !== null) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
+  }
+
+  _closeSocket(code, reason) {
+    if (this.socket && this.socket.readyState <= OPEN) {
+      try {
+        this.socket.close(code, reason);
+      } catch (error) {
+        this._observeError(error, "close");
+      }
+    }
+  }
+
+  _requireOpen() {
+    if (this.state !== "open" || !this.socket || this.socket.readyState !== OPEN) {
+      throw new Error(`Phoenix client is not open (state: ${this.state})`);
+    }
+  }
+
+  _observeError(error, type) {
+    this.metricSink.error(type, this.tags);
+    if (this.errorHandlers.size === 0) {
+      console.error(`[phoenix:${type}] ${error.message || String(error)}`);
+      return;
+    }
+    for (const handler of this.errorHandlers) {
+      try {
+        handler(error, type);
+      } catch (handlerError) {
+        console.error(
+          `[phoenix:error_handler] ${handlerError.message || String(handlerError)}`,
+        );
+      }
+    }
+  }
+}

--- a/load/k6/lib/protocol.js
+++ b/load/k6/lib/protocol.js
@@ -1,0 +1,103 @@
+const FRAME_LENGTH = 5;
+const PHOENIX_REPLY = "phx_reply";
+
+export class ProtocolError extends Error {
+  constructor(message, cause) {
+    super(message);
+    this.name = "ProtocolError";
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
+  }
+}
+
+export class RefGenerator {
+  constructor(initialRef = 0) {
+    if (!Number.isSafeInteger(initialRef) || initialRef < 0) {
+      throw new TypeError("initialRef must be a non-negative safe integer");
+    }
+    this.current = initialRef;
+  }
+
+  next() {
+    if (this.current === Number.MAX_SAFE_INTEGER) {
+      throw new RangeError("Phoenix message ref space exhausted");
+    }
+    this.current += 1;
+    return String(this.current);
+  }
+}
+
+function isRef(value) {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    (typeof value === "number" && Number.isSafeInteger(value))
+  );
+}
+
+function isPayload(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function validateFrame(frame) {
+  if (!Array.isArray(frame) || frame.length !== FRAME_LENGTH) {
+    throw new ProtocolError("Phoenix V2 frames must be five-element arrays");
+  }
+
+  const [joinRef, ref, topic, event, payload] = frame;
+  if (!isRef(joinRef)) {
+    throw new ProtocolError("frame join_ref must be null, a string, or an integer");
+  }
+  if (!isRef(ref)) {
+    throw new ProtocolError("frame ref must be null, a string, or an integer");
+  }
+  if (typeof topic !== "string" || topic.length === 0) {
+    throw new ProtocolError("frame topic must be a non-empty string");
+  }
+  if (typeof event !== "string" || event.length === 0) {
+    throw new ProtocolError("frame event must be a non-empty string");
+  }
+  if (!isPayload(payload)) {
+    throw new ProtocolError("frame payload must be an object");
+  }
+
+  return { joinRef, ref, topic, event, payload };
+}
+
+export function encodeFrame(joinRef, ref, topic, event, payload = {}) {
+  const frame = [joinRef, ref, topic, event, payload];
+  validateFrame(frame);
+  return JSON.stringify(frame);
+}
+
+export function decodeFrame(data) {
+  if (typeof data !== "string") {
+    throw new ProtocolError("expected a Phoenix V2 text frame");
+  }
+
+  let frame;
+  try {
+    frame = JSON.parse(data);
+  } catch (error) {
+    throw new ProtocolError("received invalid JSON", error);
+  }
+  return validateFrame(frame);
+}
+
+export function decodeReply(frame) {
+  const decoded = Array.isArray(frame) ? validateFrame(frame) : frame;
+  if (decoded.event !== PHOENIX_REPLY) {
+    throw new ProtocolError(`expected phx_reply, received ${decoded.event}`);
+  }
+
+  const { status, response } = decoded.payload;
+  if (typeof status !== "string" || status.length === 0) {
+    throw new ProtocolError("phx_reply payload must contain a status string");
+  }
+  if (!Object.prototype.hasOwnProperty.call(decoded.payload, "response")) {
+    throw new ProtocolError("phx_reply payload must contain a response");
+  }
+
+  return { ...decoded, status, response };
+}

--- a/load/k6/package.json
+++ b/load/k6/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/packages/beryl/gleam.toml
+++ b/packages/beryl/gleam.toml
@@ -12,6 +12,7 @@ internal_modules = [
   "beryl/internal/unsupervised",
   "beryl/log",
   "beryl/rate_limit",
+  "beryl/telemetry",
 ]
 
 [dependencies]
@@ -22,6 +23,7 @@ gleam_otp = ">= 1.2.0 and < 2.0.0"
 gleam_json = ">= 3.1.0 and < 4.0.0"
 gleam_crypto = ">= 1.6.0 and < 2.0.0"
 lattice_presence = ">= 1.0.0 and < 2.0.0"
+telemetry = ">= 1.4.2 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/packages/beryl/manifest.toml
+++ b/packages/beryl/manifest.toml
@@ -20,6 +20,7 @@ packages = [
   { name = "phoenix_channel_fixtures", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], source = "git", repo = "https://github.com/tylerbutler/phoenix_channel_fixtures.git", commit = "7daccb856d17db6278980277237c201b2acdcdf1" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
+  { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
@@ -35,3 +36,4 @@ glinter = { version = ">= 2.19.0 and < 3.0.0" }
 lattice_presence = { version = ">= 1.0.0 and < 2.0.0" }
 palabres = { version = ">= 1.0.4 and < 2.0.0" }
 phoenix_channel_fixtures = { git = "https://github.com/tylerbutler/phoenix_channel_fixtures.git", ref = "7daccb856d17db6278980277237c201b2acdcdf1" }
+telemetry = { version = ">= 1.4.2 and < 2.0.0" }

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -203,6 +203,8 @@ pub opaque type Config {
     /// Maximum joined topics per socket (default: 1000).
     /// Values <= 0 disable the cap.
     max_joined_topics_per_socket: Int,
+    /// Whether beryl emits `:telemetry` events (default: false).
+    telemetry: Bool,
     /// Logging configuration for beryl diagnostics
     logging: LoggingConfig,
   )
@@ -248,6 +250,7 @@ pub fn config(codec: codec.Codec) -> Config {
     max_event_length: 64,
     max_inbound_frame_bytes: 1_048_576,
     max_joined_topics_per_socket: 1000,
+    telemetry: False,
     logging: logging_config(level: InfoLevel, include_payloads: False),
   )
 }
@@ -255,6 +258,15 @@ pub fn config(codec: codec.Codec) -> Config {
 /// Add PubSub to a configuration for distributed broadcasts
 pub fn with_pubsub(config: Config, ps: PubSub(json.Json)) -> Config {
   Config(..config, pubsub: Some(ps))
+}
+
+/// Enable beryl's `:telemetry` events.
+///
+/// Telemetry is disabled by default. Handlers run synchronously in the
+/// process emitting an event, so handlers should enqueue or aggregate work
+/// quickly to avoid adding latency to channel and transport operations.
+pub fn with_telemetry(config: Config) -> Config {
+  Config(..config, telemetry: True)
 }
 
 /// Configure heartbeat timing.
@@ -555,6 +567,12 @@ pub fn config_max_joined_topics_per_socket(config: Config) -> Int {
   config.max_joined_topics_per_socket
 }
 
+// nolint: unused_exports -- package-internal accessor for instrumentation/tests; hidden from public docs with @internal
+@internal
+pub fn config_telemetry(config: Config) -> Bool {
+  config.telemetry
+}
+
 /// Warn when a channels system starts with every abuse control disabled.
 ///
 /// beryl ships with rate and connection limits off (like Phoenix) because
@@ -624,6 +642,7 @@ pub fn to_coordinator_config(config: Config) -> coordinator.CoordinatorConfig {
     max_topic_length: config.max_topic_length,
     max_event_length: config.max_event_length,
     max_joined_topics_per_socket: config.max_joined_topics_per_socket,
+    telemetry: config.telemetry,
     logging: coordinator_logging(config.logging),
     registry: None,
   )

--- a/packages/beryl/src/beryl/coordinator.gleam
+++ b/packages/beryl/src/beryl/coordinator.gleam
@@ -148,6 +148,8 @@ pub type CoordinatorConfig {
     max_event_length: Int,
     /// Maximum joined topics per socket. Values <= 0 disable the cap.
     max_joined_topics_per_socket: Int,
+    /// Whether internal telemetry events are enabled.
+    telemetry: Bool,
     /// Logging configuration for coordinator diagnostics.
     logging: LoggingConfig,
     /// Optional crash-survivable handler registry. When set, the
@@ -172,6 +174,7 @@ pub fn config(codec: Codec) -> CoordinatorConfig {
     max_topic_length: 256,
     max_event_length: 64,
     max_joined_topics_per_socket: 1000,
+    telemetry: False,
     logging: LoggingConfig(
       level: Info,
       include_payloads: False,

--- a/packages/beryl/src/beryl/telemetry.gleam
+++ b/packages/beryl/src/beryl/telemetry.gleam
@@ -1,0 +1,128 @@
+//// Typed internal telemetry primitives.
+////
+//// Event constructors intentionally accept only closed vocabularies. This
+//// prevents callers from putting topics, socket IDs, payloads, or arbitrary
+//// error text into metadata.
+
+import gleam/bool
+import gleam/int
+
+/// Transport implementations supported by beryl's telemetry schema.
+pub type Transport {
+  Mist
+  Ewe
+}
+
+/// Terminal outcomes shared by telemetry events.
+pub type Outcome {
+  Success
+  Rejected
+  Dropped
+  RateLimited
+  Invalid
+  Failed
+}
+
+/// WebSocket frame kinds.
+pub type FrameKind {
+  TextFrame
+  BinaryFrame
+}
+
+/// Channel message callback kinds.
+pub type MessageKind {
+  TextMessage
+  BinaryMessage
+  InfoMessage
+  HeartbeatMessage
+}
+
+/// Closed callback-result vocabulary.
+pub type CallbackResult {
+  NoReply
+  Reply
+  ReplyError
+  Push
+  Stop
+  CallbackFailed
+}
+
+/// Closed socket-disconnect reason vocabulary.
+pub type DisconnectReason {
+  ClientClosed
+  TransportClosed
+  HeartbeatTimeout
+  ServerShutdown
+  DisconnectFailed
+}
+
+/// Whether a broadcast originated on this node or a remote node.
+pub type BroadcastOrigin {
+  Local
+  Remote
+}
+
+/// Stable, low-cardinality beryl telemetry events.
+pub type Event {
+  TransportUpgradeStop(duration: Int, transport: Transport, outcome: Outcome)
+  TransportFrameStop(
+    duration: Int,
+    bytes: Int,
+    transport: Transport,
+    kind: FrameKind,
+    outcome: Outcome,
+  )
+  SocketConnected
+  SocketDisconnected(
+    duration: Int,
+    joined_channels: Int,
+    reason: DisconnectReason,
+  )
+  ChannelJoinStop(duration: Int, outcome: Outcome)
+  ChannelMessageStop(
+    duration: Int,
+    kind: MessageKind,
+    outcome: Outcome,
+    callback_result: CallbackResult,
+  )
+  BroadcastStop(
+    duration: Int,
+    recipients: Int,
+    send_failures: Int,
+    origin: BroadcastOrigin,
+  )
+}
+
+@external(erlang, "beryl_telemetry_ffi", "execute")
+fn execute(event: Event) -> Nil
+
+@external(erlang, "beryl_telemetry_ffi", "monotonic_time")
+fn monotonic_time() -> Int
+
+@external(erlang, "beryl_telemetry_ffi", "mailbox_length")
+fn current_mailbox_length() -> Int
+
+/// Emit a typed event when telemetry is enabled.
+///
+/// The disabled branch does not call the FFI or construct measurements and
+/// metadata maps.
+pub fn emit(enabled: Bool, event: Event) -> Nil {
+  use <- bool.guard(when: !enabled, return: Nil)
+  execute(event)
+}
+
+/// Capture a monotonic timestamp in the VM's native time unit.
+pub fn start_time() -> Int {
+  monotonic_time()
+}
+
+/// Return elapsed monotonic time in the VM's native time unit.
+pub fn duration_since(started_at: Int) -> Int {
+  monotonic_time()
+  |> fn(now) { int.max(now - started_at, 0) }
+}
+
+/// Return the calling process's current mailbox length.
+pub fn mailbox_length() -> Int {
+  current_mailbox_length()
+}

--- a/packages/beryl/src/beryl_telemetry_ffi.erl
+++ b/packages/beryl/src/beryl_telemetry_ffi.erl
@@ -1,0 +1,100 @@
+-module(beryl_telemetry_ffi).
+-export([execute/1, monotonic_time/0, mailbox_length/0]).
+
+execute({transport_upgrade_stop, Duration, Transport, Outcome}) ->
+    telemetry:execute(
+        [beryl, transport, upgrade, stop],
+        #{count => 1, duration => Duration},
+        #{transport => transport(Transport), outcome => outcome(Outcome)}
+    );
+execute({transport_frame_stop, Duration, Bytes, Transport, Kind, Outcome}) ->
+    telemetry:execute(
+        [beryl, transport, frame, stop],
+        #{count => 1, duration => Duration, bytes => Bytes},
+        #{
+            transport => transport(Transport),
+            frame_type => frame_kind(Kind),
+            outcome => outcome(Outcome)
+        }
+    );
+execute(socket_connected) ->
+    telemetry:execute([beryl, socket, connected], #{count => 1}, #{});
+execute({socket_disconnected, Duration, JoinedChannels, Reason}) ->
+    telemetry:execute(
+        [beryl, socket, disconnected],
+        #{
+            count => 1,
+            duration => Duration,
+            joined_channels => JoinedChannels
+        },
+        #{reason => disconnect_reason(Reason)}
+    );
+execute({channel_join_stop, Duration, Outcome}) ->
+    telemetry:execute(
+        [beryl, channel, join, stop],
+        #{count => 1, duration => Duration},
+        #{outcome => outcome(Outcome)}
+    );
+execute({channel_message_stop, Duration, Kind, Outcome, CallbackResult}) ->
+    telemetry:execute(
+        [beryl, channel, message, stop],
+        #{count => 1, duration => Duration},
+        #{
+            kind => message_kind(Kind),
+            outcome => outcome(Outcome),
+            callback_result => callback_result(CallbackResult)
+        }
+    );
+execute({broadcast_stop, Duration, Recipients, SendFailures, Origin}) ->
+    telemetry:execute(
+        [beryl, broadcast, stop],
+        #{
+            count => 1,
+            duration => Duration,
+            recipients => Recipients,
+            send_failures => SendFailures
+        },
+        #{origin => broadcast_origin(Origin)}
+    ).
+
+monotonic_time() ->
+    erlang:monotonic_time().
+
+mailbox_length() ->
+    {message_queue_len, Length} =
+        erlang:process_info(erlang:self(), message_queue_len),
+    Length.
+
+transport(mist) -> mist;
+transport(ewe) -> ewe.
+
+outcome(success) -> success;
+outcome(rejected) -> rejected;
+outcome(dropped) -> dropped;
+outcome(rate_limited) -> rate_limited;
+outcome(invalid) -> invalid;
+outcome(failed) -> failed.
+
+frame_kind(text_frame) -> text;
+frame_kind(binary_frame) -> binary.
+
+message_kind(text_message) -> text;
+message_kind(binary_message) -> binary;
+message_kind(info_message) -> info;
+message_kind(heartbeat_message) -> heartbeat.
+
+callback_result(no_reply) -> no_reply;
+callback_result(reply) -> reply;
+callback_result(reply_error) -> reply_error;
+callback_result(push) -> push;
+callback_result(stop) -> stop;
+callback_result(callback_failed) -> failed.
+
+disconnect_reason(client_closed) -> client_closed;
+disconnect_reason(transport_closed) -> transport_closed;
+disconnect_reason(heartbeat_timeout) -> heartbeat_timeout;
+disconnect_reason(server_shutdown) -> server_shutdown;
+disconnect_reason(disconnect_failed) -> failed.
+
+broadcast_origin(local) -> local;
+broadcast_origin(remote) -> remote.

--- a/packages/beryl/test/beryl_telemetry_test_ffi.erl
+++ b/packages/beryl/test/beryl_telemetry_test_ffi.erl
@@ -1,0 +1,33 @@
+-module(beryl_telemetry_test_ffi).
+-export([attach_socket_connected/0, detach/1, received_socket_connected/0]).
+
+attach_socket_connected() ->
+    HandlerId = {beryl_telemetry_test, make_ref()},
+    Self = self(),
+    ok = telemetry:attach(
+        HandlerId,
+        [beryl, socket, connected],
+        fun(Event, Measurements, Metadata, _Config) ->
+            Self ! {beryl_telemetry_test, Event, Measurements, Metadata}
+        end,
+        nil
+    ),
+    HandlerId.
+
+detach(HandlerId) ->
+    ok = telemetry:detach(HandlerId),
+    nil.
+
+received_socket_connected() ->
+    receive
+        {
+            beryl_telemetry_test,
+            [beryl, socket, connected],
+            #{count := 1},
+            Metadata
+        } when map_size(Metadata) =:= 0 ->
+            true
+    after
+        0 ->
+            false
+    end.

--- a/packages/beryl/test/beryl_test.gleam
+++ b/packages/beryl/test/beryl_test.gleam
@@ -632,6 +632,9 @@ pub fn default_config_test() {
 
   beryl.config_max_connections_per_ip(config)
   |> should.equal(0)
+
+  beryl.config_telemetry(config)
+  |> should.be_false
 }
 
 pub fn with_heartbeat_sets_interval_and_timeout_test() {
@@ -653,6 +656,19 @@ pub fn with_max_connections_per_ip_sets_limit_test() {
 
   beryl.config_max_connections_per_ip(config)
   |> should.equal(5)
+}
+
+pub fn with_telemetry_enables_telemetry_test() {
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_telemetry
+
+  beryl.config_telemetry(config)
+  |> should.be_true
+
+  let coordinator_config = beryl.to_coordinator_config(config)
+  coordinator_config.telemetry
+  |> should.be_true
 }
 
 pub fn send_info_routes_message_to_joined_channel_test() {

--- a/packages/beryl/test/telemetry_test.gleam
+++ b/packages/beryl/test/telemetry_test.gleam
@@ -1,0 +1,51 @@
+import beryl/telemetry
+import gleam/dynamic.{type Dynamic}
+import gleeunit
+import gleeunit/should
+
+@external(erlang, "beryl_telemetry_test_ffi", "attach_socket_connected")
+fn attach_socket_connected() -> Dynamic
+
+@external(erlang, "beryl_telemetry_test_ffi", "detach")
+fn detach(handler_id: Dynamic) -> Nil
+
+@external(erlang, "beryl_telemetry_test_ffi", "received_socket_connected")
+fn received_socket_connected() -> Bool
+
+pub fn main() {
+  gleeunit.main()
+}
+
+pub fn telemetry_clock_returns_non_negative_duration_test() {
+  let started_at = telemetry.start_time()
+
+  telemetry.duration_since(started_at)
+  |> fn(duration) { duration >= 0 }
+  |> should.be_true
+}
+
+pub fn mailbox_length_is_non_negative_test() {
+  telemetry.mailbox_length()
+  |> fn(length) { length >= 0 }
+  |> should.be_true
+}
+
+pub fn enabled_emit_executes_typed_event_test() {
+  let handler_id = attach_socket_connected()
+  telemetry.emit(True, telemetry.SocketConnected)
+  let received = received_socket_connected()
+  detach(handler_id)
+
+  received
+  |> should.be_true
+}
+
+pub fn disabled_emit_does_not_execute_event_test() {
+  let handler_id = attach_socket_connected()
+  telemetry.emit(False, telemetry.SocketConnected)
+  let received = received_socket_connected()
+  detach(handler_id)
+
+  received
+  |> should.be_false
+}

--- a/packages/beryl_ewe/manifest.toml
+++ b/packages/beryl_ewe/manifest.toml
@@ -3,7 +3,7 @@
 
 packages = [
   { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
-  { name = "beryl", version = "0.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres"], source = "local", path = "../beryl" },
+  { name = "beryl", version = "0.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../beryl" },
   { name = "compresso", version = "0.1.0", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_stdlib", "gleam_yielder", "logging"], otp_app = "compresso", source = "hex", outer_checksum = "8BE29A1EDA42F70826ED148EAE40C46BB3FC18E78FE472663DB01DD4A38172D4" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
   { name = "ewe", version = "4.0.1", build_tools = ["gleam"], requirements = ["compresso", "exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "logging", "websocks"], otp_app = "ewe", source = "hex", outer_checksum = "1A6CBE2E07B7E784F9B9503C94C0F23CDD644AC5EA4E1B957F3A5550541699DB" },
@@ -27,6 +27,7 @@ packages = [
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
   { name = "simplifile", version = "2.5.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "6C72DCCDF25C38A5931740B30E823969F33106831FD1637719B5EDBCA30027A4" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
+  { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
   { name = "websocks", version = "3.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_stdlib"], otp_app = "websocks", source = "hex", outer_checksum = "C70340E5B6C3390383ADA17029DCA6F8903863A7AD8CD8E1520EDCC4FE70D6FD" },
 ]

--- a/packages/beryl_mist/manifest.toml
+++ b/packages/beryl_mist/manifest.toml
@@ -4,7 +4,7 @@
 packages = [
   { name = "aquamarine", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "gluegun", "roost"], source = "git", repo = "https://github.com/tylerbutler/aquamarine.git", commit = "45451e8a5b8846258dd4a5e72094078423b82017" },
   { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
-  { name = "beryl", version = "0.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres"], source = "local", path = "../beryl" },
+  { name = "beryl", version = "0.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../beryl" },
   { name = "cowlib", version = "2.18.0", build_tools = ["make", "rebar3"], requirements = [], otp_app = "cowlib", source = "hex", outer_checksum = "C4F89D33A61162D4CFDCB5A1AF7E562D80A700B2573CC71020CE6521B152DC1A" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
   { name = "exception", version = "2.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "6BDEA95248093599391C3B5DF1835C5C6A86C353C2F99CE539B450E3432FE117" },
@@ -32,6 +32,7 @@ packages = [
   { name = "roost", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], source = "git", repo = "https://github.com/tylerbutler/roost.git", commit = "7e4dc7c327ec233c9dc22a9d2037a620e700e127" },
   { name = "simplifile", version = "2.5.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "6C72DCCDF25C38A5931740B30E823969F33106831FD1637719B5EDBCA30027A4" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
+  { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 


### PR DESCRIPTION
## Summary
- add opt-in Beryl telemetry configuration and typed internal event helpers
- add the Erlang telemetry dependency and synchronized workspace manifests
- add reusable Phoenix V2 k6 client protocol, lifecycle, and metrics helpers

## Validation
- `cd packages/beryl && gleam test -- --filter telemetry`
- `cd packages/beryl_mist && gleam check`
- `cd packages/beryl_ewe && gleam check`
- Node helper checks from sprint handoff