### PR TITLE
build(website): define pnpm workspace packages

### DIFF
--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+packages: []
 onlyBuiltDependencies:
   - esbuild
   - sharp


### PR DESCRIPTION
## Purpose
Declare the website pnpm workspace packages used by the documentation build.

## Provenance and split notes
Source PR #250; source commit(s): `55dda94b`. Direct replay of 55dda94b on current main.

## Dependency
Independent root on `main`.

## Validation
Mapped into the GREEN replacement aggregate `2dc7d3c`: pinned-toolchain CI, lint, doctor, changelog/version checks, site checks/build, load smoke, and diff check passed. The equivalence audit found zero missing or unexplained executable source changes.

## Changelog / public behavior
Build metadata only; no public behavior or changelog fragment.

Replaces part of #250.