### PR TITLE
feat(beryl): split frame and message rate limits

### DIFF
--- a/.changes/unreleased/beryl-1.toml
+++ b/.changes/unreleased/beryl-1.toml
@@ -1,0 +1,3 @@
+project = "beryl"
+kind = "Fixed"
+body = "Non-positive with_topic_rate overrides now disable limiting for matching topics without allocating per-topic buckets, while valid positive overrides still take precedence over the global channel rate."

--- a/.changes/unreleased/beryl-frame-message-rate-split.toml
+++ b/.changes/unreleased/beryl-frame-message-rate-split.toml
@@ -1,0 +1,3 @@
+project = "beryl"
+kind = "Changed"
+body = "Split per-connection frame-rate limiting (new with_frame_rate, enforced at the transport edge before decoding) from per-socket message-rate limiting (with_message_rate, now runtime-only after successful decode). The two buckets are independent with no fallback: frame_rate counts every inbound frame including malformed ones, joins, leaves, and heartbeats; message_rate counts only successfully decoded non-join envelopes (leaves, heartbeats, decoded events including semantically invalid ones, decoded and raw binary). Joins never consume message_rate; configure both when you need edge-level flood shedding plus a runtime cap on decoded traffic."

--- a/README.md
+++ b/README.md
@@ -254,9 +254,10 @@ either:
 
 In both cases the transport's receive buffer grows unbounded *before* Beryl's
 frame-size check ever runs. **Beryl's per-IP connection limit
-(`with_max_connections_per_ip`) and per-socket message-rate limit
-(`with_message_rate`) do not mitigate this vector** — the buffer grows within a
-single admitted connection and before any message is emitted to a channel.
+(`with_max_connections_per_ip`), per-connection frame-rate limit
+(`with_frame_rate`), and per-socket message-rate limit (`with_message_rate`)
+do not mitigate this vector** — all run post-assembly, so the buffer grows
+within one admitted connection before dispatch.
 
 To bound transport memory in production you **must** place an edge proxy or
 load balancer (e.g. nginx, HAProxy, Envoy, or your cloud LB) in front of Beryl

