### PR TITLE
feat(cursors): add realtime reactions

### DIFF
--- a/docs/adr/0001-type-erased-channel-registry.md
+++ b/docs/adr/0001-type-erased-channel-registry.md
@@ -10,28 +10,16 @@ public API.
 
 ## Context
 
-Beryl's unit of composition is the registered channel module, with dispatch
-inside the library (Phoenix's shape): applications register channels with
-distinct `assigns`/`info` types, and everything below follows from that
-design decision. Join requests carry client-chosen topic strings, so the
-coordinator selects a channel at runtime by matching the topic against
-every registered pattern (`State.handlers` in `coordinator.gleam`). That
-dispatch point sees channels of differing types — heterogeneity Gleam (no
-existentials, no type classes) cannot express.
+Applications register many channels with distinct `assigns`/`info` types,
+resolved by topic at runtime. The coordinator must hold them in one
+collection — a heterogeneous registry Gleam (no existentials, no type
+classes) cannot express.
 
-1. **Application-level variant type.** Keep library-side dispatch, but
-   have the app supply one union type that parameterizes every public
-   type, including the transport SPI. This borrows only half of the
-   Elm/Lustre architecture: Lustre is fully type-safe because the app
-   also owns dispatch — a parent model holds each child in a known field,
-   and `element.map` tags messages where they are constructed. With
-   dispatch inside beryl, the library can only hand each callback the
-   whole union, so every callback handles variants that "cannot" occur —
-   the unchecked cast reappears as app-visible boilerplate. Even Lustre
-   erases internally ([vdom
-   `coerce`](https://github.com/lustre-labs/lustre/blob/v5.7.1/src/lustre/vdom/vnode.gleam#L195-L197))
-   and crosses component boundaries with `Dynamic` plus decoders
-   ([`on_attribute_change`](https://github.com/lustre-labs/lustre/blob/v5.7.1/src/lustre/component.gleam#L118-L138)).
+1. **Application-level variant type (Elm/Lustre style).** One app-supplied
+   union type parameterizes everything. Type-safe, but it infects
+   every public type (including the transport SPI), forces callbacks to
+   match impossible variants, and adding a channel edits a global type,
+   breaking open registration.
 
 2. **App-side dispatch (fully Elm/Lustre).** Beryl delivers wire events to
    one app-written update function that routes topics itself. Fully
@@ -50,9 +38,8 @@ existentials, no type classes) cannot express.
 
 ## Decision
 
-Keep design 3. Beryl compiles before the application's channel types
-exist, so it can never write their union itself — only the application
-can, which is design 1's cost. Erased internals behind typed facades are
+Keep design 2. A Phoenix-shaped library is open-world — it cannot enumerate
+application channel types — and erased internals behind typed facades are
 an established Gleam/BEAM pattern: see [`gleam_otp`'s actor
 `erase`](https://github.com/gleam-lang/otp/blob/v1.2.0/src/gleam/otp/actor.gleam#L518-L519),
 [`gleam_erlang`'s
@@ -63,9 +50,10 @@ Design 2 is rejected on ergonomics, not soundness; a layered variant
 (typed core with channels as sugar on top) may merit a future ADR.
 
 Also make erasure closure-captured ("Option B"): a handler carries only
-`join`, which returns a `JoinedChannel` — closures capturing the typed
+`join`; join returns a `JoinedChannel` — closures capturing the typed
 assigns, each callback returning the next instance — so the coordinator
-never sees erased assigns and needs no per-callback coercions.
+never sees erased assigns and per-callback identity-FFI coercions
+disappear.
 
 ## Consequences
 

--- a/docs/adr/0001-type-erased-channel-registry.md
+++ b/docs/adr/0001-type-erased-channel-registry.md
@@ -10,16 +10,24 @@ public API.
 
 ## Context
 
-Applications register many channels with distinct `assigns`/`info` types,
-resolved by topic at runtime. The coordinator must hold them in one
-collection — a heterogeneous registry Gleam (no existentials, no type
-classes) cannot express.
+Applications register many channels with distinct `assigns`/`info` types.
+Join requests carry client-chosen topic strings, so the coordinator selects
+a channel at runtime by matching the topic against every registered pattern
+(`State.handlers` in `coordinator.gleam`). That dispatch point sees channels
+of differing types — heterogeneity Gleam (no existentials, no type classes)
+cannot express.
 
 1. **Application-level variant type (Elm/Lustre style).** One app-supplied
-   union type parameterizes everything. Type-safe, but it infects
-   every public type (including the transport SPI), forces callbacks to
-   match impossible variants, and adding a channel edits a global type,
-   breaking open registration.
+   union type parameterizes everything, so every public type — including
+   the transport SPI — gains the parameters. Lustre shows this is livable
+   when one author owns the whole message type, and nested wrapping
+   (`element.map`) spares callbacks from matching impossible variants. But
+   adding a channel still edits a shared type, ruling out registration of
+   independently authored channels. Even Lustre erases behind its typed
+   API ([vdom
+   `coerce`](https://github.com/lustre-labs/lustre/blob/v5.7.1/src/lustre/vdom/vnode.gleam#L195-L197))
+   and crosses component boundaries with `Dynamic` plus decoders
+   ([`on_attribute_change`](https://github.com/lustre-labs/lustre/blob/v5.7.1/src/lustre/component.gleam#L118-L138)).
 
 2. **App-side dispatch (fully Elm/Lustre).** Beryl delivers wire events to
    one app-written update function that routes topics itself. Fully
@@ -38,8 +46,9 @@ classes) cannot express.
 
 ## Decision
 
-Keep design 2. A Phoenix-shaped library is open-world — it cannot enumerate
-application channel types — and erased internals behind typed facades are
+Keep design 2. Beryl compiles before the application's channel types
+exist, so it can never write their union itself — only the application
+can, which is design 1's cost. Erased internals behind typed facades are
 an established Gleam/BEAM pattern: see [`gleam_otp`'s actor
 `erase`](https://github.com/gleam-lang/otp/blob/v1.2.0/src/gleam/otp/actor.gleam#L518-L519),
 [`gleam_erlang`'s

--- a/docs/adr/0001-type-erased-channel-registry.md
+++ b/docs/adr/0001-type-erased-channel-registry.md
@@ -10,21 +10,25 @@ public API.
 
 ## Context
 
-Applications register many channels with distinct `assigns`/`info` types.
-Join requests carry client-chosen topic strings, so the coordinator selects
-a channel at runtime by matching the topic against every registered pattern
-(`State.handlers` in `coordinator.gleam`). That dispatch point sees channels
-of differing types — heterogeneity Gleam (no existentials, no type classes)
-cannot express.
+Beryl's unit of composition is the registered channel module, with dispatch
+inside the library (Phoenix's shape): applications register channels with
+distinct `assigns`/`info` types, and everything below follows from that
+design decision. Join requests carry client-chosen topic strings, so the
+coordinator selects a channel at runtime by matching the topic against
+every registered pattern (`State.handlers` in `coordinator.gleam`). That
+dispatch point sees channels of differing types — heterogeneity Gleam (no
+existentials, no type classes) cannot express.
 
-1. **Application-level variant type (Elm/Lustre style).** One app-supplied
-   union type parameterizes everything, so every public type — including
-   the transport SPI — gains the parameters. Lustre shows this is livable
-   when one author owns the whole message type, and nested wrapping
-   (`element.map`) spares callbacks from matching impossible variants. But
-   adding a channel still edits a shared type, ruling out registration of
-   independently authored channels. Even Lustre erases behind its typed
-   API ([vdom
+1. **Application-level variant type.** Keep library-side dispatch, but
+   have the app supply one union type that parameterizes every public
+   type, including the transport SPI. This borrows only half of the
+   Elm/Lustre architecture: Lustre is fully type-safe because the app
+   also owns dispatch — a parent model holds each child in a known field,
+   and `element.map` tags messages where they are constructed. With
+   dispatch inside beryl, the library can only hand each callback the
+   whole union, so every callback handles variants that "cannot" occur —
+   the unchecked cast reappears as app-visible boilerplate. Even Lustre
+   erases internally ([vdom
    `coerce`](https://github.com/lustre-labs/lustre/blob/v5.7.1/src/lustre/vdom/vnode.gleam#L195-L197))
    and crosses component boundaries with `Dynamic` plus decoders
    ([`on_attribute_change`](https://github.com/lustre-labs/lustre/blob/v5.7.1/src/lustre/component.gleam#L118-L138)).
@@ -33,7 +37,8 @@ cannot express.
    one app-written update function that routes topics itself. Fully
    type-safe — even design 3's residual coercions (see Consequences)
    disappear, since each socket has one `msg` type and `send_info` becomes
-   an ordinary typed send. Most infrastructure could stay library-side:
+   an ordinary typed send. The application takes over routing, channel
+   lifecycle, and authorization, but most infrastructure stays library-side:
    rate limiting, presence, pubsub, and connection limits key on topic
    strings and wire data, not app types. The loss is the channel module as
    the unit of composition — colocated callbacks, no hand-written union or
@@ -46,7 +51,7 @@ cannot express.
 
 ## Decision
 
-Keep design 2. Beryl compiles before the application's channel types
+Keep design 3. Beryl compiles before the application's channel types
 exist, so it can never write their union itself — only the application
 can, which is design 1's cost. Erased internals behind typed facades are
 an established Gleam/BEAM pattern: see [`gleam_otp`'s actor
@@ -59,10 +64,9 @@ Design 2 is rejected on ergonomics, not soundness; a layered variant
 (typed core with channels as sugar on top) may merit a future ADR.
 
 Also make erasure closure-captured ("Option B"): a handler carries only
-`join`; join returns a `JoinedChannel` — closures capturing the typed
+`join`, which returns a `JoinedChannel` — closures capturing the typed
 assigns, each callback returning the next instance — so the coordinator
-never sees erased assigns and per-callback identity-FFI coercions
-disappear.
+never sees erased assigns and needs no per-callback coercions.
 
 ## Consequences
 

--- a/docs/superpowers/plans/2026-07-22-chatrooms-lobby-channel.md
+++ b/docs/superpowers/plans/2026-07-22-chatrooms-lobby-channel.md
@@ -1,0 +1,1060 @@
+# Chatrooms Lobby Channel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persistent `lobby` channel to the chatrooms example so one WebSocket connection carries both global room-directory updates and one active `room:*` chat subscription.
+
+**Architecture:** The server routes the exact `lobby` topic beside the existing `room:*` pattern and broadcasts `rooms_changed` only after room presence changes. The browser joins `lobby` once, fetches authoritative counts from the existing `/api/rooms` endpoint, and keeps that subscription while replacing its active room channel.
+
+**Tech Stack:** Gleam 1.16, Beryl app-side dispatch, example-local session presence, vanilla JavaScript, Phoenix JavaScript client, Mist, gleeunit, Playwright
+
+## Global Constraints
+
+- Use the exact topic `lobby` for the second channel type.
+- Keep `lobby` joined while the browser switches between `room:*` topics.
+- Keep `/api/rooms` as the authoritative source for room counts.
+- Broadcast `rooms_changed` only after the session tracker mutation.
+- Send `rooms_changed` on topic `lobby` with payload `{room: <room name>}`.
+- Accept no client events on `lobby`.
+- Preserve fail-closed rejection for unknown topics.
+- Rejected room joins must not broadcast `rooms_changed`.
+- If the lobby join fails, preserve room chat behavior without live counts.
+- If `/api/rooms` fails, preserve the last successful counts.
+- Ignore stale overlapping `/api/rooms` responses.
+- Add no dependencies.
+
+## File Structure
+
+- Create `examples/chatrooms/test/chatrooms_app_test.gleam` for lobby routing and room invalidation effect tests.
+- Create `examples/chatrooms/test/chatrooms_test.gleam` as the package test entrypoint.
+- Modify `examples/chatrooms/src/chatrooms/app.gleam` to add the lobby model, route lobby events, and emit room-directory invalidations.
+- Modify `examples/chatrooms/src/chatrooms/router.gleam` to add accessible room-count badges.
+- Modify `examples/chatrooms/priv/static/app.js` to keep separate lobby and room channels and refresh room counts safely.
+- Modify `examples/chatrooms/priv/static/style.css` to lay out and style room-count badges.
+- Modify `examples/chatrooms/e2e/chatrooms.spec.js` to cover dual subscriptions, count refreshes, failures, stale responses, and live updates.
+- Modify `examples/chatrooms/README.md` to document the second channel type and its events.
+
+---
+
+### Task 1: Route the Lobby Channel
+
+**Files:**
+- Create: `examples/chatrooms/test/chatrooms_app_test.gleam`
+- Create: `examples/chatrooms/test/chatrooms_test.gleam`
+- Modify: `examples/chatrooms/src/chatrooms/app.gleam:15-27`
+- Modify: `examples/chatrooms/src/chatrooms/app.gleam:32-35`
+- Modify: `examples/chatrooms/src/chatrooms/app.gleam:182-255`
+
+**Interfaces:**
+- Consumes: Existing room `join`, `update`, and `closed` functions and Beryl's ordered `Effect` list.
+- Produces: `Lobby`, `lobby_join`, `lobby_update`, `lobby_closed`, and `Standalone.lobby`, consumed by Tasks 2 and 3.
+
+- [ ] **Step 1: Add the Gleam test entrypoint**
+
+Create `examples/chatrooms/test/chatrooms_test.gleam`:
+
+```gleam
+import gleeunit
+
+/// Test entrypoint: gleeunit discovers and runs every `*_test` module in
+/// this package.
+pub fn main() {
+  gleeunit.main()
+}
+```
+
+- [ ] **Step 2: Write failing lobby and invalidation tests**
+
+Create `examples/chatrooms/test/chatrooms_app_test.gleam`:
+
+```gleam
+import beryl/event
+import beryl/group
+import chatrooms/app
+import example_helpers/session_presence
+import gleam/dict
+import gleam/dynamic
+import gleam/json
+import gleam/option.{None, Some}
+import gleeunit/should
+
+fn context() -> app.Ctx {
+  let presence_tracker = session_presence.start()
+  let assert Ok(groups) = group.start()
+  let assert Ok(_) = group.create(groups, "public")
+  let assert Ok(_) = group.add(groups, "public", "room:general")
+  app.Ctx(presence: presence_tracker, groups: groups)
+}
+
+fn lobby_ref() -> event.Ref {
+  event.make_join_ref(
+    topic: "lobby",
+    join_ref: Some("lobby-join"),
+    msg_ref: Some("lobby-ref"),
+  )
+}
+
+fn room_ref(topic: String) -> event.Ref {
+  event.make_join_ref(
+    topic: topic,
+    join_ref: Some("room-join"),
+    msg_ref: Some("room-ref"),
+  )
+}
+
+fn empty_payload() -> dynamic.Dynamic {
+  dynamic.properties([])
+}
+
+fn connect_info() -> event.ConnectInfo(Nil) {
+  event.ConnectInfo(
+    socket_id: "socket-1",
+    seed: event.empty_seed(),
+    self: event.make_sender(fn(_message) { Nil }),
+  )
+}
+
+pub fn lobby_join_is_accepted_test() {
+  let #(model, effects) = app.lobby_join(lobby_ref())
+
+  model |> should.equal(app.Lobby)
+  let assert [event.AcceptJoin(_, None)] = effects
+}
+
+pub fn lobby_messages_are_ignored_test() {
+  let #(model, effects) =
+    app.lobby_update(app.Lobby, "refresh", empty_payload(), None)
+
+  model |> should.equal(app.Lobby)
+  effects |> should.equal([])
+}
+
+pub fn standalone_routes_lobby_join_test() {
+  let #(model, _) = app.standalone_init(connect_info())
+  let next =
+    app.standalone_update(
+      context(),
+      model,
+      event.Join("lobby", empty_payload(), lobby_ref()),
+    )
+
+  let assert event.Next(
+    app.Standalone(
+      socket_id: _,
+      rooms: _,
+      lobby: Some(app.Lobby),
+    ),
+    [event.AcceptJoin(_, None)],
+  ) = next
+}
+
+pub fn closing_lobby_preserves_room_models_test() {
+  let room =
+    app.Model(username: "Alice", color: "#abcdef", room_name: "general")
+  let model =
+    app.Standalone(
+      socket_id: "socket-1",
+      rooms: dict.from_list([#("room:general", room)]),
+      lobby: Some(app.Lobby),
+    )
+
+  let next =
+    app.standalone_update(
+      context(),
+      model,
+      event.Closed("lobby", event.Normal),
+    )
+
+  let assert event.Next(
+    app.Standalone(socket_id: _, rooms: rooms, lobby: None),
+    [],
+  ) = next
+  dict.has_key(rooms, "room:general") |> should.be_true
+}
+
+pub fn unrelated_topic_is_rejected_test() {
+  let #(model, _) = app.standalone_init(connect_info())
+  let next =
+    app.standalone_update(
+      context(),
+      model,
+      event.Join(
+        "notifications:alice",
+        empty_payload(),
+        room_ref("notifications:alice"),
+      ),
+    )
+
+  let assert event.Next(_, [event.RejectJoin(_, reason)]) = next
+  json.to_string(reason)
+  |> should.equal("{\"reason\":\"unknown_topic\"}")
+}
+```
+
+- [ ] **Step 3: Run the focused tests and confirm failure**
+
+Run:
+
+```bash
+cd examples/chatrooms
+gleam test -- --filter "lobby"
+```
+
+Expected: compilation fails because `Lobby`, `lobby_join`, `lobby_update`, and `Standalone.lobby` do not exist.
+
+- [ ] **Step 4: Add the lobby model and functions**
+
+In `examples/chatrooms/src/chatrooms/app.gleam`, add after `Model`:
+
+```gleam
+/// Per-socket state for the application-wide lobby topic.
+pub type Lobby {
+  Lobby
+}
+```
+
+Add before the standalone wrapper:
+
+```gleam
+/// Accept the application-wide `lobby` topic.
+pub fn lobby_join(ref: Ref) -> #(Lobby, List(Effect)) {
+  #(Lobby, [event.AcceptJoin(ref, None)])
+}
+
+/// The lobby is read-only; client events produce no effects.
+pub fn lobby_update(
+  model: Lobby,
+  _event_name: String,
+  _payload: Dynamic,
+  _ref: Option(Ref),
+) -> #(Lobby, List(Effect)) {
+  #(model, [])
+}
+
+/// Closing the lobby requires no external cleanup.
+pub fn lobby_closed(_model: Lobby) -> List(Effect) {
+  []
+}
+```
+
+- [ ] **Step 5: Route lobby events in the standalone model**
+
+Change `Standalone` to:
+
+```gleam
+pub type Standalone {
+  Standalone(
+    socket_id: String,
+    rooms: Dict(String, Model),
+    lobby: Option(Lobby),
+  )
+}
+```
+
+Change `standalone_init` to:
+
+```gleam
+#(
+  Standalone(socket_id: info.socket_id, rooms: dict.new(), lobby: None),
+  [],
+)
+```
+
+In the `event.Join` branch, route the exact lobby topic before `room:*`:
+
+```gleam
+case topic {
+  "lobby" -> {
+    let #(lobby, effects) = lobby_join(ref)
+    event.Next(Standalone(..model, lobby: Some(lobby)), effects)
+  }
+  "room:" <> _ -> {
+    // Keep the existing room join body unchanged.
+  }
+  _ ->
+    event.Next(model, [
+      event.RejectJoin(
+        ref,
+        json.object([#("reason", json.string("unknown_topic"))]),
+      ),
+    ])
+}
+```
+
+In the `event.Message` branch, route lobby messages before room lookup:
+
+```gleam
+case topic {
+  "lobby" ->
+    case model.lobby {
+      Some(lobby) -> {
+        let #(lobby, effects) =
+          lobby_update(lobby, event_name, payload, ref)
+        event.Next(Standalone(..model, lobby: Some(lobby)), effects)
+      }
+      None -> event.Next(model, [])
+    }
+  _ ->
+    case dict.get(model.rooms, topic) {
+      // Keep the existing room update body unchanged.
+    }
+}
+```
+
+In the `event.Closed` branch, route the lobby before room lookup:
+
+```gleam
+case topic {
+  "lobby" ->
+    case model.lobby {
+      Some(lobby) ->
+        event.Next(
+          Standalone(..model, lobby: None),
+          lobby_closed(lobby),
+        )
+      None -> event.Next(model, [])
+    }
+  _ ->
+    case dict.get(model.rooms, topic) {
+      // Keep the existing room close body unchanged.
+    }
+}
+```
+
+- [ ] **Step 6: Format and run server tests**
+
+Run:
+
+```bash
+cd examples/chatrooms
+gleam format src test
+gleam test
+```
+
+Expected: all five new tests pass.
+
+- [ ] **Step 7: Commit the server channel**
+
+```bash
+git add examples/chatrooms/src/chatrooms/app.gleam examples/chatrooms/test
+git commit -m "feat(chatrooms): add lobby channel"
+```
+
+---
+
+### Task 2: Join Both Channels and Render Initial Room Counts
+
+**Files:**
+- Modify: `examples/chatrooms/src/chatrooms/router.gleam:64-87`
+- Modify: `examples/chatrooms/priv/static/app.js:11-18`
+- Modify: `examples/chatrooms/priv/static/app.js:24-40`
+- Modify: `examples/chatrooms/priv/static/app.js:246-250`
+- Modify: `examples/chatrooms/priv/static/style.css:47-71`
+- Modify: `examples/chatrooms/e2e/chatrooms.spec.js` after `Page structure`
+
+**Interfaces:**
+- Consumes: Task 1's exact `lobby` topic and the existing `GET /api/rooms` response shape `{topic, name, users}`.
+- Produces: `lobbyChannel`, `refreshRoomCounts`, `updateRoomCounts`, count badges, and lobby-first startup used by Task 3.
+
+- [ ] **Step 1: Add failing dual-channel and count tests**
+
+Add after the `Page structure` describe block in `examples/chatrooms/e2e/chatrooms.spec.js`:
+
+```javascript
+  test.describe("Lobby channel", () => {
+    test("joins lobby and a room on the same socket", async ({ page }) => {
+      const joinedTopics = [];
+      page.on("websocket", (ws) => {
+        ws.on("framesent", (frame) => {
+          try {
+            const data = JSON.parse(frame.payload);
+            if (Array.isArray(data) && data[3] === "phx_join") {
+              joinedTopics.push(data[2]);
+            }
+          } catch {
+            // ignore non-JSON frames
+          }
+        });
+      });
+
+      await gotoWithUsername(page, "LobbyUser");
+
+      await expect.poll(() => joinedTopics).toContain("lobby");
+      await expect.poll(() => joinedTopics.some((topic) =>
+        topic.startsWith("room:")
+      )).toBe(true);
+    });
+
+    test("renders a count badge for every room", async ({ page }) => {
+      await gotoWithUsername(page, "CountUser");
+
+      const badges = page.locator(".room-count");
+      await expect(badges).toHaveCount(3);
+      await expect(
+        page.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("1", { timeout: 10_000 });
+      await expect(
+        page.locator('.room-count[data-room-count="random"]')
+      ).toHaveText("0");
+      await expect(
+        page.locator('.room-count[data-room-count="help"]')
+      ).toHaveText("0");
+    });
+
+  });
+```
+
+- [ ] **Step 2: Run the focused browser tests and confirm failure**
+
+Run:
+
+```bash
+cd examples/chatrooms
+npx playwright test --grep "Lobby channel"
+```
+
+Expected: tests fail because the browser never joins `lobby` and no count badges exist.
+
+- [ ] **Step 3: Add accessible count-badge markup**
+
+In `examples/chatrooms/src/chatrooms/router.gleam`, change each room item to:
+
+```gleam
+"<li class=\"room-item\" data-room=\""
+<> name
+<> "\"><span class=\"room-hash\">#</span>"
+<> "<span class=\"room-name\">"
+<> name
+<> "</span>"
+<> "<span class=\"room-count\" data-room-count=\""
+<> name
+<> "\" aria-label=\"User count unavailable for "
+<> name
+<> "\">–</span></li>"
+```
+
+- [ ] **Step 4: Style room rows and count badges**
+
+Update `.room-item`:
+
+```css
+.room-item {
+  display: flex;
+  align-items: center;
+  padding: 0.4rem 1rem;
+  cursor: pointer;
+  color: #96989d;
+  font-size: 0.9rem;
+  border-radius: 4px;
+  margin: 1px 0.5rem;
+  transition: background 0.15s, color 0.15s;
+}
+```
+
+Replace `.room-hash`'s margin with:
+
+```css
+.room-hash {
+  color: #96989d;
+  margin-right: 4px;
+}
+```
+
+Add after `.room-hash`:
+
+```css
+.room-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.room-count {
+  min-width: 1.5rem;
+  margin-left: auto;
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: #35373c;
+  color: #b5bac1;
+  font-size: 0.7rem;
+  line-height: 1.3;
+  text-align: center;
+}
+
+.room-item.active .room-count {
+  background: #2b2d31;
+  color: #fff;
+}
+```
+
+- [ ] **Step 5: Add separate lobby state and safe room refreshes**
+
+In `examples/chatrooms/priv/static/app.js`, add to state:
+
+```javascript
+  let lobbyChannel = null;
+  let lobbyJoined = false;
+  let roomRefreshSequence = 0;
+```
+
+After the DOM references, add:
+
+```javascript
+  async function refreshRoomCounts() {
+    const requestSequence = ++roomRefreshSequence;
+
+    try {
+      const response = await fetch("/api/rooms");
+      if (!response.ok) {
+        throw new Error(`Room refresh failed with ${response.status}`);
+      }
+      const rooms = await response.json();
+      if (requestSequence !== roomRefreshSequence) return;
+      updateRoomCounts(rooms);
+    } catch (error) {
+      if (requestSequence === roomRefreshSequence) {
+        console.warn("Could not refresh room counts", error);
+      }
+    }
+  }
+
+  function updateRoomCounts(rooms) {
+    if (!Array.isArray(rooms)) return;
+
+    const counts = new Map();
+    for (const room of rooms) {
+      if (
+        room &&
+        typeof room.name === "string" &&
+        Number.isInteger(room.users) &&
+        room.users >= 0
+      ) {
+        counts.set(room.name, room.users);
+      }
+    }
+
+    document.querySelectorAll(".room-count").forEach((badge) => {
+      const roomName = badge.dataset.roomCount;
+      if (!counts.has(roomName)) return;
+      const users = counts.get(roomName);
+      badge.textContent = String(users);
+      badge.setAttribute(
+        "aria-label",
+        `${users} ${users === 1 ? "user" : "users"} in ${roomName}`
+      );
+    });
+  }
+```
+
+- [ ] **Step 6: Refresh counts after successful room joins**
+
+In the existing `currentChannel.join().receive("ok", ...)` callback, add:
+
+```javascript
+        if (lobbyJoined) {
+          refreshRoomCounts();
+        }
+```
+
+The complete callback becomes:
+
+```javascript
+      .receive("ok", (resp) => {
+        mySocketId = resp.socket_id;
+        myUsername = resp.username;
+        myColor = resp.color;
+        if (lobbyJoined) {
+          refreshRoomCounts();
+        }
+      })
+```
+
+- [ ] **Step 7: Join lobby before the first room**
+
+Replace the bottom auto-join block with:
+
+```javascript
+  function joinFirstRoom() {
+    const firstRoom = document.querySelector(".room-item");
+    if (firstRoom) {
+      joinRoom(firstRoom.dataset.room);
+    }
+  }
+
+  lobbyChannel = socket.channel("lobby", {});
+  lobbyChannel.join()
+    .receive("ok", () => {
+      lobbyJoined = true;
+      joinFirstRoom();
+    })
+    .receive("error", (response) => {
+      console.warn("Failed to join lobby", response);
+      joinFirstRoom();
+    });
+```
+
+Do not add the `rooms_changed` listener yet; Task 3 adds live invalidation.
+
+- [ ] **Step 8: Run lobby and regression browser tests**
+
+Run:
+
+```bash
+cd examples/chatrooms
+npx playwright test --grep "Lobby channel|Channel join|Room switching|API"
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 9: Commit lobby startup and initial counts**
+
+```bash
+git add examples/chatrooms/src/chatrooms/router.gleam examples/chatrooms/priv/static/app.js examples/chatrooms/priv/static/style.css examples/chatrooms/e2e/chatrooms.spec.js
+git commit -m "feat(chatrooms): show live room counts"
+```
+
+---
+
+### Task 3: Publish and Consume Live Lobby Invalidations
+
+**Files:**
+- Modify: `examples/chatrooms/test/chatrooms_app_test.gleam`
+- Modify: `examples/chatrooms/src/chatrooms/app.gleam:43-108`
+- Modify: `examples/chatrooms/src/chatrooms/app.gleam:165-180`
+- Modify: `examples/chatrooms/src/chatrooms/app.gleam:296-302`
+- Modify: `examples/chatrooms/priv/static/app.js` beside the Task 2 lobby join
+- Modify: `examples/chatrooms/e2e/chatrooms.spec.js` after the Lobby channel tests
+
+**Interfaces:**
+- Consumes: Task 1's lobby routing and Task 2's `lobbyChannel` and `refreshRoomCounts`.
+- Produces: Ordered `rooms_changed` broadcasts and live room counts that survive room switches while the lobby remains joined.
+
+- [ ] **Step 1: Add failing server invalidation tests**
+
+Append to `examples/chatrooms/test/chatrooms_app_test.gleam`:
+
+```gleam
+pub fn accepted_room_join_tracks_session_and_invalidates_lobby_test() {
+  let ctx = context()
+  let app.Ctx(presence: tracker, groups: _) = ctx
+  let #(joined, effects) =
+    app.join(
+      ctx,
+      "socket-1",
+      "room:general",
+      dynamic.properties([
+        #(dynamic.string("username"), dynamic.string("Alice")),
+      ]),
+      room_ref("room:general"),
+    )
+
+  joined |> should.be_some
+  let assert [
+    event.AcceptJoin(_, _),
+    event.Broadcast("lobby", "rooms_changed", changed),
+    event.Broadcast("room:general", "new_msg", _),
+  ] = effects
+  session_presence.count(tracker, "room:general") |> should.equal(1)
+  json.to_string(changed) |> should.equal("{\"room\":\"general\"}")
+}
+
+pub fn rejected_room_join_does_not_invalidate_lobby_test() {
+  let #(joined, effects) =
+    app.join(
+      context(),
+      "socket-1",
+      "room:missing",
+      empty_payload(),
+      room_ref("room:missing"),
+    )
+
+  joined |> should.be_none
+  let assert [event.RejectJoin(_, _)] = effects
+}
+
+pub fn room_close_untracks_session_and_invalidates_lobby_test() {
+  let ctx = context()
+  let app.Ctx(presence: tracker, groups: _) = ctx
+  session_presence.track(
+    tracker,
+    "room:general",
+    "socket-1",
+    json.object([]),
+  )
+  let model =
+    app.Model(username: "Alice", color: "#abcdef", room_name: "general")
+  let effects = app.closed(ctx, "socket-1", "room:general", model)
+
+  let assert [
+    event.Broadcast("lobby", "rooms_changed", changed),
+    event.Broadcast("room:general", "new_msg", _),
+  ] = effects
+  session_presence.count(tracker, "room:general") |> should.equal(0)
+  json.to_string(changed) |> should.equal("{\"room\":\"general\"}")
+}
+```
+
+- [ ] **Step 2: Run server invalidation tests and confirm failure**
+
+Run:
+
+```bash
+cd examples/chatrooms
+gleam test -- --filter "invalidate"
+```
+
+Expected: the accepted join and room close tests fail because no `rooms_changed` broadcast exists.
+
+- [ ] **Step 3: Add ordered room invalidations**
+
+In the successful room join path, call `session_presence.track` before
+constructing the effect list, then include the lobby invalidation:
+
+```gleam
+event.Broadcast("lobby", "rooms_changed", room_changed(room_name)),
+```
+
+The complete success effect list must be:
+
+```gleam
+[
+  event.AcceptJoin(ref, Some(reply)),
+  event.Broadcast("lobby", "rooms_changed", room_changed(room_name)),
+  event.Broadcast(topic, "new_msg", sys_payload),
+]
+```
+
+In `closed`, call `session_presence.untrack` before returning:
+
+```gleam
+[
+  event.Broadcast("lobby", "rooms_changed", room_changed(model.room_name)),
+  event.Broadcast(topic, "new_msg", sys_payload),
+]
+```
+
+Add beside `system_message`:
+
+```gleam
+fn room_changed(room_name: String) -> json.Json {
+  json.object([#("room", json.string(room_name))])
+}
+```
+
+- [ ] **Step 4: Run server tests**
+
+Run:
+
+```bash
+cd examples/chatrooms
+gleam format src test
+gleam test
+```
+
+Expected: all eight lobby and invalidation tests pass.
+
+- [ ] **Step 5: Add failing live-update browser tests**
+
+Add after the Lobby channel describe block:
+
+```javascript
+  test.describe("Live lobby updates", () => {
+    test("updates room counts when another user joins and leaves", async ({
+      browser,
+    }) => {
+      const context1 = await browser.newContext();
+      const context2 = await browser.newContext();
+      const page1 = await context1.newPage();
+      const page2 = await context2.newPage();
+
+      try {
+        await gotoWithUsername(page1, "Observer");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+
+        await gotoWithUsername(page2, "Joiner");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("2", { timeout: 10_000 });
+
+        await context2.close();
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+      } finally {
+        await context1.close();
+        await context2.close().catch(() => {});
+      }
+    });
+
+    test("keeps lobby joined while switching rooms", async ({ page }) => {
+      const leaves = [];
+      page.on("websocket", (ws) => {
+        ws.on("framesent", (frame) => {
+          try {
+            const data = JSON.parse(frame.payload);
+            if (Array.isArray(data) && data[3] === "phx_leave") {
+              leaves.push(data[2]);
+            }
+          } catch {
+            // ignore non-JSON frames
+          }
+        });
+      });
+
+      await gotoWithUsername(page, "Switcher");
+      await expect(
+        page.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("1", { timeout: 10_000 });
+
+      await page.locator('.room-item[data-room="random"]').click();
+      await expect(page.locator(".room-item.active")).toContainText("random");
+      await expect(
+        page.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("0", { timeout: 10_000 });
+      await expect(
+        page.locator('.room-count[data-room-count="random"]')
+      ).toHaveText("1", { timeout: 10_000 });
+
+      expect(leaves).toContain("room:general");
+      expect(leaves).not.toContain("lobby");
+    });
+
+    test("keeps the last counts when a live refresh fails", async ({
+      browser,
+    }) => {
+      const context1 = await browser.newContext();
+      const context2 = await browser.newContext();
+      const page1 = await context1.newPage();
+      const page2 = await context2.newPage();
+      let failRefreshes = false;
+      let failedRequests = 0;
+
+      await page1.route("**/api/rooms", async (route) => {
+        if (failRefreshes) {
+          failedRequests += 1;
+          await route.fulfill({ status: 503, body: "unavailable" });
+        } else {
+          await route.continue();
+        }
+      });
+
+      try {
+        await gotoWithUsername(page1, "FailureObserver");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+
+        failRefreshes = true;
+        await gotoWithUsername(page2, "FailureJoiner");
+        await expect.poll(() => failedRequests).toBeGreaterThan(0);
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1");
+      } finally {
+        await context1.close();
+        await context2.close();
+      }
+    });
+
+    test("ignores a stale overlapping live refresh", async ({ browser }) => {
+      const context1 = await browser.newContext();
+      const context2 = await browser.newContext();
+      const page1 = await context1.newPage();
+      const page2 = await context2.newPage();
+      let raceMode = false;
+      let delayedRequestSeen = false;
+
+      await page1.route("**/api/rooms", async (route) => {
+        if (!raceMode) {
+          await route.continue();
+        } else if (!delayedRequestSeen) {
+          delayedRequestSeen = true;
+          await new Promise((resolve) => setTimeout(resolve, 300));
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([
+              { topic: "room:general", name: "general", users: 9 },
+              { topic: "room:random", name: "random", users: 0 },
+              { topic: "room:help", name: "help", users: 0 },
+            ]),
+          });
+        } else {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([
+              { topic: "room:general", name: "general", users: 1 },
+              { topic: "room:random", name: "random", users: 1 },
+              { topic: "room:help", name: "help", users: 0 },
+            ]),
+          });
+        }
+      });
+
+      try {
+        await gotoWithUsername(page1, "RaceObserver");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+
+        raceMode = true;
+        await gotoWithUsername(page2, "RaceJoiner");
+        await expect.poll(() => delayedRequestSeen).toBe(true);
+        await page2.locator('.room-item[data-room="random"]').click();
+
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+        await expect(
+          page1.locator('.room-count[data-room-count="random"]')
+        ).toHaveText("1", { timeout: 10_000 });
+        await page1.waitForTimeout(350);
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1");
+      } finally {
+        await context1.close();
+        await context2.close();
+      }
+    });
+  });
+```
+
+- [ ] **Step 6: Run live-update tests and confirm failure**
+
+Run:
+
+```bash
+cd examples/chatrooms
+npx playwright test --grep "Live lobby updates"
+```
+
+Expected: counts remain stale because the client does not handle `rooms_changed`.
+
+- [ ] **Step 7: Subscribe to lobby invalidations**
+
+Immediately after creating `lobbyChannel`, add:
+
+```javascript
+  lobbyChannel.on("rooms_changed", () => {
+    refreshRoomCounts();
+  });
+```
+
+- [ ] **Step 8: Run focused and full browser tests**
+
+Run:
+
+```bash
+cd examples/chatrooms
+npx playwright test --grep "Lobby channel|Live lobby updates|Room switching|Multi-user presence"
+npm test
+```
+
+Expected: focused tests and the complete chatrooms Playwright suite pass.
+
+- [ ] **Step 9: Commit live invalidation handling**
+
+```bash
+git add examples/chatrooms/src/chatrooms/app.gleam examples/chatrooms/test/chatrooms_app_test.gleam examples/chatrooms/priv/static/app.js examples/chatrooms/e2e/chatrooms.spec.js
+git commit -m "feat(chatrooms): refresh counts from lobby"
+```
+
+---
+
+### Task 4: Document and Verify the Two-Channel Demo
+
+**Files:**
+- Modify: `examples/chatrooms/README.md:3-24`
+- Modify: `examples/chatrooms/README.md:26-55`
+- Modify: `examples/chatrooms/README.md:71-83`
+
+**Interfaces:**
+- Consumes: The completed lobby and room channel behavior.
+- Produces: Documentation and final verification evidence matching the implementation.
+
+- [ ] **Step 1: Update the feature list and architecture**
+
+Add after the multi-room chat feature:
+
+```markdown
+- 🧭 **Persistent lobby channel** — one socket stays joined to `lobby` while switching between `room:*` topics
+- 🔢 **Live room counts** — lobby invalidations refresh authoritative counts from `/api/rooms`
+```
+
+Add these rows to **beryl Features Exercised**:
+
+```markdown
+| **Multiple channel types** | `beryl/event` | Exact `lobby` topic plus wildcard `room:*` topics on one socket |
+| **Ordered dispatch** | `beryl/event` | Session tracker changes happen before lobby invalidations |
+```
+
+Replace the app-side dispatch architecture line with:
+
+```text
+  ├── beryl app-side dispatch
+  │   ├── lobby (persistent room-directory invalidation channel)
+  │   └── room:* (replaceable chat-room channels)
+```
+
+- [ ] **Step 2: Document lobby events**
+
+Add to the Channel Events table:
+
+```markdown
+| Server → Client | `rooms_changed` on `lobby` | Invalidate room counts after room membership changes `{room}` |
+```
+
+Add after the table:
+
+```markdown
+The browser joins `lobby` once and keeps it joined while replacing its active
+`room:*` channel. `rooms_changed` invalidates the directory; the browser then
+loads the current counts from `GET /api/rooms`.
+```
+
+- [ ] **Step 3: Format and test the chatrooms example**
+
+Run:
+
+```bash
+cd examples/chatrooms
+gleam format src test
+gleam check
+gleam test
+npm test
+```
+
+Expected: formatting completes, Gleam checks pass, all eight Gleam tests pass, and the complete Playwright suite passes.
+
+- [ ] **Step 4: Run workspace validation**
+
+Run from the repository root:
+
+```bash
+just format-check
+just check
+just test
+```
+
+Expected: all workspace formatting, type checks, and tests pass.
+
+- [ ] **Step 5: Remove generated browser artifacts**
+
+Remove only generated chatrooms test output:
+
+```bash
+rm -rf examples/chatrooms/test-results examples/chatrooms/playwright-report
+```
+
+Expected: `git status --short` lists only intended source, test, and documentation changes plus any pre-existing unrelated files.
+
+- [ ] **Step 6: Commit documentation and formatting**
+
+```bash
+git add examples/chatrooms/README.md examples/chatrooms/src examples/chatrooms/test examples/chatrooms/priv/static examples/chatrooms/e2e/chatrooms.spec.js
+git commit -m "docs(chatrooms): describe lobby channel"
+```

--- a/docs/superpowers/plans/2026-07-22-cursors-reactions.md
+++ b/docs/superpowers/plans/2026-07-22-cursors-reactions.md
@@ -1,0 +1,908 @@
+# Cursors Reactions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a selectable reaction toolbar to the cursors example and broadcast click-positioned reactions that rise and fade for every connected user.
+
+**Architecture:** The browser owns toolbar state and ephemeral animation nodes. It sends a dedicated `reaction` event with an allowed emoji and normalized coordinates; the Gleam app validates the payload and broadcasts it to every other socket without storing reaction state.
+
+**Tech Stack:** Gleam 1.16, beryl app-side dispatch, vanilla JavaScript, CSS animations, Phoenix JS client, gleeunit, Playwright
+
+## Global Constraints
+
+- Offer exactly `👍`, `❤️`, `😂`, `🎉`, and `🔥`.
+- Start with `👍` selected; selecting the active reaction again clears the selection.
+- Keep selection active across canvas clicks until the user changes or clears it.
+- Use a dedicated `reaction` event with `{ reaction, x, y }`.
+- Normalize `x` and `y` to the inclusive range `0.0` through `1.0`.
+- Broadcast reactions to every other socket with `BroadcastFrom`; render the sender's reaction locally.
+- Store no reaction history or server-side reaction state.
+- Remove each reaction node after its animation.
+- Preserve a reduced-motion fade.
+- Add no dependencies.
+
+## File Structure
+
+- Create `examples/cursors/test/cursors_app_test.gleam` for reaction payload validation and effect tests.
+- Modify `examples/cursors/src/cursors/app.gleam` to decode, validate, and broadcast reaction events.
+- Modify `examples/cursors/src/cursors/router.gleam` to render the accessible reaction toolbar.
+- Modify `examples/cursors/priv/static/app.js` to manage selection, local animation, normalized sends, and remote rendering.
+- Modify `examples/cursors/priv/static/style.css` to style the toolbar and reaction animations.
+- Modify `examples/cursors/e2e/cursors.spec.js` to cover toolbar behavior, animation cleanup, wire payloads, and multi-user rendering.
+- Modify `examples/cursors/README.md` to describe reactions in the demo and architecture.
+
+---
+
+### Task 1: Validate and Broadcast Reaction Events
+
+**Files:**
+- Create: `examples/cursors/test/cursors_app_test.gleam`
+- Modify: `examples/cursors/src/cursors/app.gleam:12-21`
+- Modify: `examples/cursors/src/cursors/app.gleam:65-88`
+- Modify: `examples/cursors/src/cursors/app.gleam:189-208`
+
+**Interfaces:**
+- Consumes: Existing `app.update(Ctx, String, String, Model, String, Dynamic) -> #(Model, List(Effect))`
+- Produces: `reaction` handling that emits `event.BroadcastFrom(topic, "reaction", payload)` only for supported emoji and normalized coordinates
+
+- [ ] **Step 1: Write failing Gleam tests**
+
+Create `examples/cursors/test/cursors_app_test.gleam`:
+
+```gleam
+import beryl/event
+import beryl/presence
+import cursors/app
+import gleam/dynamic
+import gleam/json
+import gleam/list
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+fn context() -> app.Ctx {
+  let assert Ok(handle) =
+    presence.start(presence.default_config("cursors-reaction-test"))
+  app.Ctx(presence: handle)
+}
+
+fn model() -> app.Model {
+  app.Model(username: "Alice", color: "#abcdef")
+}
+
+fn reaction_payload(
+  reaction: String,
+  x: dynamic.Dynamic,
+  y: dynamic.Dynamic,
+) -> dynamic.Dynamic {
+  dynamic.properties([
+    #(dynamic.string("reaction"), dynamic.string(reaction)),
+    #(dynamic.string("x"), x),
+    #(dynamic.string("y"), y),
+  ])
+}
+
+pub fn supported_reactions_broadcast_test() {
+  ["👍", "❤️", "😂", "🎉", "🔥"]
+  |> list.each(fn(reaction) {
+    let #(_, effects) =
+      app.update(
+        context(),
+        "socket-1",
+        "cursor:lobby",
+        model(),
+        "reaction",
+        reaction_payload(reaction, dynamic.float(0.25), dynamic.float(0.75)),
+      )
+
+    let assert [
+      event.BroadcastFrom("cursor:lobby", "reaction", payload),
+    ] = effects
+    json.to_string(payload)
+    |> should.equal(
+      "{\"reaction\":\"" <> reaction <> "\",\"x\":0.25,\"y\":0.75}",
+    )
+  })
+}
+
+pub fn integer_boundary_coordinates_broadcast_test() {
+  let #(_, effects) =
+    app.update(
+      context(),
+      "socket-1",
+      "cursor:lobby",
+      model(),
+      "reaction",
+      reaction_payload("👍", dynamic.int(0), dynamic.int(1)),
+    )
+
+  let assert [
+    event.BroadcastFrom("cursor:lobby", "reaction", payload),
+  ] = effects
+  json.to_string(payload)
+  |> should.equal("{\"reaction\":\"👍\",\"x\":0.0,\"y\":1.0}")
+}
+
+pub fn invalid_reaction_payloads_are_dropped_test() {
+  let missing_y =
+    dynamic.properties([
+      #(dynamic.string("reaction"), dynamic.string("👍")),
+      #(dynamic.string("x"), dynamic.float(0.5)),
+    ])
+  let invalid_payloads = [
+    reaction_payload("👎", dynamic.float(0.5), dynamic.float(0.5)),
+    reaction_payload("👍", dynamic.float(-0.1), dynamic.float(0.5)),
+    reaction_payload("👍", dynamic.float(0.5), dynamic.float(1.1)),
+    reaction_payload("👍", dynamic.string("middle"), dynamic.float(0.5)),
+    missing_y,
+  ]
+
+  invalid_payloads
+  |> list.each(fn(payload) {
+    let #(_, effects) =
+      app.update(
+        context(),
+        "socket-1",
+        "cursor:lobby",
+        model(),
+        "reaction",
+        payload,
+      )
+    effects |> should.equal([])
+  })
+}
+
+pub fn cursor_move_behavior_is_unchanged_test() {
+  let payload =
+    dynamic.properties([
+      #(dynamic.string("x"), dynamic.int(12)),
+      #(dynamic.string("y"), dynamic.int(34)),
+    ])
+  let #(_, effects) =
+    app.update(
+      context(),
+      "socket-1",
+      "cursor:lobby",
+      model(),
+      "cursor_move",
+      payload,
+    )
+
+  let assert [
+    event.BroadcastFrom("cursor:lobby", "cursor_move", broadcast),
+  ] = effects
+  json.to_string(broadcast)
+  |> should.equal(
+    "{\"socket_id\":\"socket-1\",\"x\":12,\"y\":34,\"username\":\"Alice\",\"color\":\"#abcdef\"}",
+  )
+}
+```
+
+- [ ] **Step 2: Run the focused tests and confirm failure**
+
+Run:
+
+```bash
+cd examples/cursors
+gleam test -- --filter "reaction"
+```
+
+Expected: `supported_reactions_broadcast_test` fails because `app.update` returns no effects for `reaction`.
+
+- [ ] **Step 3: Implement strict reaction decoding**
+
+In `examples/cursors/src/cursors/app.gleam`, add `gleam/int` to the imports and add the supported set:
+
+```gleam
+import gleam/int
+
+const supported_reactions = ["👍", "❤️", "😂", "🎉", "🔥"]
+```
+
+Add the `reaction` branch immediately after `cursor_move`:
+
+```gleam
+    "reaction" ->
+      case decode_reaction(payload) {
+        Some(#(reaction, x, y)) -> {
+          let reaction_payload =
+            json.object([
+              #("reaction", json.string(reaction)),
+              #("x", json.float(x)),
+              #("y", json.float(y)),
+            ])
+          #(model, [
+            event.BroadcastFrom(topic, "reaction", reaction_payload),
+          ])
+        }
+        None -> #(model, [])
+      }
+```
+
+Add these private helpers above `extract_json_number`:
+
+```gleam
+fn decode_reaction(payload: Dynamic) -> Option(#(String, Float, Float)) {
+  let reaction_decoder = {
+    use reaction <- decode.field("reaction", decode.string)
+    decode.success(reaction)
+  }
+
+  case
+    decode.run(payload, reaction_decoder),
+    decode_number(payload, "x"),
+    decode_number(payload, "y")
+  {
+    Ok(reaction), Ok(x), Ok(y) -> {
+      let valid =
+        list.contains(supported_reactions, reaction)
+        && coordinate_in_range(x)
+        && coordinate_in_range(y)
+      case valid {
+        True -> Some(#(reaction, x, y))
+        False -> None
+      }
+    }
+    _, _, _ -> None
+  }
+}
+
+fn decode_number(payload: Dynamic, field_name: String) -> Result(Float, Nil) {
+  let float_decoder = {
+    use value <- decode.field(field_name, decode.float)
+    decode.success(value)
+  }
+  case decode.run(payload, float_decoder) {
+    Ok(value) -> Ok(value)
+    Error(_) -> {
+      let int_decoder = {
+        use value <- decode.field(field_name, decode.int)
+        decode.success(value)
+      }
+      case decode.run(payload, int_decoder) {
+        Ok(value) -> Ok(int.to_float(value))
+        Error(_) -> Error(Nil)
+      }
+    }
+  }
+}
+
+fn coordinate_in_range(value: Float) -> Bool {
+  value >= 0.0 && value <= 1.0
+}
+```
+
+- [ ] **Step 4: Format and run the focused tests**
+
+Run:
+
+```bash
+cd examples/cursors
+gleam format src test
+gleam test -- --filter "reaction"
+gleam test -- --filter "cursor_move_behavior_is_unchanged"
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 5: Commit the server behavior**
+
+```bash
+git add examples/cursors/src/cursors/app.gleam examples/cursors/test/cursors_app_test.gleam
+git commit -m "feat(cursors): broadcast reactions"
+```
+
+---
+
+### Task 2: Add the Toolbar and Local Animation
+
+**Files:**
+- Modify: `examples/cursors/src/cursors/router.gleam:55-68`
+- Modify: `examples/cursors/priv/static/app.js:7-16`
+- Modify: `examples/cursors/priv/static/app.js:63-129`
+- Modify: `examples/cursors/priv/static/style.css:21-32`
+- Modify: `examples/cursors/priv/static/style.css:79-106`
+- Modify: `examples/cursors/e2e/cursors.spec.js:51-96`
+- Modify: `examples/cursors/e2e/cursors.spec.js:558-575`
+
+**Interfaces:**
+- Consumes: The existing `#canvas` element and Phoenix client setup
+- Produces: `#reaction-toolbar`, `.reaction-option`, `setSelectedReaction`, and `spawnReaction(reaction, x, y)`
+
+- [ ] **Step 1: Add failing toolbar and local-animation tests**
+
+Add this describe block after `Page structure` in `examples/cursors/e2e/cursors.spec.js`:
+
+```javascript
+  test.describe("Reaction toolbar", () => {
+    test("renders five accessible reactions with thumbs up selected", async ({
+      page,
+    }) => {
+      await page.goto("/");
+
+      const toolbar = page.getByRole("toolbar", { name: "Choose reaction" });
+      await expect(toolbar).toBeVisible();
+      await expect(toolbar.getByRole("button")).toHaveCount(5);
+      await expect(
+        toolbar.getByRole("button", { name: "Thumbs up" })
+      ).toHaveAttribute("aria-pressed", "true");
+    });
+
+    test("switches and clears the selected reaction", async ({ page }) => {
+      await page.goto("/");
+
+      const heart = page.getByRole("button", { name: "Heart" });
+      const thumbsUp = page.getByRole("button", { name: "Thumbs up" });
+      await heart.click();
+      await expect(heart).toHaveAttribute("aria-pressed", "true");
+      await expect(thumbsUp).toHaveAttribute("aria-pressed", "false");
+
+      await heart.click();
+      await expect(heart).toHaveAttribute("aria-pressed", "false");
+    });
+
+    test("spawns and removes the selected local reaction", async ({ page }) => {
+      await page.goto("/");
+
+      await page.locator("#canvas").click({ position: { x: 120, y: 140 } });
+      const reaction = page.locator("#canvas .reaction-burst");
+      await expect(reaction).toHaveText("👍");
+      await expect(reaction).toHaveCount(0, { timeout: 3_000 });
+    });
+
+    test("toolbar clicks do not spawn reactions", async ({ page }) => {
+      await page.goto("/");
+
+      await page.getByRole("button", { name: "Party popper" }).click();
+      await expect(page.locator("#canvas .reaction-burst")).toHaveCount(0);
+    });
+
+    test("canvas clicks do nothing after clearing selection", async ({
+      page,
+    }) => {
+      await page.goto("/");
+
+      await page.getByRole("button", { name: "Thumbs up" }).click();
+      await page.locator("#canvas").click({ position: { x: 100, y: 100 } });
+      await expect(page.locator("#canvas .reaction-burst")).toHaveCount(0);
+    });
+
+    test("keeps the selection active across rapid clicks", async ({ page }) => {
+      await page.goto("/");
+
+      const canvas = page.locator("#canvas");
+      await canvas.click({ position: { x: 100, y: 100 } });
+      await canvas.click({ position: { x: 140, y: 140 } });
+      await expect(page.locator("#canvas .reaction-burst")).toHaveCount(2);
+      await expect(
+        page.getByRole("button", { name: "Thumbs up" })
+      ).toHaveAttribute("aria-pressed", "true");
+    });
+
+    test("keeps the toolbar inside the canvas on mobile", async ({
+      browser,
+    }) => {
+      const context = await browser.newContext({
+        viewport: { width: 375, height: 667 },
+      });
+      const page = await context.newPage();
+
+      try {
+        await page.goto("/");
+        const canvasBox = await page.locator("#canvas").boundingBox();
+        const toolbarBox = await page.locator("#reaction-toolbar").boundingBox();
+        expect(toolbarBox.x).toBeGreaterThanOrEqual(canvasBox.x);
+        expect(toolbarBox.x + toolbarBox.width).toBeLessThanOrEqual(
+          canvasBox.x + canvasBox.width
+        );
+      } finally {
+        await context.close();
+      }
+    });
+
+    test("uses the reduced-motion fade", async ({ browser }) => {
+      const context = await browser.newContext({ reducedMotion: "reduce" });
+      const page = await context.newPage();
+
+      try {
+        await page.goto("/");
+        await page.locator("#canvas").click({ position: { x: 100, y: 100 } });
+        const animationName = await page
+          .locator("#canvas .reaction-burst")
+          .evaluate((el) => getComputedStyle(el).animationName);
+        expect(animationName).toBe("reaction-fade");
+      } finally {
+        await context.close();
+      }
+    });
+  });
+```
+
+- [ ] **Step 2: Run the focused browser tests and confirm failure**
+
+Run:
+
+```bash
+cd examples/cursors
+npx playwright test --grep "Reaction toolbar"
+```
+
+Expected: tests fail because the toolbar and reaction nodes do not exist.
+
+- [ ] **Step 3: Add accessible toolbar markup**
+
+Inside `#canvas` in `examples/cursors/src/cursors/router.gleam`, after `#welcome`, add:
+
+```html
+      <div id="reaction-toolbar" role="toolbar" aria-label="Choose reaction">
+        <button class="reaction-option is-selected" type="button" data-reaction="👍" aria-label="Thumbs up" aria-pressed="true">👍</button>
+        <button class="reaction-option" type="button" data-reaction="❤️" aria-label="Heart" aria-pressed="false">❤️</button>
+        <button class="reaction-option" type="button" data-reaction="😂" aria-label="Face with tears of joy" aria-pressed="false">😂</button>
+        <button class="reaction-option" type="button" data-reaction="🎉" aria-label="Party popper" aria-pressed="false">🎉</button>
+        <button class="reaction-option" type="button" data-reaction="🔥" aria-label="Fire" aria-pressed="false">🔥</button>
+      </div>
+```
+
+- [ ] **Step 4: Implement selection and local reaction rendering**
+
+In `examples/cursors/priv/static/app.js`, add beside the existing timing constants:
+
+```javascript
+  const REACTION_DURATION_MS = 1200;
+```
+
+After the existing `const canvas = document.getElementById("canvas");`, add:
+
+```javascript
+  const reactionToolbar = document.getElementById("reaction-toolbar");
+  const reactionButtons = Array.from(
+    reactionToolbar.querySelectorAll(".reaction-option")
+  );
+  let selectedReaction = "👍";
+```
+
+Add the toolbar behavior before the cursor `mousemove` listeners:
+
+```javascript
+  function setSelectedReaction(reaction) {
+    selectedReaction = selectedReaction === reaction ? null : reaction;
+    for (const button of reactionButtons) {
+      const selected = button.dataset.reaction === selectedReaction;
+      button.classList.toggle("is-selected", selected);
+      button.setAttribute("aria-pressed", String(selected));
+    }
+  }
+
+  for (const button of reactionButtons) {
+    button.addEventListener("click", (event) => {
+      event.stopPropagation();
+      setSelectedReaction(button.dataset.reaction);
+    });
+  }
+
+  canvas.addEventListener("click", (event) => {
+    if (!selectedReaction || event.target.closest("#reaction-toolbar")) return;
+
+    const rect = canvas.getBoundingClientRect();
+    spawnReaction(
+      selectedReaction,
+      event.clientX - rect.left,
+      event.clientY - rect.top
+    );
+  });
+
+  function spawnReaction(reaction, x, y) {
+    const el = document.createElement("span");
+    el.className = "reaction-burst";
+    el.textContent = reaction;
+    el.style.left = `${x}px`;
+    el.style.top = `${y}px`;
+    el.style.setProperty(
+      "--reaction-drift",
+      `${(Math.random() * 32 - 16).toFixed(1)}px`
+    );
+    el.style.setProperty(
+      "--reaction-scale",
+      (0.9 + Math.random() * 0.25).toFixed(2)
+    );
+
+    const cleanup = () => el.remove();
+    el.addEventListener("animationend", cleanup, { once: true });
+    setTimeout(cleanup, REACTION_DURATION_MS + 200);
+    canvas.appendChild(el);
+  }
+```
+
+- [ ] **Step 5: Style the toolbar and animation**
+
+Add to `examples/cursors/priv/static/style.css` after the canvas rules:
+
+```css
+/* --- Reaction toolbar --- */
+
+#reaction-toolbar {
+  position: absolute;
+  left: 50%;
+  bottom: 24px;
+  z-index: 200;
+  display: flex;
+  gap: 6px;
+  max-width: calc(100% - 16px);
+  padding: 6px;
+  transform: translateX(-50%);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(8px);
+}
+
+.reaction-option {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  cursor: pointer;
+  font-size: 1.25rem;
+  transition: background 120ms ease, transform 120ms ease;
+}
+
+.reaction-option:hover {
+  background: #f1eef9;
+}
+
+.reaction-option.is-selected {
+  background: #e8e0f7;
+  transform: translateY(-2px) scale(1.08);
+}
+
+.reaction-option:focus-visible {
+  outline: 3px solid #7c5cbf;
+  outline-offset: 2px;
+}
+
+@media (max-width: 600px) {
+  #reaction-toolbar {
+    bottom: 12px;
+    gap: 2px;
+    padding: 4px;
+  }
+
+  .reaction-option {
+    width: 28px;
+    height: 32px;
+    font-size: 1rem;
+  }
+}
+```
+
+Add after the cursor rules:
+
+```css
+/* --- Reactions --- */
+
+.reaction-burst {
+  position: absolute;
+  z-index: 150;
+  pointer-events: none;
+  font-size: 2rem;
+  line-height: 1;
+  transform: translate(-50%, -50%);
+  animation: reaction-float 1.2s ease-out forwards;
+  will-change: opacity, transform;
+}
+
+@keyframes reaction-float {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -40%) scale(0.6);
+  }
+
+  15% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform:
+      translate(calc(-50% + var(--reaction-drift)), -140px)
+      scale(var(--reaction-scale));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reaction-burst {
+    animation-name: reaction-fade;
+    animation-duration: 600ms;
+  }
+}
+
+@keyframes reaction-fade {
+  from {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+
+  to {
+    opacity: 0;
+    transform: translate(-50%, -60%);
+  }
+}
+```
+
+- [ ] **Step 6: Run the focused browser tests**
+
+Run:
+
+```bash
+cd examples/cursors
+npx playwright test --grep "Reaction toolbar"
+```
+
+Expected: all Reaction toolbar tests pass.
+
+- [ ] **Step 7: Commit the local interaction**
+
+```bash
+git add examples/cursors/src/cursors/router.gleam examples/cursors/priv/static/app.js examples/cursors/priv/static/style.css examples/cursors/e2e/cursors.spec.js
+git commit -m "feat(cursors): add reaction toolbar"
+```
+
+---
+
+### Task 3: Send and Render Collaborative Reactions
+
+**Files:**
+- Modify: `examples/cursors/priv/static/app.js:46-62`
+- Modify: `examples/cursors/priv/static/app.js` reaction click handler from Task 2
+- Modify: `examples/cursors/e2e/cursors.spec.js` after the Reaction toolbar tests
+
+**Interfaces:**
+- Consumes: Task 1's `reaction` channel event and Task 2's `spawnReaction(reaction, x, y)`
+- Produces: Normalized outbound payloads and remote reaction rendering
+
+- [ ] **Step 1: Add failing wire and multi-user tests**
+
+Add after the Reaction toolbar describe block:
+
+```javascript
+  test.describe("Collaborative reactions", () => {
+    test("sends the selected reaction with normalized coordinates", async ({
+      page,
+    }) => {
+      const sentFrames = [];
+      page.on("websocket", (ws) => {
+        ws.on("framesent", (frame) => {
+          try {
+            const data = JSON.parse(frame.payload);
+            if (Array.isArray(data) && data[3] === "reaction") {
+              sentFrames.push(data);
+            }
+          } catch {
+            // ignore non-JSON frames
+          }
+        });
+      });
+
+      await gotoWithUsername(page, "Reactor");
+      await expect(page.locator("#user-list li")).toHaveCount(1, {
+        timeout: 10_000,
+      });
+
+      const canvas = page.locator("#canvas");
+      const box = await canvas.boundingBox();
+      await canvas.click({
+        position: { x: box.width * 0.25, y: box.height * 0.75 },
+      });
+      await expect.poll(() => sentFrames.length).toBeGreaterThan(0);
+
+      const payload = sentFrames[0][4];
+      expect(payload.reaction).toBe("👍");
+      expect(payload.x).toBeCloseTo(0.25, 2);
+      expect(payload.y).toBeCloseTo(0.75, 2);
+    });
+
+    test("broadcasts a reaction to another user at the same relative point", async ({
+      browser,
+    }) => {
+      const context1 = await browser.newContext();
+      const context2 = await browser.newContext();
+      const page1 = await context1.newPage();
+      const page2 = await context2.newPage();
+
+      try {
+        await gotoWithUsername(page1, "Sender");
+        await expect(page1.locator("#user-list li")).toHaveCount(1, {
+          timeout: 10_000,
+        });
+        await gotoWithUsername(page2, "Watcher");
+        await expect(page1.locator("#user-list li")).toHaveCount(2, {
+          timeout: 10_000,
+        });
+
+        await page1.getByRole("button", { name: "Party popper" }).click();
+        const senderCanvas = page1.locator("#canvas");
+        const senderBox = await senderCanvas.boundingBox();
+        await senderCanvas.click({
+          position: { x: senderBox.width * 0.4, y: senderBox.height * 0.6 },
+        });
+
+        const remote = page2.locator("#canvas .reaction-burst");
+        await expect(remote).toHaveText("🎉", { timeout: 5_000 });
+
+        const watcherBox = await page2.locator("#canvas").boundingBox();
+        const position = await remote.evaluate((el) => ({
+          left: Number.parseFloat(el.style.left),
+          top: Number.parseFloat(el.style.top),
+        }));
+        expect(position.left).toBeCloseTo(watcherBox.width * 0.4, 0);
+        expect(position.top).toBeCloseTo(watcherBox.height * 0.6, 0);
+      } finally {
+        await context1.close();
+        await context2.close();
+      }
+    });
+  });
+```
+
+- [ ] **Step 2: Run the collaborative tests and confirm failure**
+
+Run:
+
+```bash
+cd examples/cursors
+npx playwright test --grep "Collaborative reactions"
+```
+
+Expected: the sender test sees no `reaction` frame, and the second browser sees no reaction.
+
+- [ ] **Step 3: Send normalized reactions**
+
+Replace Task 2's canvas click handler in `examples/cursors/priv/static/app.js` with:
+
+```javascript
+  canvas.addEventListener("click", (event) => {
+    if (!selectedReaction || event.target.closest("#reaction-toolbar")) return;
+
+    const rect = canvas.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    spawnReaction(selectedReaction, x, y);
+    channel.push("reaction", {
+      reaction: selectedReaction,
+      x: x / rect.width,
+      y: y / rect.height,
+    });
+  });
+```
+
+- [ ] **Step 4: Render remote reactions**
+
+Add after the existing `channel.on("cursor_move", ...)` handler:
+
+```javascript
+  channel.on("reaction", (payload) => {
+    const { reaction, x, y } = payload;
+    if (
+      !["👍", "❤️", "😂", "🎉", "🔥"].includes(reaction) ||
+      !Number.isFinite(x) ||
+      !Number.isFinite(y) ||
+      x < 0 ||
+      x > 1 ||
+      y < 0 ||
+      y > 1
+    ) {
+      return;
+    }
+
+    const rect = canvas.getBoundingClientRect();
+    spawnReaction(reaction, x * rect.width, y * rect.height);
+  });
+```
+
+- [ ] **Step 5: Run focused and regression browser tests**
+
+Run:
+
+```bash
+cd examples/cursors
+npx playwright test --grep "Reaction toolbar|Collaborative reactions|Cursor movement|Remote cursor rendering"
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 6: Commit realtime client integration**
+
+```bash
+git add examples/cursors/priv/static/app.js examples/cursors/e2e/cursors.spec.js
+git commit -m "feat(cursors): sync reactions"
+```
+
+---
+
+### Task 4: Document and Verify the Complete Example
+
+**Files:**
+- Modify: `examples/cursors/README.md:1-12`
+- Modify: `examples/cursors/README.md:46-76`
+
+**Interfaces:**
+- Consumes: The completed toolbar, server event, and browser behavior
+- Produces: User-facing run instructions and feature documentation that match the implementation
+
+- [ ] **Step 1: Update the README**
+
+Change the opening description and usage sentence to:
+
+```markdown
+A real-time collaborative cursors and reactions demo built with [beryl](https://github.com/tylerbutler/beryl). Move your mouse to share your cursor, then select a reaction and click the canvas to send it to everyone in the room.
+```
+
+Replace the PubSub row in **What It Demonstrates** with:
+
+```markdown
+| **PubSub** | `broadcast_from` fans out cursor moves and reactions to all other clients |
+```
+
+Replace the Browser line in the architecture diagram with:
+
+```text
+Browser (vanilla JS + Phoenix client)
+  ├── cursor movement
+  └── selectable, animated reactions
+```
+
+Replace the frontend stack line with:
+
+```markdown
+- **Frontend**: Vanilla JS, CSS animations, [Phoenix JS client](https://www.npmjs.com/package/phoenix) (CDN)
+```
+
+- [ ] **Step 2: Format and type-check the cursors example**
+
+Run:
+
+```bash
+cd examples/cursors
+gleam format src test
+gleam check
+gleam test
+```
+
+Expected: formatting completes, the example type-checks, and all Gleam tests pass.
+
+- [ ] **Step 3: Run the complete cursors Playwright suite**
+
+Run:
+
+```bash
+cd examples/cursors
+npm test
+```
+
+Expected: every test in `e2e/cursors.spec.js` passes. Remove any untracked `test-results` or Playwright report artifacts created by the run.
+
+- [ ] **Step 4: Run workspace checks**
+
+Run from the repository root:
+
+```bash
+just format-check
+just check
+just test
+```
+
+Expected: all workspace formatting, type checks, and tests pass.
+
+- [ ] **Step 5: Commit documentation and formatting**
+
+```bash
+git add examples/cursors/README.md examples/cursors/src examples/cursors/test examples/cursors/priv/static examples/cursors/e2e/cursors.spec.js
+git commit -m "docs(cursors): describe reactions"
+```

--- a/docs/superpowers/plans/2026-07-22-cursors-reactions.md
+++ b/docs/superpowers/plans/2026-07-22-cursors-reactions.md
@@ -51,8 +51,8 @@ Create `examples/cursors/test/cursors_app_test.gleam`:
 
 ```gleam
 import beryl/event
-import beryl/presence
 import cursors/app
+import example_helpers/session_presence
 import gleam/dynamic
 import gleam/json
 import gleam/list
@@ -64,9 +64,7 @@ pub fn main() {
 }
 
 fn context() -> app.Ctx {
-  let assert Ok(handle) =
-    presence.start(presence.default_config("cursors-reaction-test"))
-  app.Ctx(presence: handle)
+  app.Ctx(presence: session_presence.start())
 }
 
 fn model() -> app.Model {

--- a/docs/superpowers/specs/2026-07-22-chatrooms-lobby-channel-design.md
+++ b/docs/superpowers/specs/2026-07-22-chatrooms-lobby-channel-design.md
@@ -1,0 +1,142 @@
+# Chatrooms Lobby Channel Design
+
+## Goal
+
+Add a second channel type to the chatrooms example. Each browser keeps a
+`lobby` channel joined while it joins and leaves `room:*` channels. The room
+list shows live user counts, demonstrating that one WebSocket connection can
+multiplex channels with different scopes and lifecycles.
+
+## Why a Lobby Channel
+
+The existing example already joins several `room:*` topics, but every topic
+uses the same chat-room behavior. A persistent `lobby` channel adds a distinct
+channel type:
+
+- `lobby` represents application-wide room activity.
+- `room:*` represents membership and conversation within one room.
+- Switching rooms replaces the room subscription but preserves the lobby
+  subscription.
+
+This boundary reflects a typical application: global navigation data and
+room-specific interaction travel over the same socket but use separate
+channels.
+
+## Server Architecture
+
+`chatrooms/app.gleam` handles the exact `lobby` topic separately from the
+existing `room:*` pattern.
+
+The standalone socket model stores:
+
+- the existing dictionary of joined room models;
+- an optional lobby model that records whether the socket joined `lobby`.
+
+The lobby has no mutable domain state and accepts no client messages. A lobby
+join returns a normal successful join reply. Closing the lobby clears only the
+lobby model.
+
+Successful room joins mutate the example-local session tracker before returning
+a lobby invalidation. Room closes untrack the session before returning the same
+invalidation. This ordering ensures the count changes before lobby subscribers
+receive the event.
+
+The invalidation event is:
+
+```text
+topic: lobby
+event: rooms_changed
+payload: {room: <room name>}
+```
+
+The event names the affected room for diagnostics, but clients refresh the
+complete directory.
+
+## Authoritative Room Counts
+
+The lobby channel does not broadcast computed counts. The example-local session
+tracker publishes a snapshot only for the room topic it mutates, so a
+cross-topic count assembled inside `update` could race with concurrent joins.
+
+The existing `GET /api/rooms` endpoint remains the authoritative count source.
+Clients fetch it:
+
+1. after the lobby join succeeds;
+2. after each `rooms_changed` event.
+
+This design also demonstrates a common realtime pattern: WebSocket events
+invalidate data, and an HTTP endpoint returns the current snapshot.
+
+## Client Behavior
+
+`priv/static/app.js` keeps two channel references:
+
+- `lobbyChannel`, joined once for the page's lifetime;
+- `currentChannel`, replaced when the user switches rooms.
+
+The client joins `lobby` before auto-joining the first room. If the lobby join
+fails, chat remains available; the client logs the failure and joins the room
+without live count updates.
+
+Each room-list item contains a count badge. Counts begin in an unavailable
+state and update after the first successful `/api/rooms` response.
+
+Room refreshes use a monotonically increasing request sequence. The client
+applies only the newest response, preventing a slow request from overwriting a
+newer snapshot.
+
+If a refresh fails, the client keeps the last successful counts and logs the
+error. A later invalidation triggers another refresh.
+
+## Routing and Failure Behavior
+
+- `lobby` joins succeed.
+- Client messages sent to `lobby` produce no effects.
+- Closing `lobby` does not affect joined rooms.
+- Closing a room does not affect the lobby subscription.
+- Unknown topics remain fail-closed with the existing `unknown_topic`
+  rejection.
+- Rejected room joins do not broadcast `rooms_changed`.
+
+## Interface Changes
+
+The room list gains a compact count badge beside each room name. The badge has
+an accessible label such as `2 users in general`. No new panel, modal, or
+navigation mode is required.
+
+The README explains that the browser joins `lobby` and one `room:*` topic over
+the same WebSocket connection.
+
+## Testing
+
+Gleam tests cover:
+
+- accepting an exact `lobby` join;
+- ignoring lobby client messages;
+- clearing the lobby model without changing room models;
+- rejecting unrelated topics;
+- emitting `rooms_changed` only after accepted room joins;
+- tracking the session before join invalidation;
+- untracking the session before close invalidation;
+- omitting invalidation for rejected room joins.
+
+Playwright tests cover:
+
+- joining both `lobby` and a `room:*` topic on one socket;
+- keeping `lobby` joined across room switches;
+- rendering initial room counts;
+- updating counts when another user joins or leaves;
+- preserving the last counts when `/api/rooms` fails;
+- ignoring stale overlapping room-directory responses.
+
+Existing chat, presence, typing, authentication, and room-switching tests remain
+unchanged or gain regression assertions where needed.
+
+## Out of Scope
+
+- Message history or unread counts.
+- Cross-room announcements.
+- Private notifications or direct messages.
+- Lobby presence or a global user list.
+- Creating, deleting, or renaming rooms.
+- Replacing the existing `/api/rooms` endpoint.

--- a/docs/superpowers/specs/2026-07-22-cursors-reactions-design.md
+++ b/docs/superpowers/specs/2026-07-22-cursors-reactions-design.md
@@ -1,0 +1,85 @@
+# Cursors Reactions Design
+
+## Goal
+
+Add collaborative reactions to the cursors example. A user selects a reaction, clicks the canvas, and sees the reaction rise and fade from the click point. Every other user in the room sees the same reaction at the corresponding position.
+
+## Interaction
+
+The canvas contains a compact reaction toolbar centered near its bottom edge. The toolbar offers:
+
+- 👍
+- ❤️
+- 😂
+- 🎉
+- 🔥
+
+👍 starts selected. Selecting another button changes the active reaction. Clicking the active button again clears the selection. Canvas clicks create reactions only while a reaction is active, and toolbar clicks never create reactions.
+
+Each reaction begins at the click point, drifts upward with a small randomized horizontal offset and scale, and fades out in about 1.2 seconds. Rapid clicks create independent animations. The client removes each animation node when the animation ends.
+
+## Client Architecture
+
+`priv/static/app.js` owns toolbar selection and reaction rendering. A shared rendering helper creates both local and remote reactions.
+
+On a valid canvas click, the client:
+
+1. Renders the selected reaction immediately.
+2. Converts the click point to normalized `x` and `y` coordinates from 0 through 1.
+3. Pushes a `reaction` channel event with `{ reaction, x, y }`.
+
+On a remote `reaction` event, the client converts the normalized coordinates to its current canvas dimensions and calls the same rendering helper. Normalized coordinates keep reactions aligned across different viewport sizes.
+
+The client stores no reaction history. Reactions exist only as short-lived DOM nodes.
+
+## Server Architecture
+
+`src/cursors/app.gleam` handles `reaction` as a separate domain event beside `cursor_move`. This explicit event matches Gleam's preference for small, concrete data flows over speculative generic abstractions.
+
+The handler accepts only the five toolbar reactions and numeric coordinates within the normalized range. Valid events produce a `BroadcastFrom` effect, which sends the reaction to every other socket in the topic without echoing it to the sender. Invalid payloads produce no broadcast.
+
+The server stores no reaction state. Existing presence and cursor state remain unchanged.
+
+## Markup and Styling
+
+`src/cursors/router.gleam` adds the toolbar markup inside `#canvas`. Each reaction is a button with an accessible label and `aria-pressed` state.
+
+`priv/static/style.css` styles the toolbar, selected state, reaction nodes, and animation. The toolbar remains above the canvas content and clear of the Online sidebar. A `prefers-reduced-motion` rule preserves the fade while removing most movement.
+
+## Edge Cases
+
+- A click with no selected reaction does nothing.
+- A toolbar click changes selection without spawning a reaction.
+- Unsupported emoji and malformed coordinates never reach other clients.
+- Multiple reactions animate independently.
+- Animation nodes are removed after completion.
+- A client can render remote reactions before it has moved its own cursor.
+
+## Testing
+
+Gleam tests cover:
+
+- Broadcasting each supported reaction.
+- Preserving normalized coordinates.
+- Rejecting unsupported reactions.
+- Rejecting malformed or out-of-range coordinates.
+- Leaving cursor movement behavior unchanged.
+
+Playwright tests cover:
+
+- Toolbar structure and accessible labels.
+- 👍 as the initial selection.
+- Switching and clearing the selection.
+- Local reaction creation and cleanup.
+- Toolbar clicks not creating reactions.
+- No reaction when the selection is clear.
+- Two-browser reaction broadcasting.
+- Remote placement at the corresponding canvas position.
+
+## Out of Scope
+
+- Reaction history or persistence.
+- Counts, summaries, or analytics.
+- User-defined reaction sets.
+- Sound effects.
+- Server-assigned animation timing.

--- a/examples/chatrooms/README.md
+++ b/examples/chatrooms/README.md
@@ -14,6 +14,8 @@ gleam run
 ## Features
 
 - 💬 **Multi-room chat** — switch between rooms (general, random, help)
+- 🧭 **Persistent lobby channel** — one socket stays joined to `lobby` while switching between `room:*` topics
+- 🔢 **Live room counts** — lobby invalidations refresh authoritative counts from `/api/rooms`
 - 🔐 **Connection authentication** — `on_connect` hook validates auth token before WebSocket upgrade
 - 👥 **Live presence** — see who's online in each room
 - ✍️ **Typing indicators** — see when others are typing
@@ -41,6 +43,8 @@ This demo is designed to complement the [cursors demo](../cursors/) by exercisin
 | **join_rate** | `beryl` | 5 joins/sec per socket |
 | **channel_rate** | `beryl` | 10 msg/sec per channel |
 | **Multiple topics** | `beryl` | Each room is a separate topic |
+| **Multiple channel types** | `beryl/event` | Exact `lobby` topic plus wildcard `room:*` topics on one socket |
+| **Ordered dispatch** | `beryl/event` | Session tracker changes happen before lobby invalidations |
 
 ## Architecture
 
@@ -50,7 +54,9 @@ Browser (vanilla JS + Phoenix client CDN)
 Gleam/BEAM server (port 8001)
   ├── Mist HTTP routing (static files, /api/rooms)
   ├── Mist WebSocket transport (on_connect auth)
-  ├── beryl app-side dispatch (room:* topics via chatrooms/app)
+  ├── beryl app-side dispatch
+  │   ├── lobby (persistent room-directory invalidation channel)
+  │   └── room:* (replaceable chat-room channels)
   ├── beryl groups ("public" → general, random, help)
   └── example session_presence (ETS-backed online users + typing indicators)
 ```
@@ -59,7 +65,7 @@ Gleam/BEAM server (port 8001)
 
 ```bash
 npm install           # First time only
-npx playwright test   # 35 e2e tests
+npx playwright test   # 43 e2e tests
 ```
 
 ## API
@@ -81,3 +87,8 @@ npx playwright test   # 35 e2e tests
 | Server → Client | `msg_error` | Validation error `{code, error}` |
 | Server → Client | `presence_list` | Updated online user list |
 | Server → Client | `typing` | Typing indicator update |
+| Server → Client | `rooms_changed` on `lobby` | Invalidate room counts after room membership changes `{room}` |
+
+The browser joins `lobby` once and keeps it joined while replacing its active
+`room:*` channel. `rooms_changed` invalidates the directory; the browser then
+loads the current counts from `GET /api/rooms`.

--- a/examples/chatrooms/e2e/chatrooms.spec.js
+++ b/examples/chatrooms/e2e/chatrooms.spec.js
@@ -7,7 +7,7 @@ async function gotoWithUsername(page, username, path = "/?token=beryl-demo") {
   await page.goto(path);
 }
 
-// Helper: wait for Phoenix channel join reply
+// Helper: wait for Phoenix channel join reply for a room topic
 async function waitForJoinReply(page) {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(
@@ -18,7 +18,12 @@ async function waitForJoinReply(page) {
       ws.on("framereceived", (frame) => {
         try {
           const data = JSON.parse(frame.payload);
-          if (Array.isArray(data) && data[3] === "phx_reply") {
+          if (
+            Array.isArray(data) &&
+            data[3] === "phx_reply" &&
+            typeof data[2] === "string" &&
+            data[2].startsWith("room:")
+          ) {
             clearTimeout(timeout);
             resolve(data);
           }
@@ -84,6 +89,229 @@ test.describe("Chat Rooms Demo", () => {
         "href",
         "https://github.com/tylerbutler/beryl"
       );
+    });
+  });
+
+  test.describe("Lobby channel", () => {
+    test("requests room counts from the standalone mount", async ({ page }) => {
+      const roomRequests = [];
+      page.on("request", (request) => {
+        if (request.url().includes("/api/rooms")) {
+          roomRequests.push(new URL(request.url()).pathname);
+        }
+      });
+
+      await gotoWithUsername(page, "MountUser");
+
+      await expect.poll(() => roomRequests).toContain("/api/rooms");
+    });
+
+    test("joins lobby and a room on the same socket", async ({ page }) => {
+      const joinedTopics = [];
+      page.on("websocket", (ws) => {
+        ws.on("framesent", (frame) => {
+          try {
+            const data = JSON.parse(frame.payload);
+            if (Array.isArray(data) && data[3] === "phx_join") {
+              joinedTopics.push(data[2]);
+            }
+          } catch {
+            // ignore non-JSON frames
+          }
+        });
+      });
+
+      await gotoWithUsername(page, "LobbyUser");
+
+      await expect.poll(() => joinedTopics).toContain("lobby");
+      await expect.poll(() => joinedTopics.some((topic) =>
+        topic.startsWith("room:")
+      )).toBe(true);
+    });
+
+    test("renders a count badge for every room", async ({ page }) => {
+      await gotoWithUsername(page, "CountUser");
+
+      const badges = page.locator(".room-count");
+      await expect(badges).toHaveCount(3);
+      await expect(
+        page.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("1", { timeout: 10_000 });
+      await expect(
+        page.locator('.room-count[data-room-count="random"]')
+      ).toHaveText("0");
+      await expect(
+        page.locator('.room-count[data-room-count="help"]')
+      ).toHaveText("0");
+    });
+
+  });
+
+  test.describe("Live lobby updates", () => {
+    test("updates room counts when another user joins and leaves", async ({
+      browser,
+    }) => {
+      const context1 = await browser.newContext();
+      const context2 = await browser.newContext();
+      const page1 = await context1.newPage();
+      const page2 = await context2.newPage();
+
+      try {
+        await gotoWithUsername(page1, "Observer");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+
+        await gotoWithUsername(page2, "Joiner");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("2", { timeout: 10_000 });
+
+        await context2.close();
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+      } finally {
+        await context1.close();
+        await context2.close().catch(() => {});
+      }
+    });
+
+    test("keeps lobby joined while switching rooms", async ({ page }) => {
+      const leaves = [];
+      page.on("websocket", (ws) => {
+        ws.on("framesent", (frame) => {
+          try {
+            const data = JSON.parse(frame.payload);
+            if (Array.isArray(data) && data[3] === "phx_leave") {
+              leaves.push(data[2]);
+            }
+          } catch {
+            // ignore non-JSON frames
+          }
+        });
+      });
+
+      await gotoWithUsername(page, "Switcher");
+      await expect(
+        page.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("1", { timeout: 10_000 });
+
+      await page.locator('.room-item[data-room="random"]').click();
+      await expect(page.locator(".room-item.active")).toContainText("random");
+      await expect(
+        page.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("0", { timeout: 10_000 });
+      await expect(
+        page.locator('.room-count[data-room-count="random"]')
+      ).toHaveText("1", { timeout: 10_000 });
+
+      expect(leaves).toContain("room:general");
+      expect(leaves).not.toContain("lobby");
+    });
+
+    test("keeps the last counts when a live refresh fails", async ({
+      browser,
+    }) => {
+      const context1 = await browser.newContext();
+      const context2 = await browser.newContext();
+      const page1 = await context1.newPage();
+      const page2 = await context2.newPage();
+      let failRefreshes = false;
+      let failedRequests = 0;
+
+      await page1.route("**/api/rooms", async (route) => {
+        if (failRefreshes) {
+          failedRequests += 1;
+          await route.fulfill({ status: 503, body: "unavailable" });
+        } else {
+          await route.continue();
+        }
+      });
+
+      try {
+        await gotoWithUsername(page1, "FailureObserver");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+
+        failRefreshes = true;
+        await gotoWithUsername(page2, "FailureJoiner");
+        await expect.poll(() => failedRequests).toBeGreaterThan(0);
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1");
+      } finally {
+        await context1.close();
+        await context2.close();
+      }
+    });
+
+    test("ignores a stale overlapping live refresh", async ({ browser }) => {
+      const context1 = await browser.newContext();
+      const context2 = await browser.newContext();
+      const page1 = await context1.newPage();
+      const page2 = await context2.newPage();
+      let raceMode = false;
+      let delayedRequestSeen = false;
+      let delayedRequestFulfilled = false;
+
+      await page1.route("**/api/rooms", async (route) => {
+        if (!raceMode) {
+          await route.continue();
+        } else if (!delayedRequestSeen) {
+          delayedRequestSeen = true;
+          await new Promise((resolve) => setTimeout(resolve, 300));
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([
+              { topic: "room:general", name: "general", users: 9 },
+              { topic: "room:random", name: "random", users: 0 },
+              { topic: "room:help", name: "help", users: 0 },
+            ]),
+          });
+          delayedRequestFulfilled = true;
+        } else {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([
+              { topic: "room:general", name: "general", users: 1 },
+              { topic: "room:random", name: "random", users: 1 },
+              { topic: "room:help", name: "help", users: 0 },
+            ]),
+          });
+        }
+      });
+
+      try {
+        await gotoWithUsername(page1, "RaceObserver");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+
+        raceMode = true;
+        await gotoWithUsername(page2, "RaceJoiner");
+        await expect.poll(() => delayedRequestSeen).toBe(true);
+        await page2.locator('.room-item[data-room="random"]').click();
+
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+        await expect(
+          page1.locator('.room-count[data-room-count="random"]')
+        ).toHaveText("1", { timeout: 10_000 });
+        // Wait for the delayed stale response to actually be delivered before
+        // asserting it did not overwrite the newer counts.
+        await expect.poll(() => delayedRequestFulfilled, { timeout: 5_000 }).toBe(true);
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1");
+      } finally {
+        await context1.close();
+        await context2.close();
+      }
     });
   });
 

--- a/examples/chatrooms/priv/static/app.js
+++ b/examples/chatrooms/priv/static/app.js
@@ -16,6 +16,9 @@
   let myColor = null;
   let typingTimer = null;
   let isTyping = false;
+  let lobbyChannel = null;
+  let lobbyJoined = false;
+  let roomRefreshSequence = 0;
 
   // --- Username prompt ---
   const username = prompt("Choose a display name:", "User" + Math.floor(Math.random() * 1000)) || "Anonymous";
@@ -37,6 +40,53 @@
   const msgInput = document.getElementById("msg-input");
   const sendBtn = document.getElementById("send-btn");
   const userList = document.getElementById("user-list");
+  const basePath = document.getElementById("app").dataset.basePath || "";
+  const roomsUrl = `${basePath}/api/rooms`;
+
+  async function refreshRoomCounts() {
+    const requestSequence = ++roomRefreshSequence;
+
+    try {
+      const response = await fetch(roomsUrl);
+      if (!response.ok) {
+        throw new Error(`Room refresh failed with ${response.status}`);
+      }
+      const rooms = await response.json();
+      if (requestSequence !== roomRefreshSequence) return;
+      updateRoomCounts(rooms);
+    } catch (error) {
+      if (requestSequence === roomRefreshSequence) {
+        console.warn("Could not refresh room counts", error);
+      }
+    }
+  }
+
+  function updateRoomCounts(rooms) {
+    if (!Array.isArray(rooms)) return;
+
+    const counts = new Map();
+    for (const room of rooms) {
+      if (
+        room &&
+        typeof room.name === "string" &&
+        Number.isInteger(room.users) &&
+        room.users >= 0
+      ) {
+        counts.set(room.name, room.users);
+      }
+    }
+
+    document.querySelectorAll(".room-count").forEach((badge) => {
+      const roomName = badge.dataset.roomCount;
+      if (!counts.has(roomName)) return;
+      const users = counts.get(roomName);
+      badge.textContent = String(users);
+      badge.setAttribute(
+        "aria-label",
+        `${users} ${users === 1 ? "user" : "users"} in ${roomName}`
+      );
+    });
+  }
 
   // --- Room switching ---
   roomList.addEventListener("click", (e) => {
@@ -79,6 +129,9 @@
         mySocketId = resp.socket_id;
         myUsername = resp.username;
         myColor = resp.color;
+        if (lobbyJoined) {
+          refreshRoomCounts();
+        }
       })
       .receive("error", (resp) => {
         const msg = resp.error || resp.message || "Failed to join room";
@@ -243,11 +296,27 @@
     renderTypingIndicator();
   }, 1000);
 
-  // --- Auto-join first room ---
-  const firstRoom = document.querySelector(".room-item");
-  if (firstRoom) {
-    joinRoom(firstRoom.dataset.room);
+  // --- Lobby-first startup ---
+  function joinFirstRoom() {
+    const firstRoom = document.querySelector(".room-item");
+    if (firstRoom) {
+      joinRoom(firstRoom.dataset.room);
+    }
   }
+
+  lobbyChannel = socket.channel("lobby", {});
+  lobbyChannel.on("rooms_changed", () => {
+    refreshRoomCounts();
+  });
+  lobbyChannel.join()
+    .receive("ok", () => {
+      lobbyJoined = true;
+      joinFirstRoom();
+    })
+    .receive("error", (response) => {
+      console.warn("Failed to join lobby", response);
+      joinFirstRoom();
+    });
 
   // --- Utilities ---
   function escapeHtml(str) {

--- a/examples/chatrooms/priv/static/style.css
+++ b/examples/chatrooms/priv/static/style.css
@@ -45,6 +45,8 @@ body {
 }
 
 .room-item {
+  display: flex;
+  align-items: center;
   padding: 0.4rem 1rem;
   cursor: pointer;
   color: #96989d;
@@ -67,7 +69,32 @@ body {
 
 .room-hash {
   color: #96989d;
-  margin-right: 2px;
+  margin-right: 4px;
+}
+
+.room-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.room-count {
+  min-width: 1.5rem;
+  margin-left: auto;
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: #35373c;
+  color: #b5bac1;
+  font-size: 0.7rem;
+  line-height: 1.3;
+  text-align: center;
+}
+
+.room-item.active .room-count {
+  background: #2b2d31;
+  color: #fff;
 }
 
 .sidebar-footer {

--- a/examples/chatrooms/src/chatrooms/app.gleam
+++ b/examples/chatrooms/src/chatrooms/app.gleam
@@ -34,6 +34,11 @@ pub type Model {
   Model(username: String, color: String, room_name: String)
 }
 
+/// Per-socket state for the application-wide lobby topic.
+pub type Lobby {
+  Lobby
+}
+
 /// Dependencies shared by chat sockets.
 pub type Ctx {
   Ctx(presence: session_presence.Tracker, groups: Groups)
@@ -90,6 +95,7 @@ pub fn join(
             Some(Model(username: username, color: color, room_name: room_name)),
             [
               event.AcceptJoin(ref, Some(reply)),
+              event.Broadcast("lobby", "rooms_changed", room_changed(room_name)),
               event.Broadcast(topic, "new_msg", sys_payload),
             ],
           )
@@ -166,28 +172,54 @@ pub fn closed(
 ) -> List(Effect) {
   session_presence.untrack(ctx.presence, topic, socket_id)
   let sys_payload = system_message(model.username <> " left the room")
-  [event.Broadcast(topic, "new_msg", sys_payload)]
+  [
+    event.Broadcast("lobby", "rooms_changed", room_changed(model.room_name)),
+    event.Broadcast(topic, "new_msg", sys_payload),
+  ]
 }
 
 // --- Standalone app-side dispatch wrapper ---
 
-/// Socket-wide state for the standalone chatrooms server: one per-topic
-/// `Model` per joined `room:*` topic, keyed by topic.
+/// Accept the application-wide `lobby` topic.
+pub fn lobby_join(ref: Ref) -> #(Lobby, List(Effect)) {
+  #(Lobby, [event.AcceptJoin(ref, None)])
+}
+
+/// The lobby is read-only; client events produce no effects.
+pub fn lobby_update(
+  model: Lobby,
+  _event_name: String,
+  _payload: Dynamic,
+  _ref: Option(Ref),
+) -> #(Lobby, List(Effect)) {
+  #(model, [])
+}
+
+/// Closing the lobby requires no external cleanup.
+pub fn lobby_closed(_model: Lobby) -> List(Effect) {
+  []
+}
+
+/// Socket-wide state for the standalone chatrooms server: the optional
+/// application lobby plus one `Model` per joined `room:*` topic.
 pub type Standalone {
-  Standalone(socket_id: String, rooms: Dict(String, Model))
+  Standalone(
+    socket_id: String,
+    rooms: Dict(String, Model),
+    lobby: Option(Lobby),
+  )
 }
 
 /// `init` for the standalone chatrooms app-dispatch runtime.
 pub fn standalone_init(
   info: event.ConnectInfo(Nil),
 ) -> #(Standalone, List(Effect)) {
-  #(Standalone(socket_id: info.socket_id, rooms: dict.new()), [])
+  #(Standalone(socket_id: info.socket_id, rooms: dict.new(), lobby: None), [])
 }
 
 /// `update` for the standalone chatrooms app-dispatch runtime: route
-/// each event to the embeddable `join`/`update`/`closed` surface, keyed by
-/// topic. Non-`room:*` joins are rejected (fail closed), preserving the
-/// example's topic-namespace boundary.
+/// lobby events through the lobby callbacks and `room:*` events through the
+/// embeddable `join`/`update`/`closed` surface. Other joins are rejected.
 pub fn standalone_update(
   ctx: Ctx,
   model: Standalone,
@@ -196,6 +228,10 @@ pub fn standalone_update(
   case ev {
     event.Join(topic, payload, ref) ->
       case topic {
+        "lobby" -> {
+          let #(lobby, effects) = lobby_join(ref)
+          event.Next(Standalone(..model, lobby: Some(lobby)), effects)
+        }
         "room:" <> _ -> {
           let #(joined, effects) =
             join(ctx, model.socket_id, topic, payload, ref)
@@ -218,26 +254,55 @@ pub fn standalone_update(
       }
 
     event.Message(topic, event_name, payload, ref) ->
-      case dict.get(model.rooms, topic) {
-        Ok(sub) -> {
-          let #(sub, effects) =
-            update(ctx, model.socket_id, topic, sub, event_name, payload, ref)
-          event.Next(
-            Standalone(..model, rooms: dict.insert(model.rooms, topic, sub)),
-            effects,
-          )
-        }
-        Error(Nil) -> event.Next(model, [])
+      case topic {
+        "lobby" ->
+          case model.lobby {
+            Some(lobby) -> {
+              let #(lobby, effects) =
+                lobby_update(lobby, event_name, payload, ref)
+              event.Next(Standalone(..model, lobby: Some(lobby)), effects)
+            }
+            None -> event.Next(model, [])
+          }
+        _ ->
+          case dict.get(model.rooms, topic) {
+            Ok(sub) -> {
+              let #(sub, effects) =
+                update(
+                  ctx,
+                  model.socket_id,
+                  topic,
+                  sub,
+                  event_name,
+                  payload,
+                  ref,
+                )
+              event.Next(
+                Standalone(..model, rooms: dict.insert(model.rooms, topic, sub)),
+                effects,
+              )
+            }
+            Error(Nil) -> event.Next(model, [])
+          }
       }
 
     event.Closed(topic, _reason) ->
-      case dict.get(model.rooms, topic) {
-        Ok(sub) ->
-          event.Next(
-            Standalone(..model, rooms: dict.delete(model.rooms, topic)),
-            closed(ctx, model.socket_id, topic, sub),
-          )
-        Error(Nil) -> event.Next(model, [])
+      case topic {
+        "lobby" ->
+          case model.lobby {
+            Some(lobby) ->
+              event.Next(Standalone(..model, lobby: None), lobby_closed(lobby))
+            None -> event.Next(model, [])
+          }
+        _ ->
+          case dict.get(model.rooms, topic) {
+            Ok(sub) ->
+              event.Next(
+                Standalone(..model, rooms: dict.delete(model.rooms, topic)),
+                closed(ctx, model.socket_id, topic, sub),
+              )
+            Error(Nil) -> event.Next(model, [])
+          }
       }
 
     event.Binary(_, _) | event.Info(_) -> event.Next(model, [])
@@ -286,6 +351,10 @@ fn system_message(text: String) -> json.Json {
     #("type", json.string("system")),
     #("timestamp", json.int(timestamp_ms())),
   ])
+}
+
+fn room_changed(room_name: String) -> json.Json {
+  json.object([#("room", json.string(room_name))])
 }
 
 /// Reply only when the client sent a ref (matching the channel-module

--- a/examples/chatrooms/src/chatrooms/router.gleam
+++ b/examples/chatrooms/src/chatrooms/router.gleam
@@ -80,9 +80,15 @@ fn index_page(ctx: Context) -> Response(ResponseData) {
     |> list.map(fn(name) {
       "<li class=\"room-item\" data-room=\""
       <> name
-      <> "\"><span class=\"room-hash\">#</span> "
+      <> "\"><span class=\"room-hash\">#</span>"
+      <> "<span class=\"room-name\">"
       <> name
-      <> "</li>"
+      <> "</span>"
+      <> "<span class=\"room-count\" data-room-count=\""
+      <> name
+      <> "\" aria-label=\"User count unavailable for "
+      <> name
+      <> "\">–</span></li>"
     })
     |> string.join("")
 
@@ -95,7 +101,7 @@ fn index_page(ctx: Context) -> Response(ResponseData) {
   <link rel=\"stylesheet\" href=\"" <> ctx.base_path <> "/static/style.css\">
 </head>
 <body>
-  <div id=\"app\">
+  <div id=\"app\" data-base-path=\"" <> ctx.base_path <> "\">
     <nav id=\"rooms-sidebar\">
       <h2>Rooms</h2>
       <ul id=\"room-list\">" <> room_options <> "</ul>

--- a/examples/chatrooms/test/chatrooms_app_test.gleam
+++ b/examples/chatrooms/test/chatrooms_app_test.gleam
@@ -1,0 +1,182 @@
+import beryl/event
+import beryl/group
+import chatrooms/app
+import example_helpers/session_presence
+import gleam/dict
+import gleam/dynamic
+import gleam/json
+import gleam/option.{None, Some}
+import gleeunit/should
+
+fn context() -> app.Ctx {
+  let presence_tracker = session_presence.start()
+  let assert Ok(groups) = group.start()
+  let assert Ok(_) = group.create(groups, "public")
+  let assert Ok(_) = group.add(groups, "public", "room:general")
+  app.Ctx(presence: presence_tracker, groups: groups)
+}
+
+fn lobby_ref() -> event.Ref {
+  event.make_join_ref(
+    topic: "lobby",
+    join_ref: Some("lobby-join"),
+    msg_ref: Some("lobby-ref"),
+  )
+}
+
+fn room_ref(topic: String) -> event.Ref {
+  event.make_join_ref(
+    topic: topic,
+    join_ref: Some("room-join"),
+    msg_ref: Some("room-ref"),
+  )
+}
+
+fn empty_payload() -> dynamic.Dynamic {
+  dynamic.properties([])
+}
+
+fn connect_info() -> event.ConnectInfo(Nil) {
+  event.ConnectInfo(
+    socket_id: "socket-1",
+    seed: event.empty_seed(),
+    self: event.make_sender(fn(_message) { Nil }),
+  )
+}
+
+pub fn lobby_join_is_accepted_test() {
+  let #(model, effects) = app.lobby_join(lobby_ref())
+
+  model |> should.equal(app.Lobby)
+  let assert [event.AcceptJoin(_, None)] = effects
+}
+
+pub fn lobby_messages_are_ignored_test() {
+  let #(model, effects) =
+    app.lobby_update(app.Lobby, "refresh", empty_payload(), None)
+
+  model |> should.equal(app.Lobby)
+  effects |> should.equal([])
+}
+
+pub fn lobby_message_with_no_lobby_is_a_noop_test() {
+  let model =
+    app.Standalone(socket_id: "socket-1", rooms: dict.new(), lobby: None)
+
+  let assert event.Next(next_model, effects) =
+    app.standalone_update(
+      context(),
+      model,
+      event.Message("lobby", "refresh", empty_payload(), None),
+    )
+
+  next_model |> should.equal(model)
+  effects |> should.equal([])
+}
+
+pub fn standalone_routes_lobby_join_test() {
+  let #(model, _) = app.standalone_init(connect_info())
+  let next =
+    app.standalone_update(
+      context(),
+      model,
+      event.Join("lobby", empty_payload(), lobby_ref()),
+    )
+
+  let assert event.Next(
+    app.Standalone(socket_id: _, rooms: _, lobby: Some(app.Lobby)),
+    [event.AcceptJoin(_, None)],
+  ) = next
+}
+
+pub fn closing_lobby_preserves_room_models_test() {
+  let room =
+    app.Model(username: "Alice", color: "#abcdef", room_name: "general")
+  let model =
+    app.Standalone(
+      socket_id: "socket-1",
+      rooms: dict.from_list([#("room:general", room)]),
+      lobby: Some(app.Lobby),
+    )
+
+  let next =
+    app.standalone_update(context(), model, event.Closed("lobby", event.Normal))
+
+  let assert event.Next(
+    app.Standalone(socket_id: _, rooms: rooms, lobby: None),
+    [],
+  ) = next
+  dict.has_key(rooms, "room:general") |> should.be_true
+}
+
+pub fn unrelated_topic_is_rejected_test() {
+  let #(model, _) = app.standalone_init(connect_info())
+  let next =
+    app.standalone_update(
+      context(),
+      model,
+      event.Join(
+        "notifications:alice",
+        empty_payload(),
+        room_ref("notifications:alice"),
+      ),
+    )
+
+  let assert event.Next(_, [event.RejectJoin(_, reason)]) = next
+  json.to_string(reason)
+  |> should.equal("{\"reason\":\"unknown_topic\"}")
+}
+
+pub fn accepted_room_join_tracks_session_and_invalidates_lobby_test() {
+  let ctx = context()
+  let app.Ctx(presence: tracker, groups: _) = ctx
+  let #(joined, effects) =
+    app.join(
+      ctx,
+      "socket-1",
+      "room:general",
+      dynamic.properties([
+        #(dynamic.string("username"), dynamic.string("Alice")),
+      ]),
+      room_ref("room:general"),
+    )
+
+  joined |> should.be_some
+  let assert [
+    event.AcceptJoin(_, _),
+    event.Broadcast("lobby", "rooms_changed", changed),
+    event.Broadcast("room:general", "new_msg", _),
+  ] = effects
+  session_presence.count(tracker, "room:general") |> should.equal(1)
+  json.to_string(changed) |> should.equal("{\"room\":\"general\"}")
+}
+
+pub fn rejected_room_join_does_not_invalidate_lobby_test() {
+  let #(joined, effects) =
+    app.join(
+      context(),
+      "socket-1",
+      "room:missing",
+      empty_payload(),
+      room_ref("room:missing"),
+    )
+
+  joined |> should.be_none
+  let assert [event.RejectJoin(_, _)] = effects
+}
+
+pub fn room_close_untracks_session_and_invalidates_lobby_test() {
+  let ctx = context()
+  let app.Ctx(presence: tracker, groups: _) = ctx
+  session_presence.track(tracker, "room:general", "socket-1", json.object([]))
+  let model =
+    app.Model(username: "Alice", color: "#abcdef", room_name: "general")
+  let effects = app.closed(ctx, "socket-1", "room:general", model)
+
+  let assert [
+    event.Broadcast("lobby", "rooms_changed", changed),
+    event.Broadcast("room:general", "new_msg", _),
+  ] = effects
+  session_presence.count(tracker, "room:general") |> should.equal(0)
+  json.to_string(changed) |> should.equal("{\"room\":\"general\"}")
+}

--- a/examples/chatrooms/test/chatrooms_test.gleam
+++ b/examples/chatrooms/test/chatrooms_test.gleam
@@ -1,0 +1,7 @@
+import gleeunit
+
+/// Test entrypoint: gleeunit discovers and runs every `*_test` module in
+/// this package.
+pub fn main() {
+  gleeunit.main()
+}

--- a/examples/cursors/PRODUCT.md
+++ b/examples/cursors/PRODUCT.md
@@ -1,0 +1,58 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+Gleam developers evaluating or learning Beryl's realtime collaboration
+capabilities. They use the demo to see the library in action and inspect a
+small, runnable implementation.
+
+## Product Purpose
+
+Demonstrate how Beryl combines typed channel events, presence, PubSub, and a
+WebSocket transport to build a realtime collaborative experience. Success
+means developers can run the example quickly, understand the data flow, and
+adapt the patterns in their own applications.
+
+## Positioning
+
+The demo is an executable reference for Beryl's type-safe Gleam APIs rather
+than a standalone collaboration product.
+
+## Operating Context
+
+Developers run the Gleam server locally or deploy its container, then open the
+page in multiple browser tabs to exercise presence, cursor movement, and other
+ephemeral room events.
+
+## Capabilities and Constraints
+
+- The browser uses vanilla JavaScript, CSS, and the Phoenix JavaScript client.
+- The server uses Beryl's app-side dispatch with the Mist transport.
+- The example has no frontend build step and should remain dependency-light.
+- Realtime events are ephemeral; the demo does not persist room history.
+
+## Evidence on Hand
+
+The repository contains the runnable application, Playwright coverage, a
+Dockerfile, Railway deployment configuration, and developer documentation.
+Future work must not invent production adoption claims or performance
+benchmarks.
+
+## Product Principles
+
+- Teach through a working, inspectable example.
+- Keep the realtime data flow explicit and type-safe.
+- Prefer immediate interactions that make collaboration visible.
+- Preserve a small dependency and operational footprint.
+
+## Accessibility & Inclusion
+
+Interactive controls must be keyboard accessible and expose meaningful
+accessible names and state. Motion effects must retain a reduced-motion
+alternative.

--- a/examples/cursors/README.md
+++ b/examples/cursors/README.md
@@ -1,6 +1,6 @@
 # Collaborative Cursors Demo
 
-A real-time collaborative cursors demo built with [beryl](https://github.com/tylerbutler/beryl) — move your mouse and see other users' cursors in real-time.
+A real-time collaborative cursors and reactions demo built with [beryl](https://github.com/tylerbutler/beryl). Move your mouse to share your cursor, then select a reaction and click the canvas to send it to everyone in the room.
 
 ## Running
 
@@ -50,7 +50,7 @@ The Phoenix JS client in `priv/static/app.js` uses a relative `/socket` URL, so 
 | **App dispatch** | `cursor:*` topics handle join/leave and cursor events |
 | **Topic patterns** | Wildcard `cursor:*` routing matches any cursor room |
 | **Session presence (ETS)** | The example-local `session_presence` tracker stores connected users and their username + color metadata in ETS |
-| **PubSub** | `broadcast_from` fans out cursor moves to all other clients |
+| **PubSub** | `broadcast_from` fans out cursor moves and reactions to all other clients |
 | **Wire protocol** | Phoenix-compatible format — works with the official Phoenix JS client |
 | **WebSocket transport** | `mist_transport.upgrade()` handles Phoenix-compatible WebSocket requests |
 | **Rate limiting** | Throttles high-frequency cursor movement messages |
@@ -59,18 +59,17 @@ The Phoenix JS client in `priv/static/app.js` uses a relative `/socket` URL, so 
 
 ```
 Browser (vanilla JS + Phoenix client)
-  │
-  │  WebSocket (Phoenix wire protocol)
-  │
+  ├── cursor movement
+  └── selectable, animated reactions
 Server (Gleam)
   ├── Mist HTTP routing ── serves HTML + static files
   ├── beryl app-side dispatch ── cursor:* topics (cursors/app)
   ├── example session_presence ── ETS-backed user tracking
-  └── beryl pubsub ── broadcast cursor positions
+  └── beryl pubsub ── broadcast cursor positions and reactions
 ```
 
 ## Stack
 
 - **Backend**: Gleam, beryl, mist
-- **Frontend**: Vanilla JS, [Phoenix JS client](https://www.npmjs.com/package/phoenix) (CDN)
+- **Frontend**: Vanilla JS, CSS animations, [Phoenix JS client](https://www.npmjs.com/package/phoenix) (CDN)
 - **No build step** — just `gleam run`

--- a/examples/cursors/e2e/cursors.spec.js
+++ b/examples/cursors/e2e/cursors.spec.js
@@ -198,6 +198,84 @@ test.describe("Collaborative Cursors Demo", () => {
     });
   });
 
+  test.describe("Collaborative reactions", () => {
+    test("sends the selected reaction with normalized coordinates", async ({
+      page,
+    }) => {
+      const sentFrames = [];
+      page.on("websocket", (ws) => {
+        ws.on("framesent", (frame) => {
+          try {
+            const data = JSON.parse(frame.payload);
+            if (Array.isArray(data) && data[3] === "reaction") {
+              sentFrames.push(data);
+            }
+          } catch {
+            // ignore non-JSON frames
+          }
+        });
+      });
+
+      await gotoWithUsername(page, "Reactor");
+      await expect(page.locator("#user-list li")).toHaveCount(1, {
+        timeout: 10_000,
+      });
+
+      const canvas = page.locator("#canvas");
+      const box = await canvas.boundingBox();
+      await canvas.click({
+        position: { x: box.width * 0.25, y: box.height * 0.75 },
+      });
+      await expect.poll(() => sentFrames.length).toBeGreaterThan(0);
+
+      const payload = sentFrames[0][4];
+      expect(payload.reaction).toBe("👍");
+      expect(payload.x).toBeCloseTo(0.25, 2);
+      expect(payload.y).toBeCloseTo(0.75, 2);
+    });
+
+    test("broadcasts a reaction to another user at the same relative point", async ({
+      browser,
+    }) => {
+      const context1 = await browser.newContext();
+      const context2 = await browser.newContext();
+      const page1 = await context1.newPage();
+      const page2 = await context2.newPage();
+
+      try {
+        await gotoWithUsername(page1, "Sender");
+        await expect(page1.locator("#user-list li")).toHaveCount(1, {
+          timeout: 10_000,
+        });
+        await gotoWithUsername(page2, "Watcher");
+        await expect(page1.locator("#user-list li")).toHaveCount(2, {
+          timeout: 10_000,
+        });
+
+        await page1.getByRole("button", { name: "Party popper" }).click();
+        const senderCanvas = page1.locator("#canvas");
+        const senderBox = await senderCanvas.boundingBox();
+        await senderCanvas.click({
+          position: { x: senderBox.width * 0.4, y: senderBox.height * 0.6 },
+        });
+
+        const remote = page2.locator("#canvas .reaction-burst");
+        await expect(remote).toHaveText("🎉", { timeout: 5_000 });
+
+        const watcherBox = await page2.locator("#canvas").boundingBox();
+        const position = await remote.evaluate((el) => ({
+          left: Number.parseFloat(el.style.left),
+          top: Number.parseFloat(el.style.top),
+        }));
+        expect(position.left).toBeCloseTo(watcherBox.width * 0.4, 0);
+        expect(position.top).toBeCloseTo(watcherBox.height * 0.6, 0);
+      } finally {
+        await context1.close();
+        await context2.close();
+      }
+    });
+  });
+
   test.describe("Static assets", () => {
     test("loads the stylesheet", async ({ page }) => {
       const response = await page.goto("/static/style.css");

--- a/examples/cursors/e2e/cursors.spec.js
+++ b/examples/cursors/e2e/cursors.spec.js
@@ -95,6 +95,109 @@ test.describe("Collaborative Cursors Demo", () => {
     });
   });
 
+  test.describe("Reaction toolbar", () => {
+    test("renders five accessible reactions with thumbs up selected", async ({
+      page,
+    }) => {
+      await page.goto("/");
+
+      const toolbar = page.getByRole("toolbar", { name: "Choose reaction" });
+      await expect(toolbar).toBeVisible();
+      await expect(toolbar.getByRole("button")).toHaveCount(5);
+      await expect(
+        toolbar.getByRole("button", { name: "Thumbs up" })
+      ).toHaveAttribute("aria-pressed", "true");
+    });
+
+    test("switches and clears the selected reaction", async ({ page }) => {
+      await page.goto("/");
+
+      const heart = page.getByRole("button", { name: "Heart" });
+      const thumbsUp = page.getByRole("button", { name: "Thumbs up" });
+      await heart.click();
+      await expect(heart).toHaveAttribute("aria-pressed", "true");
+      await expect(thumbsUp).toHaveAttribute("aria-pressed", "false");
+
+      await heart.click();
+      await expect(heart).toHaveAttribute("aria-pressed", "false");
+    });
+
+    test("spawns and removes the selected local reaction", async ({ page }) => {
+      await page.goto("/");
+
+      await page.locator("#canvas").click({ position: { x: 120, y: 140 } });
+      const reaction = page.locator("#canvas .reaction-burst");
+      await expect(reaction).toHaveText("👍");
+      await expect(reaction).toHaveCount(0, { timeout: 3_000 });
+    });
+
+    test("toolbar clicks do not spawn reactions", async ({ page }) => {
+      await page.goto("/");
+
+      await page.getByRole("button", { name: "Party popper" }).click();
+      await expect(page.locator("#canvas .reaction-burst")).toHaveCount(0);
+    });
+
+    test("canvas clicks do nothing after clearing selection", async ({
+      page,
+    }) => {
+      await page.goto("/");
+
+      await page.getByRole("button", { name: "Thumbs up" }).click();
+      await page.locator("#canvas").click({ position: { x: 100, y: 100 } });
+      await expect(page.locator("#canvas .reaction-burst")).toHaveCount(0);
+    });
+
+    test("keeps the selection active across rapid clicks", async ({ page }) => {
+      await page.goto("/");
+
+      const canvas = page.locator("#canvas");
+      await canvas.click({ position: { x: 100, y: 100 } });
+      await canvas.click({ position: { x: 140, y: 140 } });
+      await expect(page.locator("#canvas .reaction-burst")).toHaveCount(2);
+      await expect(
+        page.getByRole("button", { name: "Thumbs up" })
+      ).toHaveAttribute("aria-pressed", "true");
+    });
+
+    test("keeps the toolbar inside the canvas on mobile", async ({
+      browser,
+    }) => {
+      const context = await browser.newContext({
+        viewport: { width: 375, height: 667 },
+      });
+      const page = await context.newPage();
+
+      try {
+        await page.goto("/");
+        const canvasBox = await page.locator("#canvas").boundingBox();
+        const toolbarBox = await page.locator("#reaction-toolbar").boundingBox();
+        expect(toolbarBox.x).toBeGreaterThanOrEqual(canvasBox.x);
+        expect(toolbarBox.x + toolbarBox.width).toBeLessThanOrEqual(
+          canvasBox.x + canvasBox.width
+        );
+      } finally {
+        await context.close();
+      }
+    });
+
+    test("uses the reduced-motion fade", async ({ browser }) => {
+      const context = await browser.newContext({ reducedMotion: "reduce" });
+      const page = await context.newPage();
+
+      try {
+        await page.goto("/");
+        await page.locator("#canvas").click({ position: { x: 100, y: 100 } });
+        const animationName = await page
+          .locator("#canvas .reaction-burst")
+          .evaluate((el) => getComputedStyle(el).animationName);
+        expect(animationName).toBe("reaction-fade");
+      } finally {
+        await context.close();
+      }
+    });
+  });
+
   test.describe("Static assets", () => {
     test("loads the stylesheet", async ({ page }) => {
       const response = await page.goto("/static/style.css");

--- a/examples/cursors/playwright.config.js
+++ b/examples/cursors/playwright.config.js
@@ -1,20 +1,23 @@
 // @ts-check
 import { defineConfig } from "@playwright/test";
 
+const port = process.env.PORT ? parseInt(process.env.PORT) : 8000;
+
 export default defineConfig({
   testDir: "./e2e",
   timeout: 30_000,
   retries: 0,
   use: {
-    baseURL: "http://localhost:8000",
+    baseURL: `http://localhost:${port}`,
     headless: true,
   },
   // Start the Gleam server before tests
   webServer: {
     command: "gleam run",
-    url: "http://localhost:8000",
+    url: `http://localhost:${port}`,
     reuseExistingServer: !process.env.CI,
     timeout: 30_000,
+    env: { PORT: String(port) },
   },
   projects: [
     {

--- a/examples/cursors/priv/static/app.js
+++ b/examples/cursors/priv/static/app.js
@@ -61,6 +61,25 @@
     cursor.el.style.transform = `translate(${x}px, ${y}px)`;
   });
 
+  // --- Handle remote reactions ---
+  channel.on("reaction", (payload) => {
+    const { reaction, x, y } = payload;
+    if (
+      !["👍", "❤️", "😂", "🎉", "🔥"].includes(reaction) ||
+      !Number.isFinite(x) ||
+      !Number.isFinite(y) ||
+      x < 0 ||
+      x > 1 ||
+      y < 0 ||
+      y > 1
+    ) {
+      return;
+    }
+
+    const rect = canvas.getBoundingClientRect();
+    spawnReaction(reaction, x * rect.width, y * rect.height);
+  });
+
   // --- DOM references and reaction state ---
   const canvas = document.getElementById("canvas");
   const reactionToolbar = document.getElementById("reaction-toolbar");
@@ -91,11 +110,14 @@
     if (!selectedReaction || event.target.closest("#reaction-toolbar")) return;
 
     const rect = canvas.getBoundingClientRect();
-    spawnReaction(
-      selectedReaction,
-      event.clientX - rect.left,
-      event.clientY - rect.top
-    );
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    spawnReaction(selectedReaction, x, y);
+    channel.push("reaction", {
+      reaction: selectedReaction,
+      x: x / rect.width,
+      y: y / rect.height,
+    });
   });
 
   function spawnReaction(reaction, x, y) {

--- a/examples/cursors/priv/static/app.js
+++ b/examples/cursors/priv/static/app.js
@@ -7,6 +7,7 @@
   // --- Config ---
   const THROTTLE_MS = 50; // 20fps cursor updates
   const CURSOR_TIMEOUT_MS = 5000; // Remove stale cursors after 5s
+  const REACTION_DURATION_MS = 1200;
 
   // --- State ---
   let mySocketId = null;
@@ -60,8 +61,65 @@
     cursor.el.style.transform = `translate(${x}px, ${y}px)`;
   });
 
-  // --- Send own cursor position ---
+  // --- DOM references and reaction state ---
   const canvas = document.getElementById("canvas");
+  const reactionToolbar = document.getElementById("reaction-toolbar");
+  const reactionButtons = Array.from(
+    reactionToolbar.querySelectorAll(".reaction-option")
+  );
+  let selectedReaction = "👍";
+
+  // --- Reaction toolbar ---
+
+  function setSelectedReaction(reaction) {
+    selectedReaction = selectedReaction === reaction ? null : reaction;
+    for (const button of reactionButtons) {
+      const selected = button.dataset.reaction === selectedReaction;
+      button.classList.toggle("is-selected", selected);
+      button.setAttribute("aria-pressed", String(selected));
+    }
+  }
+
+  for (const button of reactionButtons) {
+    button.addEventListener("click", (event) => {
+      event.stopPropagation();
+      setSelectedReaction(button.dataset.reaction);
+    });
+  }
+
+  canvas.addEventListener("click", (event) => {
+    if (!selectedReaction || event.target.closest("#reaction-toolbar")) return;
+
+    const rect = canvas.getBoundingClientRect();
+    spawnReaction(
+      selectedReaction,
+      event.clientX - rect.left,
+      event.clientY - rect.top
+    );
+  });
+
+  function spawnReaction(reaction, x, y) {
+    const el = document.createElement("span");
+    el.className = "reaction-burst";
+    el.textContent = reaction;
+    el.style.left = `${x}px`;
+    el.style.top = `${y}px`;
+    el.style.setProperty(
+      "--reaction-drift",
+      `${(Math.random() * 32 - 16).toFixed(1)}px`
+    );
+    el.style.setProperty(
+      "--reaction-scale",
+      (0.9 + Math.random() * 0.25).toFixed(2)
+    );
+
+    const cleanup = () => el.remove();
+    el.addEventListener("animationend", cleanup, { once: true });
+    setTimeout(cleanup, REACTION_DURATION_MS + 200);
+    canvas.appendChild(el);
+  }
+
+  // --- Send own cursor position ---
   let localCursorEl = null;
 
   function ensureLocalCursor() {

--- a/examples/cursors/priv/static/style.css
+++ b/examples/cursors/priv/static/style.css
@@ -76,6 +76,65 @@ body {
   text-decoration: underline;
 }
 
+/* --- Reaction toolbar --- */
+
+#reaction-toolbar {
+  position: absolute;
+  left: 50%;
+  bottom: 24px;
+  z-index: 200;
+  display: flex;
+  gap: 6px;
+  max-width: calc(100% - 16px);
+  padding: 6px;
+  transform: translateX(-50%);
+  border: 1px solid #e0e0e0;
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.reaction-option {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  cursor: pointer;
+  font-size: 1.25rem;
+  transition: background 120ms ease, transform 120ms ease;
+}
+
+.reaction-option:hover {
+  background: #f1eef9;
+}
+
+.reaction-option.is-selected {
+  background: #e8e0f7;
+  transform: translateY(-2px) scale(1.08);
+}
+
+.reaction-option:focus-visible {
+  outline: 3px solid #7c5cbf;
+  outline-offset: 2px;
+}
+
+@media (max-width: 600px) {
+  #reaction-toolbar {
+    bottom: 12px;
+    gap: 2px;
+    padding: 4px;
+  }
+
+  .reaction-option {
+    width: 28px;
+    height: 32px;
+    font-size: 1rem;
+  }
+}
+
 /* --- Remote cursors --- */
 
 .cursor {
@@ -146,4 +205,54 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* --- Reactions --- */
+
+.reaction-burst {
+  position: absolute;
+  z-index: 150;
+  pointer-events: none;
+  font-size: 2rem;
+  line-height: 1;
+  transform: translate(-50%, -50%);
+  animation: reaction-float 1.2s ease-out forwards;
+  will-change: opacity, transform;
+}
+
+@keyframes reaction-float {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -40%) scale(0.6);
+  }
+
+  15% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform:
+      translate(calc(-50% + var(--reaction-drift)), -140px)
+      scale(var(--reaction-scale));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reaction-burst {
+    animation-name: reaction-fade;
+    animation-duration: 600ms;
+  }
+}
+
+@keyframes reaction-fade {
+  from {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+
+  to {
+    opacity: 0;
+    transform: translate(-50%, -60%);
+  }
 }

--- a/examples/cursors/priv/static/style.css
+++ b/examples/cursors/priv/static/style.css
@@ -130,7 +130,7 @@ body {
 
   .reaction-option {
     width: 28px;
-    height: 32px;
+    height: 28px;
     font-size: 1rem;
   }
 }

--- a/examples/cursors/src/cursors/app.gleam
+++ b/examples/cursors/src/cursors/app.gleam
@@ -16,7 +16,9 @@ import example_helpers/session_presence
 import gleam/dict.{type Dict}
 import gleam/dynamic.{type Dynamic}
 import gleam/dynamic/decode
+import gleam/int
 import gleam/json
+import gleam/list
 import gleam/option.{type Option, None, Some}
 
 /// Per-topic state for one socket in a cursor room.
@@ -27,6 +29,8 @@ pub type Model {
 pub type Ctx {
   Ctx(presence: session_presence.Tracker)
 }
+
+const supported_reactions = ["👍", "❤️", "😂", "🎉", "🔥"]
 
 /// Handle a join for a `cursor:*` topic. Returns `None` when rejected.
 pub fn join(
@@ -77,6 +81,21 @@ pub fn update(
         ])
       #(model, [event.BroadcastFrom(topic, "cursor_move", move_payload)])
     }
+    "reaction" ->
+      case decode_reaction(payload) {
+        Some(#(reaction, x, y)) -> {
+          let reaction_payload =
+            json.object([
+              #("reaction", json.string(reaction)),
+              #("x", json.float(x)),
+              #("y", json.float(y)),
+            ])
+          #(model, [
+            event.BroadcastFrom(topic, "reaction", reaction_payload),
+          ])
+        }
+        None -> #(model, [])
+      }
     _ -> #(model, [])
   }
 }
@@ -168,6 +187,55 @@ pub fn standalone_update(
 
     event.Binary(_, _) | event.Info(_) -> event.Next(model, [])
   }
+}
+
+fn decode_reaction(payload: Dynamic) -> Option(#(String, Float, Float)) {
+  let reaction_decoder = {
+    use reaction <- decode.field("reaction", decode.string)
+    decode.success(reaction)
+  }
+
+  case
+    decode.run(payload, reaction_decoder),
+    decode_number(payload, "x"),
+    decode_number(payload, "y")
+  {
+    Ok(reaction), Ok(x), Ok(y) -> {
+      let valid =
+        list.contains(supported_reactions, reaction)
+        && coordinate_in_range(x)
+        && coordinate_in_range(y)
+      case valid {
+        True -> Some(#(reaction, x, y))
+        False -> None
+      }
+    }
+    _, _, _ -> None
+  }
+}
+
+fn decode_number(payload: Dynamic, field_name: String) -> Result(Float, Nil) {
+  let float_decoder = {
+    use value <- decode.field(field_name, decode.float)
+    decode.success(value)
+  }
+  case decode.run(payload, float_decoder) {
+    Ok(value) -> Ok(value)
+    Error(_) -> {
+      let int_decoder = {
+        use value <- decode.field(field_name, decode.int)
+        decode.success(value)
+      }
+      case decode.run(payload, int_decoder) {
+        Ok(value) -> Ok(int.to_float(value))
+        Error(_) -> Error(Nil)
+      }
+    }
+  }
+}
+
+fn coordinate_in_range(value: Float) -> Bool {
+  value >=. 0.0 && value <=. 1.0
 }
 
 /// Extract a number from a JSON payload as Json, defaulting to 0.0.

--- a/examples/cursors/src/cursors/router.gleam
+++ b/examples/cursors/src/cursors/router.gleam
@@ -55,6 +55,13 @@ fn index_page(ctx: Context) -> Response(ResponseData) {
         <p class=\"hint\">Open this page in multiple tabs to see it in action.</p>
         <p class=\"powered-by\">Powered by <a href=\"https://github.com/tylerbutler/beryl\">beryl</a></p>
       </div>
+      <div id=\"reaction-toolbar\" role=\"toolbar\" aria-label=\"Choose reaction\">
+        <button class=\"reaction-option is-selected\" type=\"button\" data-reaction=\"👍\" aria-label=\"Thumbs up\" aria-pressed=\"true\">👍</button>
+        <button class=\"reaction-option\" type=\"button\" data-reaction=\"❤️\" aria-label=\"Heart\" aria-pressed=\"false\">❤️</button>
+        <button class=\"reaction-option\" type=\"button\" data-reaction=\"😂\" aria-label=\"Face with tears of joy\" aria-pressed=\"false\">😂</button>
+        <button class=\"reaction-option\" type=\"button\" data-reaction=\"🎉\" aria-label=\"Party popper\" aria-pressed=\"false\">🎉</button>
+        <button class=\"reaction-option\" type=\"button\" data-reaction=\"🔥\" aria-label=\"Fire\" aria-pressed=\"false\">🔥</button>
+      </div>
     </div>
     <aside id=\"sidebar\">
       <h2>Online</h2>

--- a/examples/cursors/test/cursors_app_test.gleam
+++ b/examples/cursors/test/cursors_app_test.gleam
@@ -4,12 +4,7 @@ import cursors/app
 import gleam/dynamic
 import gleam/json
 import gleam/list
-import gleeunit
 import gleeunit/should
-
-pub fn main() {
-  gleeunit.main()
-}
 
 fn context() -> app.Ctx {
   let assert Ok(handle) =

--- a/examples/cursors/test/cursors_app_test.gleam
+++ b/examples/cursors/test/cursors_app_test.gleam
@@ -1,0 +1,126 @@
+import beryl/event
+import beryl/presence
+import cursors/app
+import gleam/dynamic
+import gleam/json
+import gleam/list
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+fn context() -> app.Ctx {
+  let assert Ok(handle) =
+    presence.start(presence.default_config("cursors-reaction-test"))
+  app.Ctx(presence: handle)
+}
+
+fn model() -> app.Model {
+  app.Model(username: "Alice", color: "#abcdef")
+}
+
+fn reaction_payload(
+  reaction: String,
+  x: dynamic.Dynamic,
+  y: dynamic.Dynamic,
+) -> dynamic.Dynamic {
+  dynamic.properties([
+    #(dynamic.string("reaction"), dynamic.string(reaction)),
+    #(dynamic.string("x"), x),
+    #(dynamic.string("y"), y),
+  ])
+}
+
+pub fn supported_reactions_broadcast_test() {
+  ["👍", "❤️", "😂", "🎉", "🔥"]
+  |> list.each(fn(reaction) {
+    let #(_, effects) =
+      app.update(
+        context(),
+        "socket-1",
+        "cursor:lobby",
+        model(),
+        "reaction",
+        reaction_payload(reaction, dynamic.float(0.25), dynamic.float(0.75)),
+      )
+
+    let assert [event.BroadcastFrom("cursor:lobby", "reaction", payload)] =
+      effects
+    json.to_string(payload)
+    |> should.equal(
+      "{\"reaction\":\"" <> reaction <> "\",\"x\":0.25,\"y\":0.75}",
+    )
+  })
+}
+
+pub fn integer_boundary_coordinates_broadcast_test() {
+  let #(_, effects) =
+    app.update(
+      context(),
+      "socket-1",
+      "cursor:lobby",
+      model(),
+      "reaction",
+      reaction_payload("👍", dynamic.int(0), dynamic.int(1)),
+    )
+
+  let assert [event.BroadcastFrom("cursor:lobby", "reaction", payload)] =
+    effects
+  json.to_string(payload)
+  |> should.equal("{\"reaction\":\"👍\",\"x\":0.0,\"y\":1.0}")
+}
+
+pub fn invalid_reaction_payloads_are_dropped_test() {
+  let missing_y =
+    dynamic.properties([
+      #(dynamic.string("reaction"), dynamic.string("👍")),
+      #(dynamic.string("x"), dynamic.float(0.5)),
+    ])
+  let invalid_payloads = [
+    reaction_payload("👎", dynamic.float(0.5), dynamic.float(0.5)),
+    reaction_payload("👍", dynamic.float(-0.1), dynamic.float(0.5)),
+    reaction_payload("👍", dynamic.float(0.5), dynamic.float(1.1)),
+    reaction_payload("👍", dynamic.string("middle"), dynamic.float(0.5)),
+    missing_y,
+  ]
+
+  invalid_payloads
+  |> list.each(fn(payload) {
+    let #(_, effects) =
+      app.update(
+        context(),
+        "socket-1",
+        "cursor:lobby",
+        model(),
+        "reaction",
+        payload,
+      )
+    effects |> should.equal([])
+  })
+}
+
+pub fn cursor_move_behavior_is_unchanged_test() {
+  let payload =
+    dynamic.properties([
+      #(dynamic.string("x"), dynamic.int(12)),
+      #(dynamic.string("y"), dynamic.int(34)),
+    ])
+  let #(_, effects) =
+    app.update(
+      context(),
+      "socket-1",
+      "cursor:lobby",
+      model(),
+      "cursor_move",
+      payload,
+    )
+
+  let assert [event.BroadcastFrom("cursor:lobby", "cursor_move", broadcast)] =
+    effects
+  json.to_string(broadcast)
+  |> should.equal(
+    "{\"socket_id\":\"socket-1\",\"x\":12,\"y\":34,\"username\":\"Alice\",\"color\":\"#abcdef\"}",
+  )
+}

--- a/examples/cursors/test/cursors_app_test.gleam
+++ b/examples/cursors/test/cursors_app_test.gleam
@@ -1,15 +1,13 @@
 import beryl/event
-import beryl/presence
 import cursors/app
+import example_helpers/session_presence
 import gleam/dynamic
 import gleam/json
 import gleam/list
 import gleeunit/should
 
 fn context() -> app.Ctx {
-  let assert Ok(handle) =
-    presence.start(presence.default_config("cursors-reaction-test"))
-  app.Ctx(presence: handle)
+  app.Ctx(presence: session_presence.start())
 }
 
 fn model() -> app.Model {

--- a/examples/cursors/test/cursors_test.gleam
+++ b/examples/cursors/test/cursors_test.gleam
@@ -1,0 +1,7 @@
+import gleeunit
+
+/// Test entrypoint: gleeunit discovers and runs every `*_test` module in
+/// this package.
+pub fn main() {
+  gleeunit.main()
+}

--- a/examples/showcase/e2e/showcase.spec.js
+++ b/examples/showcase/e2e/showcase.spec.js
@@ -154,6 +154,35 @@ test.describe("Showcase (app-side dispatch)", () => {
     expect(sysMsgIndex).toBeGreaterThan(ackIndex);
   });
 
+  test("chat lobby routes join, messages, and close independently", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const frames = await driveSocket(page, [
+      { send: ["1", "1", "lobby", "phx_join", {}] },
+      { waitReply: "1" },
+      {
+        send: ["2", "2", "room:general", "phx_join", {
+          username: "lobby-user",
+        }],
+      },
+      { waitReply: "2" },
+      { send: ["1", "3", "lobby", "refresh", {}] },
+      { send: ["1", "4", "lobby", "phx_leave", {}] },
+      { waitEvent: "phx_close", topic: "lobby" },
+      { send: ["2", "5", "room:general", "new_msg", { text: "still joined" }] },
+      { waitReply: "5" },
+    ]);
+
+    expect(replyStatus(repliesFor(frames, "1")[0])).toBe("ok");
+    expect(replyStatus(repliesFor(frames, "2")[0])).toBe("ok");
+    expect(replyStatus(repliesFor(frames, "5")[0])).toBe("ok");
+    expect(frames.filter((f) => f[3] === "phx_error")).toHaveLength(0);
+    expect(
+      frames.filter((f) => f[3] === "phx_close").map((f) => f[2])
+    ).toEqual(["lobby"]);
+  });
+
   test("chat page works end to end against the shared socket", async ({
     page,
   }) => {
@@ -170,6 +199,45 @@ test.describe("Showcase (app-side dispatch)", () => {
     await expect(
       page.locator("#messages").getByText("hello from the gate").first()
     ).toBeVisible();
+  });
+
+  test("chat page keeps live room counts under its mount", async ({
+    browser,
+  }) => {
+    const context1 = await browser.newContext();
+    const context2 = await browser.newContext();
+    const page1 = await context1.newPage();
+    const page2 = await context2.newPage();
+    const roomRequests = [];
+
+    page1.on("request", (request) => {
+      if (request.url().includes("/api/rooms")) {
+        roomRequests.push(new URL(request.url()).pathname);
+      }
+    });
+    page1.on("dialog", (dialog) => dialog.accept("showcase-observer"));
+    page2.on("dialog", (dialog) => dialog.accept("showcase-joiner"));
+
+    try {
+      await page1.goto("/chat");
+      await expect.poll(() => roomRequests).toContain("/chat/api/rooms");
+      await expect(
+        page1.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("1", { timeout: 10_000 });
+
+      await page2.goto("/chat");
+      await expect(
+        page1.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("2", { timeout: 10_000 });
+
+      await context2.close();
+      await expect(
+        page1.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("1", { timeout: 10_000 });
+    } finally {
+      await context1.close();
+      await context2.close().catch(() => {});
+    }
   });
 
   test("cursors page joins its channel over the shared socket", async ({

--- a/examples/showcase/src/showcase.gleam
+++ b/examples/showcase/src/showcase.gleam
@@ -27,7 +27,7 @@ import gleam/erlang/process
 import gleam/int
 import gleam/io
 import gleam/json
-import gleam/option.{None, Some}
+import gleam/option.{type Option, None, Some}
 import gleam/otp/static_supervisor
 import gleam/result
 import mist
@@ -40,6 +40,7 @@ type Model {
     socket_id: String,
     cursors: Dict(String, cursors_app.Model),
     rooms: Dict(String, chat_app.Model),
+    lobby: Option(chat_app.Lobby),
     docs: Dict(String, docs_app.Model),
   )
 }
@@ -89,6 +90,7 @@ pub fn main() {
             socket_id: info.socket_id,
             cursors: dict.new(),
             rooms: dict.new(),
+            lobby: None,
             docs: dict.new(),
           ),
           [],
@@ -164,6 +166,10 @@ fn update(ctx: Ctx, model: Model, ev: Event(Nil)) -> Next(Model, Nil) {
   case ev {
     event.Join(topic, payload, ref) ->
       case topic {
+        "lobby" -> {
+          let #(lobby, effects) = chat_app.lobby_join(ref)
+          event.Next(Model(..model, lobby: Some(lobby)), effects)
+        }
         "cursor:" <> _ -> {
           let #(joined, effects) =
             cursors_app.join(ctx.cursors, model.socket_id, topic, payload, ref)
@@ -190,6 +196,15 @@ fn update(ctx: Ctx, model: Model, ev: Event(Nil)) -> Next(Model, Nil) {
 
     event.Message(topic, event_name, payload, ref) ->
       case topic {
+        "lobby" ->
+          case model.lobby {
+            Some(lobby) -> {
+              let #(lobby, effects) =
+                chat_app.lobby_update(lobby, event_name, payload, ref)
+              event.Next(Model(..model, lobby: Some(lobby)), effects)
+            }
+            None -> event.Next(model, [])
+          }
         "cursor:" <> _ ->
           case dict.get(model.cursors, topic) {
             Ok(sub) -> {
@@ -245,6 +260,15 @@ fn update(ctx: Ctx, model: Model, ev: Event(Nil)) -> Next(Model, Nil) {
 
     event.Closed(topic, _reason) ->
       case topic {
+        "lobby" ->
+          case model.lobby {
+            Some(lobby) ->
+              event.Next(
+                Model(..model, lobby: None),
+                chat_app.lobby_closed(lobby),
+              )
+            None -> event.Next(model, [])
+          }
         "cursor:" <> _ ->
           case dict.get(model.cursors, topic) {
             Ok(sub) ->


### PR DESCRIPTION
## Purpose
Add server-validated realtime reactions to the cursors example.

## Provenance and split notes
Source PR #220; source commit(s): `a96e3dea, be4ebee3, 4b97308c, 83870db2, 5af2b33d, 71ef319e, 845443e7, 5ebf0acd`. Replays the product, server, client, docs, and test stream with session-presence compatibility.
