### PR TITLE
docs(adr): propose app-side dispatch model

### DIFF
--- a/docs/adr/0001-type-erased-channel-registry.md
+++ b/docs/adr/0001-type-erased-channel-registry.md
@@ -6,44 +6,26 @@ Accepted (2026-07-21)
 
 ## Context
 
-Beryl's unit of composition is the registered channel module, with dispatch
-inside the library (Phoenix's shape): applications register channels with
-distinct `assigns`/`info` types, and everything below follows from that
-design decision. Join requests carry client-chosen topic strings, so the
-coordinator selects a channel at runtime by matching the topic against
-every registered pattern (`State.handlers` in `coordinator.gleam`). That
-dispatch point sees channels of differing types — heterogeneity Gleam (no
-existentials, no type classes) cannot express.
+Applications register many channels with distinct `assigns`/`info` types,
+resolved by topic at runtime. The coordinator must hold them in one
+collection — a heterogeneous registry Gleam (no existentials, no type
+classes) cannot express.
 
-1. **Application-level variant type.** Keep library-side dispatch, but
-   have the app supply one union type that parameterizes every public
-   type, including the transport SPI. This borrows only half of the
-   Elm/Lustre architecture: Lustre is fully type-safe because the app
-   also owns dispatch — a parent model holds each child in a known field,
-   and `element.map` tags messages where they are constructed. With
-   dispatch inside beryl, the library can only hand each callback the
-   whole union, so every callback handles variants that "cannot" occur —
-   the unchecked cast reappears as app-visible boilerplate. Even Lustre
-   erases internally ([vdom
-   `coerce`](https://github.com/lustre-labs/lustre/blob/v5.7.1/src/lustre/vdom/vnode.gleam#L195-L197))
-   and crosses component boundaries with `Dynamic` plus decoders
-   ([`on_attribute_change`](https://github.com/lustre-labs/lustre/blob/v5.7.1/src/lustre/component.gleam#L118-L138)).
+1. **Application-level variant type (Elm/Lustre style).** One app-supplied
+   union type parameterizes everything. Type-safe, but it infects
+   every public type (including the transport SPI), forces callbacks to
+   match impossible variants, and adding a channel edits a global type,
+   breaking open registration.
 
-2. **App-side dispatch (fully Elm/Lustre).** Beryl delivers wire events to
-   one app-written update function that routes topics itself. Fully
-   type-safe, but per-channel lifecycle, authorization, rate limiting, and
-   presence move into application code.
-
-3. **Type erasure behind a typed facade (current design).** The registry
+2. **Type erasure behind a typed facade (current design).** The registry
    stores a homogeneous `List(ChannelHandler)`; typed values are erased at
    registration and restored by closures from the same `register` call. The
    public API stays fully typed; erasure never leaks from `beryl.gleam`.
 
 ## Decision
 
-Keep design 3. Beryl compiles before the application's channel types
-exist, so it can never write their union itself — only the application
-can, which is design 1's cost. Erased internals behind typed facades are
+Keep design 2. A Phoenix-shaped library is open-world — it cannot enumerate
+application channel types — and erased internals behind typed facades are
 an established Gleam/BEAM pattern: see [`gleam_otp`'s actor
 `erase`](https://github.com/gleam-lang/otp/blob/v1.2.0/src/gleam/otp/actor.gleam#L518-L519),
 [`gleam_erlang`'s
@@ -52,9 +34,10 @@ and [`mist`'s `Dynamic` request
 internals](https://github.com/rawhat/mist/blob/v6.0.3/src/mist/internal/http.gleam#L64).
 
 Also make erasure closure-captured ("Option B"): a handler carries only
-`join`, which returns a `JoinedChannel` — closures capturing the typed
+`join`; join returns a `JoinedChannel` — closures capturing the typed
 assigns, each callback returning the next instance — so the coordinator
-never sees erased assigns and needs no per-callback coercions.
+never sees erased assigns and per-callback identity-FFI coercions
+disappear.
 
 ## Consequences
 

--- a/docs/adr/0001-type-erased-channel-registry.md
+++ b/docs/adr/0001-type-erased-channel-registry.md
@@ -31,8 +31,13 @@ existentials, no type classes) cannot express.
 
 2. **App-side dispatch (fully Elm/Lustre).** Beryl delivers wire events to
    one app-written update function that routes topics itself. Fully
-   type-safe, but per-channel lifecycle, authorization, rate limiting, and
-   presence move into application code.
+   type-safe — even design 3's residual coercions (see Consequences)
+   disappear, since each socket has one `msg` type and `send_info` becomes
+   an ordinary typed send. Most infrastructure could stay library-side:
+   rate limiting, presence, pubsub, and connection limits key on topic
+   strings and wire data, not app types. The loss is the channel module as
+   the unit of composition — colocated callbacks, no hand-written union or
+   router, third-party channels without app-side wiring.
 
 3. **Type erasure behind a typed facade (current design).** The registry
    stores a homogeneous `List(ChannelHandler)`; typed values are erased at
@@ -50,6 +55,8 @@ an established Gleam/BEAM pattern: see [`gleam_otp`'s actor
 `unsafely_create_subject`](https://github.com/gleam-lang/erlang/blob/v1.3.0/src/gleam/erlang/process.gleam#L90),
 and [`mist`'s `Dynamic` request
 internals](https://github.com/rawhat/mist/blob/v6.0.3/src/mist/internal/http.gleam#L64).
+Design 2 is rejected on ergonomics, not soundness; a layered variant
+(typed core with channels as sugar on top) may merit a future ADR.
 
 Also make erasure closure-captured ("Option B"): a handler carries only
 `join`, which returns a `JoinedChannel` — closures capturing the typed

--- a/docs/adr/0001-type-erased-channel-registry.md
+++ b/docs/adr/0001-type-erased-channel-registry.md
@@ -6,33 +6,42 @@ Accepted (2026-07-21)
 
 ## Context
 
-Applications register many channels with distinct `assigns`/`info` types.
-Join requests carry client-chosen topic strings, so the coordinator selects
-a channel at runtime by matching the topic against every registered pattern
-(`State.handlers` in `coordinator.gleam`). That dispatch point sees channels
-of differing types — heterogeneity Gleam (no existentials, no type classes)
-cannot express.
+Beryl's unit of composition is the registered channel module, with dispatch
+inside the library (Phoenix's shape): applications register channels with
+distinct `assigns`/`info` types, and everything below follows from that
+design decision. Join requests carry client-chosen topic strings, so the
+coordinator selects a channel at runtime by matching the topic against
+every registered pattern (`State.handlers` in `coordinator.gleam`). That
+dispatch point sees channels of differing types — heterogeneity Gleam (no
+existentials, no type classes) cannot express.
 
-1. **Application-level variant type (Elm/Lustre style).** One app-supplied
-   union type parameterizes everything, so every public type — including
-   the transport SPI — gains the parameters. Lustre shows this is livable
-   when one author owns the whole message type, and nested wrapping
-   (`element.map`) spares callbacks from matching impossible variants. But
-   adding a channel still edits a shared type, ruling out registration of
-   independently authored channels. Even Lustre erases behind its typed
-   API ([vdom
+1. **Application-level variant type.** Keep library-side dispatch, but
+   have the app supply one union type that parameterizes every public
+   type, including the transport SPI. This borrows only half of the
+   Elm/Lustre architecture: Lustre is fully type-safe because the app
+   also owns dispatch — a parent model holds each child in a known field,
+   and `element.map` tags messages where they are constructed. With
+   dispatch inside beryl, the library can only hand each callback the
+   whole union, so every callback handles variants that "cannot" occur —
+   the unchecked cast reappears as app-visible boilerplate. Even Lustre
+   erases internally ([vdom
    `coerce`](https://github.com/lustre-labs/lustre/blob/v5.7.1/src/lustre/vdom/vnode.gleam#L195-L197))
    and crosses component boundaries with `Dynamic` plus decoders
    ([`on_attribute_change`](https://github.com/lustre-labs/lustre/blob/v5.7.1/src/lustre/component.gleam#L118-L138)).
 
-2. **Type erasure behind a typed facade (current design).** The registry
+2. **App-side dispatch (fully Elm/Lustre).** Beryl delivers wire events to
+   one app-written update function that routes topics itself. Fully
+   type-safe, but per-channel lifecycle, authorization, rate limiting, and
+   presence move into application code.
+
+3. **Type erasure behind a typed facade (current design).** The registry
    stores a homogeneous `List(ChannelHandler)`; typed values are erased at
    registration and restored by closures from the same `register` call. The
    public API stays fully typed; erasure never leaks from `beryl.gleam`.
 
 ## Decision
 
-Keep design 2. Beryl compiles before the application's channel types
+Keep design 3. Beryl compiles before the application's channel types
 exist, so it can never write their union itself — only the application
 can, which is design 1's cost. Erased internals behind typed facades are
 an established Gleam/BEAM pattern: see [`gleam_otp`'s actor
@@ -43,10 +52,9 @@ and [`mist`'s `Dynamic` request
 internals](https://github.com/rawhat/mist/blob/v6.0.3/src/mist/internal/http.gleam#L64).
 
 Also make erasure closure-captured ("Option B"): a handler carries only
-`join`; join returns a `JoinedChannel` — closures capturing the typed
+`join`, which returns a `JoinedChannel` — closures capturing the typed
 assigns, each callback returning the next instance — so the coordinator
-never sees erased assigns and per-callback identity-FFI coercions
-disappear.
+never sees erased assigns and needs no per-callback coercions.
 
 ## Consequences
 

--- a/docs/adr/0001-type-erased-channel-registry.md
+++ b/docs/adr/0001-type-erased-channel-registry.md
@@ -6,16 +6,24 @@ Accepted (2026-07-21)
 
 ## Context
 
-Applications register many channels with distinct `assigns`/`info` types,
-resolved by topic at runtime. The coordinator must hold them in one
-collection — a heterogeneous registry Gleam (no existentials, no type
-classes) cannot express.
+Applications register many channels with distinct `assigns`/`info` types.
+Join requests carry client-chosen topic strings, so the coordinator selects
+a channel at runtime by matching the topic against every registered pattern
+(`State.handlers` in `coordinator.gleam`). That dispatch point sees channels
+of differing types — heterogeneity Gleam (no existentials, no type classes)
+cannot express.
 
 1. **Application-level variant type (Elm/Lustre style).** One app-supplied
-   union type parameterizes everything. Type-safe, but it infects
-   every public type (including the transport SPI), forces callbacks to
-   match impossible variants, and adding a channel edits a global type,
-   breaking open registration.
+   union type parameterizes everything, so every public type — including
+   the transport SPI — gains the parameters. Lustre shows this is livable
+   when one author owns the whole message type, and nested wrapping
+   (`element.map`) spares callbacks from matching impossible variants. But
+   adding a channel still edits a shared type, ruling out registration of
+   independently authored channels. Even Lustre erases behind its typed
+   API ([vdom
+   `coerce`](https://github.com/lustre-labs/lustre/blob/v5.7.1/src/lustre/vdom/vnode.gleam#L195-L197))
+   and crosses component boundaries with `Dynamic` plus decoders
+   ([`on_attribute_change`](https://github.com/lustre-labs/lustre/blob/v5.7.1/src/lustre/component.gleam#L118-L138)).
 
 2. **Type erasure behind a typed facade (current design).** The registry
    stores a homogeneous `List(ChannelHandler)`; typed values are erased at
@@ -24,8 +32,9 @@ classes) cannot express.
 
 ## Decision
 
-Keep design 2. A Phoenix-shaped library is open-world — it cannot enumerate
-application channel types — and erased internals behind typed facades are
+Keep design 2. Beryl compiles before the application's channel types
+exist, so it can never write their union itself — only the application
+can, which is design 1's cost. Erased internals behind typed facades are
 an established Gleam/BEAM pattern: see [`gleam_otp`'s actor
 `erase`](https://github.com/gleam-lang/otp/blob/v1.2.0/src/gleam/otp/actor.gleam#L518-L519),
 [`gleam_erlang`'s

--- a/docs/adr/0002-app-side-dispatch.md
+++ b/docs/adr/0002-app-side-dispatch.md
@@ -1,0 +1,61 @@
+# ADR 0002: Single app-side dispatch model
+
+## Status
+
+Proposed (2026-07-21). Supersedes [ADR 0001](0001-type-erased-channel-registry.md)
+if accepted.
+
+## Context
+
+ADR 0001 chose type erasure given library-side dispatch, and its analysis
+surfaced two facts that motivate revisiting that premise:
+
+- App-side dispatch (ADR 0001's design 2) is the only considered design
+  with no unchecked casts anywhere — including the two residual coercions
+  ADR 0001 documents, which close structurally: `send_info` becomes an
+  ordinary typed `Subject(msg)` send, and connect-time assigns disappear
+  because the app's `init` produces the model.
+- Nearly all library infrastructure keys on topic strings and wire data,
+  not app types: rate limiting, connection limits, presence, pubsub, and
+  the wire codec stay library-side under either model. The transport SPI
+  is already frame-level and carries no app types, so `beryl_mist` and
+  `beryl_ewe` are unaffected.
+
+Phoenix compatibility is a wire-protocol property (`phx_join`, refs,
+heartbeats, `presence_state`/`presence_diff`); clients cannot observe the
+server-side programming model. ADR 0001 kept channel modules for their
+ergonomics. This ADR proposes trading those ergonomics for soundness and a
+single API, rather than maintaining two APIs (the layered variant ADR 0001
+deferred).
+
+## Decision (proposed)
+
+Replace the channel-module API entirely with app-side dispatch:
+
+- One entry point, roughly `beryl.start(config, init, update)`: the app
+  supplies `init: fn(ConnectInfo) -> model` and
+  `update: fn(model, Event(msg)) -> Next(model, msg)` per socket, and
+  routes topics itself.
+- Callback returns become an effects list (reply, push, broadcast,
+  presence ops, stop), replacing today's one-action `HandleResult`.
+- Channel modules, the registry, and all identity-FFI erasure are removed.
+- Third-party functionality ships as embeddable `model`/`msg`/`update`
+  triples that apps wire in with a wrapper variant — the composition
+  pattern established by the Elm/Lustre ecosystem.
+- Abuse controls become declarative per-topic-pattern config at `start`.
+
+API strawman, current-to-new mapping, and open questions:
+[socket-api-strawman](../design/socket-api-strawman.md).
+
+## Consequences
+
+- Full breaking rewrite of the `packages/beryl` public API, docs, and
+  examples. Hex publishing is currently disabled, so external migration
+  cost is low today and grows with every release under the old model.
+- Transports are unaffected; the typed core sits behind the existing
+  frame-level SPI via closures captured at `start`.
+- Union-and-router boilerplate scales with channel count: zero for
+  single-channel apps (use your types directly), linear otherwise.
+- The effects type is the main design risk (join-ack ordering, presence
+  interplay). Acceptance gate: the strawman survives those cases and one
+  real example app is rewritten to gauge boilerplate at scale.

--- a/docs/design/socket-api-strawman.md
+++ b/docs/design/socket-api-strawman.md
@@ -1,0 +1,138 @@
+# Socket API strawman (ADR 0002)
+
+Strawman for the app-side dispatch API proposed in
+[ADR 0002](../adr/0002-app-side-dispatch.md). Nothing here compiles;
+names and shapes are for discussion.
+
+## Core types
+
+```gleam
+/// Everything the core delivers to the app's update function.
+pub type Event(msg) {
+  /// Client asked to join a topic. Must be answered with `AcceptJoin`
+  /// or `RejectJoin` (see open question 1).
+  Join(topic: String, payload: Dynamic, ref: Ref)
+  /// Client message on a joined topic. `ref` is present for messages
+  /// that expect a `phx_reply`.
+  Message(topic: String, event: String, payload: Dynamic, ref: Option(Ref))
+  /// Binary frame on a joined topic.
+  Binary(topic: String, data: BitArray)
+  /// A joined topic ended (client leave, kick, or socket close).
+  /// Replaces the per-channel `terminate` callback.
+  Closed(topic: String, reason: StopReason)
+  /// Typed server-side message, sent via the socket's `Subject(msg)`.
+  /// Replaces `send_info` — no erasure involved.
+  Info(msg)
+}
+
+pub type Next(model, msg) {
+  Next(model: model, effects: List(Effect))
+  Stop(reason: StopReason)
+}
+
+/// One update may return several effects — unlike today's
+/// `HandleResult`, which couples a single action to the socket value.
+pub type Effect {
+  AcceptJoin(ref: Ref, reply: Option(Json))
+  RejectJoin(ref: Ref, reason: Json)
+  ReplyOk(ref: Ref, payload: Json)
+  ReplyError(ref: Ref, payload: Json)
+  Push(topic: String, event: String, payload: Json)
+  Broadcast(topic: String, event: String, payload: Json)
+  PresenceTrack(topic: String, key: String, meta: Json)
+  PresenceUntrack(topic: String, key: String)
+  KickTopic(topic: String)
+}
+```
+
+## Entry point
+
+```gleam
+pub fn start(
+  config: Config,
+  init: fn(ConnectInfo) -> #(model, List(Effect)),
+  update: fn(model, Event(msg)) -> Next(model, msg),
+) -> Sockets
+```
+
+`Sockets` is opaque and non-generic: `start` captures `model`/`msg` in
+closures, so transports keep receiving an unparameterized handle through
+the existing frame-level SPI. This is closure capture by a generic
+function — plain Gleam, no identity FFI. Per-topic-pattern abuse config
+(rate limits, join caps) moves into `Config` as data.
+
+## Mapping from the current API
+
+| Today (`beryl/channel`)          | Strawman                              |
+| -------------------------------- | ------------------------------------- |
+| `join` callback                  | `Join` event + `AcceptJoin`/`RejectJoin` |
+| `JoinOk(reply, socket)`          | `Next(model, [AcceptJoin(ref, reply)])` |
+| `handle_in` / `Reply` / `Push`   | `Message` event + `ReplyOk`/`Push`    |
+| `handle_binary`                  | `Binary` event                        |
+| `handle_info` (erased `Dynamic`) | `Info(msg)` event (typed)             |
+| `terminate`                      | `Closed` event                        |
+| `Stop(reason)`                   | `Stop(reason)`                        |
+| assigns threading via `Socket`   | `model` threading via `Next`          |
+
+## Single-channel app — no union, no router
+
+```gleam
+type Model { Model(user: String, joined: Bool) }
+// msg = whatever the app sends itself; no wrapper needed.
+
+fn update(model: Model, event: beryl.Event(Msg)) -> beryl.Next(Model, Msg) {
+  case event {
+    beryl.Join("room:" <> _, _payload, ref) ->
+      beryl.Next(Model(..model, joined: True), [beryl.AcceptJoin(ref, None)])
+    beryl.Message(topic, "new_msg", payload, _ref) ->
+      beryl.Next(model, [beryl.Broadcast(topic, "new_msg", relay(payload))])
+    _ -> beryl.Next(model, [])
+  }
+}
+```
+
+## Multi-channel app — union and router
+
+```gleam
+type Model { Model(chats: Dict(String, chat.Model), admin: admin.Model) }
+type Msg  { ChatMsg(topic: String, msg: chat.Msg)  AdminMsg(admin.Msg) }
+
+fn update(model: Model, event: beryl.Event(Msg)) -> beryl.Next(Model, Msg) {
+  case event {
+    beryl.Join("chat:" <> id, payload, ref) ->
+      // delegate to chat.join, store its model in the dict
+      ...
+    beryl.Join("admin", payload, ref) -> ...
+    beryl.Info(ChatMsg(topic, msg)) ->
+      // total match: every variant here is reachable
+      ...
+    ...
+  }
+}
+```
+
+Third-party functionality ships as `chat.Model` / `chat.Msg` /
+`chat.update` and is embedded exactly as above — the Elm/Lustre
+composition pattern.
+
+## Open questions
+
+1. **Join acknowledgment.** Explicit `AcceptJoin` effect (as drafted) vs
+   inferring acceptance from `ReplyOk` on a join ref. Explicit is clearer;
+   either way the core must reject `Push`/`Broadcast` to a topic whose
+   join is unanswered, and define what happens if `update` never answers.
+2. **Effect ordering.** Are effects applied in list order, and is a
+   `Push` ordered after an `AcceptJoin` in the same list guaranteed to
+   arrive after the join ack on the wire?
+3. **Crash blast radius.** Today a crashing callback takes down state for
+   the whole socket. One `update` per socket keeps that blast radius —
+   confirm this matches current behavior rather than regressing it.
+4. **Presence delivery.** Presence stays library-side (`Track`/`Untrack`
+   effects; the core emits `presence_state`/`presence_diff` on the wire).
+   Does the app ever need presence changes as `Event`s, or is wire-level
+   sync enough (today it is)?
+5. **Reply-outside-update.** Today `handle_info` can `Reply` only for it
+   to be dropped without a client ref. The `ref`-carrying effects make
+   this unrepresentable — verify no legitimate use is lost.
+6. **Groups.** `group.send` to sockets sharing one app `msg` type is a
+   typed send; confirm the group API needs no `Dynamic` anywhere.


### PR DESCRIPTION
## Purpose
Introduce ADR 0002 and the rationale for app-side dispatch.

## Provenance and split notes
Source PR #220; source commit(s): `74b08dd3, ce37aa0a, 893d84d4, 001dcdee, b0e36835`. Folds the five ADR drafting/review commits into a reviewable documentation root.

## Changelog / public behavior
Documentation-only; no public behavior or changelog fragment.

Replaces part of #220.