--- a/examples/chatrooms/src/chatrooms.gleam
+++ b/examples/chatrooms/src/chatrooms.gleam
@@ -30,6 +30,7 @@ pub fn main() {
   // Rate limiting matches the previous channel-module deployment.
   let config =
     beryl.config(wire.phoenix_codec())
+    |> beryl.with_frame_rate(per_second: 30, burst: 60)
     |> beryl.with_message_rate(per_second: 30, burst: 60)
     |> beryl.with_join_rate(per_second: 5, burst: 10)
     |> beryl.with_channel_rate(per_second: 10, burst: 20)

--- a/examples/cursors/src/cursors.gleam
+++ b/examples/cursors/src/cursors.gleam
@@ -21,6 +21,7 @@ pub fn main() {
   // Rate limiting for cursor events.
   let config =
     beryl.config(wire.phoenix_codec())
+    |> beryl.with_frame_rate(per_second: 30, burst: 60)
     |> beryl.with_message_rate(per_second: 30, burst: 60)
 
   let assert Ok(#(channels, beryl_spec)) =

--- a/examples/showcase/src/showcase.gleam
+++ b/examples/showcase/src/showcase.gleam
@@ -72,8 +72,11 @@ pub fn main() {
 
   // Per-topic-pattern rate limits replace the old single global
   // channel-rate compromise: cursors stream fast, chat and docs do not.
+  // with_frame_rate covers the transport edge (every inbound frame,
+  // pre-decode) since with_message_rate alone no longer sheds floods there.
   let config =
     beryl.config(wire.phoenix_codec())
+    |> beryl.with_frame_rate(per_second: 30, burst: 60)
     |> beryl.with_message_rate(per_second: 30, burst: 60)
     |> beryl.with_join_rate(per_second: 5, burst: 10)
     |> beryl.with_topic_rate(pattern: "cursor:*", per_second: 30, burst: 60)

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -126,7 +126,14 @@ pub opaque type Config {
     max_connections: Int,
     /// Optional PubSub for distributed broadcasts across nodes
     pubsub: Option(PubSub(json.Json)),
-    /// Per-socket message rate limit (messages/sec, 0 = unlimited)
+    /// Per-connection inbound frame rate limit (frames/sec, 0 = unlimited).
+    /// Enforced at the transport edge before decoding; every complete text
+    /// or binary frame consumes a token, including malformed frames and joins.
+    frame_rate: Int,
+    /// Per-connection frame burst capacity (0 = defaults to frame_rate)
+    frame_burst: Int,
+    /// Per-socket decoded message rate limit (messages/sec, 0 = unlimited).
+    /// Enforced by the runtime for non-join envelopes after decode.
     message_rate: Int,
     /// Per-socket message burst capacity (0 = defaults to message_rate)
     message_burst: Int,
@@ -193,6 +200,8 @@ pub fn config(codec: codec.Codec) -> Config {
     max_connections_per_ip: 0,
     max_connections: 0,
     pubsub: None,
+    frame_rate: 0,
+    frame_burst: 0,
     message_rate: 0,
     message_burst: 0,
     join_rate: 0,
@@ -328,7 +337,24 @@ pub fn with_payload_preview_bytes(
   LoggingConfig(..logging, payload_preview_bytes: int.max(bytes, 0))
 }
 
-/// Configure per-socket message rate limiting
+/// Configure per-connection frame-rate limiting at the transport edge.
+///
+/// Every complete inbound text or binary frame consumes this independent
+/// bucket before decoding. Configure it alongside `with_message_rate` to
+/// combine edge shedding with a runtime cap on decoded non-join traffic.
+pub fn with_frame_rate(
+  config: Config,
+  per_second rate: Int,
+  burst burst: Int,
+) -> Config {
+  Config(..config, frame_rate: rate, frame_burst: burst)
+}
+
+/// Configure per-socket decoded message-rate limiting in the runtime.
+///
+/// Joins use `with_join_rate`; decoded leaves, heartbeats, events, decoded
+/// binary, and raw `Binary` inputs consume this bucket. It is independent of
+/// `with_frame_rate`.
 pub fn with_message_rate(
   config: Config,
   per_second rate: Int,
@@ -409,9 +435,9 @@ pub fn with_max_event_length(
 ///
 /// For a true transport memory bound you **must** place an edge proxy or load
 /// balancer in front of Beryl and configure a WebSocket frame-size limit
-/// there (and a matching request/body size limit). Beryl's per-IP connection
-/// limit and per-socket message-rate limit do not mitigate this vector. See
-/// the README's "Security" section for deployment guidance.
+/// there (and a matching request/body size limit). Beryl's connection,
+/// frame-rate, and message-rate limits all run after frame assembly and do not
+/// mitigate this vector. See the README's "Security" section.
 ///
 /// Values <= 0 disable the cap. The default is 1 MiB.
 pub fn with_max_inbound_frame_bytes(
@@ -443,6 +469,7 @@ pub fn warn_if_unprotected(config: Config) -> Nil {
   let unprotected =
     config.max_connections_per_ip <= 0
     && config.max_connections <= 0
+    && config.frame_rate <= 0
     && config.message_rate <= 0
     && config.join_rate <= 0
     && config.channel_rate <= 0
@@ -452,9 +479,9 @@ pub fn warn_if_unprotected(config: Config) -> Nil {
     #(
       "hint",
       "rate and connection limits are all disabled; fine for development, "
-        <> "but for production configure with_message_rate, with_join_rate, "
-        <> "with_max_connections_per_ip, and with_max_connections (see the "
-        <> "production hardening guide)",
+        <> "but for production configure with_frame_rate, with_message_rate, "
+        <> "with_join_rate, with_max_connections_per_ip, and "
+        <> "with_max_connections (see the production hardening guide)",
     ),
   ])
 }
@@ -468,14 +495,12 @@ fn optional_limits(
   Some(rate_limit.config(per_second: rate, burst: burst))
 }
 
-/// Per-socket message rate limits for transports, `None` when unlimited.
+/// Per-connection frame rate limits for transports, `None` when unlimited.
 ///
-/// Transports enforce this with a local token bucket per connection so
-/// flooded sockets are shed at the edge, before frames are decoded or
-/// enqueued on the runtime.
+/// This edge bucket is independent of the runtime's message-rate bucket.
 @internal
-pub fn message_limits(channels: Sockets) -> Option(rate_limit.RateLimitConfig) {
-  optional_limits(channels.config.message_rate, channels.config.message_burst)
+pub fn frame_limits(channels: Sockets) -> Option(rate_limit.RateLimitConfig) {
+  optional_limits(channels.config.frame_rate, channels.config.frame_burst)
 }
 
 /// Runtime system handle.

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -167,8 +167,9 @@ pub opaque type Config {
     /// Logging configuration for Beryl diagnostics
     logging: LoggingConfig,
     /// Per-topic-pattern message rate limits (app-dispatch systems only).
-    /// Ordered; the first matching pattern wins.
-    topic_rates: List(#(String, rate_limit.RateLimitConfig)),
+    /// Ordered; the first matching pattern wins. `None` is an explicit
+    /// unlimited override for that pattern.
+    topic_rates: List(#(String, Option(rate_limit.RateLimitConfig))),
   )
 }
 
@@ -226,7 +227,9 @@ pub fn config(codec: codec.Codec) -> Config {
 /// `"document:*:ops"`, `"*"`). Limits are consulted in the order they were
 /// added and the first matching pattern wins; topics matching no pattern
 /// fall back to the global `with_channel_rate` limit. The limiter applies
-/// only after a socket has joined the topic.
+/// only after a socket has joined the topic. A non-positive `per_second`
+/// explicitly disables limiting for matching topics, including any global
+/// channel limit, and allocates no bucket.
 pub fn with_topic_rate(
   config: Config,
   pattern pattern: String,
@@ -236,7 +239,7 @@ pub fn with_topic_rate(
   Config(
     ..config,
     topic_rates: list.append(config.topic_rates, [
-      #(pattern, rate_limit.config(per_second: rate, burst: burst)),
+      #(pattern, optional_limits(rate, burst)),
     ]),
   )
 }

--- a/packages/beryl/src/beryl/runtime.gleam
+++ b/packages/beryl/src/beryl/runtime.gleam
@@ -680,7 +680,14 @@ fn dispatch_inbound(
       }
     }
     codec.Leave -> {
-      use state <- with_message_rate_limit(state, socket_id, "leave")
+      let started_at = telemetry_start(state)
+      use state <- with_message_rate_limit(
+        state,
+        socket_id,
+        [#("kind", "leave")],
+        started_at,
+        message_kind,
+      )
       case is_valid_topic(msg_topic, state.config) {
         False -> {
           state.logger
@@ -702,35 +709,34 @@ fn dispatch_inbound(
     }
     codec.Heartbeat -> {
       let started_at = telemetry_start(state)
-      let #(state, allowed) = check_message_rate(state, socket_id)
-      case allowed {
-        False -> {
-          state.logger
-          |> log.warn("Message rate limited", [
-            #("socket_id", socket_id),
-            #("kind", "heartbeat"),
-          ])
-          emit_message_stop(
-            state,
-            started_at,
-            telemetry.HeartbeatMessage,
-            telemetry.MessageRateLimited,
-            telemetry.NotApplicable,
-          )
-          actor.continue(state)
-        }
-        True -> handle_heartbeat(state, socket_id, msg_ref, started_at)
-      }
+      use state <- with_message_rate_limit(
+        state,
+        socket_id,
+        [#("kind", "heartbeat")],
+        started_at,
+        telemetry.HeartbeatMessage,
+      )
+      handle_heartbeat(state, socket_id, msg_ref, started_at)
     }
     codec.Event(event_name) -> {
       let started_at = telemetry_start(state)
+      use state <- with_message_rate_limit(
+        state,
+        socket_id,
+        [
+          #("topic", topic.sanitize_for_log(msg_topic)),
+          #("event", topic.sanitize_for_log(event_name)),
+        ],
+        started_at,
+        message_kind,
+      )
       let resolved = resolve_event_topic(state, socket_id, msg_topic)
       case
         is_valid_topic(resolved, state.config),
         is_valid_event(event_name, state.config)
       {
         True, True ->
-          handle_in(
+          handle_in_subscribed(
             state,
             socket_id,
             resolved,
@@ -819,12 +825,13 @@ fn is_valid_event(event_name: String, config: Config) -> Bool {
   && result.is_ok(topic.validate_event(event_name))
 }
 
-/// Apply the per-socket message limiter to protocol frames (heartbeat,
-/// leave) so flooding them cannot bypass `with_message_rate`.
+/// Apply the per-socket decoded-message limiter before semantic validation.
 fn with_message_rate_limit(
   state: State(model, msg),
   socket_id: String,
-  kind: String,
+  metadata: List(#(String, String)),
+  started_at: Int,
+  kind: telemetry.MessageKind,
   next: fn(State(model, msg)) -> actor.Next(State(model, msg), Msg(msg)),
 ) -> actor.Next(State(model, msg), Msg(msg)) {
   let #(state, allowed) = check_message_rate(state, socket_id)
@@ -833,8 +840,15 @@ fn with_message_rate_limit(
       state.logger
       |> log.warn("Message rate limited", [
         #("socket_id", socket_id),
-        #("kind", kind),
+        ..metadata
       ])
+      emit_message_stop(
+        state,
+        started_at,
+        kind,
+        telemetry.MessageRateLimited,
+        telemetry.NotApplicable,
+      )
       actor.continue(state)
     }
     True -> next(state)
@@ -1099,49 +1113,6 @@ fn joined_ref(
 }
 
 // ── Client messages ─────────────────────────────────────────────────────────
-
-fn handle_in(
-  state: State(model, msg),
-  socket_id: String,
-  topic_name: String,
-  event_name: String,
-  payload: Dynamic,
-  msg_join_ref: Option(String),
-  ref: Option(String),
-  started_at: Int,
-  kind: telemetry.MessageKind,
-) -> actor.Next(State(model, msg), Msg(msg)) {
-  let #(state, allowed) = check_message_rate(state, socket_id)
-  case allowed {
-    False -> {
-      state.logger
-      |> log.warn("Message rate limited", [
-        #("socket_id", socket_id),
-        #("topic", topic_name),
-      ])
-      emit_message_stop(
-        state,
-        started_at,
-        kind,
-        telemetry.MessageRateLimited,
-        telemetry.NotApplicable,
-      )
-      actor.continue(state)
-    }
-    True ->
-      handle_in_subscribed(
-        state,
-        socket_id,
-        topic_name,
-        event_name,
-        payload,
-        msg_join_ref,
-        ref,
-        started_at,
-        kind,
-      )
-  }
-}
 
 fn handle_in_subscribed(
   state: State(model, msg),

--- a/packages/beryl/src/beryl/runtime.gleam
+++ b/packages/beryl/src/beryl/runtime.gleam
@@ -684,7 +684,7 @@ fn dispatch_inbound(
       use state <- with_message_rate_limit(
         state,
         socket_id,
-        [#("kind", "leave")],
+        fn() { [#("kind", "leave")] },
         started_at,
         message_kind,
       )
@@ -712,7 +712,7 @@ fn dispatch_inbound(
       use state <- with_message_rate_limit(
         state,
         socket_id,
-        [#("kind", "heartbeat")],
+        fn() { [#("kind", "heartbeat")] },
         started_at,
         telemetry.HeartbeatMessage,
       )
@@ -723,10 +723,12 @@ fn dispatch_inbound(
       use state <- with_message_rate_limit(
         state,
         socket_id,
-        [
-          #("topic", topic.sanitize_for_log(msg_topic)),
-          #("event", topic.sanitize_for_log(event_name)),
-        ],
+        fn() {
+          [
+            #("topic", topic.sanitize_for_log(msg_topic)),
+            #("event", topic.sanitize_for_log(event_name)),
+          ]
+        },
         started_at,
         message_kind,
       )
@@ -825,11 +827,12 @@ fn is_valid_event(event_name: String, config: Config) -> Bool {
   && result.is_ok(topic.validate_event(event_name))
 }
 
-/// Apply the per-socket decoded-message limiter before semantic validation.
+/// Apply the decoded-message limiter before semantic validation. Metadata is
+/// built only on the over-rate path, and attacker-driven drops log at debug.
 fn with_message_rate_limit(
   state: State(model, msg),
   socket_id: String,
-  metadata: List(#(String, String)),
+  metadata: fn() -> List(#(String, String)),
   started_at: Int,
   kind: telemetry.MessageKind,
   next: fn(State(model, msg)) -> actor.Next(State(model, msg), Msg(msg)),
@@ -838,9 +841,9 @@ fn with_message_rate_limit(
   case allowed {
     False -> {
       state.logger
-      |> log.warn("Message rate limited", [
+      |> log.debug("Message rate limited", [
         #("socket_id", socket_id),
-        ..metadata
+        ..metadata()
       ])
       emit_message_stop(
         state,
@@ -1443,7 +1446,8 @@ fn handle_binary_in(
 }
 
 /// Rate-limit and fan an undecoded binary frame out to each joined topic.
-/// The frame keeps binary telemetry classification throughout the fan-out.
+/// The frame keeps binary telemetry classification; attacker-driven drops
+/// log at debug to avoid warning-level amplification.
 fn handle_undecoded_binary_in(
   state: State(model, msg),
   socket_id: String,
@@ -1454,7 +1458,7 @@ fn handle_undecoded_binary_in(
   case allowed, dict.get(state.sockets, socket_id) {
     False, _ -> {
       state.logger
-      |> log.warn("Binary message rate limited", [#("socket_id", socket_id)])
+      |> log.debug("Binary message rate limited", [#("socket_id", socket_id)])
       emit_message_stop(
         state,
         started_at,

--- a/packages/beryl/src/beryl/runtime.gleam
+++ b/packages/beryl/src/beryl/runtime.gleam
@@ -49,8 +49,9 @@ pub type Config {
     channel_limits: Option(RateLimitConfig),
     channel_limiter_max_keys_per_socket: Int,
     /// Per-topic-pattern message rate limits. The first matching pattern
-    /// wins; topics matching no pattern fall back to `channel_limits`.
-    topic_rates: List(#(TopicPattern, RateLimitConfig)),
+    /// wins; `None` disables limiting for a matching pattern, while topics
+    /// matching no pattern fall back to `channel_limits`.
+    topic_rates: List(#(TopicPattern, Option(RateLimitConfig))),
     max_topic_length: Int,
     max_event_length: Int,
     max_joined_topics_per_socket: Int,
@@ -2569,7 +2570,7 @@ fn resolve_channel_limits(
       topic.matches(entry.0, topic_name)
     })
   {
-    Ok(#(_pattern, limits)) -> Some(limits)
+    Ok(#(_pattern, limits)) -> limits
     Error(Nil) -> config.channel_limits
   }
 }

--- a/packages/beryl/src/beryl/transport/server.gleam
+++ b/packages/beryl/src/beryl/transport/server.gleam
@@ -5,7 +5,7 @@
 //// its builders, the upgrade admission pipeline (path matching, origin
 //// policy, `?vsn` negotiation, connection limits, `on_connect`
 //// authentication), per-connection lifecycle choreography, and the inbound
-//// frame pipeline (size caps, rate limiting, decoding, routing).
+//// frame pipeline (size caps, frame-rate limiting, decoding, routing).
 ////
 //// Transport packages such as `beryl_mist` and `beryl_ewe` supply only the
 //// server-specific glue: the WebSocket upgrade call, frame sending, and peer
@@ -419,10 +419,10 @@ pub opaque type ConnectionState {
     /// runtime.
     codec: Codec,
     telemetry: transport.Telemetry,
-    /// Per-connection message-rate limiter (`None` = unlimited).
-    /// Enforced at the edge: frames over the rate are shed before decode,
-    /// so a flooding socket cannot fill the runtime's mailbox.
-    message_limiter: Option(rate_limit.Bucket),
+    /// Per-connection frame-rate limiter (`None` = unlimited).
+    /// Every complete text or binary frame consumes this bucket before decode.
+    /// It is independent of the runtime's decoded-message limiter.
+    frame_limiter: Option(rate_limit.Bucket),
     logger: log.Logger,
   )
 }
@@ -526,7 +526,7 @@ pub fn init_connection(
       max_inbound_frame_bytes: beryl.max_inbound_frame_bytes(sockets),
       codec: option.unwrap(socket_codec, beryl.configured_codec(sockets)),
       telemetry: telemetry,
-      message_limiter: beryl.message_limits(sockets)
+      frame_limiter: beryl.frame_limits(sockets)
         |> option.map(rate_limit.new_bucket),
       logger: internal.logger(logger_name),
     )
@@ -671,7 +671,7 @@ fn admit_frame(
       Stop
     },
   )
-  let #(state, allowed) = take_message_token(state)
+  let #(state, allowed) = take_frame_token(state)
   use <- bool.lazy_guard(when: !allowed, return: fn() {
     emit_frame_stop(state, started_at, bytes, kind, transport.FrameRateLimited)
     Continue(state)
@@ -695,15 +695,15 @@ fn emit_frame_stop(
   )
 }
 
-/// Take a token from the connection's message limiter; always allowed when
-/// no message rate is configured.
-fn take_message_token(state: ConnectionState) -> #(ConnectionState, Bool) {
-  case state.message_limiter {
+/// Take a token from the connection's frame limiter; always allowed when
+/// no frame rate is configured.
+fn take_frame_token(state: ConnectionState) -> #(ConnectionState, Bool) {
+  case state.frame_limiter {
     None -> #(state, True)
     Some(bucket) -> {
       let #(bucket, taken) = rate_limit.take(bucket)
       #(
-        ConnectionState(..state, message_limiter: Some(bucket)),
+        ConnectionState(..state, frame_limiter: Some(bucket)),
         result.is_ok(taken),
       )
     }

--- a/packages/beryl/test/app_abuse_test.gleam
+++ b/packages/beryl/test/app_abuse_test.gleam
@@ -1,13 +1,20 @@
 //// Abuse controls for app-side dispatch: the join-rate limiter rejects
-//// excess joins, the message-rate limiter sheds flooded messages and
-//// protocol frames, the per-socket topic cap rejects extra joins, and the
+//// excess joins, the message-rate limiter (runtime, post-decode) sheds
+//// flooded messages and protocol frames without ever consuming a token for
+//// joins, the per-socket topic cap rejects extra joins, and the
 //// channel-rate bucket cap bounds the number of distinct topic buckets a
 //// socket may allocate (recovering when a topic closes, isolated per socket).
+//// These tests drive the runtime directly through `transport.route_decoded`
+//// (via the `app_test_helpers` wrappers), the same path any transport uses
+//// after decoding a frame; frame-rate edge admission is covered separately
+//// in `transport_server_rate_test.gleam`.
 
 import app_test_helpers as h
 import beryl
 import beryl/socket.{Join, Message}
+import beryl/transport
 import beryl/wire
+import beryl/wire/codec
 import gleam/erlang/process
 import gleam/int
 import gleam/string
@@ -65,8 +72,8 @@ pub fn message_rate_limit_sheds_flood_test() {
   let frames = h.connect(channels, "s1")
   join_ok(channels, events, frames, "s1", "room:a", "jr-1")
 
-  // Burst of 1: the first message is delivered, the second is shed at the
-  // transport edge.
+  // Burst of 1: the first message is delivered, the second is shed by the
+  // runtime's message-rate limiter (post-decode).
   h.push(channels, "s1", "room:a", "msg", "r-2")
   h.push(channels, "s1", "room:a", "msg", "r-3")
   let assert Ok(Message("room:a", "msg", _, _)) = process.receive(events, 500)
@@ -88,6 +95,81 @@ pub fn heartbeat_flood_is_message_rate_limited_test() {
   let reply = h.recv(frames)
   reply |> string.contains("hb-1") |> should.be_true
   h.recv_none(frames)
+}
+
+pub fn joins_do_not_consume_message_rate_token_test() {
+  // Regression: joins never touch the message-rate bucket. A message-rate
+  // burst of exactly 1 stays fully available after two joins, so it still
+  // gates on the first post-join message rather than being pre-spent.
+  let events = process.new_subject()
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_message_rate(per_second: 1, burst: 1)
+  let channels = h.start_observed(config, events)
+  let frames = h.connect(channels, "s1")
+  join_ok(channels, events, frames, "s1", "room:a", "jr-1")
+  join_ok(channels, events, frames, "s1", "room:b", "jr-2")
+
+  // The single message token is still available: the first message lands.
+  h.push(channels, "s1", "room:a", "msg", "r-1")
+  let assert Ok(Message("room:a", "msg", _, _)) = process.receive(events, 500)
+
+  // The second message spends the token the joins never touched.
+  h.push(channels, "s1", "room:b", "msg", "r-2")
+  process.receive(events, 100) |> should.be_error
+}
+
+pub fn invalid_decoded_event_consumes_message_rate_token_test() {
+  // Regression: a decoded event with a semantically invalid topic/event
+  // still consumes a message-rate token, even though it never reaches the
+  // app. With a burst of 1, the invalid envelope spends the only token, so
+  // a following valid message is shed too.
+  let events = process.new_subject()
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_message_rate(per_second: 1, burst: 1)
+  let channels = h.start_observed(config, events)
+  let frames = h.connect(channels, "s1")
+  join_ok(channels, events, frames, "s1", "room:a", "jr-1")
+
+  // A control-character topic on a Message frame is decoded successfully
+  // but rejected as an invalid topic before dispatch.
+  h.route(
+    channels,
+    "s1",
+    "[null,\"r-bad\",\"room:\\nbad\",\"client_event\",{}]",
+  )
+  // The valid follow-up message finds the bucket already spent.
+  h.push(channels, "s1", "room:a", "msg", "r-good")
+  process.receive(events, 200) |> should.be_error
+}
+
+pub fn direct_route_decoded_enforces_message_rate_test() {
+  // `beryl/transport.route_decoded` is the direct SPI entry a custom
+  // transport calls after decoding a frame itself; it goes through the
+  // same runtime message-rate enforcement as the `app_test_helpers.route`
+  // wrapper used elsewhere in this file (which forwards to it).
+  let events = process.new_subject()
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_message_rate(per_second: 1, burst: 1)
+  let channels = h.start_observed(config, events)
+  let frames = h.connect(channels, "s1")
+  join_ok(channels, events, frames, "s1", "room:a", "jr-1")
+
+  let assert Ok(first) =
+    codec.decode_text(transport.active_codec(channels))(
+      "[null,\"r-1\",\"room:a\",\"msg\",{}]",
+    )
+  transport.route_decoded(channels, "s1", first)
+  let assert Ok(Message("room:a", "msg", _, _)) = process.receive(events, 500)
+
+  let assert Ok(second) =
+    codec.decode_text(transport.active_codec(channels))(
+      "[null,\"r-2\",\"room:a\",\"msg\",{}]",
+    )
+  transport.route_decoded(channels, "s1", second)
+  process.receive(events, 100) |> should.be_error
 }
 
 // ── Per-socket topic cap ─────────────────────────────────────────────────────

--- a/packages/beryl/test/app_binary_test.gleam
+++ b/packages/beryl/test/app_binary_test.gleam
@@ -77,7 +77,7 @@ pub fn raw_binary_consumes_one_message_rate_token_test() {
   let channels =
     start_with(
       beryl.config(text_only_codec())
-        |> beryl.with_message_rate(per_second: 100, burst: 1),
+        |> beryl.with_message_rate(per_second: 1, burst: 1),
       events,
     )
   let frames = h.connect(channels, "s1")

--- a/packages/beryl/test/app_binary_test.gleam
+++ b/packages/beryl/test/app_binary_test.gleam
@@ -11,6 +11,7 @@ import beryl/wire
 import beryl/wire/codec
 import gleam/erlang/process
 import gleeunit
+import gleeunit/should
 
 pub fn main() {
   gleeunit.main()
@@ -30,7 +31,14 @@ fn text_only_codec() -> codec.Codec {
 }
 
 fn start_system(events: process.Subject(socket.Input(Nil))) -> beryl.Sockets {
-  h.start_observed(beryl.config(text_only_codec()), events)
+  start_with(beryl.config(text_only_codec()), events)
+}
+
+fn start_with(
+  config: beryl.Config,
+  events: process.Subject(socket.Input(Nil)),
+) -> beryl.Sockets {
+  h.start_observed(config, events)
 }
 
 pub fn raw_binary_fans_out_to_joined_topics_in_sorted_order_test() {
@@ -59,4 +67,29 @@ pub fn binary_to_unjoined_socket_is_dropped_test() {
   transport.route_binary(channels, "s1", <<1, 2, 3>>)
 
   let assert Error(Nil) = process.receive(events, 100)
+}
+
+pub fn raw_binary_consumes_one_message_rate_token_test() {
+  // Regression: raw binary delivered as an application `Binary` input
+  // (codec has no binary decoder) consumes the runtime's message-rate
+  // bucket exactly like a decoded text event does.
+  let events = process.new_subject()
+  let channels =
+    start_with(
+      beryl.config(text_only_codec())
+        |> beryl.with_message_rate(per_second: 100, burst: 1),
+      events,
+    )
+  let frames = h.connect(channels, "s1")
+  h.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _join_reply = h.recv(frames)
+  let assert Ok(Join(_, _, _)) = process.receive(events, 500)
+
+  // The first raw binary frame spends the single token and fans out.
+  transport.route_binary(channels, "s1", <<1, 2, 3>>)
+  let assert Ok(Binary("room:a", <<1, 2, 3>>)) = process.receive(events, 500)
+
+  // The second is shed by the runtime's message limiter.
+  transport.route_binary(channels, "s1", <<4, 5, 6>>)
+  process.receive(events, 100) |> should.be_error
 }

--- a/packages/beryl/test/app_lifecycle_test.gleam
+++ b/packages/beryl/test/app_lifecycle_test.gleam
@@ -68,6 +68,20 @@ pub fn start_rejects_invalid_config_test() {
   |> should.equal(Error(beryl.HeartbeatTimeoutTooLow(2)))
 }
 
+pub fn validate_config_rejects_invalid_disabled_topic_pattern_test() {
+  let bad = "room:" <> control_char
+  let result =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_topic_rate(pattern: bad, per_second: 0, burst: 0)
+    |> beryl.validate_config
+
+  case result {
+    Error(beryl.InvalidTopicPattern(pattern, _reason)) ->
+      pattern |> should.equal(bad)
+    _ -> should.fail()
+  }
+}
+
 pub fn child_spec_rejects_invalid_config_test() {
   let result =
     beryl.child_spec(

--- a/packages/beryl/test/app_logging_test.gleam
+++ b/packages/beryl/test/app_logging_test.gleam
@@ -9,77 +9,13 @@ import beryl
 import beryl/socket.{AcceptJoin, Join, Next}
 import beryl/wire
 import gleam/dict
-import gleam/dynamic
-import gleam/dynamic/decode
-import gleam/erlang/atom
-import gleam/erlang/process
 import gleam/option.{None}
 import gleeunit
 import gleeunit/should
+import test_helpers.{begin_capture, receive_log, stop_capture}
 
 pub fn main() {
   gleeunit.main()
-}
-
-type CapturedLog {
-  CapturedLog(message: String, metadata: dict.Dict(String, String))
-}
-
-@external(erlang, "beryl_log_capture", "start")
-fn start_capture(pid: process.Pid) -> Nil
-
-@external(erlang, "beryl_log_capture", "stop")
-fn stop_capture() -> Nil
-
-fn captured_decoder() -> decode.Decoder(CapturedLog) {
-  use message <- decode.field(1, decode.string)
-  use metadata <- decode.field(2, decode.dict(decode.string, decode.string))
-  decode.success(CapturedLog(message:, metadata:))
-}
-
-fn coerce_captured(value: dynamic.Dynamic) -> CapturedLog {
-  case decode.run(value, captured_decoder()) {
-    Ok(captured) -> captured
-    Error(_) -> CapturedLog(message: "", metadata: dict.new())
-  }
-}
-
-fn captured_selector() -> process.Selector(CapturedLog) {
-  process.new_selector()
-  |> process.select_record(atom.create("captured_log"), 2, coerce_captured)
-}
-
-fn begin_capture() -> process.Selector(CapturedLog) {
-  start_capture(process.self())
-  let selector = captured_selector()
-  drain(selector)
-  selector
-}
-
-fn drain(selector: process.Selector(CapturedLog)) -> Nil {
-  case process.selector_receive(selector, 0) {
-    Ok(_) -> drain(selector)
-    Error(Nil) -> Nil
-  }
-}
-
-fn receive_log(
-  selector: process.Selector(CapturedLog),
-  message: String,
-  attempts: Int,
-) -> Result(CapturedLog, Nil) {
-  case attempts <= 0 {
-    True -> Error(Nil)
-    False ->
-      case process.selector_receive(selector, 500) {
-        Ok(captured) ->
-          case captured.message == message {
-            True -> Ok(captured)
-            False -> receive_log(selector, message, attempts - 1)
-          }
-        Error(Nil) -> Error(Nil)
-      }
-  }
 }
 
 pub fn start_warns_when_no_abuse_controls_configured_test() {

--- a/packages/beryl/test/app_logging_test.gleam
+++ b/packages/beryl/test/app_logging_test.gleam
@@ -6,6 +6,7 @@
 
 import app_test_helpers as h
 import beryl
+import beryl/internal
 import beryl/socket.{AcceptJoin, Join, Next}
 import beryl/wire
 import gleam/dict
@@ -13,6 +14,17 @@ import gleam/option.{None}
 import gleeunit
 import gleeunit/should
 import test_helpers.{begin_capture, receive_log, stop_capture}
+
+/// Palabres's level is a global, singleton setting (see
+/// `beryl/internal.configure`); restore it to Beryl's own default so a
+/// `DebugLevel` test doesn't leak verbosity into tests that run after it.
+fn restore_default_logging_level() -> Nil {
+  internal.configure(internal.LoggingConfig(
+    level: internal.Info,
+    include_payloads: False,
+    payload_preview_bytes: 200,
+  ))
+}
 
 pub fn main() {
   gleeunit.main()
@@ -86,4 +98,5 @@ pub fn inbound_routing_log_omits_payload_by_default_test() {
 
   let _ = beryl.stop(channels)
   stop_capture()
+  restore_default_logging_level()
 }

--- a/packages/beryl/test/test_helpers.gleam
+++ b/packages/beryl/test/test_helpers.gleam
@@ -1,8 +1,16 @@
 //// Shared test helpers for beryl tests
 ////
 //// Provides polling utilities to replace fragile `process.sleep()` calls
-//// with deterministic condition-based waiting.
+//// with deterministic condition-based waiting, plus a palabres log-capture
+//// harness (backed by the `beryl_log_capture` Erlang test handler) used to
+//// observe runtime-side logging as a proxy for "did the decoded envelope
+//// reach the runtime", where reply presence/absence alone cannot
+//// distinguish edge-level shedding from runtime-level shedding.
 
+import gleam/dict
+import gleam/dynamic
+import gleam/dynamic/decode
+import gleam/erlang/atom
 import gleam/erlang/process
 import gleeunit/should
 
@@ -34,5 +42,81 @@ pub fn wait_until(
         }
       }
     }
+  }
+}
+
+// ── Palabres log capture ────────────────────────────────────────────────────
+
+/// A single captured palabres log: its message and string-keyed metadata.
+pub type CapturedLog {
+  CapturedLog(message: String, metadata: dict.Dict(String, String))
+}
+
+@external(erlang, "beryl_log_capture", "start")
+fn start_capture(pid: process.Pid) -> Nil
+
+@external(erlang, "beryl_log_capture", "stop")
+fn stop_capture_ffi() -> Nil
+
+fn captured_decoder() -> decode.Decoder(CapturedLog) {
+  use message <- decode.field(1, decode.string)
+  use metadata <- decode.field(2, decode.dict(decode.string, decode.string))
+  decode.success(CapturedLog(message:, metadata:))
+}
+
+fn coerce_captured(value: dynamic.Dynamic) -> CapturedLog {
+  case decode.run(value, captured_decoder()) {
+    Ok(captured) -> captured
+    Error(_) -> CapturedLog(message: "", metadata: dict.new())
+  }
+}
+
+fn captured_selector() -> process.Selector(CapturedLog) {
+  process.new_selector()
+  |> process.select_record(atom.create("captured_log"), 2, coerce_captured)
+}
+
+fn drain(selector: process.Selector(CapturedLog)) -> Nil {
+  case process.selector_receive(selector, 0) {
+    Ok(_) -> drain(selector)
+    Error(Nil) -> Nil
+  }
+}
+
+/// Install the capture handler (bound to the calling process) and return a
+/// drained selector ready to observe logs emitted from this point on. Pair
+/// with `stop_capture` once the test is done.
+pub fn begin_capture() -> process.Selector(CapturedLog) {
+  start_capture(process.self())
+  let selector = captured_selector()
+  drain(selector)
+  selector
+}
+
+/// Remove the capture handler installed by `begin_capture`.
+pub fn stop_capture() -> Nil {
+  stop_capture_ffi()
+}
+
+/// Receive captured logs from `selector` until one matching `message`
+/// arrives (`Ok`) or `attempts` are exhausted without a match (`Error(Nil)`).
+/// Each attempt waits up to 500ms, so this also serves as an absence check
+/// with a small `attempts` count.
+pub fn receive_log(
+  selector: process.Selector(CapturedLog),
+  message: String,
+  attempts: Int,
+) -> Result(CapturedLog, Nil) {
+  case attempts <= 0 {
+    True -> Error(Nil)
+    False ->
+      case process.selector_receive(selector, 500) {
+        Ok(captured) ->
+          case captured.message == message {
+            True -> Ok(captured)
+            False -> receive_log(selector, message, attempts - 1)
+          }
+        Error(Nil) -> Error(Nil)
+      }
   }
 }

--- a/packages/beryl/test/test_helpers.gleam
+++ b/packages/beryl/test/test_helpers.gleam
@@ -99,9 +99,10 @@ pub fn stop_capture() -> Nil {
 }
 
 /// Receive captured logs from `selector` until one matching `message`
-/// arrives (`Ok`) or `attempts` are exhausted without a match (`Error(Nil)`).
-/// Each attempt waits up to 500ms, so this also serves as an absence check
-/// with a small `attempts` count.
+/// arrives (`Ok`), a mismatching log has been seen `attempts` times without
+/// a match, or no further log arrives within 500ms (`Error(Nil)` in either
+/// case). A small `attempts` count combined with the 500ms per-attempt wait
+/// also makes this usable as an absence check.
 pub fn receive_log(
   selector: process.Selector(CapturedLog),
   message: String,

--- a/packages/beryl/test/topic_policy_test.gleam
+++ b/packages/beryl/test/topic_policy_test.gleam
@@ -81,3 +81,31 @@ pub fn no_matching_limits_means_unlimited_test() {
   let assert Ok(Message(_, _, _, _)) = process.receive(events, 500)
   let assert Ok(Message(_, _, _, _)) = process.receive(events, 500)
 }
+
+fn non_positive_topic_rate_disables_global_limit(rate: Int) -> Nil {
+  let events = process.new_subject()
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_channel_rate(per_second: 1, burst: 1)
+    |> beryl.with_topic_rate(pattern: "room:*", per_second: rate, burst: 1)
+  let channels = h.start_observed(config, events)
+  let frames = h.connect(channels, "s1")
+  drain_join(channels, events, frames, "s1", "room:a")
+
+  h.push(channels, "s1", "room:a", "msg", "r-2")
+  h.push(channels, "s1", "room:a", "msg", "r-3")
+  h.push(channels, "s1", "room:a", "msg", "r-4")
+
+  let assert Ok(Message("room:a", _, _, _)) = process.receive(events, 500)
+  let assert Ok(Message("room:a", _, _, _)) = process.receive(events, 500)
+  let assert Ok(Message("room:a", _, _, _)) = process.receive(events, 500)
+  Nil
+}
+
+pub fn zero_topic_rate_disables_override_without_allocating_bucket_test() {
+  non_positive_topic_rate_disables_global_limit(0)
+}
+
+pub fn negative_topic_rate_disables_override_without_allocating_bucket_test() {
+  non_positive_topic_rate_disables_global_limit(-1)
+}

--- a/packages/beryl/test/transport_server_rate_test.gleam
+++ b/packages/beryl/test/transport_server_rate_test.gleam
@@ -15,6 +15,7 @@
 
 import app_test_helpers as h
 import beryl
+import beryl/internal
 import beryl/socket
 import beryl/transport
 import beryl/transport/server
@@ -28,6 +29,17 @@ import test_helpers.{begin_capture, receive_log, stop_capture}
 
 pub fn main() {
   gleeunit.main()
+}
+
+/// Palabres's level is a global, singleton setting (see
+/// `beryl/internal.configure`); restore it to Beryl's own default so a
+/// `DebugLevel` test doesn't leak verbosity into tests that run after it.
+fn restore_default_logging_level() -> Nil {
+  internal.configure(internal.LoggingConfig(
+    level: internal.Info,
+    include_payloads: False,
+    payload_preview_bytes: 200,
+  ))
 }
 
 fn start_system(config: beryl.Config) -> beryl.Sockets {
@@ -151,6 +163,7 @@ pub fn message_rate_alone_does_not_shed_at_the_edge_test() {
 
   let _conn = conn
   stop_capture()
+  restore_default_logging_level()
 }
 
 // ── Combined accounting ──────────────────────────────────────────────────

--- a/packages/beryl/test/transport_server_rate_test.gleam
+++ b/packages/beryl/test/transport_server_rate_test.gleam
@@ -1,0 +1,186 @@
+//// Frame-rate vs. message-rate accounting at the transport edge.
+////
+//// `beryl/transport/server` carries the inbound frame pipeline (size caps,
+//// frame-rate limiting, decode, routing) that a real transport such as
+//// `beryl_mist`/`beryl_ewe` drives from a live socket. These tests drive
+//// that same pipeline directly — `server.init_connection` plus
+//// `server.handle_text_frame` — without a network round trip, so the edge
+//// admission logic is exercised exactly as a transport would use it.
+////
+//// `with_frame_rate` governs the edge bucket here (every complete frame,
+//// pre-decode); `with_message_rate` governs the runtime's post-decode
+//// bucket (see `app_abuse_test.gleam`). The two are independent: this file
+//// proves neither setting alone does the other's job, and that configuring
+//// both makes valid traffic pay both costs.
+
+import app_test_helpers as h
+import beryl
+import beryl/socket
+import beryl/transport
+import beryl/transport/server
+import beryl/wire
+import gleam/erlang/process
+import gleam/option
+import gleam/string
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+fn start_system(config: beryl.Config) -> beryl.Sockets {
+  let assert Ok(channels) =
+    h.start_app(config, init: h.accepting_init, update: h.accepting_update)
+  channels
+}
+
+type Conn {
+  Conn(
+    state: server.ConnectionState,
+    selector: process.Selector(server.SendRequest),
+  )
+}
+
+fn connect(channels: beryl.Sockets, ip: String) -> Conn {
+  let assert Ok(permit) = beryl.acquire_connection_slot(channels, ip)
+  let #(state, selector) =
+    server.init_connection(
+      sockets: channels,
+      seed: socket.empty_seed(),
+      connection_permit: permit,
+      base_selector: process.new_selector(),
+      logger_name: "transport_server_rate_test",
+      telemetry: transport.telemetry(channels, transport.Mist),
+      codec: option.None,
+    )
+  Conn(state, selector)
+}
+
+/// Feed one text frame through the edge pipeline, returning the updated
+/// connection (state carries the frame limiter's bucket forward).
+fn send_text(conn: Conn, text: String) -> Conn {
+  case server.handle_text_frame(conn.state, text) {
+    server.Continue(state) -> Conn(..conn, state: state)
+    server.Stop -> conn
+  }
+}
+
+fn heartbeat(ref: String) -> String {
+  "[null,\"" <> ref <> "\",\"phoenix\",\"heartbeat\",{}]"
+}
+
+/// Receive the next frame the runtime/edge sent back, `Error(Nil)` if none
+/// arrives within the timeout.
+fn recv(conn: Conn) -> Result(String, Nil) {
+  case process.selector_receive(from: conn.selector, within: 300) {
+    Ok(server.SendText(text)) -> Ok(text)
+    Ok(server.SendBinary(_)) -> Error(Nil)
+    Ok(server.Close) -> Error(Nil)
+    Error(Nil) -> Error(Nil)
+  }
+}
+
+// ── Frame-only ───────────────────────────────────────────────────────────
+
+pub fn frame_rate_alone_sheds_flood_before_decode_test() {
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_frame_rate(per_second: 1, burst: 1)
+  let channels = start_system(config)
+  let conn = connect(channels, "10.10.10.1")
+
+  let conn = send_text(conn, heartbeat("hb-1"))
+  let assert Ok(reply) = recv(conn)
+  reply |> string.contains("hb-1") |> should.be_true
+
+  let conn = send_text(conn, heartbeat("hb-2"))
+  recv(conn) |> should.equal(Error(Nil))
+}
+
+pub fn frame_rate_counts_malformed_frames_test() {
+  // A malformed frame consumes a frame-rate token exactly like a
+  // well-formed one — it never reaches decode, but it still counts.
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_frame_rate(per_second: 1, burst: 1)
+  let channels = start_system(config)
+  let conn = connect(channels, "10.10.10.2")
+
+  let conn = send_text(conn, "not-valid-json")
+  let conn = send_text(conn, heartbeat("hb-1"))
+
+  // The single frame token was spent on the malformed frame, so the
+  // following valid heartbeat is shed at the edge with no reply.
+  recv(conn) |> should.equal(Error(Nil))
+}
+
+// ── Message-only ─────────────────────────────────────────────────────────
+
+pub fn message_rate_alone_does_not_shed_at_the_edge_test() {
+  // With no frame_rate configured, every frame reaches decode and routing;
+  // the runtime's message-rate bucket is what sheds the flood (invisible
+  // from this layer as anything other than a dropped reply — the edge
+  // itself never rejects the frame).
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_message_rate(per_second: 1, burst: 1)
+  let channels = start_system(config)
+  let conn = connect(channels, "10.10.10.3")
+
+  let conn = send_text(conn, heartbeat("hb-1"))
+  let assert Ok(reply) = recv(conn)
+  reply |> string.contains("hb-1") |> should.be_true
+
+  let conn = send_text(conn, heartbeat("hb-2"))
+  recv(conn) |> should.equal(Error(Nil))
+}
+
+// ── Combined accounting ──────────────────────────────────────────────────
+
+pub fn combined_rates_both_gate_valid_traffic_test() {
+  // frame_rate's burst (3) is generous; message_rate's burst (1) is the
+  // binding constraint. Every heartbeat reaches decode/routing (frame
+  // gate clears), but only the first gets a reply (message gate binds).
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_frame_rate(per_second: 1, burst: 3)
+    |> beryl.with_message_rate(per_second: 1, burst: 1)
+  let channels = start_system(config)
+  let conn = connect(channels, "10.10.10.4")
+
+  let conn = send_text(conn, heartbeat("hb-1"))
+  let assert Ok(reply) = recv(conn)
+  reply |> string.contains("hb-1") |> should.be_true
+
+  let conn = send_text(conn, heartbeat("hb-2"))
+  recv(conn) |> should.equal(Error(Nil))
+
+  let conn = send_text(conn, heartbeat("hb-3"))
+  recv(conn) |> should.equal(Error(Nil))
+
+  let _conn = conn
+  Nil
+}
+
+pub fn combined_rates_frame_gate_binds_first_test() {
+  // Reversed: frame_rate's burst (1) is the binding constraint here, even
+  // though message_rate would allow more. Proves the frame gate runs
+  // before decode regardless of how generous the message gate is.
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_frame_rate(per_second: 1, burst: 1)
+    |> beryl.with_message_rate(per_second: 1, burst: 3)
+  let channels = start_system(config)
+  let conn = connect(channels, "10.10.10.5")
+
+  let conn = send_text(conn, heartbeat("hb-1"))
+  let assert Ok(reply) = recv(conn)
+  reply |> string.contains("hb-1") |> should.be_true
+
+  let conn = send_text(conn, heartbeat("hb-2"))
+  recv(conn) |> should.equal(Error(Nil))
+
+  let _conn = conn
+  Nil
+}

--- a/packages/beryl/test/transport_server_rate_test.gleam
+++ b/packages/beryl/test/transport_server_rate_test.gleam
@@ -24,6 +24,7 @@ import gleam/option
 import gleam/string
 import gleeunit
 import gleeunit/should
+import test_helpers.{begin_capture, receive_log, stop_capture}
 
 pub fn main() {
   gleeunit.main()
@@ -119,14 +120,22 @@ pub fn frame_rate_counts_malformed_frames_test() {
 
 pub fn message_rate_alone_does_not_shed_at_the_edge_test() {
   // With no frame_rate configured, every frame reaches decode and routing;
-  // the runtime's message-rate bucket is what sheds the flood (invisible
-  // from this layer as anything other than a dropped reply — the edge
-  // itself never rejects the frame).
+  // the runtime's message-rate bucket is what sheds the flood. A dropped
+  // reply alone would be identical to edge-level shedding, so this test
+  // additionally observes the runtime's own "Message rate limited" debug
+  // log — it only fires once the decoded envelope has reached the runtime
+  // and been rejected there, which an edge-level shed (no decode, no
+  // runtime dispatch at all) could never produce.
   let config =
     beryl.config(wire.phoenix_codec())
     |> beryl.with_message_rate(per_second: 1, burst: 1)
+    |> beryl.with_logging(beryl.logging_config(
+      level: beryl.DebugLevel,
+      include_payloads: False,
+    ))
   let channels = start_system(config)
   let conn = connect(channels, "10.10.10.3")
+  let selector = begin_capture()
 
   let conn = send_text(conn, heartbeat("hb-1"))
   let assert Ok(reply) = recv(conn)
@@ -134,6 +143,14 @@ pub fn message_rate_alone_does_not_shed_at_the_edge_test() {
 
   let conn = send_text(conn, heartbeat("hb-2"))
   recv(conn) |> should.equal(Error(Nil))
+
+  // The second heartbeat's envelope reached the runtime and was rejected
+  // by the message-rate gate there — proof the edge itself admitted the
+  // frame and did no shedding of its own.
+  receive_log(selector, "Message rate limited", 10) |> should.be_ok
+
+  let _conn = conn
+  stop_capture()
 }
 
 // ── Combined accounting ──────────────────────────────────────────────────

--- a/packages/beryl_ewe/README.md
+++ b/packages/beryl_ewe/README.md
@@ -64,7 +64,7 @@ pub fn main() {
 The transport serves WebSocket upgrades and regular HTTP from a single Ewe
 listener, runs an optional `on_connect` authentication hook before the
 upgrade, validates the `Origin` header (same-origin by default, allow-list,
-or allow-all), and enforces beryl's frame-size, message-rate, and connection
+or allow-all), and enforces beryl's frame-size, frame-rate, and connection
 limits at the edge.
 
 It mirrors the [`beryl_mist`](https://hex.pm/packages/beryl_mist) package: both

--- a/packages/beryl_ewe/test/beryl_log_capture.erl
+++ b/packages/beryl_ewe/test/beryl_log_capture.erl
@@ -1,0 +1,61 @@
+%% Test-only Erlang logger handler that captures palabres log reports and
+%% forwards them to a registered test process. Palabres emits its logs as
+%% reports of the shape `{palabres, Fields, Message, At}` through the Erlang
+%% `logger`; this handler decodes the message and string fields and sends a
+%% `{captured_log, Message, Metadata}` tuple to the test pid, where Metadata is a
+%% map of `KeyBinary => ValueBinary`. This mirrors the Gleam `CapturedLog`
+%% record shape, giving deterministic, in-memory assertions without depending on
+%% file output flush timing.
+-module(beryl_log_capture).
+
+-export([start/1, stop/0, log/2]).
+
+-define(HANDLER_ID, beryl_log_capture).
+
+%% Install (or reinstall) the capture handler bound to Pid. Idempotent across
+%% tests: any previous handler is removed first so each test owns the sink.
+start(Pid) ->
+    _ = logger:remove_handler(?HANDLER_ID),
+    ok = logger:add_handler(?HANDLER_ID, ?MODULE, #{config => #{pid => Pid}}),
+    nil.
+
+%% Remove the capture handler.
+stop() ->
+    _ = logger:remove_handler(?HANDLER_ID),
+    nil.
+
+%% Logger handler callback. Only palabres reports are forwarded; everything else
+%% is ignored. The forwarded tuple matches the Gleam `CapturedLog` record shape
+%% so the test can decode it directly from the received message.
+log(#{msg := {report, [{palabres, Fields, Message, _At}]}},
+    #{config := #{pid := Pid}}) ->
+    Pid ! {captured_log, to_binary(Message), maps:from_list(simplify_fields(Fields))},
+    ok;
+log(_LogEvent, _Config) ->
+    ok.
+
+%% Flatten palabres fields (`[{Key, [Field]}]`) to `[{KeyBin, ValueBin}]`,
+%% dropping keys with no values (e.g. the default empty `at`/`when` slots).
+simplify_fields(Fields) ->
+    lists:filtermap(
+        fun({Key, Values}) ->
+            case Values of
+                [] -> false;
+                [Value | _] -> {true, {to_binary(Key), field_to_binary(Value)}}
+            end
+        end,
+        Fields).
+
+field_to_binary({string_field, V}) -> to_binary(V);
+field_to_binary({int_field, V}) -> integer_to_binary(V);
+field_to_binary({float_field, V}) -> float_to_binary(V);
+field_to_binary({bool_field, true}) -> <<"true">>;
+field_to_binary({bool_field, false}) -> <<"false">>;
+field_to_binary(null_field) -> <<"null">>;
+field_to_binary({lazy_field, Fun}) -> field_to_binary(Fun());
+field_to_binary(Other) -> to_binary(Other).
+
+to_binary(V) when is_binary(V) -> V;
+to_binary(V) when is_list(V) -> unicode:characters_to_binary(V);
+to_binary(V) when is_atom(V) -> atom_to_binary(V, utf8);
+to_binary(V) -> unicode:characters_to_binary(io_lib:format("~p", [V])).

--- a/packages/beryl_ewe/test/ewe_handler_test.gleam
+++ b/packages/beryl_ewe/test/ewe_handler_test.gleam
@@ -384,7 +384,33 @@ pub fn handler_allows_unlimited_connections_when_limit_is_zero_test() {
   stop_supervisor(server_pid)
 }
 
-pub fn handler_sheds_message_flood_at_the_edge_test() {
+pub fn handler_sheds_frame_flood_at_the_edge_test() {
+  let channels =
+    start_app_system(
+      beryl.config(wire.phoenix_codec())
+      |> beryl.with_frame_rate(per_second: 1, burst: 2),
+    )
+  let #(port, server_pid) = start_server(channels)
+  let assert Ok(client) = connect_websocket(port, "/socket")
+
+  // Flood heartbeats: only the burst allowance may produce replies. The
+  // rest are shed by the connection process, pre-decode, before reaching
+  // the runtime — `with_frame_rate` alone accomplishes this with no
+  // `with_message_rate` configured.
+  send_heartbeats(client, 10)
+  let replies = count_replies(client, 0)
+  { replies <= 2 } |> should.be_true
+  { replies >= 1 } |> should.be_true
+
+  close(client)
+  stop_supervisor(server_pid)
+}
+
+pub fn handler_message_rate_alone_does_not_shed_frames_at_the_edge_test() {
+  // Regression: `with_message_rate` governs the runtime bucket only. A
+  // heartbeat flood still gets shed (the runtime's message limiter catches
+  // it after decode), but the two settings are independent — this proves
+  // `with_message_rate` is not silently doing edge-level frame shedding.
   let channels =
     start_app_system(
       beryl.config(wire.phoenix_codec())
@@ -393,13 +419,33 @@ pub fn handler_sheds_message_flood_at_the_edge_test() {
   let #(port, server_pid) = start_server(channels)
   let assert Ok(client) = connect_websocket(port, "/socket")
 
-  // Flood heartbeats: only the burst allowance may produce replies. The
-  // rest are shed by the connection process before reaching the
-  // runtime.
   send_heartbeats(client, 10)
   let replies = count_replies(client, 0)
   { replies <= 2 } |> should.be_true
   { replies >= 1 } |> should.be_true
+
+  close(client)
+  stop_supervisor(server_pid)
+}
+
+pub fn handler_frame_rate_counts_malformed_frames_test() {
+  // Regression: the frame-rate bucket counts every complete inbound frame
+  // before decoding, so a malformed frame consumes a token the same as a
+  // well-formed one — a single-token burst spent on garbage leaves no
+  // token for a following valid heartbeat.
+  let channels =
+    start_app_system(
+      beryl.config(wire.phoenix_codec())
+      |> beryl.with_frame_rate(per_second: 1, burst: 1),
+    )
+  let #(port, server_pid) = start_server(channels)
+  let assert Ok(client) = connect_websocket(port, "/socket")
+
+  let assert Ok(_) = send_text(client, "not-valid-json")
+  let assert Ok(_) =
+    send_text(client, "[null,\"hb\",\"phoenix\",\"heartbeat\",{}]")
+
+  receive_text(client, 200) |> should.equal(Error(Nil))
 
   close(client)
   stop_supervisor(server_pid)

--- a/packages/beryl_ewe/test/ewe_handler_test.gleam
+++ b/packages/beryl_ewe/test/ewe_handler_test.gleam
@@ -12,7 +12,10 @@ import beryl/wire
 import beryl_ewe as ewe_transport
 import ewe
 import gleam/bit_array
+import gleam/dict
 import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode
+import gleam/erlang/atom
 import gleam/erlang/process
 import gleam/http/request
 import gleam/http/response
@@ -86,6 +89,68 @@ fn http_get(port: Int, path: String) -> Result(Int, Nil)
 
 @external(erlang, "beryl_ewe_transport_test_ffi", "stop_supervisor")
 fn stop_supervisor(pid: process.Pid) -> Nil
+
+// Runtime log capture distinguishes edge shedding from runtime shedding.
+type CapturedLog {
+  CapturedLog(message: String, metadata: dict.Dict(String, String))
+}
+
+@external(erlang, "beryl_log_capture", "start")
+fn start_capture(pid: process.Pid) -> Nil
+
+@external(erlang, "beryl_log_capture", "stop")
+fn stop_capture() -> Nil
+
+fn captured_decoder() -> decode.Decoder(CapturedLog) {
+  use message <- decode.field(1, decode.string)
+  use metadata <- decode.field(2, decode.dict(decode.string, decode.string))
+  decode.success(CapturedLog(message:, metadata:))
+}
+
+fn coerce_captured(value: dynamic.Dynamic) -> CapturedLog {
+  case decode.run(value, captured_decoder()) {
+    Ok(captured) -> captured
+    Error(_) -> CapturedLog(message: "", metadata: dict.new())
+  }
+}
+
+fn captured_selector() -> process.Selector(CapturedLog) {
+  process.new_selector()
+  |> process.select_record(atom.create("captured_log"), 2, coerce_captured)
+}
+
+fn drain_captured(selector: process.Selector(CapturedLog)) -> Nil {
+  case process.selector_receive(selector, 0) {
+    Ok(_) -> drain_captured(selector)
+    Error(Nil) -> Nil
+  }
+}
+
+fn begin_capture() -> process.Selector(CapturedLog) {
+  start_capture(process.self())
+  let selector = captured_selector()
+  drain_captured(selector)
+  selector
+}
+
+fn receive_log(
+  selector: process.Selector(CapturedLog),
+  message: String,
+  attempts: Int,
+) -> Result(CapturedLog, Nil) {
+  case attempts <= 0 {
+    True -> Error(Nil)
+    False ->
+      case process.selector_receive(selector, 500) {
+        Ok(captured) ->
+          case captured.message == message {
+            True -> Ok(captured)
+            False -> receive_log(selector, message, attempts - 1)
+          }
+        Error(Nil) -> Error(Nil)
+      }
+  }
+}
 
 // The HTTP fallback replies with a distinctive 418 so routing to the fallback
 // is observable from the test client.
@@ -414,15 +479,22 @@ pub fn handler_message_rate_alone_does_not_shed_frames_at_the_edge_test() {
   let channels =
     start_app_system(
       beryl.config(wire.phoenix_codec())
-      |> beryl.with_message_rate(per_second: 1, burst: 2),
+      |> beryl.with_message_rate(per_second: 1, burst: 2)
+      |> beryl.with_logging(beryl.logging_config(
+        level: beryl.DebugLevel,
+        include_payloads: False,
+      )),
     )
   let #(port, server_pid) = start_server(channels)
   let assert Ok(client) = connect_websocket(port, "/socket")
+  let selector = begin_capture()
 
   send_heartbeats(client, 10)
   let replies = count_replies(client, 0)
   { replies <= 2 } |> should.be_true
   { replies >= 1 } |> should.be_true
+  receive_log(selector, "Message rate limited", 20) |> should.be_ok
+  stop_capture()
 
   close(client)
   stop_supervisor(server_pid)

--- a/packages/beryl_mist/README.md
+++ b/packages/beryl_mist/README.md
@@ -64,7 +64,7 @@ pub fn main() {
 The transport serves WebSocket upgrades and regular HTTP from a single Mist
 listener, runs an optional `on_connect` authentication hook before the
 upgrade, validates the `Origin` header (same-origin by default, allow-list,
-or allow-all), and enforces beryl's frame-size, message-rate, and connection
+or allow-all), and enforces beryl's frame-size, frame-rate, and connection
 limits at the edge.
 
 ## Documentation

--- a/packages/beryl_mist/test/beryl_log_capture.erl
+++ b/packages/beryl_mist/test/beryl_log_capture.erl
@@ -1,0 +1,61 @@
+%% Test-only Erlang logger handler that captures palabres log reports and
+%% forwards them to a registered test process. Palabres emits its logs as
+%% reports of the shape `{palabres, Fields, Message, At}` through the Erlang
+%% `logger`; this handler decodes the message and string fields and sends a
+%% `{captured_log, Message, Metadata}` tuple to the test pid, where Metadata is a
+%% map of `KeyBinary => ValueBinary`. This mirrors the Gleam `CapturedLog`
+%% record shape, giving deterministic, in-memory assertions without depending on
+%% file output flush timing.
+-module(beryl_log_capture).
+
+-export([start/1, stop/0, log/2]).
+
+-define(HANDLER_ID, beryl_log_capture).
+
+%% Install (or reinstall) the capture handler bound to Pid. Idempotent across
+%% tests: any previous handler is removed first so each test owns the sink.
+start(Pid) ->
+    _ = logger:remove_handler(?HANDLER_ID),
+    ok = logger:add_handler(?HANDLER_ID, ?MODULE, #{config => #{pid => Pid}}),
+    nil.
+
+%% Remove the capture handler.
+stop() ->
+    _ = logger:remove_handler(?HANDLER_ID),
+    nil.
+
+%% Logger handler callback. Only palabres reports are forwarded; everything else
+%% is ignored. The forwarded tuple matches the Gleam `CapturedLog` record shape
+%% so the test can decode it directly from the received message.
+log(#{msg := {report, [{palabres, Fields, Message, _At}]}},
+    #{config := #{pid := Pid}}) ->
+    Pid ! {captured_log, to_binary(Message), maps:from_list(simplify_fields(Fields))},
+    ok;
+log(_LogEvent, _Config) ->
+    ok.
+
+%% Flatten palabres fields (`[{Key, [Field]}]`) to `[{KeyBin, ValueBin}]`,
+%% dropping keys with no values (e.g. the default empty `at`/`when` slots).
+simplify_fields(Fields) ->
+    lists:filtermap(
+        fun({Key, Values}) ->
+            case Values of
+                [] -> false;
+                [Value | _] -> {true, {to_binary(Key), field_to_binary(Value)}}
+            end
+        end,
+        Fields).
+
+field_to_binary({string_field, V}) -> to_binary(V);
+field_to_binary({int_field, V}) -> integer_to_binary(V);
+field_to_binary({float_field, V}) -> float_to_binary(V);
+field_to_binary({bool_field, true}) -> <<"true">>;
+field_to_binary({bool_field, false}) -> <<"false">>;
+field_to_binary(null_field) -> <<"null">>;
+field_to_binary({lazy_field, Fun}) -> field_to_binary(Fun());
+field_to_binary(Other) -> to_binary(Other).
+
+to_binary(V) when is_binary(V) -> V;
+to_binary(V) when is_list(V) -> unicode:characters_to_binary(V);
+to_binary(V) when is_atom(V) -> atom_to_binary(V, utf8);
+to_binary(V) -> unicode:characters_to_binary(io_lib:format("~p", [V])).

--- a/packages/beryl_mist/test/mist_handler_test.gleam
+++ b/packages/beryl_mist/test/mist_handler_test.gleam
@@ -11,7 +11,10 @@ import beryl/wire
 import beryl_mist as mist_transport
 import gleam/bit_array
 import gleam/bytes_tree
+import gleam/dict
 import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode
+import gleam/erlang/atom
 import gleam/erlang/process
 import gleam/http/response
 import gleam/int
@@ -82,6 +85,68 @@ fn http_get(port: Int, path: String) -> Result(Int, Nil)
 
 @external(erlang, "beryl_mist_transport_test_ffi", "stop_supervisor")
 fn stop_supervisor(pid: process.Pid) -> Nil
+
+// Runtime log capture distinguishes edge shedding from runtime shedding.
+type CapturedLog {
+  CapturedLog(message: String, metadata: dict.Dict(String, String))
+}
+
+@external(erlang, "beryl_log_capture", "start")
+fn start_capture(pid: process.Pid) -> Nil
+
+@external(erlang, "beryl_log_capture", "stop")
+fn stop_capture() -> Nil
+
+fn captured_decoder() -> decode.Decoder(CapturedLog) {
+  use message <- decode.field(1, decode.string)
+  use metadata <- decode.field(2, decode.dict(decode.string, decode.string))
+  decode.success(CapturedLog(message:, metadata:))
+}
+
+fn coerce_captured(value: dynamic.Dynamic) -> CapturedLog {
+  case decode.run(value, captured_decoder()) {
+    Ok(captured) -> captured
+    Error(_) -> CapturedLog(message: "", metadata: dict.new())
+  }
+}
+
+fn captured_selector() -> process.Selector(CapturedLog) {
+  process.new_selector()
+  |> process.select_record(atom.create("captured_log"), 2, coerce_captured)
+}
+
+fn drain_captured(selector: process.Selector(CapturedLog)) -> Nil {
+  case process.selector_receive(selector, 0) {
+    Ok(_) -> drain_captured(selector)
+    Error(Nil) -> Nil
+  }
+}
+
+fn begin_capture() -> process.Selector(CapturedLog) {
+  start_capture(process.self())
+  let selector = captured_selector()
+  drain_captured(selector)
+  selector
+}
+
+fn receive_log(
+  selector: process.Selector(CapturedLog),
+  message: String,
+  attempts: Int,
+) -> Result(CapturedLog, Nil) {
+  case attempts <= 0 {
+    True -> Error(Nil)
+    False ->
+      case process.selector_receive(selector, 500) {
+        Ok(captured) ->
+          case captured.message == message {
+            True -> Ok(captured)
+            False -> receive_log(selector, message, attempts - 1)
+          }
+        Error(Nil) -> Error(Nil)
+      }
+  }
+}
 
 // The HTTP fallback replies with a distinctive 418 so routing to the fallback
 // is observable from the test client.
@@ -410,15 +475,22 @@ pub fn handler_message_rate_alone_does_not_shed_frames_at_the_edge_test() {
   let channels =
     start_app_system(
       beryl.config(wire.phoenix_codec())
-      |> beryl.with_message_rate(per_second: 1, burst: 2),
+      |> beryl.with_message_rate(per_second: 1, burst: 2)
+      |> beryl.with_logging(beryl.logging_config(
+        level: beryl.DebugLevel,
+        include_payloads: False,
+      )),
     )
   let #(port, server_pid) = start_server(channels)
   let assert Ok(client) = connect_websocket(port, "/socket")
+  let selector = begin_capture()
 
   send_heartbeats(client, 10)
   let replies = count_replies(client, 0)
   { replies <= 2 } |> should.be_true
   { replies >= 1 } |> should.be_true
+  receive_log(selector, "Message rate limited", 20) |> should.be_ok
+  stop_capture()
 
   close(client)
   stop_supervisor(server_pid)

--- a/packages/beryl_mist/test/mist_handler_test.gleam
+++ b/packages/beryl_mist/test/mist_handler_test.gleam
@@ -380,7 +380,33 @@ pub fn handler_allows_unlimited_connections_when_limit_is_zero_test() {
   stop_supervisor(server_pid)
 }
 
-pub fn handler_sheds_message_flood_at_the_edge_test() {
+pub fn handler_sheds_frame_flood_at_the_edge_test() {
+  let channels =
+    start_app_system(
+      beryl.config(wire.phoenix_codec())
+      |> beryl.with_frame_rate(per_second: 1, burst: 2),
+    )
+  let #(port, server_pid) = start_server(channels)
+  let assert Ok(client) = connect_websocket(port, "/socket")
+
+  // Flood heartbeats: only the burst allowance may produce replies. The
+  // rest are shed by the connection process, pre-decode, before reaching
+  // the runtime — `with_frame_rate` alone accomplishes this with no
+  // `with_message_rate` configured.
+  send_heartbeats(client, 10)
+  let replies = count_replies(client, 0)
+  { replies <= 2 } |> should.be_true
+  { replies >= 1 } |> should.be_true
+
+  close(client)
+  stop_supervisor(server_pid)
+}
+
+pub fn handler_message_rate_alone_does_not_shed_frames_at_the_edge_test() {
+  // Regression: `with_message_rate` governs the runtime bucket only. A
+  // heartbeat flood still gets shed (the runtime's message limiter catches
+  // it after decode), but the two settings are independent — this proves
+  // `with_message_rate` is not silently doing edge-level frame shedding.
   let channels =
     start_app_system(
       beryl.config(wire.phoenix_codec())
@@ -389,13 +415,33 @@ pub fn handler_sheds_message_flood_at_the_edge_test() {
   let #(port, server_pid) = start_server(channels)
   let assert Ok(client) = connect_websocket(port, "/socket")
 
-  // Flood heartbeats: only the burst allowance may produce replies. The
-  // rest are shed by the connection process before reaching the
-  // runtime.
   send_heartbeats(client, 10)
   let replies = count_replies(client, 0)
   { replies <= 2 } |> should.be_true
   { replies >= 1 } |> should.be_true
+
+  close(client)
+  stop_supervisor(server_pid)
+}
+
+pub fn handler_frame_rate_counts_malformed_frames_test() {
+  // Regression: the frame-rate bucket counts every complete inbound frame
+  // before decoding, so a malformed frame consumes a token the same as a
+  // well-formed one — a single-token burst spent on garbage leaves no
+  // token for a following valid heartbeat.
+  let channels =
+    start_app_system(
+      beryl.config(wire.phoenix_codec())
+      |> beryl.with_frame_rate(per_second: 1, burst: 1),
+    )
+  let #(port, server_pid) = start_server(channels)
+  let assert Ok(client) = connect_websocket(port, "/socket")
+
+  let assert Ok(_) = send_text(client, "not-valid-json")
+  let assert Ok(_) =
+    send_text(client, "[null,\"hb\",\"phoenix\",\"heartbeat\",{}]")
+
+  receive_text(client, 200) |> should.equal(Error(Nil))
 
   close(client)
   stop_supervisor(server_pid)

--- a/website/src/content/docs/guides/error-handling.md
+++ b/website/src/content/docs/guides/error-handling.md
@@ -139,7 +139,9 @@ When a client exceeds a configured rate limit, the offending frame or message is
 | `channel_rate` | Per socket+topic | Runtime | `beryl.with_channel_rate` |
 | `topic_rates` | First matching pattern | Runtime | `beryl.with_topic_rate` |
 
-The frame and message buckets are independent; joins consume only join tokens.
+The frame and message buckets are independent. Joins consume frame tokens like
+every inbound frame, never message tokens, and use `join_rate` for runtime
+accounting.
 
 ```gleam
 let config =

--- a/website/src/content/docs/guides/error-handling.md
+++ b/website/src/content/docs/guides/error-handling.md
@@ -129,18 +129,22 @@ Crash descriptions are depth-limited and truncated before logging so client-trig
 
 ## Rate limiting
 
-When a client exceeds a configured rate limit, the offending message is **dropped**. No error is sent to the client (joins are the exception: an over-rate join gets an error reply with `reason: "rate_limited"`). Rate limits are applied at these levels:
+When a client exceeds a configured rate limit, the offending frame or message is **dropped**. No error is sent to the client (joins are the exception: an over-rate join gets an error reply with `reason: "rate_limited"`).
 
-| Limit | Scope | Config function |
-|-------|-------|-----------------|
-| `message_rate` | Per socket, all topics | `beryl.with_message_rate` |
-| `join_rate` | Per socket, join attempts | `beryl.with_join_rate` |
-| `channel_rate` | Per socket+topic | `beryl.with_channel_rate` |
-| `topic_rates` | Per socket+topic for matching patterns | `beryl.with_topic_rate` |
+| Limit | Scope | Enforced | Config function |
+|-------|-------|----------|-----------------|
+| `frame_rate` | Per connection, every complete frame | Transport edge | `beryl.with_frame_rate` |
+| `message_rate` | Per socket, decoded non-join traffic | Runtime | `beryl.with_message_rate` |
+| `join_rate` | Per socket, joins | Runtime | `beryl.with_join_rate` |
+| `channel_rate` | Per socket+topic | Runtime | `beryl.with_channel_rate` |
+| `topic_rates` | First matching pattern | Runtime | `beryl.with_topic_rate` |
+
+The frame and message buckets are independent; joins consume only join tokens.
 
 ```gleam
 let config =
   beryl.config(wire.phoenix_codec())
+  |> beryl.with_frame_rate(per_second: 150, burst: 300)
   |> beryl.with_message_rate(per_second: 100, burst: 200)
   |> beryl.with_join_rate(per_second: 5, burst: 10)
   |> beryl.with_channel_rate(per_second: 50, burst: 100)

--- a/website/src/content/docs/guides/error-handling.md
+++ b/website/src/content/docs/guides/error-handling.md
@@ -153,7 +153,13 @@ let config =
   |> beryl.with_topic_rate(pattern: "cursor:*", per_second: 30, burst: 60)
 ```
 
-`with_topic_rate` overrides the global `channel_rate` for topics matching its pattern — use it to give a fast-streaming namespace (like live cursors) more headroom than chat. If you need to inform the client that it has been rate-limited, implement application-level tracking in `update` and return an explicit `ReplyError`.
+`with_topic_rate` overrides the global `channel_rate` for topics matching its
+pattern — use it to give a fast-streaming namespace (like live cursors) more
+headroom than chat. A non-positive `per_second` makes matching topics unlimited,
+even when a global channel limit is configured, and allocates no per-topic
+bucket. If you need to inform the client that it has been rate-limited,
+implement application-level tracking in `update` and return an explicit
+`ReplyError`.
 
 ## Group errors
 

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -45,10 +45,10 @@ let config =
   |> beryl.with_max_connections(max_connections: 10_000)
 ```
 
-`with_frame_rate` and `with_message_rate` are independent. The frame bucket
-counts malformed frames, joins, leaves, heartbeats, and messages before decode;
-the message bucket counts decoded non-join envelopes in the runtime. Configure
-both, with frame capacity slightly higher to leave room for protocol traffic.
+`with_frame_rate` and `with_message_rate` are independent. Joins consume frame
+and join quota, but not message quota; leaves and heartbeats consume both frame
+and message quota. Configure both, with frame capacity slightly higher for
+protocol traffic and malformed frames that never reach the runtime.
 
 Optionally, `with_channel_rate` adds a per-socket-per-topic limit on top of
 the global per-socket message rate, useful when a single busy topic must not

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -20,8 +20,7 @@ Even with no configuration, beryl enforces:
 - **Joined-topic cap**: a socket may join at most 1000 topics
   (`with_max_joined_topics_per_socket`).
 - **Protocol hygiene**: reserved `phx_*` events, reserved `beryl:*` topics,
-  and messages carrying a stale `join_ref` are dropped; heartbeat and leave
-  frames count against the message rate limit when one is configured.
+  and messages carrying a stale `join_ref` are dropped.
 - **Heartbeat eviction**: sockets that stop sending heartbeats are evicted
   and their connections closed (60 s window by default, `with_heartbeat`).
 
@@ -30,6 +29,8 @@ Even with no configuration, beryl enforces:
 ```gleam
 let config =
   beryl.config(wire.phoenix_codec())
+  // Shed all complete frames at the transport edge before decode.
+  |> beryl.with_frame_rate(per_second: 150, burst: 300)
   // Cap messages per socket. Size to your chattiest legitimate client:
   // for most interactive apps 50-100 msg/s with 2x burst is generous.
   |> beryl.with_message_rate(per_second: 100, burst: 200)
@@ -43,6 +44,11 @@ let config =
   // single node's process/socket/runtime budget; see below.
   |> beryl.with_max_connections(max_connections: 10_000)
 ```
+
+`with_frame_rate` and `with_message_rate` are independent. The frame bucket
+counts malformed frames, joins, leaves, heartbeats, and messages before decode;
+the message bucket counts decoded non-join envelopes in the runtime. Configure
+both, with frame capacity slightly higher to leave room for protocol traffic.
 
 Optionally, `with_channel_rate` adds a per-socket-per-topic limit on top of
 the global per-socket message rate, useful when a single busy topic must not

--- a/website/src/content/docs/guides/websocket.md
+++ b/website/src/content/docs/guides/websocket.md
@@ -217,17 +217,22 @@ Protect against flood attacks with built-in rate limiting:
 ```gleam
 let config =
   beryl.config(wire.phoenix_codec())
+  |> beryl.with_frame_rate(per_second: 150, burst: 300)
   |> beryl.with_message_rate(per_second: 100, burst: 200)
   |> beryl.with_join_rate(per_second: 5, burst: 10)
   |> beryl.with_channel_rate(per_second: 50, burst: 100)
 ```
 
-| Limiter | Scope | Description |
-|---------|-------|-------------|
-| `message_rate` | Per socket | Total messages per second across all topics |
-| `join_rate` | Per socket | Join attempts per second |
-| `channel_rate` | Per socket+topic | Messages per second on a single topic |
-| `topic_rates` | Per socket+topic | Pattern-scoped override of `channel_rate` (`with_topic_rate`) |
+| Limiter | Scope | Enforced |
+|---------|-------|----------|
+| `frame_rate` | Per connection, all complete frames | Transport edge |
+| `message_rate` | Per socket, decoded non-join traffic | Runtime |
+| `join_rate` | Per socket, joins | Runtime |
+| `channel_rate` | Per socket+topic | Runtime |
+| `topic_rates` | Pattern-scoped override of `channel_rate` | Runtime |
+
+Frame and message buckets are independent. Malformed frames and joins consume
+frame tokens; joins do not consume message tokens.
 
 ## Per-IP connection limits
 

--- a/website/src/content/docs/reference/api/beryl-transport-server.md
+++ b/website/src/content/docs/reference/api/beryl-transport-server.md
@@ -16,7 +16,7 @@ Server-agnostic WebSocket transport infrastructure.
  its builders, the upgrade admission pipeline (path matching, origin
  policy, `?vsn` negotiation, connection limits, `on_connect`
  authentication), per-connection lifecycle choreography, and the inbound
- frame pipeline (size caps, rate limiting, decoding, routing).
+ frame pipeline (size caps, frame-rate limiting, decoding, routing).
 
  Transport packages such as `beryl_mist` and `beryl_ewe` supply only the
  server-specific glue: the WebSocket upgrade call, frame sending, and peer

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -462,6 +462,22 @@ pub fn with_channel_rate_max_keys_per_socket(
 ) -> Config
 ```
 
+### `with_frame_rate`
+
+Configure per-connection frame-rate limiting at the transport edge.
+
+ Every complete inbound text or binary frame consumes this independent
+ bucket before decoding. Configure it alongside `with_message_rate` to
+ combine edge shedding with a runtime cap on decoded non-join traffic.
+
+```gleam
+pub fn with_frame_rate(
+  Config,
+  per_second: Int,
+  burst: Int
+) -> Config
+```
+
 ### `with_heartbeat`
 
 Configure the server-side heartbeat staleness window.
@@ -600,9 +616,9 @@ Configure the maximum allowed inbound WebSocket frame size in bytes.
 
  For a true transport memory bound you **must** place an edge proxy or load
  balancer in front of Beryl and configure a WebSocket frame-size limit
- there (and a matching request/body size limit). Beryl's per-IP connection
- limit and per-socket message-rate limit do not mitigate this vector. See
- the README's "Security" section for deployment guidance.
+ there (and a matching request/body size limit). Beryl's connection,
+ frame-rate, and message-rate limits all run after frame assembly and do not
+ mitigate this vector. See the README's "Security" section.
 
  Values <= 0 disable the cap. The default is 1 MiB.
 
@@ -644,7 +660,11 @@ pub fn with_max_topic_length(
 
 ### `with_message_rate`
 
-Configure per-socket message rate limiting
+Configure per-socket decoded message-rate limiting in the runtime.
+
+ Joins use `with_join_rate`; decoded leaves, heartbeats, events, decoded
+ binary, and raw `Binary` inputs consume this bucket. It is independent of
+ `with_frame_rate`.
 
 ```gleam
 pub fn with_message_rate(

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -713,7 +713,9 @@ Configure a per-topic-pattern message rate limit for an app-dispatch
  `"document:*:ops"`, `"*"`). Limits are consulted in the order they were
  added and the first matching pattern wins; topics matching no pattern
  fall back to the global `with_channel_rate` limit. The limiter applies
- only after a socket has joined the topic.
+ only after a socket has joined the topic. A non-positive `per_second`
+ explicitly disables limiting for matching topics, including any global
+ channel limit, and allocates no bucket.
 
 ```gleam
 pub fn with_topic_rate(

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -60,7 +60,7 @@ This page lists common symptoms with targeted diagnosis steps. Start from your s
 
 1. **Did the client successfully join?** `Message` events are only delivered after a successful `phx_join`. If join was rejected, messages to the topic get an `unmatched topic` error reply (when they carry a ref) or are dropped.
 
-2. **Rate limits dropping messages.** If `with_message_rate`, `with_channel_rate`, or `with_topic_rate` is configured and the client is sending faster than the limit, excess messages are silently dropped. Check your rate limit values or the `Message rate limited` / `Channel rate limited` warnings in the logs.
+2. **Rate limits dropping traffic.** `with_frame_rate` sheds complete frames at the transport edge before decode. `with_message_rate`, `with_channel_rate`, and `with_topic_rate` apply after decode in the runtime.
 
 3. **Event name mismatch.** The `Message` event carries the raw event string. Verify the client sends the exact event name your `update` matches on.
 
@@ -185,9 +185,11 @@ let logging =
 
 1. **Check burst values.** The `burst` parameter sets the token bucket capacity. If burst is too small, a legitimate burst of messages (e.g., on reconnect) exceeds the limit.
 
-2. **message_rate vs. channel_rate.** `message_rate` is per-socket total; `channel_rate` is per-socket-per-topic. If a client joins many topics, `message_rate` limits across all of them while `channel_rate` limits each topic independently.
+2. **frame_rate vs. message_rate.** These are independent. `frame_rate` counts malformed frames, joins, leaves, heartbeats, and messages before decode; `message_rate` counts decoded non-join envelopes.
 
-3. **No error is sent to the client.** Rate-limited messages are dropped silently (over-rate joins get an error reply). If you need clients to know they were limited, implement application-level feedback in `update`.
+3. **message_rate vs. channel_rate.** `message_rate` is per-socket total; `channel_rate` is per-socket-per-topic.
+
+4. **No error is sent to the client.** Rate-limited traffic is dropped silently (over-rate joins get an error reply). Add application-level feedback if needed.
 
 ---
 


### PR DESCRIPTION
## Purpose
Separate edge frame-rate limits from runtime message-rate limits.

## Provenance and split notes
Source PR #220; source commit(s): `5e9e68c6, 5c657cba, 9d827fb8, 30d40c77`. Combines the source stream with disabled non-positive override semantics, discriminating shed tests, logging fixes, and final reference docs.
