### PR TITLE
refactor(transport)!: adopt atomic app admission

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ flowchart TD
 - **PubSub** — pg-based distributed publish/subscribe
 - **Actor bridge** — forward an external OTP actor's stream to a socket with `beryl/bridge`
 - **WebSocket transport** — Mist integration with Phoenix-compatible wire protocol
-- **Connect hook** — Socket-level `on_connect` authentication (Phoenix `UserSocket.connect/3` analogue): runs once per socket, can reject the whole connection before any join, and seeds initial assigns
+- **Connect hook** — Socket-level `on_connect` authentication (Phoenix `UserSocket.connect/3` analogue): runs once per socket, can reject the whole connection before any join, and seeds ordered connect metadata delivered to the app's `init` via `ConnectInfo.seed`
 - **Observability** — Opt-in stable telemetry events and local coordinator snapshots, with export owned by the host application
 
 ## Examples

--- a/examples/chatrooms/src/chatrooms.gleam
+++ b/examples/chatrooms/src/chatrooms.gleam
@@ -58,7 +58,7 @@ pub fn main() {
     mist_transport.default_config("/socket/websocket")
     |> mist_transport.with_on_connect(fn(req) {
       case get_query_param(req, "token") {
-        Ok("beryl-demo") -> Ok(Nil)
+        Ok("beryl-demo") -> Ok([])
         _ -> Error(mist_transport.ConnectRejected)
       }
     })

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -1501,10 +1501,13 @@ pub fn transport_socket_connected(
   send: fn(String) -> Result(Nil, Nil),
   send_binary: fn(BitArray) -> Result(Nil, Nil),
   codec: Option(codec.Codec),
-  assigns: Dynamic,
   seed: event.ConnectSeed,
 ) -> Nil {
   case channels {
+    // Legacy channel-module systems have no public path for connect-time
+    // assigns (the transport SPI is monomorphic over `ConnectSeed`); seed
+    // `Nil` privately rather than let an arbitrary typed value cross the
+    // public SPI.
     Channels(coordinator: coordinator_subject, ..) ->
       process.send(
         coordinator_subject,
@@ -1513,7 +1516,7 @@ pub fn transport_socket_connected(
           send,
           send_binary,
           codec,
-          assigns,
+          dynamic.nil(),
         ),
       )
     AppChannels(app: app, ..) ->
@@ -1529,7 +1532,6 @@ pub fn transport_admit_socket(
   send: fn(String) -> Result(Nil, Nil),
   send_binary: fn(BitArray) -> Result(Nil, Nil),
   socket_codec: Option(codec.Codec),
-  assigns: Dynamic,
   seed: event.ConnectSeed,
   close: fn() -> Nil,
 ) -> Bool {
@@ -1542,7 +1544,7 @@ pub fn transport_admit_socket(
           send,
           send_binary,
           socket_codec,
-          assigns,
+          dynamic.nil(),
         ),
       )
       process.send(

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -1501,7 +1501,7 @@ pub fn transport_socket_connected(
   send: fn(String) -> Result(Nil, Nil),
   send_binary: fn(BitArray) -> Result(Nil, Nil),
   codec: Option(codec.Codec),
-  seed: event.ConnectSeed,
+  _seed: event.ConnectSeed,
 ) -> Nil {
   case channels {
     // Legacy channel-module systems have no public path for connect-time
@@ -1519,8 +1519,7 @@ pub fn transport_socket_connected(
           dynamic.nil(),
         ),
       )
-    AppChannels(app: app, ..) ->
-      app.socket_connected(socket_id, send, send_binary, codec, seed)
+    AppChannels(..) -> Nil
   }
 }
 
@@ -1579,7 +1578,7 @@ pub fn transport_register_closer(
         coordinator_subject,
         coordinator.RegisterCloser(socket_id, close),
       )
-    AppChannels(app: app, ..) -> app.register_closer(socket_id, close)
+    AppChannels(..) -> Nil
   }
 }
 

--- a/packages/beryl/src/beryl/transport.gleam
+++ b/packages/beryl/src/beryl/transport.gleam
@@ -223,11 +223,10 @@ pub fn telemetry_frame_stop(
 // --- Socket lifecycle ---
 
 // nolint: unused_exports -- transport SPI, consumed by transport packages such as beryl_mist
-/// Announce a newly connected socket. `send`/`send_binary` deliver outbound
-/// frames on this connection. `seed` carries the upgrade request's
-/// connection data (path, query, headers, and any `with_on_connect`
-/// metadata), delivered to the app's `init` as `ConnectInfo.seed`. Call
-/// `register_closer` immediately after this.
+/// Compatibility registration for coordinator-backed `OwnerUnmonitored`
+/// systems. App-runtime transports must use `connection_owner` and
+/// `admit_socket` so registration and closer installation are tied to one
+/// exact runtime pid.
 pub fn socket_connected(
   channels channels: Channels,
   socket_id socket_id: String,
@@ -245,7 +244,11 @@ pub fn socket_connected(
   )
 }
 
-/// Announce a newly connected socket that negotiates its own wire format.
+/// Compatibility registration with a connection-specific wire format.
+///
+/// This is for coordinator-backed `OwnerUnmonitored` systems. App-runtime
+/// transports must pass the codec to `admit_socket`.
+///
 /// `Some(codec)` frames this connection's outbound messages with `codec`
 /// instead of the configured one, so a single coordinator — sharing channels,
 /// pubsub and presence — can serve transports speaking different framings.
@@ -269,9 +272,10 @@ pub fn socket_connected_with_codec(
 }
 
 // nolint: unused_exports -- transport SPI, consumed by transport packages such as beryl_mist
-/// Register a function that force-closes the socket's underlying connection
-/// so the coordinator can actively evict it (e.g. heartbeat timeout) instead
-/// of leaving a zombie socket whose frames are silently dropped.
+/// Install a closer for a coordinator-backed `OwnerUnmonitored` socket.
+///
+/// App-runtime transports install the closer atomically with `admit_socket`;
+/// this compatibility function intentionally does nothing for those systems.
 pub fn register_closer(
   channels channels: Channels,
   socket_id socket_id: String,

--- a/packages/beryl/src/beryl/transport.gleam
+++ b/packages/beryl/src/beryl/transport.gleam
@@ -3,28 +3,107 @@
 ////
 //// A transport implementation:
 //// 1. Admits a connection (origin/auth policy is the transport's concern),
-////    acquiring a slot with `beryl.acquire_connection_slot` and binding it
-////    with `beryl.bind_connection_slot`.
+////    acquiring a slot with `acquire_connection_slot` and binding it with
+////    `bind_connection_slot`.
 //// 2. Captures `connection_owner`, installs its monitor, and atomically
 ////    registers the socket and closer with `admit_socket`.
-//// 3. Decodes inbound frames with the codec from `active_codec` (see
-////    `beryl/wire/codec`) and routes them with `route_decoded` /
+//// 3. Decodes inbound frames with the codec from `active_codec` and routes
+////    them with `route_decoded` /
 ////    `route_binary`, shedding over-rate frames via `new_message_limiter` /
-////    `take_token` and oversized frames via `beryl.max_inbound_frame_bytes`.
+////    `take_token` and oversized frames via `max_inbound_frame_bytes`.
 //// 4. Announces disconnects with `socket_disconnected` and releases the
-////    slot with `beryl.release_connection_slot`.
+////    slot with `release_connection_slot`.
 
-import beryl.{type Channels}
-import beryl/event.{type ConnectSeed}
+import beryl
+import beryl/event
 import beryl/internal
 import beryl/log
 import beryl/rate_limit
 import beryl/telemetry
-import beryl/wire/codec.{type Codec, type Inbound}
+import beryl/wire/codec
 import gleam/bool
 import gleam/erlang/process
 import gleam/option.{type Option, None, Some}
 import gleam/result
+
+/// Channel-system handle accepted by transport implementations.
+pub type Channels =
+  beryl.Channels
+
+/// Connection slot permit held by a transport connection.
+pub type ConnectionPermit =
+  beryl.ConnectionPermit
+
+/// Connection metadata delivered to the app's `init`.
+pub type ConnectSeed =
+  event.ConnectSeed
+
+/// Wire codec used by a transport connection.
+pub type Codec =
+  codec.Codec
+
+/// Decoded inbound wire message.
+pub type Inbound =
+  codec.Inbound
+
+/// Wire decode failure.
+pub type DecodeError =
+  codec.DecodeError
+
+/// Build connection metadata for a WebSocket upgrade.
+pub fn connect_seed(
+  path path: String,
+  query query: List(#(String, String)),
+  headers headers: List(#(String, String)),
+  metadata metadata: List(#(String, String)),
+) -> ConnectSeed {
+  event.ConnectSeed(
+    path: path,
+    query: query,
+    headers: headers,
+    metadata: metadata,
+  )
+}
+
+/// Decode an inbound text frame with a codec.
+pub fn decode_text(codec: Codec) -> fn(String) -> Result(Inbound, DecodeError) {
+  codec.decode_text(codec)
+}
+
+/// Return the codec's optional binary decoder.
+pub fn decode_binary(
+  codec: Codec,
+) -> Option(fn(BitArray) -> Result(Inbound, DecodeError)) {
+  codec.decode_binary(codec)
+}
+
+/// Format a wire decode failure for transport logging.
+pub fn format_decode_error(error: DecodeError) -> String {
+  codec.format_decode_error(error)
+}
+
+/// Acquire a configured connection slot.
+pub fn acquire_connection_slot(
+  channels: Channels,
+  ip: String,
+) -> Result(ConnectionPermit, Nil) {
+  beryl.acquire_connection_slot(channels, ip)
+}
+
+/// Bind a connection slot to the current transport process.
+pub fn bind_connection_slot(permit: ConnectionPermit) -> Nil {
+  beryl.bind_connection_slot(permit)
+}
+
+/// Release a held connection slot.
+pub fn release_connection_slot(permit: ConnectionPermit) -> Nil {
+  beryl.release_connection_slot(permit)
+}
+
+/// Return the configured maximum inbound frame size.
+pub fn max_inbound_frame_bytes(channels: Channels) -> Int {
+  beryl.max_inbound_frame_bytes(channels)
+}
 
 // --- Telemetry ---
 

--- a/packages/beryl/src/beryl/transport.gleam
+++ b/packages/beryl/src/beryl/transport.gleam
@@ -22,7 +22,6 @@ import beryl/rate_limit
 import beryl/telemetry
 import beryl/wire/codec.{type Codec, type Inbound}
 import gleam/bool
-import gleam/dynamic.{type Dynamic}
 import gleam/erlang/process
 import gleam/option.{type Option, None, Some}
 import gleam/result
@@ -146,17 +145,15 @@ pub fn telemetry_frame_stop(
 
 // nolint: unused_exports -- transport SPI, consumed by transport packages such as beryl_mist
 /// Announce a newly connected socket. `send`/`send_binary` deliver outbound
-/// frames on this connection. `assigns` seeds connect-time socket assigns
-/// (type-erased internally) for channel-module systems; `seed` carries the
-/// upgrade request's connection data for app-dispatch systems (delivered to
-/// the app's `init` as `ConnectInfo.seed`). Call `register_closer`
-/// immediately after this.
+/// frames on this connection. `seed` carries the upgrade request's
+/// connection data (path, query, headers, and any `with_on_connect`
+/// metadata), delivered to the app's `init` as `ConnectInfo.seed`. Call
+/// `register_closer` immediately after this.
 pub fn socket_connected(
   channels channels: Channels,
   socket_id socket_id: String,
   send send: fn(String) -> Result(Nil, Nil),
   send_binary send_binary: fn(BitArray) -> Result(Nil, Nil),
-  assigns assigns: assigns,
   seed seed: ConnectSeed,
 ) -> Nil {
   socket_connected_with_codec(
@@ -165,7 +162,6 @@ pub fn socket_connected(
     send: send,
     send_binary: send_binary,
     codec: None,
-    assigns: assigns,
     seed: seed,
   )
 }
@@ -181,7 +177,6 @@ pub fn socket_connected_with_codec(
   send send: fn(String) -> Result(Nil, Nil),
   send_binary send_binary: fn(BitArray) -> Result(Nil, Nil),
   codec codec: Option(Codec),
-  assigns assigns: assigns,
   seed seed: ConnectSeed,
 ) -> Nil {
   beryl.transport_socket_connected(
@@ -190,7 +185,6 @@ pub fn socket_connected_with_codec(
     send,
     send_binary,
     codec,
-    erase(assigns),
     seed,
   )
 }
@@ -313,10 +307,6 @@ pub fn log_warning(
   log.warn(logger.inner, message, metadata)
 }
 
-/// Type-erase connect-time assigns before handing them to the coordinator.
-@external(erlang, "beryl_ffi", "identity")
-fn erase(value: anything) -> Dynamic
-
 // --- Connection ownership ---
 
 /// The lifecycle relationship between a transport connection and the runtime
@@ -356,7 +346,6 @@ pub fn admit_socket(
   send send: fn(String) -> Result(Nil, Nil),
   send_binary send_binary: fn(BitArray) -> Result(Nil, Nil),
   codec codec: Option(Codec),
-  assigns assigns: assigns,
   seed seed: ConnectSeed,
   close close: fn() -> Nil,
 ) -> Result(Nil, Nil) {
@@ -379,7 +368,6 @@ pub fn admit_socket(
           send,
           send_binary,
           codec,
-          erase(assigns),
           seed,
           close,
         )

--- a/packages/beryl/test/app_binary_codec_test.gleam
+++ b/packages/beryl/test/app_binary_codec_test.gleam
@@ -67,7 +67,6 @@ fn connect_binary(
       process.send(binary, data)
       Ok(Nil)
     },
-    assigns: Nil,
     seed: event.empty_seed(),
   )
   process.sleep(10)

--- a/packages/beryl/test/app_binary_codec_test.gleam
+++ b/packages/beryl/test/app_binary_codec_test.gleam
@@ -56,8 +56,9 @@ fn connect_binary(
 ) -> #(process.Subject(String), process.Subject(BitArray)) {
   let text = process.new_subject()
   let binary = process.new_subject()
-  transport.socket_connected(
+  transport.admit_socket(
     channels: channels,
+    owner: transport.connection_owner(channels),
     socket_id: socket_id,
     send: fn(message) {
       process.send(text, message)
@@ -67,9 +68,11 @@ fn connect_binary(
       process.send(binary, data)
       Ok(Nil)
     },
+    codec: None,
     seed: event.empty_seed(),
+    close: fn() { Nil },
   )
-  process.sleep(10)
+  |> should.equal(Ok(Nil))
   #(text, binary)
 }
 

--- a/packages/beryl/test/app_crash_test.gleam
+++ b/packages/beryl/test/app_crash_test.gleam
@@ -166,7 +166,6 @@ pub fn init_crash_leaves_socket_unregistered_test() {
     },
     send_binary: fn(_data) { Ok(Nil) },
     codec: None,
-    assigns: Nil,
     seed: event.empty_seed(),
     close: fn() { Nil },
   )

--- a/packages/beryl/test/app_heartbeat_test.gleam
+++ b/packages/beryl/test/app_heartbeat_test.gleam
@@ -7,7 +7,6 @@
 import app_test_helpers as h
 import beryl
 import beryl/event.{AcceptJoin, Closed, Join, Next}
-import beryl/transport
 import beryl/wire
 import gleam/erlang/process
 import gleam/option.{None}
@@ -41,13 +40,7 @@ fn connect_with_closer(
   socket_id: String,
   closed: process.Subject(Nil),
 ) -> process.Subject(String) {
-  let frames = h.connect(channels, socket_id)
-  transport.register_closer(
-    channels: channels,
-    socket_id: socket_id,
-    close: fn() { process.send(closed, Nil) },
-  )
-  frames
+  h.connect_with_close(channels, socket_id, fn() { process.send(closed, Nil) })
 }
 
 pub fn heartbeat_timeout_evicts_stale_socket_and_runs_closer_test() {

--- a/packages/beryl/test/app_kick_stop_test.gleam
+++ b/packages/beryl/test/app_kick_stop_test.gleam
@@ -6,7 +6,6 @@
 import app_test_helpers as h
 import beryl
 import beryl/event.{AcceptJoin, Closed, Join, KickTopic, Message, Next, Stop}
-import beryl/transport
 import beryl/wire
 import gleam/erlang/process
 import gleam/option.{None}
@@ -104,11 +103,9 @@ pub fn kick_chain_from_closed_terminates_test() {
 pub fn stop_tears_down_socket_and_calls_closer_test() {
   let events = process.new_subject()
   let channels = start_system(events)
-  let frames = h.connect(channels, "s1")
   let closed = process.new_subject()
-  transport.register_closer(channels: channels, socket_id: "s1", close: fn() {
-    process.send(closed, Nil)
-  })
+  let frames =
+    h.connect_with_close(channels, "s1", fn() { process.send(closed, Nil) })
   join_rooms(channels, events, frames, "s1", ["room:a", "room:b"])
 
   h.push(channels, "s1", "room:a", "stop", "r-2")

--- a/packages/beryl/test/app_supervision_test.gleam
+++ b/packages/beryl/test/app_supervision_test.gleam
@@ -556,7 +556,6 @@ pub fn timed_out_admission_cannot_register_or_apply_init_effects_test() {
           },
           send_binary: fn(_data) { Ok(Nil) },
           codec: None,
-          assigns: Nil,
           seed: event.empty_seed(),
           close: fn() {
             beryl.release_connection_slot(permit)

--- a/packages/beryl/test/app_supervision_test.gleam
+++ b/packages/beryl/test/app_supervision_test.gleam
@@ -83,7 +83,6 @@ fn admit(
     send: fn(_message) { Ok(Nil) },
     send_binary: fn(_data) { Ok(Nil) },
     codec: None,
-    assigns: Nil,
     seed: event.empty_seed(),
     close: close,
   )

--- a/packages/beryl/test/app_test_helpers.gleam
+++ b/packages/beryl/test/app_test_helpers.gleam
@@ -35,6 +35,18 @@ pub fn connect(
   channels: beryl.Channels,
   socket_id: String,
 ) -> process.Subject(String) {
+  connect_with_seed(channels, socket_id, event.empty_seed())
+}
+
+/// Connect a socket with an explicit `ConnectSeed` (e.g. to assert that
+/// transport-provided metadata reaches the app's `init` via
+/// `ConnectInfo.seed`), returning the subject that captures its outbound
+/// text frames.
+pub fn connect_with_seed(
+  channels: beryl.Channels,
+  socket_id: String,
+  seed: event.ConnectSeed,
+) -> process.Subject(String) {
   let sent = process.new_subject()
   let owner = transport.connection_owner(channels)
   transport.admit_socket(
@@ -47,8 +59,7 @@ pub fn connect(
     },
     send_binary: fn(_data) { Ok(Nil) },
     codec: None,
-    assigns: Nil,
-    seed: event.empty_seed(),
+    seed: seed,
     close: fn() { Nil },
   )
   |> should.equal(Ok(Nil))

--- a/packages/beryl/test/app_test_helpers.gleam
+++ b/packages/beryl/test/app_test_helpers.gleam
@@ -35,7 +35,17 @@ pub fn connect(
   channels: beryl.Channels,
   socket_id: String,
 ) -> process.Subject(String) {
-  connect_with_seed(channels, socket_id, event.empty_seed())
+  connect_with_seed_and_close(channels, socket_id, event.empty_seed(), fn() {
+    Nil
+  })
+}
+
+pub fn connect_with_close(
+  channels: beryl.Channels,
+  socket_id: String,
+  close: fn() -> Nil,
+) -> process.Subject(String) {
+  connect_with_seed_and_close(channels, socket_id, event.empty_seed(), close)
 }
 
 /// Connect a socket with an explicit `ConnectSeed` (e.g. to assert that
@@ -46,6 +56,15 @@ pub fn connect_with_seed(
   channels: beryl.Channels,
   socket_id: String,
   seed: event.ConnectSeed,
+) -> process.Subject(String) {
+  connect_with_seed_and_close(channels, socket_id, seed, fn() { Nil })
+}
+
+fn connect_with_seed_and_close(
+  channels: beryl.Channels,
+  socket_id: String,
+  seed: event.ConnectSeed,
+  close: fn() -> Nil,
 ) -> process.Subject(String) {
   let sent = process.new_subject()
   let owner = transport.connection_owner(channels)
@@ -60,7 +79,7 @@ pub fn connect_with_seed(
     send_binary: fn(_data) { Ok(Nil) },
     codec: None,
     seed: seed,
-    close: fn() { Nil },
+    close: close,
   )
   |> should.equal(Ok(Nil))
   sent

--- a/packages/beryl/test/per_socket_codec_test.gleam
+++ b/packages/beryl/test/per_socket_codec_test.gleam
@@ -6,7 +6,6 @@ import beryl/internal/unsupervised
 import beryl/transport
 import beryl/wire
 import beryl/wire/codec
-import gleam/dynamic
 import gleam/erlang/process
 import gleam/json
 import gleam/option
@@ -68,7 +67,6 @@ fn connect(
     },
     send_binary: fn(_data) { Ok(Nil) },
     codec: socket_codec,
-    assigns: dynamic.nil(),
     seed: event.empty_seed(),
   )
   sent

--- a/packages/beryl_ewe/src/beryl_ewe.gleam
+++ b/packages/beryl_ewe/src/beryl_ewe.gleam
@@ -25,10 +25,7 @@ import gleam/result
 import gleam/string
 
 /// Configuration for the Ewe WebSocket transport
-///
-/// The `assigns` type parameter is the socket-level state produced by the
-/// `on_connect` hook. It defaults to `Nil` when no hook is configured.
-pub opaque type TransportConfig(assigns) {
+pub opaque type TransportConfig {
   TransportConfig(
     /// URL path to match for WebSocket upgrade (e.g., "/socket")
     path: String,
@@ -37,11 +34,15 @@ pub opaque type TransportConfig(assigns) {
     ///
     /// Runs the Phoenix `UserSocket.connect/3` analogue: it authenticates the
     /// whole connection a single time and can reject it before any channel
-    /// join. Return `Ok(assigns)` to allow the connection and seed initial
-    /// socket assigns (visible to channels at join), or `Error(ConnectRejected)` to reject
-    /// with a 403 Forbidden response. When None, all connections are allowed
-    /// and assigns start empty (`Nil`).
-    on_connect: Option(fn(Request(Connection)) -> Result(assigns, ConnectError)),
+    /// join. Return `Ok(metadata)` to allow the connection and seed
+    /// `ConnectSeed.metadata` (an ordered list of string pairs, visible to
+    /// the app's `init` via `ConnectInfo.seed`; channel-module systems ignore
+    /// it), or `Error(ConnectRejected)` to reject with a 403 Forbidden
+    /// response. When `None`, all connections are allowed and metadata
+    /// starts empty (`[]`).
+    on_connect: Option(
+      fn(Request(Connection)) -> Result(List(#(String, String)), ConnectError),
+    ),
     /// Policy applied to the request `Origin` header before the WebSocket
     /// handshake. Defaults to [`SameOrigin`](#originpolicy).
     origin_policy: OriginPolicy,
@@ -97,30 +98,36 @@ pub type OriginPolicy {
 
 /// Create a default transport config with no connect hook.
 ///
-/// The resulting config seeds `Nil` assigns and applies the
+/// The resulting config seeds empty (`[]`) `ConnectSeed.metadata` and applies
 /// [`SameOrigin`](#originpolicy) origin policy, which rejects cross-site
 /// WebSocket upgrades before the handshake (CSWSH protection). Same-origin
 /// upgrades and non-browser clients (no `Origin` header) are admitted without
 /// configuration.
 ///
-/// Add `with_on_connect` to authenticate connections and/or seed initial
-/// assigns. Use `with_allowed_origins` to pin an explicit allow-list, or
+/// Add `with_on_connect` to authenticate connections and/or seed connect
+/// metadata. Use `with_allowed_origins` to pin an explicit allow-list, or
 /// `with_allow_all_origins` to opt out of origin checking entirely.
-pub fn default_config(path: String) -> TransportConfig(Nil) {
+pub fn default_config(path: String) -> TransportConfig {
   TransportConfig(path: path, on_connect: None, origin_policy: SameOrigin)
 }
 
 /// Set a socket-level connect/authentication callback on the transport config.
 ///
 /// The callback receives the HTTP request before the WebSocket upgrade and
-/// runs once per socket. Return `Ok(assigns)` to allow the connection and seed
-/// initial socket assigns that channels can read at join time, or
+/// runs once per socket. Return `Ok(metadata)` to allow the connection and
+/// seed `ConnectSeed.metadata` — an ordered list of string pairs delivered to
+/// an app-dispatch system's `init` via `ConnectInfo.seed` (see
+/// `ConnectInfo.init`); channel-module systems ignore it — or
 /// `Error(ConnectRejected)` to reject the connection with a 403 Forbidden
 /// response before any channel join occurs.
+///
+/// Callback order and duplicate keys are preserved verbatim in
+/// `ConnectSeed.metadata`; this transport never logs metadata values.
 pub fn with_on_connect(
-  config: TransportConfig(a),
-  callback: fn(Request(Connection)) -> Result(assigns, ConnectError),
-) -> TransportConfig(assigns) {
+  config: TransportConfig,
+  callback: fn(Request(Connection)) ->
+    Result(List(#(String, String)), ConnectError),
+) -> TransportConfig {
   TransportConfig(
     path: config.path,
     on_connect: Some(callback),
@@ -141,9 +148,9 @@ pub fn with_on_connect(
 /// that should be allowed (e.g. behind a reverse proxy that rewrites the
 /// `Host` header, where `SameOrigin` cannot see the public host).
 pub fn with_allowed_origins(
-  config: TransportConfig(assigns),
+  config: TransportConfig,
   origins: List(String),
-) -> TransportConfig(assigns) {
+) -> TransportConfig {
   TransportConfig(
     path: config.path,
     on_connect: config.on_connect,
@@ -159,9 +166,7 @@ pub fn with_allowed_origins(
 /// sessions) for authorization, or that authenticate every message
 /// independently. For cookie/session-authenticated apps, prefer the default
 /// `SameOrigin` policy or `with_allowed_origins`.
-pub fn with_allow_all_origins(
-  config: TransportConfig(assigns),
-) -> TransportConfig(assigns) {
+pub fn with_allow_all_origins(config: TransportConfig) -> TransportConfig {
   TransportConfig(
     path: config.path,
     on_connect: config.on_connect,
@@ -242,7 +247,7 @@ type SendRequest {
 pub fn upgrade(
   request: Request(Connection),
   channels: Channels,
-  config: TransportConfig(assigns),
+  config: TransportConfig,
   next: fn() -> Response(ResponseBody),
 ) -> Response(ResponseBody) {
   // Check if path matches
@@ -257,7 +262,7 @@ pub fn upgrade(
 fn handle_matched_upgrade(
   request: Request(Connection),
   channels: Channels,
-  config: TransportConfig(assigns),
+  config: TransportConfig,
 ) -> Response(ResponseBody) {
   let telemetry = transport.telemetry(channels, transport.Ewe)
   let started_at = transport.telemetry_start(telemetry)
@@ -391,7 +396,7 @@ fn forbidden() -> Response(ResponseBody) {
 fn run_connect_and_upgrade(
   request: Request(Connection),
   channels: Channels,
-  config: TransportConfig(assigns),
+  config: TransportConfig,
   connection_permit: beryl.ConnectionPermit,
   telemetry: transport.Telemetry,
   started_at: Int,
@@ -400,11 +405,11 @@ fn run_connect_and_upgrade(
   case config.on_connect {
     Some(callback) ->
       case callback(request) {
-        Ok(assigns) ->
+        Ok(metadata) ->
           do_upgrade(
             request,
             channels,
-            assigns,
+            metadata,
             Some(connection_permit),
             telemetry,
             started_at,
@@ -424,7 +429,7 @@ fn run_connect_and_upgrade(
       do_upgrade(
         request,
         channels,
-        Nil,
+        [],
         Some(connection_permit),
         telemetry,
         started_at,
@@ -474,7 +479,7 @@ pub fn is_websocket_request(request: Request(Connection)) -> Bool {
 /// ```
 pub fn handler(
   channels: Channels,
-  config: TransportConfig(assigns),
+  config: TransportConfig,
   http_fallback: fn(Request(Connection)) -> Response(ResponseBody),
 ) -> fn(Request(Connection)) -> Response(ResponseBody) {
   fn(request) {
@@ -489,9 +494,10 @@ pub fn handler(
 /// Alternative: upgrade any request to WebSocket (caller handles path matching)
 ///
 /// Note: This function does not invoke the `on_connect` callback from
-/// `TransportConfig`. Sockets upgraded this way start with empty (`Nil`)
-/// assigns. If you need authentication or seeded assigns, either use `upgrade`
-/// with a full config or call your auth check before this function.
+/// `TransportConfig`. Sockets upgraded this way start with empty (`[]`)
+/// `ConnectSeed.metadata`. If you need authentication or seeded metadata,
+/// either use `upgrade` with a full config or call your auth check before
+/// this function.
 pub fn upgrade_connection(
   request: Request(Connection),
   channels: Channels,
@@ -500,7 +506,7 @@ pub fn upgrade_connection(
   do_upgrade(
     request,
     channels,
-    Nil,
+    [],
     None,
     telemetry,
     transport.telemetry_start(telemetry),
@@ -509,12 +515,19 @@ pub fn upgrade_connection(
 
 /// Assemble the connection seed delivered to an app-dispatch system's
 /// `init` (`ConnectInfo.seed`). Channel-module systems ignore it.
-fn connect_seed(request: Request(Connection)) -> event.ConnectSeed {
+///
+/// `metadata` is the ordered list of string pairs returned by the
+/// configured `on_connect` callback (empty when none is configured or it
+/// returns no metadata); order and duplicate keys are preserved verbatim.
+fn connect_seed(
+  request: Request(Connection),
+  metadata: List(#(String, String)),
+) -> event.ConnectSeed {
   event.ConnectSeed(
     path: request.path,
     query: request.get_query(request) |> result.unwrap([]),
     headers: request.headers,
-    metadata: [],
+    metadata: metadata,
   )
 }
 
@@ -522,14 +535,14 @@ fn connect_seed(request: Request(Connection)) -> event.ConnectSeed {
 fn do_upgrade(
   request: Request(Connection),
   channels: Channels,
-  connect_assigns: assigns,
+  connect_metadata: List(#(String, String)),
   connection_permit: Option(beryl.ConnectionPermit),
   telemetry: transport.Telemetry,
   started_at: Int,
 ) -> Response(ResponseBody) {
   let max_inbound_frame_bytes = beryl.max_inbound_frame_bytes(channels)
   let active_codec = transport.active_codec(channels)
-  let seed = connect_seed(request)
+  let seed = connect_seed(request, connect_metadata)
   let response =
     ewe.upgrade_websocket(
       request,
@@ -538,7 +551,6 @@ fn do_upgrade(
           connection,
           base_selector,
           channels,
-          connect_assigns,
           seed,
           connection_permit,
           max_inbound_frame_bytes,
@@ -581,7 +593,6 @@ fn on_init(
   _connection: WebsocketConnection,
   base_selector: Selector(SendRequest),
   channels: Channels,
-  connect_assigns: assigns,
   seed: event.ConnectSeed,
   connection_permit: Option(beryl.ConnectionPermit),
   max_inbound_frame_bytes: Int,
@@ -627,7 +638,6 @@ fn on_init(
           send: send_fn,
           send_binary: send_binary_fn,
           codec: None,
-          assigns: connect_assigns,
           seed: seed,
           close: fn() { process.send(send_subject, Close) },
         )
@@ -649,7 +659,6 @@ fn on_init(
           send: send_fn,
           send_binary: send_binary_fn,
           codec: None,
-          assigns: connect_assigns,
           seed: seed,
           close: fn() { process.send(send_subject, Close) },
         )

--- a/packages/beryl_ewe/src/beryl_ewe.gleam
+++ b/packages/beryl_ewe/src/beryl_ewe.gleam
@@ -8,10 +8,7 @@
 //// either web server by choosing the matching transport package. Both consume
 //// only beryl's public `beryl/transport` SPI.
 
-import beryl.{type Channels}
-import beryl/event
-import beryl/transport
-import beryl/wire/codec
+import beryl/transport.{type Channels}
 import ewe.{type Connection, type ResponseBody, type WebsocketConnection}
 import gleam/bit_array
 import gleam/bool
@@ -179,12 +176,12 @@ type ConnectionState {
   ConnectionState(
     socket_id: String,
     channels: Channels,
-    connection_permit: Option(beryl.ConnectionPermit),
+    connection_permit: Option(transport.ConnectionPermit),
     max_inbound_frame_bytes: Int,
     /// Wire codec for decoding inbound frames here in the connection
     /// process, so parse cost and malformed input never reach the shared
     /// coordinator.
-    codec: codec.Codec,
+    codec: transport.Codec,
     telemetry: transport.Telemetry,
     /// Per-connection message-rate limiter (`None` = unlimited).
     /// Enforced at the edge: frames over the rate are shed before decode,
@@ -276,7 +273,7 @@ fn handle_matched_upgrade(
     reject_upgrade(telemetry, started_at, transport.VersionRejected)
   })
   let ip = request_ip(request)
-  case beryl.acquire_connection_slot(channels, ip) {
+  case transport.acquire_connection_slot(channels, ip) {
     Error(Nil) -> {
       transport.telemetry_upgrade_stop(
         telemetry,
@@ -397,7 +394,7 @@ fn run_connect_and_upgrade(
   request: Request(Connection),
   channels: Channels,
   config: TransportConfig,
-  connection_permit: beryl.ConnectionPermit,
+  connection_permit: transport.ConnectionPermit,
   telemetry: transport.Telemetry,
   started_at: Int,
 ) -> Response(ResponseBody) {
@@ -415,7 +412,7 @@ fn run_connect_and_upgrade(
             started_at,
           )
         Error(ConnectRejected) -> {
-          beryl.release_connection_slot(connection_permit)
+          transport.release_connection_slot(connection_permit)
           transport.telemetry_upgrade_stop(
             telemetry,
             started_at,
@@ -522,8 +519,8 @@ pub fn upgrade_connection(
 fn connect_seed(
   request: Request(Connection),
   metadata: List(#(String, String)),
-) -> event.ConnectSeed {
-  event.ConnectSeed(
+) -> transport.ConnectSeed {
+  transport.connect_seed(
     path: request.path,
     query: request.get_query(request) |> result.unwrap([]),
     headers: request.headers,
@@ -536,11 +533,11 @@ fn do_upgrade(
   request: Request(Connection),
   channels: Channels,
   connect_metadata: List(#(String, String)),
-  connection_permit: Option(beryl.ConnectionPermit),
+  connection_permit: Option(transport.ConnectionPermit),
   telemetry: transport.Telemetry,
   started_at: Int,
 ) -> Response(ResponseBody) {
-  let max_inbound_frame_bytes = beryl.max_inbound_frame_bytes(channels)
+  let max_inbound_frame_bytes = transport.max_inbound_frame_bytes(channels)
   let active_codec = transport.active_codec(channels)
   let seed = connect_seed(request, connect_metadata)
   let response =
@@ -567,7 +564,7 @@ fn do_upgrade(
   case response.status >= 400 {
     True -> {
       case connection_permit {
-        Some(permit) -> beryl.release_connection_slot(permit)
+        Some(permit) -> transport.release_connection_slot(permit)
         None -> Nil
       }
       transport.telemetry_upgrade_stop(
@@ -593,16 +590,16 @@ fn on_init(
   _connection: WebsocketConnection,
   base_selector: Selector(SendRequest),
   channels: Channels,
-  seed: event.ConnectSeed,
-  connection_permit: Option(beryl.ConnectionPermit),
+  seed: transport.ConnectSeed,
+  connection_permit: Option(transport.ConnectionPermit),
   max_inbound_frame_bytes: Int,
-  active_codec: codec.Codec,
+  active_codec: transport.Codec,
   telemetry: transport.Telemetry,
 ) -> #(ConnectionState, Selector(SendRequest)) {
   // Bind the per-IP slot to this WebSocket process so it is reclaimed even
   // if the process dies without running on_close.
   case connection_permit {
-    Some(permit) -> beryl.bind_connection_slot(permit)
+    Some(permit) -> transport.bind_connection_slot(permit)
     None -> Nil
   }
 
@@ -761,7 +758,7 @@ fn handle_inbound_text(
     )
     ewe.websocket_continue(state)
   })
-  case codec.decode_text(state.codec)(text) {
+  case transport.decode_text(state.codec)(text) {
     Ok(msg) -> {
       transport.route_decoded(state.channels, state.socket_id, msg)
       transport.telemetry_frame_stop(
@@ -779,7 +776,7 @@ fn handle_inbound_text(
         "Failed to decode wire protocol message",
         [
           #("socket_id", state.socket_id),
-          #("error", codec.format_decode_error(err)),
+          #("error", transport.format_decode_error(err)),
         ],
       )
       transport.telemetry_frame_stop(
@@ -814,7 +811,7 @@ fn handle_inbound_binary(
     )
     ewe.websocket_continue(state)
   })
-  case codec.decode_binary(state.codec) {
+  case transport.decode_binary(state.codec) {
     None -> {
       transport.route_binary(state.channels, state.socket_id, data)
       transport.telemetry_frame_stop(
@@ -845,7 +842,7 @@ fn handle_inbound_binary(
             "Failed to decode binary wire protocol message",
             [
               #("socket_id", state.socket_id),
-              #("error", codec.format_decode_error(err)),
+              #("error", transport.format_decode_error(err)),
             ],
           )
           transport.telemetry_frame_stop(
@@ -884,7 +881,7 @@ fn frame_too_large(max_bytes: Int, actual_bytes: Int) -> Bool {
 /// Cleanup when connection closes
 fn on_close(_connection: WebsocketConnection, state: ConnectionState) -> Nil {
   case state.connection_permit {
-    Some(permit) -> beryl.release_connection_slot(permit)
+    Some(permit) -> transport.release_connection_slot(permit)
     None -> Nil
   }
   transport.socket_disconnected(state.channels, state.socket_id)

--- a/packages/beryl_ewe/test/ewe_handler_test.gleam
+++ b/packages/beryl_ewe/test/ewe_handler_test.gleam
@@ -95,7 +95,7 @@ fn start_server(channels: beryl.Channels) -> #(Int, process.Pid) {
 
 fn start_server_with_config(
   channels: beryl.Channels,
-  config: ewe_transport.TransportConfig(assigns),
+  config: ewe_transport.TransportConfig,
 ) -> #(Int, process.Pid) {
   let port_subject = process.new_subject()
   let http_fallback = fn(_request) {

--- a/packages/beryl_ewe/test/ewe_handler_test.gleam
+++ b/packages/beryl_ewe/test/ewe_handler_test.gleam
@@ -14,9 +14,11 @@ import ewe
 import gleam/bit_array
 import gleam/dynamic.{type Dynamic}
 import gleam/erlang/process
+import gleam/http/request
 import gleam/http/response
 import gleam/int
 import gleam/json
+import gleam/list
 import gleam/option.{None, Some}
 import gleam/otp/actor
 import gleam/otp/static_supervisor
@@ -572,4 +574,48 @@ fn start_app(
     |> static_supervisor.add(spec)
     |> static_supervisor.start()
   Ok(sockets)
+}
+
+// Socket-level connect/auth hook — on_connect metadata reaches init
+
+fn auth_query(req, name: String) -> Result(String, Nil) {
+  case request.get_query(req) {
+    Ok(params) -> list.key_find(params, name)
+    Error(_) -> Error(Nil)
+  }
+}
+
+pub fn on_connect_seeds_metadata_visible_in_connect_info_test() {
+  // `with_on_connect` returns ordered string metadata; it lands verbatim in
+  // `ConnectInfo.seed.metadata` for an app-dispatch system's `init`.
+  // Duplicate keys must be preserved — the runtime must not deduplicate them.
+  let seeds = process.new_subject()
+  let assert Ok(channels) =
+    start_app(
+      beryl.config(wire.phoenix_codec()),
+      init: fn(info: event.ConnectInfo(Nil)) {
+        process.send(seeds, info.seed)
+        #(Nil, [])
+      },
+      update: fn(model, _ev) { event.Next(model, []) },
+    )
+
+  let config =
+    ewe_transport.default_config("/socket")
+    |> ewe_transport.with_on_connect(fn(req) {
+      auth_query(req, "token")
+      |> result.map(fn(token) { [#("user", token), #("user", token)] })
+      |> result.map_error(fn(_) { ewe_transport.ConnectRejected })
+    })
+  let #(port, server_pid) = start_server_with_config(channels, config)
+
+  let assert Ok(client) = connect_websocket(port, "/socket?token=alice")
+  let assert Ok(seed) = process.receive(seeds, 1000)
+
+  // Order and duplicate keys are preserved verbatim, not deduplicated.
+  seed.metadata |> should.equal([#("user", "alice"), #("user", "alice")])
+  seed.path |> should.equal("/socket")
+
+  close(client)
+  stop_supervisor(server_pid)
 }

--- a/packages/beryl_ewe/test/ewe_transport_test.gleam
+++ b/packages/beryl_ewe/test/ewe_transport_test.gleam
@@ -4,14 +4,14 @@ import gleam/http/request.{type Request}
 import gleeunit/should
 
 pub fn default_config_creates_with_path_test() {
-  let _config: ewe_transport.TransportConfig(Nil) =
+  let _config: ewe_transport.TransportConfig =
     ewe_transport.default_config("/socket")
 
   should.be_true(True)
 }
 
 pub fn default_config_slash_ws_test() {
-  let _config: ewe_transport.TransportConfig(Nil) =
+  let _config: ewe_transport.TransportConfig =
     ewe_transport.default_config("/ws")
 
   should.be_true(True)
@@ -19,29 +19,29 @@ pub fn default_config_slash_ws_test() {
 
 pub fn with_on_connect_sets_callback_test() {
   let callback = fn(_req: Request(Connection)) -> Result(
-    Nil,
+    List(#(String, String)),
     ewe_transport.ConnectError,
   ) {
-    Ok(Nil)
+    Ok([])
   }
 
   let config =
     ewe_transport.default_config("/socket")
     |> ewe_transport.with_on_connect(callback)
 
-  let _typed_config: ewe_transport.TransportConfig(Nil) = config
+  let _typed_config: ewe_transport.TransportConfig = config
   should.be_true(True)
 }
 
 pub fn with_on_connect_replaces_callback_test() {
   let callback1 = fn(_req: Request(Connection)) -> Result(
-    Nil,
+    List(#(String, String)),
     ewe_transport.ConnectError,
   ) {
-    Ok(Nil)
+    Ok([])
   }
   let callback2 = fn(_req: Request(Connection)) -> Result(
-    Nil,
+    List(#(String, String)),
     ewe_transport.ConnectError,
   ) {
     Error(ewe_transport.ConnectRejected)
@@ -52,24 +52,24 @@ pub fn with_on_connect_replaces_callback_test() {
     |> ewe_transport.with_on_connect(callback1)
     |> ewe_transport.with_on_connect(callback2)
 
-  let _typed_config: ewe_transport.TransportConfig(Nil) = config
+  let _typed_config: ewe_transport.TransportConfig = config
   should.be_true(True)
 }
 
-pub fn with_on_connect_seeding_assigns_sets_callback_test() {
-  // on_connect may return seeded socket-level assigns, not just Nil.
+pub fn with_on_connect_seeding_metadata_sets_callback_test() {
+  // on_connect may return ordered string metadata, not just an empty list.
   let callback = fn(_req: Request(Connection)) -> Result(
-    String,
+    List(#(String, String)),
     ewe_transport.ConnectError,
   ) {
-    Ok("user-123")
+    Ok([#("user", "user-123")])
   }
 
   let config =
     ewe_transport.default_config("/socket")
     |> ewe_transport.with_on_connect(callback)
 
-  let _typed_config: ewe_transport.TransportConfig(String) = config
+  let _typed_config: ewe_transport.TransportConfig = config
   should.be_true(True)
 }
 
@@ -93,7 +93,7 @@ pub fn with_allowed_origins_sets_list_test() {
     ewe_transport.default_config("/socket")
     |> ewe_transport.with_allowed_origins(["https://app.example.com"])
 
-  let _typed_config: ewe_transport.TransportConfig(Nil) = config
+  let _typed_config: ewe_transport.TransportConfig = config
   should.be_true(True)
 }
 
@@ -102,7 +102,7 @@ pub fn with_allow_all_origins_is_exported_test() {
     ewe_transport.default_config("/socket")
     |> ewe_transport.with_allow_all_origins()
 
-  let _typed_config: ewe_transport.TransportConfig(Nil) = config
+  let _typed_config: ewe_transport.TransportConfig = config
   should.be_true(True)
 }
 

--- a/packages/beryl_mist/src/beryl_mist.gleam
+++ b/packages/beryl_mist/src/beryl_mist.gleam
@@ -8,10 +8,7 @@
 //// either web server by choosing the matching transport package. Both consume
 //// only beryl's public `beryl/transport` SPI.
 
-import beryl.{type Channels}
-import beryl/event
-import beryl/transport
-import beryl/wire/codec
+import beryl/transport.{type Channels}
 import gleam/bit_array
 import gleam/bool
 import gleam/bytes_tree
@@ -180,12 +177,12 @@ type ConnectionState {
   ConnectionState(
     socket_id: String,
     channels: Channels,
-    connection_permit: Option(beryl.ConnectionPermit),
+    connection_permit: Option(transport.ConnectionPermit),
     max_inbound_frame_bytes: Int,
     /// Wire codec for decoding inbound frames here in the connection
     /// process, so parse cost and malformed input never reach the shared
     /// coordinator.
-    codec: codec.Codec,
+    codec: transport.Codec,
     telemetry: transport.Telemetry,
     /// Per-connection message-rate limiter (`None` = unlimited).
     /// Enforced at the edge: frames over the rate are shed before decode,
@@ -277,7 +274,7 @@ fn handle_matched_upgrade(
     reject_upgrade(telemetry, started_at, transport.VersionRejected)
   })
   let ip = request_ip(request)
-  case beryl.acquire_connection_slot(channels, ip) {
+  case transport.acquire_connection_slot(channels, ip) {
     Error(Nil) -> {
       transport.telemetry_upgrade_stop(
         telemetry,
@@ -398,7 +395,7 @@ fn run_connect_and_upgrade(
   request: Request(Connection),
   channels: Channels,
   config: TransportConfig,
-  connection_permit: beryl.ConnectionPermit,
+  connection_permit: transport.ConnectionPermit,
   telemetry: transport.Telemetry,
   started_at: Int,
 ) -> Response(ResponseData) {
@@ -416,7 +413,7 @@ fn run_connect_and_upgrade(
             started_at,
           )
         Error(ConnectRejected) -> {
-          beryl.release_connection_slot(connection_permit)
+          transport.release_connection_slot(connection_permit)
           transport.telemetry_upgrade_stop(
             telemetry,
             started_at,
@@ -523,8 +520,8 @@ pub fn upgrade_connection(
 fn connect_seed(
   request: Request(Connection),
   metadata: List(#(String, String)),
-) -> event.ConnectSeed {
-  event.ConnectSeed(
+) -> transport.ConnectSeed {
+  transport.connect_seed(
     path: request.path,
     query: request.get_query(request) |> result.unwrap([]),
     headers: request.headers,
@@ -537,11 +534,11 @@ fn do_upgrade(
   request: Request(Connection),
   channels: Channels,
   connect_metadata: List(#(String, String)),
-  connection_permit: Option(beryl.ConnectionPermit),
+  connection_permit: Option(transport.ConnectionPermit),
   telemetry: transport.Telemetry,
   started_at: Int,
 ) -> Response(ResponseData) {
-  let max_inbound_frame_bytes = beryl.max_inbound_frame_bytes(channels)
+  let max_inbound_frame_bytes = transport.max_inbound_frame_bytes(channels)
   let active_codec = transport.active_codec(channels)
   let seed = connect_seed(request, connect_metadata)
   let response =
@@ -569,7 +566,7 @@ fn do_upgrade(
   case response.status >= 400 {
     True -> {
       case connection_permit {
-        Some(permit) -> beryl.release_connection_slot(permit)
+        Some(permit) -> transport.release_connection_slot(permit)
         None -> Nil
       }
       transport.telemetry_upgrade_stop(
@@ -594,16 +591,16 @@ fn do_upgrade(
 fn on_init(
   _connection: WebsocketConnection,
   channels: Channels,
-  seed: event.ConnectSeed,
-  connection_permit: Option(beryl.ConnectionPermit),
+  seed: transport.ConnectSeed,
+  connection_permit: Option(transport.ConnectionPermit),
   max_inbound_frame_bytes: Int,
-  active_codec: codec.Codec,
+  active_codec: transport.Codec,
   telemetry: transport.Telemetry,
 ) -> #(ConnectionState, Option(process.Selector(SendRequest))) {
   // Bind the per-IP slot to this WebSocket process so it is reclaimed even
   // if the process dies without running on_close.
   case connection_permit {
-    Some(permit) -> beryl.bind_connection_slot(permit)
+    Some(permit) -> transport.bind_connection_slot(permit)
     None -> Nil
   }
 
@@ -763,7 +760,7 @@ fn handle_inbound_text(
     )
     mist.continue(state)
   })
-  case codec.decode_text(state.codec)(text) {
+  case transport.decode_text(state.codec)(text) {
     Ok(msg) -> {
       transport.route_decoded(state.channels, state.socket_id, msg)
       transport.telemetry_frame_stop(
@@ -781,7 +778,7 @@ fn handle_inbound_text(
         "Failed to decode wire protocol message",
         [
           #("socket_id", state.socket_id),
-          #("error", codec.format_decode_error(err)),
+          #("error", transport.format_decode_error(err)),
         ],
       )
       transport.telemetry_frame_stop(
@@ -816,7 +813,7 @@ fn handle_inbound_binary(
     )
     mist.continue(state)
   })
-  case codec.decode_binary(state.codec) {
+  case transport.decode_binary(state.codec) {
     None -> {
       transport.route_binary(state.channels, state.socket_id, data)
       transport.telemetry_frame_stop(
@@ -847,7 +844,7 @@ fn handle_inbound_binary(
             "Failed to decode binary wire protocol message",
             [
               #("socket_id", state.socket_id),
-              #("error", codec.format_decode_error(err)),
+              #("error", transport.format_decode_error(err)),
             ],
           )
           transport.telemetry_frame_stop(
@@ -886,7 +883,7 @@ fn frame_too_large(max_bytes: Int, actual_bytes: Int) -> Bool {
 /// Cleanup when connection closes
 fn on_close(state: ConnectionState) -> Nil {
   case state.connection_permit {
-    Some(permit) -> beryl.release_connection_slot(permit)
+    Some(permit) -> transport.release_connection_slot(permit)
     None -> Nil
   }
   transport.socket_disconnected(state.channels, state.socket_id)

--- a/packages/beryl_mist/src/beryl_mist.gleam
+++ b/packages/beryl_mist/src/beryl_mist.gleam
@@ -26,10 +26,7 @@ import gleam/string
 import mist.{type Connection, type ResponseData, type WebsocketConnection}
 
 /// Configuration for the Mist WebSocket transport
-///
-/// The `assigns` type parameter is the socket-level state produced by the
-/// `on_connect` hook. It defaults to `Nil` when no hook is configured.
-pub opaque type TransportConfig(assigns) {
+pub opaque type TransportConfig {
   TransportConfig(
     /// URL path to match for WebSocket upgrade (e.g., "/socket")
     path: String,
@@ -38,11 +35,15 @@ pub opaque type TransportConfig(assigns) {
     ///
     /// Runs the Phoenix `UserSocket.connect/3` analogue: it authenticates the
     /// whole connection a single time and can reject it before any channel
-    /// join. Return `Ok(assigns)` to allow the connection and seed initial
-    /// socket assigns (visible to channels at join), or `Error(ConnectRejected)` to reject
-    /// with a 403 Forbidden response. When None, all connections are allowed
-    /// and assigns start empty (`Nil`).
-    on_connect: Option(fn(Request(Connection)) -> Result(assigns, ConnectError)),
+    /// join. Return `Ok(metadata)` to allow the connection and seed
+    /// `ConnectSeed.metadata` (an ordered list of string pairs, visible to
+    /// the app's `init` via `ConnectInfo.seed`; channel-module systems ignore
+    /// it), or `Error(ConnectRejected)` to reject with a 403 Forbidden
+    /// response. When `None`, all connections are allowed and metadata
+    /// starts empty (`[]`).
+    on_connect: Option(
+      fn(Request(Connection)) -> Result(List(#(String, String)), ConnectError),
+    ),
     /// Policy applied to the request `Origin` header before the WebSocket
     /// handshake. Defaults to [`SameOrigin`](#originpolicy).
     origin_policy: OriginPolicy,
@@ -98,30 +99,36 @@ pub type OriginPolicy {
 
 /// Create a default transport config with no connect hook.
 ///
-/// The resulting config seeds `Nil` assigns and applies the
+/// The resulting config seeds empty (`[]`) `ConnectSeed.metadata` and applies
 /// [`SameOrigin`](#originpolicy) origin policy, which rejects cross-site
 /// WebSocket upgrades before the handshake (CSWSH protection). Same-origin
 /// upgrades and non-browser clients (no `Origin` header) are admitted without
 /// configuration.
 ///
-/// Add `with_on_connect` to authenticate connections and/or seed initial
-/// assigns. Use `with_allowed_origins` to pin an explicit allow-list, or
+/// Add `with_on_connect` to authenticate connections and/or seed connect
+/// metadata. Use `with_allowed_origins` to pin an explicit allow-list, or
 /// `with_allow_all_origins` to opt out of origin checking entirely.
-pub fn default_config(path: String) -> TransportConfig(Nil) {
+pub fn default_config(path: String) -> TransportConfig {
   TransportConfig(path: path, on_connect: None, origin_policy: SameOrigin)
 }
 
 /// Set a socket-level connect/authentication callback on the transport config.
 ///
 /// The callback receives the HTTP request before the WebSocket upgrade and
-/// runs once per socket. Return `Ok(assigns)` to allow the connection and seed
-/// initial socket assigns that channels can read at join time, or
+/// runs once per socket. Return `Ok(metadata)` to allow the connection and
+/// seed `ConnectSeed.metadata` — an ordered list of string pairs delivered to
+/// an app-dispatch system's `init` via `ConnectInfo.seed` (see
+/// `ConnectInfo.init`); channel-module systems ignore it — or
 /// `Error(ConnectRejected)` to reject the connection with a 403 Forbidden
 /// response before any channel join occurs.
+///
+/// Callback order and duplicate keys are preserved verbatim in
+/// `ConnectSeed.metadata`; this transport never logs metadata values.
 pub fn with_on_connect(
-  config: TransportConfig(a),
-  callback: fn(Request(Connection)) -> Result(assigns, ConnectError),
-) -> TransportConfig(assigns) {
+  config: TransportConfig,
+  callback: fn(Request(Connection)) ->
+    Result(List(#(String, String)), ConnectError),
+) -> TransportConfig {
   TransportConfig(
     path: config.path,
     on_connect: Some(callback),
@@ -142,9 +149,9 @@ pub fn with_on_connect(
 /// that should be allowed (e.g. behind a reverse proxy that rewrites the
 /// `Host` header, where `SameOrigin` cannot see the public host).
 pub fn with_allowed_origins(
-  config: TransportConfig(assigns),
+  config: TransportConfig,
   origins: List(String),
-) -> TransportConfig(assigns) {
+) -> TransportConfig {
   TransportConfig(
     path: config.path,
     on_connect: config.on_connect,
@@ -160,9 +167,7 @@ pub fn with_allowed_origins(
 /// sessions) for authorization, or that authenticate every message
 /// independently. For cookie/session-authenticated apps, prefer the default
 /// `SameOrigin` policy or `with_allowed_origins`.
-pub fn with_allow_all_origins(
-  config: TransportConfig(assigns),
-) -> TransportConfig(assigns) {
+pub fn with_allow_all_origins(config: TransportConfig) -> TransportConfig {
   TransportConfig(
     path: config.path,
     on_connect: config.on_connect,
@@ -243,7 +248,7 @@ type SendRequest {
 pub fn upgrade(
   request: Request(Connection),
   channels: Channels,
-  config: TransportConfig(assigns),
+  config: TransportConfig,
   next: fn() -> Response(ResponseData),
 ) -> Response(ResponseData) {
   // Check if path matches
@@ -258,7 +263,7 @@ pub fn upgrade(
 fn handle_matched_upgrade(
   request: Request(Connection),
   channels: Channels,
-  config: TransportConfig(assigns),
+  config: TransportConfig,
 ) -> Response(ResponseData) {
   let telemetry = transport.telemetry(channels, transport.Mist)
   let started_at = transport.telemetry_start(telemetry)
@@ -392,7 +397,7 @@ fn forbidden() -> Response(ResponseData) {
 fn run_connect_and_upgrade(
   request: Request(Connection),
   channels: Channels,
-  config: TransportConfig(assigns),
+  config: TransportConfig,
   connection_permit: beryl.ConnectionPermit,
   telemetry: transport.Telemetry,
   started_at: Int,
@@ -401,11 +406,11 @@ fn run_connect_and_upgrade(
   case config.on_connect {
     Some(callback) ->
       case callback(request) {
-        Ok(assigns) ->
+        Ok(metadata) ->
           do_upgrade(
             request,
             channels,
-            assigns,
+            metadata,
             Some(connection_permit),
             telemetry,
             started_at,
@@ -425,7 +430,7 @@ fn run_connect_and_upgrade(
       do_upgrade(
         request,
         channels,
-        Nil,
+        [],
         Some(connection_permit),
         telemetry,
         started_at,
@@ -475,7 +480,7 @@ pub fn is_websocket_request(request: Request(Connection)) -> Bool {
 /// ```
 pub fn handler(
   channels: Channels,
-  config: TransportConfig(assigns),
+  config: TransportConfig,
   http_fallback: fn(Request(Connection)) -> Response(ResponseData),
 ) -> fn(Request(Connection)) -> Response(ResponseData) {
   fn(request) {
@@ -490,9 +495,10 @@ pub fn handler(
 /// Alternative: upgrade any request to WebSocket (caller handles path matching)
 ///
 /// Note: This function does not invoke the `on_connect` callback from
-/// `TransportConfig`. Sockets upgraded this way start with empty (`Nil`)
-/// assigns. If you need authentication or seeded assigns, either use `upgrade`
-/// with a full config or call your auth check before this function.
+/// `TransportConfig`. Sockets upgraded this way start with empty (`[]`)
+/// `ConnectSeed.metadata`. If you need authentication or seeded metadata,
+/// either use `upgrade` with a full config or call your auth check before
+/// this function.
 pub fn upgrade_connection(
   request: Request(Connection),
   channels: Channels,
@@ -501,7 +507,7 @@ pub fn upgrade_connection(
   do_upgrade(
     request,
     channels,
-    Nil,
+    [],
     None,
     telemetry,
     transport.telemetry_start(telemetry),
@@ -510,12 +516,19 @@ pub fn upgrade_connection(
 
 /// Assemble the connection seed delivered to an app-dispatch system's
 /// `init` (`ConnectInfo.seed`). Channel-module systems ignore it.
-fn connect_seed(request: Request(Connection)) -> event.ConnectSeed {
+///
+/// `metadata` is the ordered list of string pairs returned by the
+/// configured `on_connect` callback (empty when none is configured or it
+/// returns no metadata); order and duplicate keys are preserved verbatim.
+fn connect_seed(
+  request: Request(Connection),
+  metadata: List(#(String, String)),
+) -> event.ConnectSeed {
   event.ConnectSeed(
     path: request.path,
     query: request.get_query(request) |> result.unwrap([]),
     headers: request.headers,
-    metadata: [],
+    metadata: metadata,
   )
 }
 
@@ -523,14 +536,14 @@ fn connect_seed(request: Request(Connection)) -> event.ConnectSeed {
 fn do_upgrade(
   request: Request(Connection),
   channels: Channels,
-  connect_assigns: assigns,
+  connect_metadata: List(#(String, String)),
   connection_permit: Option(beryl.ConnectionPermit),
   telemetry: transport.Telemetry,
   started_at: Int,
 ) -> Response(ResponseData) {
   let max_inbound_frame_bytes = beryl.max_inbound_frame_bytes(channels)
   let active_codec = transport.active_codec(channels)
-  let seed = connect_seed(request)
+  let seed = connect_seed(request, connect_metadata)
   let response =
     mist.websocket(
       request: request,
@@ -541,7 +554,6 @@ fn do_upgrade(
         on_init(
           connection,
           channels,
-          connect_assigns,
           seed,
           connection_permit,
           max_inbound_frame_bytes,
@@ -582,7 +594,6 @@ fn do_upgrade(
 fn on_init(
   _connection: WebsocketConnection,
   channels: Channels,
-  connect_assigns: assigns,
   seed: event.ConnectSeed,
   connection_permit: Option(beryl.ConnectionPermit),
   max_inbound_frame_bytes: Int,
@@ -628,7 +639,6 @@ fn on_init(
           send: send_fn,
           send_binary: send_binary_fn,
           codec: None,
-          assigns: connect_assigns,
           seed: seed,
           close: fn() { process.send(send_subject, Close) },
         )
@@ -650,7 +660,6 @@ fn on_init(
           send: send_fn,
           send_binary: send_binary_fn,
           codec: None,
-          assigns: connect_assigns,
           seed: seed,
           close: fn() { process.send(send_subject, Close) },
         )

--- a/packages/beryl_mist/test/mist_handler_test.gleam
+++ b/packages/beryl_mist/test/mist_handler_test.gleam
@@ -93,7 +93,7 @@ fn start_server(channels: beryl.Channels) -> #(Int, process.Pid) {
 
 fn start_server_with_config(
   channels: beryl.Channels,
-  config: mist_transport.TransportConfig(assigns),
+  config: mist_transport.TransportConfig,
 ) -> #(Int, process.Pid) {
   let port_subject = process.new_subject()
   let http_fallback = fn(_request) {

--- a/packages/beryl_mist/test/mist_transport_test.gleam
+++ b/packages/beryl_mist/test/mist_transport_test.gleam
@@ -4,14 +4,14 @@ import gleeunit/should
 import mist.{type Connection}
 
 pub fn default_config_creates_with_path_test() {
-  let _config: mist_transport.TransportConfig(Nil) =
+  let _config: mist_transport.TransportConfig =
     mist_transport.default_config("/socket")
 
   should.be_true(True)
 }
 
 pub fn default_config_slash_ws_test() {
-  let _config: mist_transport.TransportConfig(Nil) =
+  let _config: mist_transport.TransportConfig =
     mist_transport.default_config("/ws")
 
   should.be_true(True)
@@ -19,29 +19,29 @@ pub fn default_config_slash_ws_test() {
 
 pub fn with_on_connect_sets_callback_test() {
   let callback = fn(_req: Request(Connection)) -> Result(
-    Nil,
+    List(#(String, String)),
     mist_transport.ConnectError,
   ) {
-    Ok(Nil)
+    Ok([])
   }
 
   let config =
     mist_transport.default_config("/socket")
     |> mist_transport.with_on_connect(callback)
 
-  let _typed_config: mist_transport.TransportConfig(Nil) = config
+  let _typed_config: mist_transport.TransportConfig = config
   should.be_true(True)
 }
 
 pub fn with_on_connect_replaces_callback_test() {
   let callback1 = fn(_req: Request(Connection)) -> Result(
-    Nil,
+    List(#(String, String)),
     mist_transport.ConnectError,
   ) {
-    Ok(Nil)
+    Ok([])
   }
   let callback2 = fn(_req: Request(Connection)) -> Result(
-    Nil,
+    List(#(String, String)),
     mist_transport.ConnectError,
   ) {
     Error(mist_transport.ConnectRejected)
@@ -52,24 +52,24 @@ pub fn with_on_connect_replaces_callback_test() {
     |> mist_transport.with_on_connect(callback1)
     |> mist_transport.with_on_connect(callback2)
 
-  let _typed_config: mist_transport.TransportConfig(Nil) = config
+  let _typed_config: mist_transport.TransportConfig = config
   should.be_true(True)
 }
 
-pub fn with_on_connect_seeding_assigns_sets_callback_test() {
-  // on_connect may return seeded socket-level assigns, not just Nil.
+pub fn with_on_connect_seeding_metadata_sets_callback_test() {
+  // on_connect may return ordered string metadata, not just an empty list.
   let callback = fn(_req: Request(Connection)) -> Result(
-    String,
+    List(#(String, String)),
     mist_transport.ConnectError,
   ) {
-    Ok("user-123")
+    Ok([#("user", "user-123")])
   }
 
   let config =
     mist_transport.default_config("/socket")
     |> mist_transport.with_on_connect(callback)
 
-  let _typed_config: mist_transport.TransportConfig(String) = config
+  let _typed_config: mist_transport.TransportConfig = config
   should.be_true(True)
 }
 
@@ -86,7 +86,7 @@ pub fn with_allowed_origins_sets_list_test() {
     mist_transport.default_config("/socket")
     |> mist_transport.with_allowed_origins(["https://app.example.com"])
 
-  let _typed_config: mist_transport.TransportConfig(Nil) = config
+  let _typed_config: mist_transport.TransportConfig = config
   should.be_true(True)
 }
 
@@ -95,7 +95,7 @@ pub fn with_allow_all_origins_is_exported_test() {
     mist_transport.default_config("/socket")
     |> mist_transport.with_allow_all_origins()
 
-  let _typed_config: mist_transport.TransportConfig(Nil) = config
+  let _typed_config: mist_transport.TransportConfig = config
   should.be_true(True)
 }
 

--- a/packages/beryl_mist/test/phoenix_contract_test.gleam
+++ b/packages/beryl_mist/test/phoenix_contract_test.gleam
@@ -430,7 +430,7 @@ fn auth_query(req, name: String) -> Result(String, Nil) {
 
 fn start_auth_server(
   channels: beryl.Channels,
-  config: mist_transport.TransportConfig(a),
+  config: mist_transport.TransportConfig,
 ) -> #(Int, process.Pid) {
   let port_subject = process.new_subject()
   let handler = fn(request) {
@@ -458,7 +458,7 @@ pub fn on_connect_rejects_connection_without_token_test() {
     mist_transport.default_config("/socket/websocket")
     |> mist_transport.with_on_connect(fn(req) {
       case auth_query(req, "token") {
-        Ok("secret") -> Ok(Nil)
+        Ok("secret") -> Ok([])
         _ -> Error(mist_transport.ConnectRejected)
       }
     })
@@ -475,42 +475,38 @@ pub fn on_connect_rejects_connection_without_token_test() {
   stop_supervisor(server_pid)
 }
 
-pub fn on_connect_seeds_assigns_visible_at_join_test() {
-  let serializer = json_serializer()
-  let assert Ok(channels) = start_supervised(beryl.config(wire.phoenix_codec()))
-
-  // The channel's assigns is the connect-seeded user id; join echoes it back
-  // without re-authenticating.
-  let handler =
-    channel.new(fn(_topic, _payload, client_socket) {
-      let user_id = socket.get_assigns(client_socket)
-      channel.JoinOk(
-        reply: Some(json.object([#("user", json.string(user_id))])),
-        socket: client_socket,
-      )
-    })
-  let assert Ok(_) = beryl.register(channels, "room:*", handler)
+pub fn on_connect_seeds_metadata_visible_in_connect_info_test() {
+  // `with_on_connect` returns ordered string metadata (not arbitrary typed
+  // assigns); it lands verbatim in `ConnectInfo.seed.metadata` for an
+  // app-dispatch system's `init`, without re-authenticating.
+  let seeds = process.new_subject()
+  let assert Ok(channels) =
+    start_app(
+      beryl.config(wire.phoenix_codec()),
+      init: fn(info: event.ConnectInfo(Nil)) {
+        process.send(seeds, info.seed)
+        #(Nil, [])
+      },
+      update: fn(model, _ev) { event.Next(model, []) },
+    )
 
   let config =
     mist_transport.default_config("/socket/websocket")
     |> mist_transport.with_on_connect(fn(req) {
       auth_query(req, "token")
+      |> result.map(fn(token) { [#("user", token), #("user", token)] })
       |> result.map_error(fn(_) { mist_transport.ConnectRejected })
     })
   let #(port, server_pid) = start_auth_server(channels, config)
 
   let assert Ok(client) =
     connect_websocket(port, "/socket/websocket?token=alice")
-  let assert Ok(client) =
-    send_text(
-      client,
-      serializer.join("join-ref", "join-1", "room:lobby", json.object([])),
-    )
-  let reply = latest_text_message(client)
-  let frame =
-    assert_reply(serializer, reply, Some("join-ref"), "join-1", "room:lobby")
-  let response = dynamic_field(frame.payload, "response")
-  assert_json_string(response, "user", "alice")
+  let assert Ok(seed) = process.receive(seeds, 1000)
+
+  // Order and duplicate keys are preserved verbatim, not deduplicated.
+  seed.metadata |> should.equal([#("user", "alice"), #("user", "alice")])
+  seed.path |> should.equal("/socket/websocket")
+
   close(client)
   stop_supervisor(server_pid)
 }

--- a/website/src/content/docs/reference/api/beryl-transport.md
+++ b/website/src/content/docs/reference/api/beryl-transport.md
@@ -14,16 +14,16 @@ Transport SPI — the contract between beryl core and WebSocket transport
 
  A transport implementation:
  1. Admits a connection (origin/auth policy is the transport's concern),
-    acquiring a slot with `beryl.acquire_connection_slot` and binding it
-    with `beryl.bind_connection_slot`.
+    acquiring a slot with `acquire_connection_slot` and binding it with
+    `bind_connection_slot`.
  2. Captures `connection_owner`, installs its monitor, and atomically
     registers the socket and closer with `admit_socket`.
- 3. Decodes inbound frames with the codec from `active_codec` (see
-    `beryl/wire/codec`) and routes them with `route_decoded` /
+ 3. Decodes inbound frames with the codec from `active_codec` and routes
+    them with `route_decoded` /
     `route_binary`, shedding over-rate frames via `new_message_limiter` /
-    `take_token` and oversized frames via `beryl.max_inbound_frame_bytes`.
+    `take_token` and oversized frames via `max_inbound_frame_bytes`.
  4. Announces disconnects with `socket_disconnected` and releases the
-    slot with `beryl.release_connection_slot`.
+    slot with `release_connection_slot`.
 
 ## Types
 
@@ -143,7 +143,68 @@ pub type UpgradeOutcome {
 }
 ```
 
+## Type aliases
+
+### `Channels`
+
+Channel-system handle accepted by transport implementations.
+
+```gleam
+pub type Channels = beryl.Sockets
+```
+
+### `Codec`
+
+Wire codec used by a transport connection.
+
+```gleam
+pub type Codec = codec.Codec
+```
+
+### `ConnectionPermit`
+
+Connection slot permit held by a transport connection.
+
+```gleam
+pub type ConnectionPermit = beryl.ConnectionPermit
+```
+
+### `ConnectSeed`
+
+Connection metadata delivered to the app's `init`.
+
+```gleam
+pub type ConnectSeed = event.ConnectSeed
+```
+
+### `DecodeError`
+
+Wire decode failure.
+
+```gleam
+pub type DecodeError = codec.DecodeError
+```
+
+### `Inbound`
+
+Decoded inbound wire message.
+
+```gleam
+pub type Inbound = codec.Inbound
+```
+
 ## Functions
+
+### `acquire_connection_slot`
+
+Acquire a configured connection slot.
+
+```gleam
+pub fn acquire_connection_slot(
+  beryl.Sockets,
+  String
+) -> Result(beryl.ConnectionPermit, Nil)
+```
 
 ### `active_codec`
 
@@ -172,10 +233,30 @@ pub fn admit_socket(
   send: fn(String) -> Result(Nil, Nil),
   send_binary: fn(BitArray) -> Result(Nil, Nil),
   codec: option.Option(codec.Codec),
-  assigns: a,
   seed: event.ConnectSeed,
   close: fn() -> Nil
 ) -> Result(Nil, Nil)
+```
+
+### `bind_connection_slot`
+
+Bind a connection slot to the current transport process.
+
+```gleam
+pub fn bind_connection_slot(beryl.ConnectionPermit) -> Nil
+```
+
+### `connect_seed`
+
+Build connection metadata for a WebSocket upgrade.
+
+```gleam
+pub fn connect_seed(
+  path: String,
+  query: List(#(String, String)),
+  headers: List(#(String, String)),
+  metadata: List(#(String, String))
+) -> event.ConnectSeed
 ```
 
 ### `connection_owner`
@@ -187,6 +268,30 @@ Determine how a newly accepted connection is owned. Call this in the
 
 ```gleam
 pub fn connection_owner(beryl.Sockets) -> ConnectionOwner
+```
+
+### `decode_binary`
+
+Return the codec's optional binary decoder.
+
+```gleam
+pub fn decode_binary(codec.Codec) -> option.Option(fn(BitArray) -> Result(codec.Inbound, codec.DecodeError))
+```
+
+### `decode_text`
+
+Decode an inbound text frame with a codec.
+
+```gleam
+pub fn decode_text(codec.Codec) -> fn(String) -> Result(codec.Inbound, codec.DecodeError)
+```
+
+### `format_decode_error`
+
+Format a wire decode failure for transport logging.
+
+```gleam
+pub fn format_decode_error(codec.DecodeError) -> String
 ```
 
 ### `log_warning`
@@ -209,6 +314,14 @@ Create a named transport logger (e.g. `"beryl.transport.mist"`).
 pub fn logger(String) -> Logger
 ```
 
+### `max_inbound_frame_bytes`
+
+Return the configured maximum inbound frame size.
+
+```gleam
+pub fn max_inbound_frame_bytes(beryl.Sockets) -> Int
+```
+
 ### `new_message_limiter`
 
 Create a fresh per-connection message limiter, `None` when no message
@@ -220,9 +333,10 @@ pub fn new_message_limiter(beryl.Sockets) -> option.Option(RateLimiter)
 
 ### `register_closer`
 
-Register a function that force-closes the socket's underlying connection
- so the coordinator can actively evict it (e.g. heartbeat timeout) instead
- of leaving a zombie socket whose frames are silently dropped.
+Install a closer for a coordinator-backed `OwnerUnmonitored` socket.
+
+ App-runtime transports install the closer atomically with `admit_socket`;
+ this compatibility function intentionally does nothing for those systems.
 
 ```gleam
 pub fn register_closer(
@@ -230,6 +344,14 @@ pub fn register_closer(
   socket_id: String,
   close: fn() -> Nil
 ) -> Nil
+```
+
+### `release_connection_slot`
+
+Release a held connection slot.
+
+```gleam
+pub fn release_connection_slot(beryl.ConnectionPermit) -> Nil
 ```
 
 ### `route_binary`
@@ -277,12 +399,10 @@ pub fn route_decoded_binary(
 
 ### `socket_connected`
 
-Announce a newly connected socket. `send`/`send_binary` deliver outbound
- frames on this connection. `assigns` seeds connect-time socket assigns
- (type-erased internally) for channel-module systems; `seed` carries the
- upgrade request's connection data for app-dispatch systems (delivered to
- the app's `init` as `ConnectInfo.seed`). Call `register_closer`
- immediately after this.
+Compatibility registration for coordinator-backed `OwnerUnmonitored`
+ systems. App-runtime transports must use `connection_owner` and
+ `admit_socket` so registration and closer installation are tied to one
+ exact runtime pid.
 
 ```gleam
 pub fn socket_connected(
@@ -290,14 +410,17 @@ pub fn socket_connected(
   socket_id: String,
   send: fn(String) -> Result(Nil, Nil),
   send_binary: fn(BitArray) -> Result(Nil, Nil),
-  assigns: a,
   seed: event.ConnectSeed
 ) -> Nil
 ```
 
 ### `socket_connected_with_codec`
 
-Announce a newly connected socket that negotiates its own wire format.
+Compatibility registration with a connection-specific wire format.
+
+ This is for coordinator-backed `OwnerUnmonitored` systems. App-runtime
+ transports must pass the codec to `admit_socket`.
+
  `Some(codec)` frames this connection's outbound messages with `codec`
  instead of the configured one, so a single coordinator — sharing channels,
  pubsub and presence — can serve transports speaking different framings.
@@ -310,7 +433,6 @@ pub fn socket_connected_with_codec(
   send: fn(String) -> Result(Nil, Nil),
   send_binary: fn(BitArray) -> Result(Nil, Nil),
   codec: option.Option(codec.Codec),
-  assigns: a,
   seed: event.ConnectSeed
 ) -> Nil
 ```

--- a/website/src/content/docs/reference/api/beryl_ewe.md
+++ b/website/src/content/docs/reference/api/beryl_ewe.md
@@ -98,11 +98,8 @@ Allow every upgrade regardless of `Origin`. This is an explicit opt-out
 
 Configuration for the Ewe WebSocket transport
 
- The `assigns` type parameter is the socket-level state produced by the
- `on_connect` hook. It defaults to `Nil` when no hook is configured.
-
 ```gleam
-pub type TransportConfig(a)
+pub type TransportConfig
 ```
 
 ## Functions
@@ -111,18 +108,18 @@ pub type TransportConfig(a)
 
 Create a default transport config with no connect hook.
 
- The resulting config seeds `Nil` assigns and applies the
+ The resulting config seeds empty (`[]`) `ConnectSeed.metadata` and applies
  [`SameOrigin`](#originpolicy) origin policy, which rejects cross-site
  WebSocket upgrades before the handshake (CSWSH protection). Same-origin
  upgrades and non-browser clients (no `Origin` header) are admitted without
  configuration.
 
- Add `with_on_connect` to authenticate connections and/or seed initial
- assigns. Use `with_allowed_origins` to pin an explicit allow-list, or
+ Add `with_on_connect` to authenticate connections and/or seed connect
+ metadata. Use `with_allowed_origins` to pin an explicit allow-list, or
  `with_allow_all_origins` to opt out of origin checking entirely.
 
 ```gleam
-pub fn default_config(String) -> TransportConfig(Nil)
+pub fn default_config(String) -> TransportConfig
 ```
 
 ### `handler`
@@ -151,7 +148,7 @@ Build a combined request handler that serves both WebSocket channels and
 ```gleam
 pub fn handler(
   beryl.Sockets,
-  TransportConfig(a),
+  TransportConfig,
   fn(request.Request(http1.Connection)) -> response.Response(ewe.ResponseBody)
 ) -> fn(request.Request(http1.Connection)) -> response.Response(ewe.ResponseBody)
 ```
@@ -207,7 +204,7 @@ Upgrade a request to WebSocket if it matches the configured path
 pub fn upgrade(
   request.Request(http1.Connection),
   beryl.Sockets,
-  TransportConfig(a),
+  TransportConfig,
   fn() -> response.Response(ewe.ResponseBody)
 ) -> response.Response(ewe.ResponseBody)
 ```
@@ -217,9 +214,10 @@ pub fn upgrade(
 Alternative: upgrade any request to WebSocket (caller handles path matching)
 
  Note: This function does not invoke the `on_connect` callback from
- `TransportConfig`. Sockets upgraded this way start with empty (`Nil`)
- assigns. If you need authentication or seeded assigns, either use `upgrade`
- with a full config or call your auth check before this function.
+ `TransportConfig`. Sockets upgraded this way start with empty (`[]`)
+ `ConnectSeed.metadata`. If you need authentication or seeded metadata,
+ either use `upgrade` with a full config or call your auth check before
+ this function.
 
 ```gleam
 pub fn upgrade_connection(
@@ -240,7 +238,7 @@ Disable `Origin` checking, allowing WebSocket upgrades from any origin.
  `SameOrigin` policy or `with_allowed_origins`.
 
 ```gleam
-pub fn with_allow_all_origins(TransportConfig(a)) -> TransportConfig(a)
+pub fn with_allow_all_origins(TransportConfig) -> TransportConfig
 ```
 
 ### `with_allowed_origins`
@@ -260,9 +258,9 @@ Restrict WebSocket upgrades to requests whose `Origin` header exactly
 
 ```gleam
 pub fn with_allowed_origins(
-  TransportConfig(a),
+  TransportConfig,
   List(String)
-) -> TransportConfig(a)
+) -> TransportConfig
 ```
 
 ### `with_on_connect`
@@ -270,14 +268,19 @@ pub fn with_allowed_origins(
 Set a socket-level connect/authentication callback on the transport config.
 
  The callback receives the HTTP request before the WebSocket upgrade and
- runs once per socket. Return `Ok(assigns)` to allow the connection and seed
- initial socket assigns that channels can read at join time, or
+ runs once per socket. Return `Ok(metadata)` to allow the connection and
+ seed `ConnectSeed.metadata` — an ordered list of string pairs delivered to
+ an app-dispatch system's `init` via `ConnectInfo.seed` (see
+ `ConnectInfo.init`); channel-module systems ignore it — or
  `Error(ConnectRejected)` to reject the connection with a 403 Forbidden
  response before any channel join occurs.
 
+ Callback order and duplicate keys are preserved verbatim in
+ `ConnectSeed.metadata`; this transport never logs metadata values.
+
 ```gleam
 pub fn with_on_connect(
-  TransportConfig(a),
-  fn(request.Request(http1.Connection)) -> Result(b, ConnectError)
-) -> TransportConfig(b)
+  TransportConfig,
+  fn(request.Request(http1.Connection)) -> Result(List(#(String, String)), ConnectError)
+) -> TransportConfig
 ```

--- a/website/src/content/docs/reference/api/beryl_mist.md
+++ b/website/src/content/docs/reference/api/beryl_mist.md
@@ -98,11 +98,8 @@ Allow every upgrade regardless of `Origin`. This is an explicit opt-out
 
 Configuration for the Mist WebSocket transport
 
- The `assigns` type parameter is the socket-level state produced by the
- `on_connect` hook. It defaults to `Nil` when no hook is configured.
-
 ```gleam
-pub type TransportConfig(a)
+pub type TransportConfig
 ```
 
 ## Functions
@@ -111,18 +108,18 @@ pub type TransportConfig(a)
 
 Create a default transport config with no connect hook.
 
- The resulting config seeds `Nil` assigns and applies the
+ The resulting config seeds empty (`[]`) `ConnectSeed.metadata` and applies
  [`SameOrigin`](#originpolicy) origin policy, which rejects cross-site
  WebSocket upgrades before the handshake (CSWSH protection). Same-origin
  upgrades and non-browser clients (no `Origin` header) are admitted without
  configuration.
 
- Add `with_on_connect` to authenticate connections and/or seed initial
- assigns. Use `with_allowed_origins` to pin an explicit allow-list, or
+ Add `with_on_connect` to authenticate connections and/or seed connect
+ metadata. Use `with_allowed_origins` to pin an explicit allow-list, or
  `with_allow_all_origins` to opt out of origin checking entirely.
 
 ```gleam
-pub fn default_config(String) -> TransportConfig(Nil)
+pub fn default_config(String) -> TransportConfig
 ```
 
 ### `handler`
@@ -151,7 +148,7 @@ Build a combined request handler that serves both WebSocket channels and
 ```gleam
 pub fn handler(
   beryl.Sockets,
-  TransportConfig(a),
+  TransportConfig,
   fn(request.Request(http.Connection)) -> response.Response(mist.ResponseData)
 ) -> fn(request.Request(http.Connection)) -> response.Response(mist.ResponseData)
 ```
@@ -207,7 +204,7 @@ Upgrade a request to WebSocket if it matches the configured path
 pub fn upgrade(
   request.Request(http.Connection),
   beryl.Sockets,
-  TransportConfig(a),
+  TransportConfig,
   fn() -> response.Response(mist.ResponseData)
 ) -> response.Response(mist.ResponseData)
 ```
@@ -217,9 +214,10 @@ pub fn upgrade(
 Alternative: upgrade any request to WebSocket (caller handles path matching)
 
  Note: This function does not invoke the `on_connect` callback from
- `TransportConfig`. Sockets upgraded this way start with empty (`Nil`)
- assigns. If you need authentication or seeded assigns, either use `upgrade`
- with a full config or call your auth check before this function.
+ `TransportConfig`. Sockets upgraded this way start with empty (`[]`)
+ `ConnectSeed.metadata`. If you need authentication or seeded metadata,
+ either use `upgrade` with a full config or call your auth check before
+ this function.
 
 ```gleam
 pub fn upgrade_connection(
@@ -240,7 +238,7 @@ Disable `Origin` checking, allowing WebSocket upgrades from any origin.
  `SameOrigin` policy or `with_allowed_origins`.
 
 ```gleam
-pub fn with_allow_all_origins(TransportConfig(a)) -> TransportConfig(a)
+pub fn with_allow_all_origins(TransportConfig) -> TransportConfig
 ```
 
 ### `with_allowed_origins`
@@ -260,9 +258,9 @@ Restrict WebSocket upgrades to requests whose `Origin` header exactly
 
 ```gleam
 pub fn with_allowed_origins(
-  TransportConfig(a),
+  TransportConfig,
   List(String)
-) -> TransportConfig(a)
+) -> TransportConfig
 ```
 
 ### `with_on_connect`
@@ -270,14 +268,19 @@ pub fn with_allowed_origins(
 Set a socket-level connect/authentication callback on the transport config.
 
  The callback receives the HTTP request before the WebSocket upgrade and
- runs once per socket. Return `Ok(assigns)` to allow the connection and seed
- initial socket assigns that channels can read at join time, or
+ runs once per socket. Return `Ok(metadata)` to allow the connection and
+ seed `ConnectSeed.metadata` — an ordered list of string pairs delivered to
+ an app-dispatch system's `init` via `ConnectInfo.seed` (see
+ `ConnectInfo.init`); channel-module systems ignore it — or
  `Error(ConnectRejected)` to reject the connection with a 403 Forbidden
  response before any channel join occurs.
 
+ Callback order and duplicate keys are preserved verbatim in
+ `ConnectSeed.metadata`; this transport never logs metadata values.
+
 ```gleam
 pub fn with_on_connect(
-  TransportConfig(a),
-  fn(request.Request(http.Connection)) -> Result(b, ConnectError)
-) -> TransportConfig(b)
+  TransportConfig,
+  fn(request.Request(http.Connection)) -> Result(List(#(String, String)), ConnectError)
+) -> TransportConfig
 ```


### PR DESCRIPTION
## Purpose
Move transports to the monomorphic connection seed and atomic app admission contract.

## Provenance and split notes
Source PR #220; source commit(s): `083bcb23, 8f885753`. Combines the transport cutover with correctness adaptations preserving per-socket codecs, exact-owner admission, telemetry, and public SPI boundaries.
