### PR TITLE
feat(chatrooms): add live lobby counts

### DIFF
--- a/docs/superpowers/plans/2026-07-22-chatrooms-lobby-channel.md
+++ b/docs/superpowers/plans/2026-07-22-chatrooms-lobby-channel.md
@@ -6,14 +6,14 @@
 
 **Architecture:** The server routes the exact `lobby` topic beside the existing `room:*` pattern and broadcasts `rooms_changed` only after room presence changes. The browser joins `lobby` once, fetches authoritative counts from the existing `/api/rooms` endpoint, and keeps that subscription while replacing its active room channel.
 
-**Tech Stack:** Gleam 1.16, Beryl app-side dispatch, Beryl presence, vanilla JavaScript, Phoenix JavaScript client, Mist, gleeunit, Playwright
+**Tech Stack:** Gleam 1.16, Beryl app-side dispatch, example-local session presence, vanilla JavaScript, Phoenix JavaScript client, Mist, gleeunit, Playwright
 
 ## Global Constraints
 
 - Use the exact topic `lobby` for the second channel type.
 - Keep `lobby` joined while the browser switches between `room:*` topics.
 - Keep `/api/rooms` as the authoritative source for room counts.
-- Broadcast `rooms_changed` only after `PresenceTrack` or `PresenceUntrack`.
+- Broadcast `rooms_changed` only after the session tracker mutation.
 - Send `rooms_changed` on topic `lobby` with payload `{room: <room name>}`.
 - Accept no client events on `lobby`.
 - Preserve fail-closed rejection for unknown topics.
@@ -70,8 +70,8 @@ Create `examples/chatrooms/test/chatrooms_app_test.gleam`:
 ```gleam
 import beryl/event
 import beryl/group
-import beryl/presence
 import chatrooms/app
+import example_helpers/session_presence
 import gleam/dict
 import gleam/dynamic
 import gleam/json
@@ -79,12 +79,11 @@ import gleam/option.{None, Some}
 import gleeunit/should
 
 fn context() -> app.Ctx {
-  let assert Ok(presence_handle) =
-    presence.start(presence.default_config("chatrooms-lobby-test"))
+  let presence_tracker = session_presence.start()
   let assert Ok(groups) = group.start()
   let assert Ok(_) = group.create(groups, "public")
   let assert Ok(_) = group.add(groups, "public", "room:general")
-  app.Ctx(presence: presence_handle, groups: groups)
+  app.Ctx(presence: presence_tracker, groups: groups)
 }
 
 fn lobby_ref() -> event.Ref {
@@ -635,10 +634,12 @@ git commit -m "feat(chatrooms): show live room counts"
 Append to `examples/chatrooms/test/chatrooms_app_test.gleam`:
 
 ```gleam
-pub fn accepted_room_join_invalidates_lobby_after_presence_track_test() {
+pub fn accepted_room_join_tracks_session_and_invalidates_lobby_test() {
+  let ctx = context()
+  let app.Ctx(presence: tracker, groups: _) = ctx
   let #(joined, effects) =
     app.join(
-      context(),
+      ctx,
       "socket-1",
       "room:general",
       dynamic.properties([
@@ -650,11 +651,10 @@ pub fn accepted_room_join_invalidates_lobby_after_presence_track_test() {
   joined |> should.be_some
   let assert [
     event.AcceptJoin(_, _),
-    event.PresenceTrack("room:general", "Alice", _),
     event.Broadcast("lobby", "rooms_changed", changed),
     event.Broadcast("room:general", "new_msg", _),
-    event.BroadcastPresence("room:general", "presence_list", _),
   ] = effects
+  session_presence.count(tracker, "room:general") |> should.equal(1)
   json.to_string(changed) |> should.equal("{\"room\":\"general\"}")
 }
 
@@ -672,18 +672,24 @@ pub fn rejected_room_join_does_not_invalidate_lobby_test() {
   let assert [event.RejectJoin(_, _)] = effects
 }
 
-pub fn room_close_invalidates_lobby_after_presence_untrack_test() {
+pub fn room_close_untracks_session_and_invalidates_lobby_test() {
+  let ctx = context()
+  let app.Ctx(presence: tracker, groups: _) = ctx
+  session_presence.track(
+    tracker,
+    "room:general",
+    "socket-1",
+    json.object([]),
+  )
   let model =
     app.Model(username: "Alice", color: "#abcdef", room_name: "general")
-  let effects =
-    app.closed(context(), "socket-1", "room:general", model)
+  let effects = app.closed(ctx, "socket-1", "room:general", model)
 
   let assert [
-    event.PresenceUntrack("room:general", "Alice"),
     event.Broadcast("lobby", "rooms_changed", changed),
     event.Broadcast("room:general", "new_msg", _),
-    event.BroadcastPresence("room:general", "presence_list", _),
   ] = effects
+  session_presence.count(tracker, "room:general") |> should.equal(0)
   json.to_string(changed) |> should.equal("{\"room\":\"general\"}")
 }
 ```
@@ -701,7 +707,8 @@ Expected: the accepted join and room close tests fail because no `rooms_changed`
 
 - [ ] **Step 3: Add ordered room invalidations**
 
-In the successful room join effect list, insert the lobby broadcast immediately after `PresenceTrack`:
+In the successful room join path, call `session_presence.track` before
+constructing the effect list, then include the lobby invalidation:
 
 ```gleam
 event.Broadcast("lobby", "rooms_changed", room_changed(room_name)),
@@ -712,21 +719,17 @@ The complete success effect list must be:
 ```gleam
 [
   event.AcceptJoin(ref, Some(reply)),
-  event.PresenceTrack(topic, username, meta),
   event.Broadcast("lobby", "rooms_changed", room_changed(room_name)),
   event.Broadcast(topic, "new_msg", sys_payload),
-  event.BroadcastPresence(topic, "presence_list", encode_users),
 ]
 ```
 
-In `closed`, place the lobby broadcast immediately after `PresenceUntrack`:
+In `closed`, call `session_presence.untrack` before returning:
 
 ```gleam
 [
-  event.PresenceUntrack(topic, model.username),
   event.Broadcast("lobby", "rooms_changed", room_changed(model.room_name)),
   event.Broadcast(topic, "new_msg", sys_payload),
-  event.BroadcastPresence(topic, "presence_list", encode_users),
 ]
 ```
 
@@ -986,7 +989,7 @@ Add these rows to **beryl Features Exercised**:
 
 ```markdown
 | **Multiple channel types** | `beryl/event` | Exact `lobby` topic plus wildcard `room:*` topics on one socket |
-| **Ordered effects** | `beryl/event` | Presence changes apply before lobby invalidations |
+| **Ordered dispatch** | `beryl/event` | Session tracker changes happen before lobby invalidations |
 ```
 
 Replace the app-side dispatch architecture line with:

--- a/docs/superpowers/plans/2026-07-22-chatrooms-lobby-channel.md
+++ b/docs/superpowers/plans/2026-07-22-chatrooms-lobby-channel.md
@@ -1,0 +1,1057 @@
+# Chatrooms Lobby Channel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persistent `lobby` channel to the chatrooms example so one WebSocket connection carries both global room-directory updates and one active `room:*` chat subscription.
+
+**Architecture:** The server routes the exact `lobby` topic beside the existing `room:*` pattern and broadcasts `rooms_changed` only after room presence changes. The browser joins `lobby` once, fetches authoritative counts from the existing `/api/rooms` endpoint, and keeps that subscription while replacing its active room channel.
+
+**Tech Stack:** Gleam 1.16, Beryl app-side dispatch, Beryl presence, vanilla JavaScript, Phoenix JavaScript client, Mist, gleeunit, Playwright
+
+## Global Constraints
+
+- Use the exact topic `lobby` for the second channel type.
+- Keep `lobby` joined while the browser switches between `room:*` topics.
+- Keep `/api/rooms` as the authoritative source for room counts.
+- Broadcast `rooms_changed` only after `PresenceTrack` or `PresenceUntrack`.
+- Send `rooms_changed` on topic `lobby` with payload `{room: <room name>}`.
+- Accept no client events on `lobby`.
+- Preserve fail-closed rejection for unknown topics.
+- Rejected room joins must not broadcast `rooms_changed`.
+- If the lobby join fails, preserve room chat behavior without live counts.
+- If `/api/rooms` fails, preserve the last successful counts.
+- Ignore stale overlapping `/api/rooms` responses.
+- Add no dependencies.
+
+## File Structure
+
+- Create `examples/chatrooms/test/chatrooms_app_test.gleam` for lobby routing and room invalidation effect tests.
+- Create `examples/chatrooms/test/chatrooms_test.gleam` as the package test entrypoint.
+- Modify `examples/chatrooms/src/chatrooms/app.gleam` to add the lobby model, route lobby events, and emit room-directory invalidations.
+- Modify `examples/chatrooms/src/chatrooms/router.gleam` to add accessible room-count badges.
+- Modify `examples/chatrooms/priv/static/app.js` to keep separate lobby and room channels and refresh room counts safely.
+- Modify `examples/chatrooms/priv/static/style.css` to lay out and style room-count badges.
+- Modify `examples/chatrooms/e2e/chatrooms.spec.js` to cover dual subscriptions, count refreshes, failures, stale responses, and live updates.
+- Modify `examples/chatrooms/README.md` to document the second channel type and its events.
+
+---
+
+### Task 1: Route the Lobby Channel
+
+**Files:**
+- Create: `examples/chatrooms/test/chatrooms_app_test.gleam`
+- Create: `examples/chatrooms/test/chatrooms_test.gleam`
+- Modify: `examples/chatrooms/src/chatrooms/app.gleam:15-27`
+- Modify: `examples/chatrooms/src/chatrooms/app.gleam:32-35`
+- Modify: `examples/chatrooms/src/chatrooms/app.gleam:182-255`
+
+**Interfaces:**
+- Consumes: Existing room `join`, `update`, and `closed` functions and Beryl's ordered `Effect` list.
+- Produces: `Lobby`, `lobby_join`, `lobby_update`, `lobby_closed`, and `Standalone.lobby`, consumed by Tasks 2 and 3.
+
+- [ ] **Step 1: Add the Gleam test entrypoint**
+
+Create `examples/chatrooms/test/chatrooms_test.gleam`:
+
+```gleam
+import gleeunit
+
+/// Test entrypoint: gleeunit discovers and runs every `*_test` module in
+/// this package.
+pub fn main() {
+  gleeunit.main()
+}
+```
+
+- [ ] **Step 2: Write failing lobby and invalidation tests**
+
+Create `examples/chatrooms/test/chatrooms_app_test.gleam`:
+
+```gleam
+import beryl/event
+import beryl/group
+import beryl/presence
+import chatrooms/app
+import gleam/dict
+import gleam/dynamic
+import gleam/json
+import gleam/option.{None, Some}
+import gleeunit/should
+
+fn context() -> app.Ctx {
+  let assert Ok(presence_handle) =
+    presence.start(presence.default_config("chatrooms-lobby-test"))
+  let assert Ok(groups) = group.start()
+  let assert Ok(_) = group.create(groups, "public")
+  let assert Ok(_) = group.add(groups, "public", "room:general")
+  app.Ctx(presence: presence_handle, groups: groups)
+}
+
+fn lobby_ref() -> event.Ref {
+  event.make_join_ref(
+    topic: "lobby",
+    join_ref: Some("lobby-join"),
+    msg_ref: Some("lobby-ref"),
+  )
+}
+
+fn room_ref(topic: String) -> event.Ref {
+  event.make_join_ref(
+    topic: topic,
+    join_ref: Some("room-join"),
+    msg_ref: Some("room-ref"),
+  )
+}
+
+fn empty_payload() -> dynamic.Dynamic {
+  dynamic.properties([])
+}
+
+fn connect_info() -> event.ConnectInfo(Nil) {
+  event.ConnectInfo(
+    socket_id: "socket-1",
+    seed: event.empty_seed(),
+    self: event.make_sender(fn(_message) { Nil }),
+  )
+}
+
+pub fn lobby_join_is_accepted_test() {
+  let #(model, effects) = app.lobby_join(lobby_ref())
+
+  model |> should.equal(app.Lobby)
+  let assert [event.AcceptJoin(_, None)] = effects
+}
+
+pub fn lobby_messages_are_ignored_test() {
+  let #(model, effects) =
+    app.lobby_update(app.Lobby, "refresh", empty_payload(), None)
+
+  model |> should.equal(app.Lobby)
+  effects |> should.equal([])
+}
+
+pub fn standalone_routes_lobby_join_test() {
+  let #(model, _) = app.standalone_init(connect_info())
+  let next =
+    app.standalone_update(
+      context(),
+      model,
+      event.Join("lobby", empty_payload(), lobby_ref()),
+    )
+
+  let assert event.Next(
+    app.Standalone(
+      socket_id: _,
+      rooms: _,
+      lobby: Some(app.Lobby),
+    ),
+    [event.AcceptJoin(_, None)],
+  ) = next
+}
+
+pub fn closing_lobby_preserves_room_models_test() {
+  let room =
+    app.Model(username: "Alice", color: "#abcdef", room_name: "general")
+  let model =
+    app.Standalone(
+      socket_id: "socket-1",
+      rooms: dict.from_list([#("room:general", room)]),
+      lobby: Some(app.Lobby),
+    )
+
+  let next =
+    app.standalone_update(
+      context(),
+      model,
+      event.Closed("lobby", event.Normal),
+    )
+
+  let assert event.Next(
+    app.Standalone(socket_id: _, rooms: rooms, lobby: None),
+    [],
+  ) = next
+  dict.has_key(rooms, "room:general") |> should.be_true
+}
+
+pub fn unrelated_topic_is_rejected_test() {
+  let #(model, _) = app.standalone_init(connect_info())
+  let next =
+    app.standalone_update(
+      context(),
+      model,
+      event.Join(
+        "notifications:alice",
+        empty_payload(),
+        room_ref("notifications:alice"),
+      ),
+    )
+
+  let assert event.Next(_, [event.RejectJoin(_, reason)]) = next
+  json.to_string(reason)
+  |> should.equal("{\"reason\":\"unknown_topic\"}")
+}
+```
+
+- [ ] **Step 3: Run the focused tests and confirm failure**
+
+Run:
+
+```bash
+cd examples/chatrooms
+gleam test -- --filter "lobby"
+```
+
+Expected: compilation fails because `Lobby`, `lobby_join`, `lobby_update`, and `Standalone.lobby` do not exist.
+
+- [ ] **Step 4: Add the lobby model and functions**
+
+In `examples/chatrooms/src/chatrooms/app.gleam`, add after `Model`:
+
+```gleam
+/// Per-socket state for the application-wide lobby topic.
+pub type Lobby {
+  Lobby
+}
+```
+
+Add before the standalone wrapper:
+
+```gleam
+/// Accept the application-wide `lobby` topic.
+pub fn lobby_join(ref: Ref) -> #(Lobby, List(Effect)) {
+  #(Lobby, [event.AcceptJoin(ref, None)])
+}
+
+/// The lobby is read-only; client events produce no effects.
+pub fn lobby_update(
+  model: Lobby,
+  _event_name: String,
+  _payload: Dynamic,
+  _ref: Option(Ref),
+) -> #(Lobby, List(Effect)) {
+  #(model, [])
+}
+
+/// Closing the lobby requires no external cleanup.
+pub fn lobby_closed(_model: Lobby) -> List(Effect) {
+  []
+}
+```
+
+- [ ] **Step 5: Route lobby events in the standalone model**
+
+Change `Standalone` to:
+
+```gleam
+pub type Standalone {
+  Standalone(
+    socket_id: String,
+    rooms: Dict(String, Model),
+    lobby: Option(Lobby),
+  )
+}
+```
+
+Change `standalone_init` to:
+
+```gleam
+#(
+  Standalone(socket_id: info.socket_id, rooms: dict.new(), lobby: None),
+  [],
+)
+```
+
+In the `event.Join` branch, route the exact lobby topic before `room:*`:
+
+```gleam
+case topic {
+  "lobby" -> {
+    let #(lobby, effects) = lobby_join(ref)
+    event.Next(Standalone(..model, lobby: Some(lobby)), effects)
+  }
+  "room:" <> _ -> {
+    // Keep the existing room join body unchanged.
+  }
+  _ ->
+    event.Next(model, [
+      event.RejectJoin(
+        ref,
+        json.object([#("reason", json.string("unknown_topic"))]),
+      ),
+    ])
+}
+```
+
+In the `event.Message` branch, route lobby messages before room lookup:
+
+```gleam
+case topic {
+  "lobby" ->
+    case model.lobby {
+      Some(lobby) -> {
+        let #(lobby, effects) =
+          lobby_update(lobby, event_name, payload, ref)
+        event.Next(Standalone(..model, lobby: Some(lobby)), effects)
+      }
+      None -> event.Next(model, [])
+    }
+  _ ->
+    case dict.get(model.rooms, topic) {
+      // Keep the existing room update body unchanged.
+    }
+}
+```
+
+In the `event.Closed` branch, route the lobby before room lookup:
+
+```gleam
+case topic {
+  "lobby" ->
+    case model.lobby {
+      Some(lobby) ->
+        event.Next(
+          Standalone(..model, lobby: None),
+          lobby_closed(lobby),
+        )
+      None -> event.Next(model, [])
+    }
+  _ ->
+    case dict.get(model.rooms, topic) {
+      // Keep the existing room close body unchanged.
+    }
+}
+```
+
+- [ ] **Step 6: Format and run server tests**
+
+Run:
+
+```bash
+cd examples/chatrooms
+gleam format src test
+gleam test
+```
+
+Expected: all five new tests pass.
+
+- [ ] **Step 7: Commit the server channel**
+
+```bash
+git add examples/chatrooms/src/chatrooms/app.gleam examples/chatrooms/test
+git commit -m "feat(chatrooms): add lobby channel"
+```
+
+---
+
+### Task 2: Join Both Channels and Render Initial Room Counts
+
+**Files:**
+- Modify: `examples/chatrooms/src/chatrooms/router.gleam:64-87`
+- Modify: `examples/chatrooms/priv/static/app.js:11-18`
+- Modify: `examples/chatrooms/priv/static/app.js:24-40`
+- Modify: `examples/chatrooms/priv/static/app.js:246-250`
+- Modify: `examples/chatrooms/priv/static/style.css:47-71`
+- Modify: `examples/chatrooms/e2e/chatrooms.spec.js` after `Page structure`
+
+**Interfaces:**
+- Consumes: Task 1's exact `lobby` topic and the existing `GET /api/rooms` response shape `{topic, name, users}`.
+- Produces: `lobbyChannel`, `refreshRoomCounts`, `updateRoomCounts`, count badges, and lobby-first startup used by Task 3.
+
+- [ ] **Step 1: Add failing dual-channel and count tests**
+
+Add after the `Page structure` describe block in `examples/chatrooms/e2e/chatrooms.spec.js`:
+
+```javascript
+  test.describe("Lobby channel", () => {
+    test("joins lobby and a room on the same socket", async ({ page }) => {
+      const joinedTopics = [];
+      page.on("websocket", (ws) => {
+        ws.on("framesent", (frame) => {
+          try {
+            const data = JSON.parse(frame.payload);
+            if (Array.isArray(data) && data[3] === "phx_join") {
+              joinedTopics.push(data[2]);
+            }
+          } catch {
+            // ignore non-JSON frames
+          }
+        });
+      });
+
+      await gotoWithUsername(page, "LobbyUser");
+
+      await expect.poll(() => joinedTopics).toContain("lobby");
+      await expect.poll(() => joinedTopics.some((topic) =>
+        topic.startsWith("room:")
+      )).toBe(true);
+    });
+
+    test("renders a count badge for every room", async ({ page }) => {
+      await gotoWithUsername(page, "CountUser");
+
+      const badges = page.locator(".room-count");
+      await expect(badges).toHaveCount(3);
+      await expect(
+        page.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("1", { timeout: 10_000 });
+      await expect(
+        page.locator('.room-count[data-room-count="random"]')
+      ).toHaveText("0");
+      await expect(
+        page.locator('.room-count[data-room-count="help"]')
+      ).toHaveText("0");
+    });
+
+  });
+```
+
+- [ ] **Step 2: Run the focused browser tests and confirm failure**
+
+Run:
+
+```bash
+cd examples/chatrooms
+npx playwright test --grep "Lobby channel"
+```
+
+Expected: tests fail because the browser never joins `lobby` and no count badges exist.
+
+- [ ] **Step 3: Add accessible count-badge markup**
+
+In `examples/chatrooms/src/chatrooms/router.gleam`, change each room item to:
+
+```gleam
+"<li class=\"room-item\" data-room=\""
+<> name
+<> "\"><span class=\"room-hash\">#</span>"
+<> "<span class=\"room-name\">"
+<> name
+<> "</span>"
+<> "<span class=\"room-count\" data-room-count=\""
+<> name
+<> "\" aria-label=\"User count unavailable for "
+<> name
+<> "\">–</span></li>"
+```
+
+- [ ] **Step 4: Style room rows and count badges**
+
+Update `.room-item`:
+
+```css
+.room-item {
+  display: flex;
+  align-items: center;
+  padding: 0.4rem 1rem;
+  cursor: pointer;
+  color: #96989d;
+  font-size: 0.9rem;
+  border-radius: 4px;
+  margin: 1px 0.5rem;
+  transition: background 0.15s, color 0.15s;
+}
+```
+
+Replace `.room-hash`'s margin with:
+
+```css
+.room-hash {
+  color: #96989d;
+  margin-right: 4px;
+}
+```
+
+Add after `.room-hash`:
+
+```css
+.room-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.room-count {
+  min-width: 1.5rem;
+  margin-left: auto;
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: #35373c;
+  color: #b5bac1;
+  font-size: 0.7rem;
+  line-height: 1.3;
+  text-align: center;
+}
+
+.room-item.active .room-count {
+  background: #2b2d31;
+  color: #fff;
+}
+```
+
+- [ ] **Step 5: Add separate lobby state and safe room refreshes**
+
+In `examples/chatrooms/priv/static/app.js`, add to state:
+
+```javascript
+  let lobbyChannel = null;
+  let lobbyJoined = false;
+  let roomRefreshSequence = 0;
+```
+
+After the DOM references, add:
+
+```javascript
+  async function refreshRoomCounts() {
+    const requestSequence = ++roomRefreshSequence;
+
+    try {
+      const response = await fetch("/api/rooms");
+      if (!response.ok) {
+        throw new Error(`Room refresh failed with ${response.status}`);
+      }
+      const rooms = await response.json();
+      if (requestSequence !== roomRefreshSequence) return;
+      updateRoomCounts(rooms);
+    } catch (error) {
+      if (requestSequence === roomRefreshSequence) {
+        console.warn("Could not refresh room counts", error);
+      }
+    }
+  }
+
+  function updateRoomCounts(rooms) {
+    if (!Array.isArray(rooms)) return;
+
+    const counts = new Map();
+    for (const room of rooms) {
+      if (
+        room &&
+        typeof room.name === "string" &&
+        Number.isInteger(room.users) &&
+        room.users >= 0
+      ) {
+        counts.set(room.name, room.users);
+      }
+    }
+
+    document.querySelectorAll(".room-count").forEach((badge) => {
+      const roomName = badge.dataset.roomCount;
+      if (!counts.has(roomName)) return;
+      const users = counts.get(roomName);
+      badge.textContent = String(users);
+      badge.setAttribute(
+        "aria-label",
+        `${users} ${users === 1 ? "user" : "users"} in ${roomName}`
+      );
+    });
+  }
+```
+
+- [ ] **Step 6: Refresh counts after successful room joins**
+
+In the existing `currentChannel.join().receive("ok", ...)` callback, add:
+
+```javascript
+        if (lobbyJoined) {
+          refreshRoomCounts();
+        }
+```
+
+The complete callback becomes:
+
+```javascript
+      .receive("ok", (resp) => {
+        mySocketId = resp.socket_id;
+        myUsername = resp.username;
+        myColor = resp.color;
+        if (lobbyJoined) {
+          refreshRoomCounts();
+        }
+      })
+```
+
+- [ ] **Step 7: Join lobby before the first room**
+
+Replace the bottom auto-join block with:
+
+```javascript
+  function joinFirstRoom() {
+    const firstRoom = document.querySelector(".room-item");
+    if (firstRoom) {
+      joinRoom(firstRoom.dataset.room);
+    }
+  }
+
+  lobbyChannel = socket.channel("lobby", {});
+  lobbyChannel.join()
+    .receive("ok", () => {
+      lobbyJoined = true;
+      joinFirstRoom();
+    })
+    .receive("error", (response) => {
+      console.warn("Failed to join lobby", response);
+      joinFirstRoom();
+    });
+```
+
+Do not add the `rooms_changed` listener yet; Task 3 adds live invalidation.
+
+- [ ] **Step 8: Run lobby and regression browser tests**
+
+Run:
+
+```bash
+cd examples/chatrooms
+npx playwright test --grep "Lobby channel|Channel join|Room switching|API"
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 9: Commit lobby startup and initial counts**
+
+```bash
+git add examples/chatrooms/src/chatrooms/router.gleam examples/chatrooms/priv/static/app.js examples/chatrooms/priv/static/style.css examples/chatrooms/e2e/chatrooms.spec.js
+git commit -m "feat(chatrooms): show live room counts"
+```
+
+---
+
+### Task 3: Publish and Consume Live Lobby Invalidations
+
+**Files:**
+- Modify: `examples/chatrooms/test/chatrooms_app_test.gleam`
+- Modify: `examples/chatrooms/src/chatrooms/app.gleam:43-108`
+- Modify: `examples/chatrooms/src/chatrooms/app.gleam:165-180`
+- Modify: `examples/chatrooms/src/chatrooms/app.gleam:296-302`
+- Modify: `examples/chatrooms/priv/static/app.js` beside the Task 2 lobby join
+- Modify: `examples/chatrooms/e2e/chatrooms.spec.js` after the Lobby channel tests
+
+**Interfaces:**
+- Consumes: Task 1's lobby routing and Task 2's `lobbyChannel` and `refreshRoomCounts`.
+- Produces: Ordered `rooms_changed` broadcasts and live room counts that survive room switches while the lobby remains joined.
+
+- [ ] **Step 1: Add failing server invalidation tests**
+
+Append to `examples/chatrooms/test/chatrooms_app_test.gleam`:
+
+```gleam
+pub fn accepted_room_join_invalidates_lobby_after_presence_track_test() {
+  let #(joined, effects) =
+    app.join(
+      context(),
+      "socket-1",
+      "room:general",
+      dynamic.properties([
+        #(dynamic.string("username"), dynamic.string("Alice")),
+      ]),
+      room_ref("room:general"),
+    )
+
+  joined |> should.be_some
+  let assert [
+    event.AcceptJoin(_, _),
+    event.PresenceTrack("room:general", "Alice", _),
+    event.Broadcast("lobby", "rooms_changed", changed),
+    event.Broadcast("room:general", "new_msg", _),
+    event.BroadcastPresence("room:general", "presence_list", _),
+  ] = effects
+  json.to_string(changed) |> should.equal("{\"room\":\"general\"}")
+}
+
+pub fn rejected_room_join_does_not_invalidate_lobby_test() {
+  let #(joined, effects) =
+    app.join(
+      context(),
+      "socket-1",
+      "room:missing",
+      empty_payload(),
+      room_ref("room:missing"),
+    )
+
+  joined |> should.be_none
+  let assert [event.RejectJoin(_, _)] = effects
+}
+
+pub fn room_close_invalidates_lobby_after_presence_untrack_test() {
+  let model =
+    app.Model(username: "Alice", color: "#abcdef", room_name: "general")
+  let effects =
+    app.closed(context(), "socket-1", "room:general", model)
+
+  let assert [
+    event.PresenceUntrack("room:general", "Alice"),
+    event.Broadcast("lobby", "rooms_changed", changed),
+    event.Broadcast("room:general", "new_msg", _),
+    event.BroadcastPresence("room:general", "presence_list", _),
+  ] = effects
+  json.to_string(changed) |> should.equal("{\"room\":\"general\"}")
+}
+```
+
+- [ ] **Step 2: Run server invalidation tests and confirm failure**
+
+Run:
+
+```bash
+cd examples/chatrooms
+gleam test -- --filter "invalidate"
+```
+
+Expected: the accepted join and room close tests fail because no `rooms_changed` broadcast exists.
+
+- [ ] **Step 3: Add ordered room invalidations**
+
+In the successful room join effect list, insert the lobby broadcast immediately after `PresenceTrack`:
+
+```gleam
+event.Broadcast("lobby", "rooms_changed", room_changed(room_name)),
+```
+
+The complete success effect list must be:
+
+```gleam
+[
+  event.AcceptJoin(ref, Some(reply)),
+  event.PresenceTrack(topic, username, meta),
+  event.Broadcast("lobby", "rooms_changed", room_changed(room_name)),
+  event.Broadcast(topic, "new_msg", sys_payload),
+  event.BroadcastPresence(topic, "presence_list", encode_users),
+]
+```
+
+In `closed`, place the lobby broadcast immediately after `PresenceUntrack`:
+
+```gleam
+[
+  event.PresenceUntrack(topic, model.username),
+  event.Broadcast("lobby", "rooms_changed", room_changed(model.room_name)),
+  event.Broadcast(topic, "new_msg", sys_payload),
+  event.BroadcastPresence(topic, "presence_list", encode_users),
+]
+```
+
+Add beside `system_message`:
+
+```gleam
+fn room_changed(room_name: String) -> json.Json {
+  json.object([#("room", json.string(room_name))])
+}
+```
+
+- [ ] **Step 4: Run server tests**
+
+Run:
+
+```bash
+cd examples/chatrooms
+gleam format src test
+gleam test
+```
+
+Expected: all eight lobby and invalidation tests pass.
+
+- [ ] **Step 5: Add failing live-update browser tests**
+
+Add after the Lobby channel describe block:
+
+```javascript
+  test.describe("Live lobby updates", () => {
+    test("updates room counts when another user joins and leaves", async ({
+      browser,
+    }) => {
+      const context1 = await browser.newContext();
+      const context2 = await browser.newContext();
+      const page1 = await context1.newPage();
+      const page2 = await context2.newPage();
+
+      try {
+        await gotoWithUsername(page1, "Observer");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+
+        await gotoWithUsername(page2, "Joiner");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("2", { timeout: 10_000 });
+
+        await context2.close();
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+      } finally {
+        await context1.close();
+        await context2.close().catch(() => {});
+      }
+    });
+
+    test("keeps lobby joined while switching rooms", async ({ page }) => {
+      const leaves = [];
+      page.on("websocket", (ws) => {
+        ws.on("framesent", (frame) => {
+          try {
+            const data = JSON.parse(frame.payload);
+            if (Array.isArray(data) && data[3] === "phx_leave") {
+              leaves.push(data[2]);
+            }
+          } catch {
+            // ignore non-JSON frames
+          }
+        });
+      });
+
+      await gotoWithUsername(page, "Switcher");
+      await expect(
+        page.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("1", { timeout: 10_000 });
+
+      await page.locator('.room-item[data-room="random"]').click();
+      await expect(page.locator(".room-item.active")).toContainText("random");
+      await expect(
+        page.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("0", { timeout: 10_000 });
+      await expect(
+        page.locator('.room-count[data-room-count="random"]')
+      ).toHaveText("1", { timeout: 10_000 });
+
+      expect(leaves).toContain("room:general");
+      expect(leaves).not.toContain("lobby");
+    });
+
+    test("keeps the last counts when a live refresh fails", async ({
+      browser,
+    }) => {
+      const context1 = await browser.newContext();
+      const context2 = await browser.newContext();
+      const page1 = await context1.newPage();
+      const page2 = await context2.newPage();
+      let failRefreshes = false;
+      let failedRequests = 0;
+
+      await page1.route("**/api/rooms", async (route) => {
+        if (failRefreshes) {
+          failedRequests += 1;
+          await route.fulfill({ status: 503, body: "unavailable" });
+        } else {
+          await route.continue();
+        }
+      });
+
+      try {
+        await gotoWithUsername(page1, "FailureObserver");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+
+        failRefreshes = true;
+        await gotoWithUsername(page2, "FailureJoiner");
+        await expect.poll(() => failedRequests).toBeGreaterThan(0);
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1");
+      } finally {
+        await context1.close();
+        await context2.close();
+      }
+    });
+
+    test("ignores a stale overlapping live refresh", async ({ browser }) => {
+      const context1 = await browser.newContext();
+      const context2 = await browser.newContext();
+      const page1 = await context1.newPage();
+      const page2 = await context2.newPage();
+      let raceMode = false;
+      let delayedRequestSeen = false;
+
+      await page1.route("**/api/rooms", async (route) => {
+        if (!raceMode) {
+          await route.continue();
+        } else if (!delayedRequestSeen) {
+          delayedRequestSeen = true;
+          await new Promise((resolve) => setTimeout(resolve, 300));
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([
+              { topic: "room:general", name: "general", users: 9 },
+              { topic: "room:random", name: "random", users: 0 },
+              { topic: "room:help", name: "help", users: 0 },
+            ]),
+          });
+        } else {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([
+              { topic: "room:general", name: "general", users: 1 },
+              { topic: "room:random", name: "random", users: 1 },
+              { topic: "room:help", name: "help", users: 0 },
+            ]),
+          });
+        }
+      });
+
+      try {
+        await gotoWithUsername(page1, "RaceObserver");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+
+        raceMode = true;
+        await gotoWithUsername(page2, "RaceJoiner");
+        await expect.poll(() => delayedRequestSeen).toBe(true);
+        await page2.locator('.room-item[data-room="random"]').click();
+
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+        await expect(
+          page1.locator('.room-count[data-room-count="random"]')
+        ).toHaveText("1", { timeout: 10_000 });
+        await page1.waitForTimeout(350);
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1");
+      } finally {
+        await context1.close();
+        await context2.close();
+      }
+    });
+  });
+```
+
+- [ ] **Step 6: Run live-update tests and confirm failure**
+
+Run:
+
+```bash
+cd examples/chatrooms
+npx playwright test --grep "Live lobby updates"
+```
+
+Expected: counts remain stale because the client does not handle `rooms_changed`.
+
+- [ ] **Step 7: Subscribe to lobby invalidations**
+
+Immediately after creating `lobbyChannel`, add:
+
+```javascript
+  lobbyChannel.on("rooms_changed", () => {
+    refreshRoomCounts();
+  });
+```
+
+- [ ] **Step 8: Run focused and full browser tests**
+
+Run:
+
+```bash
+cd examples/chatrooms
+npx playwright test --grep "Lobby channel|Live lobby updates|Room switching|Multi-user presence"
+npm test
+```
+
+Expected: focused tests and the complete chatrooms Playwright suite pass.
+
+- [ ] **Step 9: Commit live invalidation handling**
+
+```bash
+git add examples/chatrooms/src/chatrooms/app.gleam examples/chatrooms/test/chatrooms_app_test.gleam examples/chatrooms/priv/static/app.js examples/chatrooms/e2e/chatrooms.spec.js
+git commit -m "feat(chatrooms): refresh counts from lobby"
+```
+
+---
+
+### Task 4: Document and Verify the Two-Channel Demo
+
+**Files:**
+- Modify: `examples/chatrooms/README.md:3-24`
+- Modify: `examples/chatrooms/README.md:26-55`
+- Modify: `examples/chatrooms/README.md:71-83`
+
+**Interfaces:**
+- Consumes: The completed lobby and room channel behavior.
+- Produces: Documentation and final verification evidence matching the implementation.
+
+- [ ] **Step 1: Update the feature list and architecture**
+
+Add after the multi-room chat feature:
+
+```markdown
+- 🧭 **Persistent lobby channel** — one socket stays joined to `lobby` while switching between `room:*` topics
+- 🔢 **Live room counts** — lobby invalidations refresh authoritative counts from `/api/rooms`
+```
+
+Add these rows to **beryl Features Exercised**:
+
+```markdown
+| **Multiple channel types** | `beryl/event` | Exact `lobby` topic plus wildcard `room:*` topics on one socket |
+| **Ordered effects** | `beryl/event` | Presence changes apply before lobby invalidations |
+```
+
+Replace the app-side dispatch architecture line with:
+
+```text
+  ├── beryl app-side dispatch
+  │   ├── lobby (persistent room-directory invalidation channel)
+  │   └── room:* (replaceable chat-room channels)
+```
+
+- [ ] **Step 2: Document lobby events**
+
+Add to the Channel Events table:
+
+```markdown
+| Server → Client | `rooms_changed` on `lobby` | Invalidate room counts after room membership changes `{room}` |
+```
+
+Add after the table:
+
+```markdown
+The browser joins `lobby` once and keeps it joined while replacing its active
+`room:*` channel. `rooms_changed` invalidates the directory; the browser then
+loads the current counts from `GET /api/rooms`.
+```
+
+- [ ] **Step 3: Format and test the chatrooms example**
+
+Run:
+
+```bash
+cd examples/chatrooms
+gleam format src test
+gleam check
+gleam test
+npm test
+```
+
+Expected: formatting completes, Gleam checks pass, all eight Gleam tests pass, and the complete Playwright suite passes.
+
+- [ ] **Step 4: Run workspace validation**
+
+Run from the repository root:
+
+```bash
+just format-check
+just check
+just test
+```
+
+Expected: all workspace formatting, type checks, and tests pass.
+
+- [ ] **Step 5: Remove generated browser artifacts**
+
+Remove only generated chatrooms test output:
+
+```bash
+rm -rf examples/chatrooms/test-results examples/chatrooms/playwright-report
+```
+
+Expected: `git status --short` lists only intended source, test, and documentation changes plus any pre-existing unrelated files.
+
+- [ ] **Step 6: Commit documentation and formatting**
+
+```bash
+git add examples/chatrooms/README.md examples/chatrooms/src examples/chatrooms/test examples/chatrooms/priv/static examples/chatrooms/e2e/chatrooms.spec.js
+git commit -m "docs(chatrooms): describe lobby channel"
+```

--- a/docs/superpowers/specs/2026-07-22-chatrooms-lobby-channel-design.md
+++ b/docs/superpowers/specs/2026-07-22-chatrooms-lobby-channel-design.md
@@ -36,9 +36,9 @@ The lobby has no mutable domain state and accepts no client messages. A lobby
 join returns a normal successful join reply. Closing the lobby clears only the
 lobby model.
 
-Successful room joins append a lobby invalidation after `PresenceTrack`.
-Room closes append the same invalidation after `PresenceUntrack`. Strict effect
-ordering ensures the presence mutation completes before lobby subscribers
+Successful room joins mutate the example-local session tracker before returning
+a lobby invalidation. Room closes untrack the session before returning the same
+invalidation. This ordering ensures the count changes before lobby subscribers
 receive the event.
 
 The invalidation event is:
@@ -54,8 +54,8 @@ complete directory.
 
 ## Authoritative Room Counts
 
-The lobby channel does not broadcast computed counts. Beryl's apply-time
-presence effects produce a snapshot only for the topic they target, so a
+The lobby channel does not broadcast computed counts. The example-local session
+tracker publishes a snapshot only for the room topic it mutates, so a
 cross-topic count assembled inside `update` could race with concurrent joins.
 
 The existing `GET /api/rooms` endpoint remains the authoritative count source.
@@ -116,8 +116,8 @@ Gleam tests cover:
 - clearing the lobby model without changing room models;
 - rejecting unrelated topics;
 - emitting `rooms_changed` only after accepted room joins;
-- ordering `PresenceTrack` before join invalidation;
-- ordering `PresenceUntrack` before close invalidation;
+- tracking the session before join invalidation;
+- untracking the session before close invalidation;
 - omitting invalidation for rejected room joins.
 
 Playwright tests cover:

--- a/docs/superpowers/specs/2026-07-22-chatrooms-lobby-channel-design.md
+++ b/docs/superpowers/specs/2026-07-22-chatrooms-lobby-channel-design.md
@@ -1,0 +1,142 @@
+# Chatrooms Lobby Channel Design
+
+## Goal
+
+Add a second channel type to the chatrooms example. Each browser keeps a
+`lobby` channel joined while it joins and leaves `room:*` channels. The room
+list shows live user counts, demonstrating that one WebSocket connection can
+multiplex channels with different scopes and lifecycles.
+
+## Why a Lobby Channel
+
+The existing example already joins several `room:*` topics, but every topic
+uses the same chat-room behavior. A persistent `lobby` channel adds a distinct
+channel type:
+
+- `lobby` represents application-wide room activity.
+- `room:*` represents membership and conversation within one room.
+- Switching rooms replaces the room subscription but preserves the lobby
+  subscription.
+
+This boundary reflects a typical application: global navigation data and
+room-specific interaction travel over the same socket but use separate
+channels.
+
+## Server Architecture
+
+`chatrooms/app.gleam` handles the exact `lobby` topic separately from the
+existing `room:*` pattern.
+
+The standalone socket model stores:
+
+- the existing dictionary of joined room models;
+- an optional lobby model that records whether the socket joined `lobby`.
+
+The lobby has no mutable domain state and accepts no client messages. A lobby
+join returns a normal successful join reply. Closing the lobby clears only the
+lobby model.
+
+Successful room joins append a lobby invalidation after `PresenceTrack`.
+Room closes append the same invalidation after `PresenceUntrack`. Strict effect
+ordering ensures the presence mutation completes before lobby subscribers
+receive the event.
+
+The invalidation event is:
+
+```text
+topic: lobby
+event: rooms_changed
+payload: {room: <room name>}
+```
+
+The event names the affected room for diagnostics, but clients refresh the
+complete directory.
+
+## Authoritative Room Counts
+
+The lobby channel does not broadcast computed counts. Beryl's apply-time
+presence effects produce a snapshot only for the topic they target, so a
+cross-topic count assembled inside `update` could race with concurrent joins.
+
+The existing `GET /api/rooms` endpoint remains the authoritative count source.
+Clients fetch it:
+
+1. after the lobby join succeeds;
+2. after each `rooms_changed` event.
+
+This design also demonstrates a common realtime pattern: WebSocket events
+invalidate data, and an HTTP endpoint returns the current snapshot.
+
+## Client Behavior
+
+`priv/static/app.js` keeps two channel references:
+
+- `lobbyChannel`, joined once for the page's lifetime;
+- `currentChannel`, replaced when the user switches rooms.
+
+The client joins `lobby` before auto-joining the first room. If the lobby join
+fails, chat remains available; the client logs the failure and joins the room
+without live count updates.
+
+Each room-list item contains a count badge. Counts begin in an unavailable
+state and update after the first successful `/api/rooms` response.
+
+Room refreshes use a monotonically increasing request sequence. The client
+applies only the newest response, preventing a slow request from overwriting a
+newer snapshot.
+
+If a refresh fails, the client keeps the last successful counts and logs the
+error. A later invalidation triggers another refresh.
+
+## Routing and Failure Behavior
+
+- `lobby` joins succeed.
+- Client messages sent to `lobby` produce no effects.
+- Closing `lobby` does not affect joined rooms.
+- Closing a room does not affect the lobby subscription.
+- Unknown topics remain fail-closed with the existing `unknown_topic`
+  rejection.
+- Rejected room joins do not broadcast `rooms_changed`.
+
+## Interface Changes
+
+The room list gains a compact count badge beside each room name. The badge has
+an accessible label such as `2 users in general`. No new panel, modal, or
+navigation mode is required.
+
+The README explains that the browser joins `lobby` and one `room:*` topic over
+the same WebSocket connection.
+
+## Testing
+
+Gleam tests cover:
+
+- accepting an exact `lobby` join;
+- ignoring lobby client messages;
+- clearing the lobby model without changing room models;
+- rejecting unrelated topics;
+- emitting `rooms_changed` only after accepted room joins;
+- ordering `PresenceTrack` before join invalidation;
+- ordering `PresenceUntrack` before close invalidation;
+- omitting invalidation for rejected room joins.
+
+Playwright tests cover:
+
+- joining both `lobby` and a `room:*` topic on one socket;
+- keeping `lobby` joined across room switches;
+- rendering initial room counts;
+- updating counts when another user joins or leaves;
+- preserving the last counts when `/api/rooms` fails;
+- ignoring stale overlapping room-directory responses.
+
+Existing chat, presence, typing, authentication, and room-switching tests remain
+unchanged or gain regression assertions where needed.
+
+## Out of Scope
+
+- Message history or unread counts.
+- Cross-room announcements.
+- Private notifications or direct messages.
+- Lobby presence or a global user list.
+- Creating, deleting, or renaming rooms.
+- Replacing the existing `/api/rooms` endpoint.

--- a/examples/chatrooms/README.md
+++ b/examples/chatrooms/README.md
@@ -65,7 +65,7 @@ Gleam/BEAM server (port 8001)
 
 ```bash
 npm install           # First time only
-npx playwright test   # 35 e2e tests
+npx playwright test   # 42 e2e tests
 ```
 
 ## API

--- a/examples/chatrooms/README.md
+++ b/examples/chatrooms/README.md
@@ -44,7 +44,7 @@ This demo is designed to complement the [cursors demo](../cursors/) by exercisin
 | **channel_rate** | `beryl` | 10 msg/sec per channel |
 | **Multiple topics** | `beryl` | Each room is a separate topic |
 | **Multiple channel types** | `beryl/event` | Exact `lobby` topic plus wildcard `room:*` topics on one socket |
-| **Ordered effects** | `beryl/event` | Presence changes apply before lobby invalidations |
+| **Ordered dispatch** | `beryl/event` | Session tracker changes happen before lobby invalidations |
 
 ## Architecture
 

--- a/examples/chatrooms/README.md
+++ b/examples/chatrooms/README.md
@@ -65,7 +65,7 @@ Gleam/BEAM server (port 8001)
 
 ```bash
 npm install           # First time only
-npx playwright test   # 42 e2e tests
+npx playwright test   # 43 e2e tests
 ```
 
 ## API

--- a/examples/chatrooms/README.md
+++ b/examples/chatrooms/README.md
@@ -14,6 +14,8 @@ gleam run
 ## Features
 
 - 💬 **Multi-room chat** — switch between rooms (general, random, help)
+- 🧭 **Persistent lobby channel** — one socket stays joined to `lobby` while switching between `room:*` topics
+- 🔢 **Live room counts** — lobby invalidations refresh authoritative counts from `/api/rooms`
 - 🔐 **Connection authentication** — `on_connect` hook validates auth token before WebSocket upgrade
 - 👥 **Live presence** — see who's online in each room
 - ✍️ **Typing indicators** — see when others are typing
@@ -41,6 +43,8 @@ This demo is designed to complement the [cursors demo](../cursors/) by exercisin
 | **join_rate** | `beryl` | 5 joins/sec per socket |
 | **channel_rate** | `beryl` | 10 msg/sec per channel |
 | **Multiple topics** | `beryl` | Each room is a separate topic |
+| **Multiple channel types** | `beryl/event` | Exact `lobby` topic plus wildcard `room:*` topics on one socket |
+| **Ordered effects** | `beryl/event` | Presence changes apply before lobby invalidations |
 
 ## Architecture
 
@@ -50,7 +54,9 @@ Browser (vanilla JS + Phoenix client CDN)
 Gleam/BEAM server (port 8001)
   ├── Mist HTTP routing (static files, /api/rooms)
   ├── Mist WebSocket transport (on_connect auth)
-  ├── beryl app-side dispatch (room:* topics via chatrooms/app)
+  ├── beryl app-side dispatch
+  │   ├── lobby (persistent room-directory invalidation channel)
+  │   └── room:* (replaceable chat-room channels)
   ├── beryl groups ("public" → general, random, help)
   └── example session_presence (ETS-backed online users + typing indicators)
 ```
@@ -81,3 +87,8 @@ npx playwright test   # 35 e2e tests
 | Server → Client | `msg_error` | Validation error `{code, error}` |
 | Server → Client | `presence_list` | Updated online user list |
 | Server → Client | `typing` | Typing indicator update |
+| Server → Client | `rooms_changed` on `lobby` | Invalidate room counts after room membership changes `{room}` |
+
+The browser joins `lobby` once and keeps it joined while replacing its active
+`room:*` channel. `rooms_changed` invalidates the directory; the browser then
+loads the current counts from `GET /api/rooms`.

--- a/examples/chatrooms/e2e/chatrooms.spec.js
+++ b/examples/chatrooms/e2e/chatrooms.spec.js
@@ -134,6 +134,170 @@ test.describe("Chat Rooms Demo", () => {
 
   });
 
+  test.describe("Live lobby updates", () => {
+    test("updates room counts when another user joins and leaves", async ({
+      browser,
+    }) => {
+      const context1 = await browser.newContext();
+      const context2 = await browser.newContext();
+      const page1 = await context1.newPage();
+      const page2 = await context2.newPage();
+
+      try {
+        await gotoWithUsername(page1, "Observer");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+
+        await gotoWithUsername(page2, "Joiner");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("2", { timeout: 10_000 });
+
+        await context2.close();
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+      } finally {
+        await context1.close();
+        await context2.close().catch(() => {});
+      }
+    });
+
+    test("keeps lobby joined while switching rooms", async ({ page }) => {
+      const leaves = [];
+      page.on("websocket", (ws) => {
+        ws.on("framesent", (frame) => {
+          try {
+            const data = JSON.parse(frame.payload);
+            if (Array.isArray(data) && data[3] === "phx_leave") {
+              leaves.push(data[2]);
+            }
+          } catch {
+            // ignore non-JSON frames
+          }
+        });
+      });
+
+      await gotoWithUsername(page, "Switcher");
+      await expect(
+        page.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("1", { timeout: 10_000 });
+
+      await page.locator('.room-item[data-room="random"]').click();
+      await expect(page.locator(".room-item.active")).toContainText("random");
+      await expect(
+        page.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("0", { timeout: 10_000 });
+      await expect(
+        page.locator('.room-count[data-room-count="random"]')
+      ).toHaveText("1", { timeout: 10_000 });
+
+      expect(leaves).toContain("room:general");
+      expect(leaves).not.toContain("lobby");
+    });
+
+    test("keeps the last counts when a live refresh fails", async ({
+      browser,
+    }) => {
+      const context1 = await browser.newContext();
+      const context2 = await browser.newContext();
+      const page1 = await context1.newPage();
+      const page2 = await context2.newPage();
+      let failRefreshes = false;
+      let failedRequests = 0;
+
+      await page1.route("**/api/rooms", async (route) => {
+        if (failRefreshes) {
+          failedRequests += 1;
+          await route.fulfill({ status: 503, body: "unavailable" });
+        } else {
+          await route.continue();
+        }
+      });
+
+      try {
+        await gotoWithUsername(page1, "FailureObserver");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+
+        failRefreshes = true;
+        await gotoWithUsername(page2, "FailureJoiner");
+        await expect.poll(() => failedRequests).toBeGreaterThan(0);
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1");
+      } finally {
+        await context1.close();
+        await context2.close();
+      }
+    });
+
+    test("ignores a stale overlapping live refresh", async ({ browser }) => {
+      const context1 = await browser.newContext();
+      const context2 = await browser.newContext();
+      const page1 = await context1.newPage();
+      const page2 = await context2.newPage();
+      let raceMode = false;
+      let delayedRequestSeen = false;
+
+      await page1.route("**/api/rooms", async (route) => {
+        if (!raceMode) {
+          await route.continue();
+        } else if (!delayedRequestSeen) {
+          delayedRequestSeen = true;
+          await new Promise((resolve) => setTimeout(resolve, 300));
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([
+              { topic: "room:general", name: "general", users: 9 },
+              { topic: "room:random", name: "random", users: 0 },
+              { topic: "room:help", name: "help", users: 0 },
+            ]),
+          });
+        } else {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([
+              { topic: "room:general", name: "general", users: 1 },
+              { topic: "room:random", name: "random", users: 1 },
+              { topic: "room:help", name: "help", users: 0 },
+            ]),
+          });
+        }
+      });
+
+      try {
+        await gotoWithUsername(page1, "RaceObserver");
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+
+        raceMode = true;
+        await gotoWithUsername(page2, "RaceJoiner");
+        await expect.poll(() => delayedRequestSeen).toBe(true);
+        await page2.locator('.room-item[data-room="random"]').click();
+
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1", { timeout: 10_000 });
+        await expect(
+          page1.locator('.room-count[data-room-count="random"]')
+        ).toHaveText("1", { timeout: 10_000 });
+        await page1.waitForTimeout(350);
+        await expect(
+          page1.locator('.room-count[data-room-count="general"]')
+        ).toHaveText("1");
+      } finally {
+        await context1.close();
+        await context2.close();
+      }
+    });
+  });
+
   test.describe("Static assets", () => {
     test("loads the stylesheet", async ({ page }) => {
       const response = await page.goto("/static/style.css");

--- a/examples/chatrooms/e2e/chatrooms.spec.js
+++ b/examples/chatrooms/e2e/chatrooms.spec.js
@@ -7,7 +7,7 @@ async function gotoWithUsername(page, username, path = "/?token=beryl-demo") {
   await page.goto(path);
 }
 
-// Helper: wait for Phoenix channel join reply
+// Helper: wait for Phoenix channel join reply for a room topic
 async function waitForJoinReply(page) {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(
@@ -18,7 +18,12 @@ async function waitForJoinReply(page) {
       ws.on("framereceived", (frame) => {
         try {
           const data = JSON.parse(frame.payload);
-          if (Array.isArray(data) && data[3] === "phx_reply") {
+          if (
+            Array.isArray(data) &&
+            data[3] === "phx_reply" &&
+            typeof data[2] === "string" &&
+            data[2].startsWith("room:")
+          ) {
             clearTimeout(timeout);
             resolve(data);
           }
@@ -85,6 +90,48 @@ test.describe("Chat Rooms Demo", () => {
         "https://github.com/tylerbutler/beryl"
       );
     });
+  });
+
+  test.describe("Lobby channel", () => {
+    test("joins lobby and a room on the same socket", async ({ page }) => {
+      const joinedTopics = [];
+      page.on("websocket", (ws) => {
+        ws.on("framesent", (frame) => {
+          try {
+            const data = JSON.parse(frame.payload);
+            if (Array.isArray(data) && data[3] === "phx_join") {
+              joinedTopics.push(data[2]);
+            }
+          } catch {
+            // ignore non-JSON frames
+          }
+        });
+      });
+
+      await gotoWithUsername(page, "LobbyUser");
+
+      await expect.poll(() => joinedTopics).toContain("lobby");
+      await expect.poll(() => joinedTopics.some((topic) =>
+        topic.startsWith("room:")
+      )).toBe(true);
+    });
+
+    test("renders a count badge for every room", async ({ page }) => {
+      await gotoWithUsername(page, "CountUser");
+
+      const badges = page.locator(".room-count");
+      await expect(badges).toHaveCount(3);
+      await expect(
+        page.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("1", { timeout: 10_000 });
+      await expect(
+        page.locator('.room-count[data-room-count="random"]')
+      ).toHaveText("0");
+      await expect(
+        page.locator('.room-count[data-room-count="help"]')
+      ).toHaveText("0");
+    });
+
   });
 
   test.describe("Static assets", () => {

--- a/examples/chatrooms/e2e/chatrooms.spec.js
+++ b/examples/chatrooms/e2e/chatrooms.spec.js
@@ -93,6 +93,19 @@ test.describe("Chat Rooms Demo", () => {
   });
 
   test.describe("Lobby channel", () => {
+    test("requests room counts from the standalone mount", async ({ page }) => {
+      const roomRequests = [];
+      page.on("request", (request) => {
+        if (request.url().includes("/api/rooms")) {
+          roomRequests.push(new URL(request.url()).pathname);
+        }
+      });
+
+      await gotoWithUsername(page, "MountUser");
+
+      await expect.poll(() => roomRequests).toContain("/api/rooms");
+    });
+
     test("joins lobby and a room on the same socket", async ({ page }) => {
       const joinedTopics = [];
       page.on("websocket", (ws) => {

--- a/examples/chatrooms/e2e/chatrooms.spec.js
+++ b/examples/chatrooms/e2e/chatrooms.spec.js
@@ -241,6 +241,7 @@ test.describe("Chat Rooms Demo", () => {
       const page2 = await context2.newPage();
       let raceMode = false;
       let delayedRequestSeen = false;
+      let delayedRequestFulfilled = false;
 
       await page1.route("**/api/rooms", async (route) => {
         if (!raceMode) {
@@ -257,6 +258,7 @@ test.describe("Chat Rooms Demo", () => {
               { topic: "room:help", name: "help", users: 0 },
             ]),
           });
+          delayedRequestFulfilled = true;
         } else {
           await route.fulfill({
             status: 200,
@@ -287,7 +289,9 @@ test.describe("Chat Rooms Demo", () => {
         await expect(
           page1.locator('.room-count[data-room-count="random"]')
         ).toHaveText("1", { timeout: 10_000 });
-        await page1.waitForTimeout(350);
+        // Wait for the delayed stale response to actually be delivered before
+        // asserting it did not overwrite the newer counts.
+        await expect.poll(() => delayedRequestFulfilled, { timeout: 5_000 }).toBe(true);
         await expect(
           page1.locator('.room-count[data-room-count="general"]')
         ).toHaveText("1");

--- a/examples/chatrooms/priv/static/app.js
+++ b/examples/chatrooms/priv/static/app.js
@@ -40,12 +40,14 @@
   const msgInput = document.getElementById("msg-input");
   const sendBtn = document.getElementById("send-btn");
   const userList = document.getElementById("user-list");
+  const basePath = document.getElementById("app").dataset.basePath || "";
+  const roomsUrl = `${basePath}/api/rooms`;
 
   async function refreshRoomCounts() {
     const requestSequence = ++roomRefreshSequence;
 
     try {
-      const response = await fetch("/api/rooms");
+      const response = await fetch(roomsUrl);
       if (!response.ok) {
         throw new Error(`Room refresh failed with ${response.status}`);
       }

--- a/examples/chatrooms/priv/static/app.js
+++ b/examples/chatrooms/priv/static/app.js
@@ -16,6 +16,9 @@
   let myColor = null;
   let typingTimer = null;
   let isTyping = false;
+  let lobbyChannel = null;
+  let lobbyJoined = false;
+  let roomRefreshSequence = 0;
 
   // --- Username prompt ---
   const username = prompt("Choose a display name:", "User" + Math.floor(Math.random() * 1000)) || "Anonymous";
@@ -37,6 +40,51 @@
   const msgInput = document.getElementById("msg-input");
   const sendBtn = document.getElementById("send-btn");
   const userList = document.getElementById("user-list");
+
+  async function refreshRoomCounts() {
+    const requestSequence = ++roomRefreshSequence;
+
+    try {
+      const response = await fetch("/api/rooms");
+      if (!response.ok) {
+        throw new Error(`Room refresh failed with ${response.status}`);
+      }
+      const rooms = await response.json();
+      if (requestSequence !== roomRefreshSequence) return;
+      updateRoomCounts(rooms);
+    } catch (error) {
+      if (requestSequence === roomRefreshSequence) {
+        console.warn("Could not refresh room counts", error);
+      }
+    }
+  }
+
+  function updateRoomCounts(rooms) {
+    if (!Array.isArray(rooms)) return;
+
+    const counts = new Map();
+    for (const room of rooms) {
+      if (
+        room &&
+        typeof room.name === "string" &&
+        Number.isInteger(room.users) &&
+        room.users >= 0
+      ) {
+        counts.set(room.name, room.users);
+      }
+    }
+
+    document.querySelectorAll(".room-count").forEach((badge) => {
+      const roomName = badge.dataset.roomCount;
+      if (!counts.has(roomName)) return;
+      const users = counts.get(roomName);
+      badge.textContent = String(users);
+      badge.setAttribute(
+        "aria-label",
+        `${users} ${users === 1 ? "user" : "users"} in ${roomName}`
+      );
+    });
+  }
 
   // --- Room switching ---
   roomList.addEventListener("click", (e) => {
@@ -79,6 +127,9 @@
         mySocketId = resp.socket_id;
         myUsername = resp.username;
         myColor = resp.color;
+        if (lobbyJoined) {
+          refreshRoomCounts();
+        }
       })
       .receive("error", (resp) => {
         const msg = resp.error || resp.message || "Failed to join room";
@@ -243,11 +294,24 @@
     renderTypingIndicator();
   }, 1000);
 
-  // --- Auto-join first room ---
-  const firstRoom = document.querySelector(".room-item");
-  if (firstRoom) {
-    joinRoom(firstRoom.dataset.room);
+  // --- Lobby-first startup ---
+  function joinFirstRoom() {
+    const firstRoom = document.querySelector(".room-item");
+    if (firstRoom) {
+      joinRoom(firstRoom.dataset.room);
+    }
   }
+
+  lobbyChannel = socket.channel("lobby", {});
+  lobbyChannel.join()
+    .receive("ok", () => {
+      lobbyJoined = true;
+      joinFirstRoom();
+    })
+    .receive("error", (response) => {
+      console.warn("Failed to join lobby", response);
+      joinFirstRoom();
+    });
 
   // --- Utilities ---
   function escapeHtml(str) {

--- a/examples/chatrooms/priv/static/app.js
+++ b/examples/chatrooms/priv/static/app.js
@@ -303,6 +303,9 @@
   }
 
   lobbyChannel = socket.channel("lobby", {});
+  lobbyChannel.on("rooms_changed", () => {
+    refreshRoomCounts();
+  });
   lobbyChannel.join()
     .receive("ok", () => {
       lobbyJoined = true;

--- a/examples/chatrooms/priv/static/style.css
+++ b/examples/chatrooms/priv/static/style.css
@@ -73,6 +73,8 @@ body {
 }
 
 .room-name {
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/examples/chatrooms/priv/static/style.css
+++ b/examples/chatrooms/priv/static/style.css
@@ -45,6 +45,8 @@ body {
 }
 
 .room-item {
+  display: flex;
+  align-items: center;
   padding: 0.4rem 1rem;
   cursor: pointer;
   color: #96989d;
@@ -67,7 +69,30 @@ body {
 
 .room-hash {
   color: #96989d;
-  margin-right: 2px;
+  margin-right: 4px;
+}
+
+.room-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.room-count {
+  min-width: 1.5rem;
+  margin-left: auto;
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: #35373c;
+  color: #b5bac1;
+  font-size: 0.7rem;
+  line-height: 1.3;
+  text-align: center;
+}
+
+.room-item.active .room-count {
+  background: #2b2d31;
+  color: #fff;
 }
 
 .sidebar-footer {

--- a/examples/chatrooms/src/chatrooms/app.gleam
+++ b/examples/chatrooms/src/chatrooms/app.gleam
@@ -200,8 +200,8 @@ pub fn lobby_closed(_model: Lobby) -> List(Effect) {
   []
 }
 
-/// Socket-wide state for the standalone chatrooms server: one per-topic
-/// `Model` per joined `room:*` topic, keyed by topic.
+/// Socket-wide state for the standalone chatrooms server: the optional
+/// application lobby plus one `Model` per joined `room:*` topic.
 pub type Standalone {
   Standalone(
     socket_id: String,
@@ -218,9 +218,8 @@ pub fn standalone_init(
 }
 
 /// `update` for the standalone chatrooms app-dispatch runtime: route
-/// each event to the embeddable `join`/`update`/`closed` surface, keyed by
-/// topic. Non-`room:*` joins are rejected (fail closed), preserving the
-/// example's topic-namespace boundary.
+/// lobby events through the lobby callbacks and `room:*` events through the
+/// embeddable `join`/`update`/`closed` surface. Other joins are rejected.
 pub fn standalone_update(
   ctx: Ctx,
   model: Standalone,

--- a/examples/chatrooms/src/chatrooms/app.gleam
+++ b/examples/chatrooms/src/chatrooms/app.gleam
@@ -34,6 +34,11 @@ pub type Model {
   Model(username: String, color: String, room_name: String)
 }
 
+/// Per-socket state for the application-wide lobby topic.
+pub type Lobby {
+  Lobby
+}
+
 /// Dependencies shared by chat sockets.
 pub type Ctx {
   Ctx(presence: session_presence.Tracker, groups: Groups)
@@ -171,17 +176,41 @@ pub fn closed(
 
 // --- Standalone app-side dispatch wrapper ---
 
+/// Accept the application-wide `lobby` topic.
+pub fn lobby_join(ref: Ref) -> #(Lobby, List(Effect)) {
+  #(Lobby, [event.AcceptJoin(ref, None)])
+}
+
+/// The lobby is read-only; client events produce no effects.
+pub fn lobby_update(
+  model: Lobby,
+  _event_name: String,
+  _payload: Dynamic,
+  _ref: Option(Ref),
+) -> #(Lobby, List(Effect)) {
+  #(model, [])
+}
+
+/// Closing the lobby requires no external cleanup.
+pub fn lobby_closed(_model: Lobby) -> List(Effect) {
+  []
+}
+
 /// Socket-wide state for the standalone chatrooms server: one per-topic
 /// `Model` per joined `room:*` topic, keyed by topic.
 pub type Standalone {
-  Standalone(socket_id: String, rooms: Dict(String, Model))
+  Standalone(
+    socket_id: String,
+    rooms: Dict(String, Model),
+    lobby: Option(Lobby),
+  )
 }
 
 /// `init` for the standalone chatrooms app-dispatch runtime.
 pub fn standalone_init(
   info: event.ConnectInfo(Nil),
 ) -> #(Standalone, List(Effect)) {
-  #(Standalone(socket_id: info.socket_id, rooms: dict.new()), [])
+  #(Standalone(socket_id: info.socket_id, rooms: dict.new(), lobby: None), [])
 }
 
 /// `update` for the standalone chatrooms app-dispatch runtime: route
@@ -196,6 +225,10 @@ pub fn standalone_update(
   case ev {
     event.Join(topic, payload, ref) ->
       case topic {
+        "lobby" -> {
+          let #(lobby, effects) = lobby_join(ref)
+          event.Next(Standalone(..model, lobby: Some(lobby)), effects)
+        }
         "room:" <> _ -> {
           let #(joined, effects) =
             join(ctx, model.socket_id, topic, payload, ref)
@@ -218,26 +251,55 @@ pub fn standalone_update(
       }
 
     event.Message(topic, event_name, payload, ref) ->
-      case dict.get(model.rooms, topic) {
-        Ok(sub) -> {
-          let #(sub, effects) =
-            update(ctx, model.socket_id, topic, sub, event_name, payload, ref)
-          event.Next(
-            Standalone(..model, rooms: dict.insert(model.rooms, topic, sub)),
-            effects,
-          )
-        }
-        Error(Nil) -> event.Next(model, [])
+      case topic {
+        "lobby" ->
+          case model.lobby {
+            Some(lobby) -> {
+              let #(lobby, effects) =
+                lobby_update(lobby, event_name, payload, ref)
+              event.Next(Standalone(..model, lobby: Some(lobby)), effects)
+            }
+            None -> event.Next(model, [])
+          }
+        _ ->
+          case dict.get(model.rooms, topic) {
+            Ok(sub) -> {
+              let #(sub, effects) =
+                update(
+                  ctx,
+                  model.socket_id,
+                  topic,
+                  sub,
+                  event_name,
+                  payload,
+                  ref,
+                )
+              event.Next(
+                Standalone(..model, rooms: dict.insert(model.rooms, topic, sub)),
+                effects,
+              )
+            }
+            Error(Nil) -> event.Next(model, [])
+          }
       }
 
     event.Closed(topic, _reason) ->
-      case dict.get(model.rooms, topic) {
-        Ok(sub) ->
-          event.Next(
-            Standalone(..model, rooms: dict.delete(model.rooms, topic)),
-            closed(ctx, model.socket_id, topic, sub),
-          )
-        Error(Nil) -> event.Next(model, [])
+      case topic {
+        "lobby" ->
+          case model.lobby {
+            Some(lobby) ->
+              event.Next(Standalone(..model, lobby: None), lobby_closed(lobby))
+            None -> event.Next(model, [])
+          }
+        _ ->
+          case dict.get(model.rooms, topic) {
+            Ok(sub) ->
+              event.Next(
+                Standalone(..model, rooms: dict.delete(model.rooms, topic)),
+                closed(ctx, model.socket_id, topic, sub),
+              )
+            Error(Nil) -> event.Next(model, [])
+          }
       }
 
     event.Binary(_, _) | event.Info(_) -> event.Next(model, [])

--- a/examples/chatrooms/src/chatrooms/app.gleam
+++ b/examples/chatrooms/src/chatrooms/app.gleam
@@ -95,6 +95,7 @@ pub fn join(
             Some(Model(username: username, color: color, room_name: room_name)),
             [
               event.AcceptJoin(ref, Some(reply)),
+              event.Broadcast("lobby", "rooms_changed", room_changed(room_name)),
               event.Broadcast(topic, "new_msg", sys_payload),
             ],
           )
@@ -171,7 +172,10 @@ pub fn closed(
 ) -> List(Effect) {
   session_presence.untrack(ctx.presence, topic, socket_id)
   let sys_payload = system_message(model.username <> " left the room")
-  [event.Broadcast(topic, "new_msg", sys_payload)]
+  [
+    event.Broadcast("lobby", "rooms_changed", room_changed(model.room_name)),
+    event.Broadcast(topic, "new_msg", sys_payload),
+  ]
 }
 
 // --- Standalone app-side dispatch wrapper ---
@@ -348,6 +352,10 @@ fn system_message(text: String) -> json.Json {
     #("type", json.string("system")),
     #("timestamp", json.int(timestamp_ms())),
   ])
+}
+
+fn room_changed(room_name: String) -> json.Json {
+  json.object([#("room", json.string(room_name))])
 }
 
 /// Reply only when the client sent a ref (matching the channel-module

--- a/examples/chatrooms/src/chatrooms/router.gleam
+++ b/examples/chatrooms/src/chatrooms/router.gleam
@@ -101,7 +101,7 @@ fn index_page(ctx: Context) -> Response(ResponseData) {
   <link rel=\"stylesheet\" href=\"" <> ctx.base_path <> "/static/style.css\">
 </head>
 <body>
-  <div id=\"app\">
+  <div id=\"app\" data-base-path=\"" <> ctx.base_path <> "\">
     <nav id=\"rooms-sidebar\">
       <h2>Rooms</h2>
       <ul id=\"room-list\">" <> room_options <> "</ul>

--- a/examples/chatrooms/src/chatrooms/router.gleam
+++ b/examples/chatrooms/src/chatrooms/router.gleam
@@ -80,9 +80,15 @@ fn index_page(ctx: Context) -> Response(ResponseData) {
     |> list.map(fn(name) {
       "<li class=\"room-item\" data-room=\""
       <> name
-      <> "\"><span class=\"room-hash\">#</span> "
+      <> "\"><span class=\"room-hash\">#</span>"
+      <> "<span class=\"room-name\">"
       <> name
-      <> "</li>"
+      <> "</span>"
+      <> "<span class=\"room-count\" data-room-count=\""
+      <> name
+      <> "\" aria-label=\"User count unavailable for "
+      <> name
+      <> "\">–</span></li>"
     })
     |> string.join("")
 

--- a/examples/chatrooms/test/chatrooms_app_test.gleam
+++ b/examples/chatrooms/test/chatrooms_app_test.gleam
@@ -1,0 +1,114 @@
+import beryl/event
+import beryl/group
+import beryl/presence
+import chatrooms/app
+import gleam/dict
+import gleam/dynamic
+import gleam/json
+import gleam/option.{None, Some}
+import gleeunit/should
+
+fn context() -> app.Ctx {
+  let assert Ok(presence_handle) =
+    presence.start(presence.default_config("chatrooms-lobby-test"))
+  let assert Ok(groups) = group.start()
+  let assert Ok(_) = group.create(groups, "public")
+  let assert Ok(_) = group.add(groups, "public", "room:general")
+  app.Ctx(presence: presence_handle, groups: groups)
+}
+
+fn lobby_ref() -> event.Ref {
+  event.make_join_ref(
+    topic: "lobby",
+    join_ref: Some("lobby-join"),
+    msg_ref: Some("lobby-ref"),
+  )
+}
+
+fn room_ref(topic: String) -> event.Ref {
+  event.make_join_ref(
+    topic: topic,
+    join_ref: Some("room-join"),
+    msg_ref: Some("room-ref"),
+  )
+}
+
+fn empty_payload() -> dynamic.Dynamic {
+  dynamic.properties([])
+}
+
+fn connect_info() -> event.ConnectInfo(Nil) {
+  event.ConnectInfo(
+    socket_id: "socket-1",
+    seed: event.empty_seed(),
+    self: event.make_sender(fn(_message) { Nil }),
+  )
+}
+
+pub fn lobby_join_is_accepted_test() {
+  let #(model, effects) = app.lobby_join(lobby_ref())
+
+  model |> should.equal(app.Lobby)
+  let assert [event.AcceptJoin(_, None)] = effects
+}
+
+pub fn lobby_messages_are_ignored_test() {
+  let #(model, effects) =
+    app.lobby_update(app.Lobby, "refresh", empty_payload(), None)
+
+  model |> should.equal(app.Lobby)
+  effects |> should.equal([])
+}
+
+pub fn standalone_routes_lobby_join_test() {
+  let #(model, _) = app.standalone_init(connect_info())
+  let next =
+    app.standalone_update(
+      context(),
+      model,
+      event.Join("lobby", empty_payload(), lobby_ref()),
+    )
+
+  let assert event.Next(
+    app.Standalone(socket_id: _, rooms: _, lobby: Some(app.Lobby)),
+    [event.AcceptJoin(_, None)],
+  ) = next
+}
+
+pub fn closing_lobby_preserves_room_models_test() {
+  let room =
+    app.Model(username: "Alice", color: "#abcdef", room_name: "general")
+  let model =
+    app.Standalone(
+      socket_id: "socket-1",
+      rooms: dict.from_list([#("room:general", room)]),
+      lobby: Some(app.Lobby),
+    )
+
+  let next =
+    app.standalone_update(context(), model, event.Closed("lobby", event.Normal))
+
+  let assert event.Next(
+    app.Standalone(socket_id: _, rooms: rooms, lobby: None),
+    [],
+  ) = next
+  dict.has_key(rooms, "room:general") |> should.be_true
+}
+
+pub fn unrelated_topic_is_rejected_test() {
+  let #(model, _) = app.standalone_init(connect_info())
+  let next =
+    app.standalone_update(
+      context(),
+      model,
+      event.Join(
+        "notifications:alice",
+        empty_payload(),
+        room_ref("notifications:alice"),
+      ),
+    )
+
+  let assert event.Next(_, [event.RejectJoin(_, reason)]) = next
+  json.to_string(reason)
+  |> should.equal("{\"reason\":\"unknown_topic\"}")
+}

--- a/examples/chatrooms/test/chatrooms_app_test.gleam
+++ b/examples/chatrooms/test/chatrooms_app_test.gleam
@@ -60,6 +60,21 @@ pub fn lobby_messages_are_ignored_test() {
   effects |> should.equal([])
 }
 
+pub fn lobby_message_with_no_lobby_is_a_noop_test() {
+  let model =
+    app.Standalone(socket_id: "socket-1", rooms: dict.new(), lobby: None)
+
+  let assert event.Next(next_model, effects) =
+    app.standalone_update(
+      context(),
+      model,
+      event.Message("lobby", "refresh", empty_payload(), None),
+    )
+
+  next_model |> should.equal(model)
+  effects |> should.equal([])
+}
+
 pub fn standalone_routes_lobby_join_test() {
   let #(model, _) = app.standalone_init(connect_info())
   let next =

--- a/examples/chatrooms/test/chatrooms_app_test.gleam
+++ b/examples/chatrooms/test/chatrooms_app_test.gleam
@@ -112,3 +112,54 @@ pub fn unrelated_topic_is_rejected_test() {
   json.to_string(reason)
   |> should.equal("{\"reason\":\"unknown_topic\"}")
 }
+
+pub fn accepted_room_join_invalidates_lobby_after_presence_track_test() {
+  let #(joined, effects) =
+    app.join(
+      context(),
+      "socket-1",
+      "room:general",
+      dynamic.properties([
+        #(dynamic.string("username"), dynamic.string("Alice")),
+      ]),
+      room_ref("room:general"),
+    )
+
+  joined |> should.be_some
+  let assert [
+    event.AcceptJoin(_, _),
+    event.PresenceTrack("room:general", "Alice", _),
+    event.Broadcast("lobby", "rooms_changed", changed),
+    event.Broadcast("room:general", "new_msg", _),
+    event.BroadcastPresence("room:general", "presence_list", _),
+  ] = effects
+  json.to_string(changed) |> should.equal("{\"room\":\"general\"}")
+}
+
+pub fn rejected_room_join_does_not_invalidate_lobby_test() {
+  let #(joined, effects) =
+    app.join(
+      context(),
+      "socket-1",
+      "room:missing",
+      empty_payload(),
+      room_ref("room:missing"),
+    )
+
+  joined |> should.be_none
+  let assert [event.RejectJoin(_, _)] = effects
+}
+
+pub fn room_close_invalidates_lobby_after_presence_untrack_test() {
+  let model =
+    app.Model(username: "Alice", color: "#abcdef", room_name: "general")
+  let effects = app.closed(context(), "socket-1", "room:general", model)
+
+  let assert [
+    event.PresenceUntrack("room:general", "Alice"),
+    event.Broadcast("lobby", "rooms_changed", changed),
+    event.Broadcast("room:general", "new_msg", _),
+    event.BroadcastPresence("room:general", "presence_list", _),
+  ] = effects
+  json.to_string(changed) |> should.equal("{\"room\":\"general\"}")
+}

--- a/examples/chatrooms/test/chatrooms_app_test.gleam
+++ b/examples/chatrooms/test/chatrooms_app_test.gleam
@@ -1,7 +1,7 @@
 import beryl/event
 import beryl/group
-import beryl/presence
 import chatrooms/app
+import example_helpers/session_presence
 import gleam/dict
 import gleam/dynamic
 import gleam/json
@@ -9,12 +9,11 @@ import gleam/option.{None, Some}
 import gleeunit/should
 
 fn context() -> app.Ctx {
-  let assert Ok(presence_handle) =
-    presence.start(presence.default_config("chatrooms-lobby-test"))
+  let presence_tracker = session_presence.start()
   let assert Ok(groups) = group.start()
   let assert Ok(_) = group.create(groups, "public")
   let assert Ok(_) = group.add(groups, "public", "room:general")
-  app.Ctx(presence: presence_handle, groups: groups)
+  app.Ctx(presence: presence_tracker, groups: groups)
 }
 
 fn lobby_ref() -> event.Ref {
@@ -128,10 +127,12 @@ pub fn unrelated_topic_is_rejected_test() {
   |> should.equal("{\"reason\":\"unknown_topic\"}")
 }
 
-pub fn accepted_room_join_invalidates_lobby_after_presence_track_test() {
+pub fn accepted_room_join_tracks_session_and_invalidates_lobby_test() {
+  let ctx = context()
+  let app.Ctx(presence: tracker, groups: _) = ctx
   let #(joined, effects) =
     app.join(
-      context(),
+      ctx,
       "socket-1",
       "room:general",
       dynamic.properties([
@@ -143,11 +144,10 @@ pub fn accepted_room_join_invalidates_lobby_after_presence_track_test() {
   joined |> should.be_some
   let assert [
     event.AcceptJoin(_, _),
-    event.PresenceTrack("room:general", "Alice", _),
     event.Broadcast("lobby", "rooms_changed", changed),
     event.Broadcast("room:general", "new_msg", _),
-    event.BroadcastPresence("room:general", "presence_list", _),
   ] = effects
+  session_presence.count(tracker, "room:general") |> should.equal(1)
   json.to_string(changed) |> should.equal("{\"room\":\"general\"}")
 }
 
@@ -165,16 +165,18 @@ pub fn rejected_room_join_does_not_invalidate_lobby_test() {
   let assert [event.RejectJoin(_, _)] = effects
 }
 
-pub fn room_close_invalidates_lobby_after_presence_untrack_test() {
+pub fn room_close_untracks_session_and_invalidates_lobby_test() {
+  let ctx = context()
+  let app.Ctx(presence: tracker, groups: _) = ctx
+  session_presence.track(tracker, "room:general", "socket-1", json.object([]))
   let model =
     app.Model(username: "Alice", color: "#abcdef", room_name: "general")
-  let effects = app.closed(context(), "socket-1", "room:general", model)
+  let effects = app.closed(ctx, "socket-1", "room:general", model)
 
   let assert [
-    event.PresenceUntrack("room:general", "Alice"),
     event.Broadcast("lobby", "rooms_changed", changed),
     event.Broadcast("room:general", "new_msg", _),
-    event.BroadcastPresence("room:general", "presence_list", _),
   ] = effects
+  session_presence.count(tracker, "room:general") |> should.equal(0)
   json.to_string(changed) |> should.equal("{\"room\":\"general\"}")
 }

--- a/examples/chatrooms/test/chatrooms_test.gleam
+++ b/examples/chatrooms/test/chatrooms_test.gleam
@@ -1,0 +1,7 @@
+import gleeunit
+
+/// Test entrypoint: gleeunit discovers and runs every `*_test` module in
+/// this package.
+pub fn main() {
+  gleeunit.main()
+}

--- a/examples/showcase/e2e/showcase.spec.js
+++ b/examples/showcase/e2e/showcase.spec.js
@@ -154,6 +154,35 @@ test.describe("Showcase (app-side dispatch)", () => {
     expect(sysMsgIndex).toBeGreaterThan(ackIndex);
   });
 
+  test("chat lobby routes join, messages, and close independently", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const frames = await driveSocket(page, [
+      { send: ["1", "1", "lobby", "phx_join", {}] },
+      { waitReply: "1" },
+      {
+        send: ["2", "2", "room:general", "phx_join", {
+          username: "lobby-user",
+        }],
+      },
+      { waitReply: "2" },
+      { send: ["1", "3", "lobby", "refresh", {}] },
+      { send: ["1", "4", "lobby", "phx_leave", {}] },
+      { waitEvent: "phx_close", topic: "lobby" },
+      { send: ["2", "5", "room:general", "new_msg", { text: "still joined" }] },
+      { waitReply: "5" },
+    ]);
+
+    expect(replyStatus(repliesFor(frames, "1")[0])).toBe("ok");
+    expect(replyStatus(repliesFor(frames, "2")[0])).toBe("ok");
+    expect(replyStatus(repliesFor(frames, "5")[0])).toBe("ok");
+    expect(frames.filter((f) => f[3] === "phx_error")).toHaveLength(0);
+    expect(
+      frames.filter((f) => f[3] === "phx_close").map((f) => f[2])
+    ).toEqual(["lobby"]);
+  });
+
   test("chat page works end to end against the shared socket", async ({
     page,
   }) => {
@@ -170,6 +199,45 @@ test.describe("Showcase (app-side dispatch)", () => {
     await expect(
       page.locator("#messages").getByText("hello from the gate").first()
     ).toBeVisible();
+  });
+
+  test("chat page keeps live room counts under its mount", async ({
+    browser,
+  }) => {
+    const context1 = await browser.newContext();
+    const context2 = await browser.newContext();
+    const page1 = await context1.newPage();
+    const page2 = await context2.newPage();
+    const roomRequests = [];
+
+    page1.on("request", (request) => {
+      if (request.url().includes("/api/rooms")) {
+        roomRequests.push(new URL(request.url()).pathname);
+      }
+    });
+    page1.on("dialog", (dialog) => dialog.accept("showcase-observer"));
+    page2.on("dialog", (dialog) => dialog.accept("showcase-joiner"));
+
+    try {
+      await page1.goto("/chat");
+      await expect.poll(() => roomRequests).toContain("/chat/api/rooms");
+      await expect(
+        page1.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("1", { timeout: 10_000 });
+
+      await page2.goto("/chat");
+      await expect(
+        page1.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("2", { timeout: 10_000 });
+
+      await context2.close();
+      await expect(
+        page1.locator('.room-count[data-room-count="general"]')
+      ).toHaveText("1", { timeout: 10_000 });
+    } finally {
+      await context1.close();
+      await context2.close().catch(() => {});
+    }
   });
 
   test("cursors page joins its channel over the shared socket", async ({

--- a/examples/showcase/src/showcase.gleam
+++ b/examples/showcase/src/showcase.gleam
@@ -27,7 +27,7 @@ import gleam/erlang/process
 import gleam/int
 import gleam/io
 import gleam/json
-import gleam/option.{None, Some}
+import gleam/option.{type Option, None, Some}
 import gleam/otp/static_supervisor
 import gleam/result
 import mist
@@ -40,6 +40,7 @@ type Model {
     socket_id: String,
     cursors: Dict(String, cursors_app.Model),
     rooms: Dict(String, chat_app.Model),
+    lobby: Option(chat_app.Lobby),
     docs: Dict(String, docs_app.Model),
   )
 }
@@ -89,6 +90,7 @@ pub fn main() {
             socket_id: info.socket_id,
             cursors: dict.new(),
             rooms: dict.new(),
+            lobby: None,
             docs: dict.new(),
           ),
           [],
@@ -164,6 +166,10 @@ fn update(ctx: Ctx, model: Model, ev: Event(Nil)) -> Next(Model, Nil) {
   case ev {
     event.Join(topic, payload, ref) ->
       case topic {
+        "lobby" -> {
+          let #(lobby, effects) = chat_app.lobby_join(ref)
+          event.Next(Model(..model, lobby: Some(lobby)), effects)
+        }
         "cursor:" <> _ -> {
           let #(joined, effects) =
             cursors_app.join(ctx.cursors, model.socket_id, topic, payload, ref)
@@ -190,6 +196,15 @@ fn update(ctx: Ctx, model: Model, ev: Event(Nil)) -> Next(Model, Nil) {
 
     event.Message(topic, event_name, payload, ref) ->
       case topic {
+        "lobby" ->
+          case model.lobby {
+            Some(lobby) -> {
+              let #(lobby, effects) =
+                chat_app.lobby_update(lobby, event_name, payload, ref)
+              event.Next(Model(..model, lobby: Some(lobby)), effects)
+            }
+            None -> event.Next(model, [])
+          }
         "cursor:" <> _ ->
           case dict.get(model.cursors, topic) {
             Ok(sub) -> {
@@ -245,6 +260,15 @@ fn update(ctx: Ctx, model: Model, ev: Event(Nil)) -> Next(Model, Nil) {
 
     event.Closed(topic, _reason) ->
       case topic {
+        "lobby" ->
+          case model.lobby {
+            Some(lobby) ->
+              event.Next(
+                Model(..model, lobby: None),
+                chat_app.lobby_closed(lobby),
+              )
+            None -> event.Next(model, [])
+          }
         "cursor:" <> _ ->
           case dict.get(model.cursors, topic) {
             Ok(sub) ->


### PR DESCRIPTION
## Purpose
Add a persistent chatrooms lobby with live room counts.

## Provenance and split notes
Source PR #220; source commit(s): `09311403, fd886ac7, 96bf4caa, 5c24122a, 38be8d4f, 7f4af1ca, ee6cd2e3, e50979de`. Replays the lobby stream with mounted-route and count-invalidation correctness fixes.
