### PR TITLE
feat(beryl_channels): add dispatch adapter

### DIFF
--- a/.changes/unreleased/beryl_channels-3.toml
+++ b/.changes/unreleased/beryl_channels-3.toml
@@ -1,0 +1,3 @@
+project = "beryl_channels"
+kind = "Added"
+body = "A supervised beryl_channels.child_spec entry point compiles ordered handlers into beryl core init and update, giving each socket a router with a live topic dictionary and monotonic join generations. Joins take the first matching pattern and an unmatched topic is refused with the reason unmatched topic; client messages, binary frames and typed server-side sends route to the owning channel; actions lower in order onto core effects scoped to the channel own topic; close applies its actions then kicks the topic; termination runs exactly once per accepted join; and sends bound to a superseded generation are dropped before their payload is unsealed."

--- a/packages/beryl_channels/README.md
+++ b/packages/beryl_channels/README.md
@@ -14,9 +14,12 @@ channel that owns its topic — no hand-written message union and no
 hand-written router.
 
 ```gleam
+import beryl
+import beryl/wire
 import beryl_channels
 import beryl_channels/channel
 import gleam/json
+import gleam/otp/static_supervisor
 
 pub fn room() -> channel.Handler {
   channel.handler("room:*", fn(_info, _topic, _payload) {
@@ -35,7 +38,16 @@ pub fn room() -> channel.Handler {
 }
 
 pub fn main() {
-  let assert Ok(Nil) = beryl_channels.validate_handlers([room()])
+  let assert Ok(#(sockets, spec)) =
+    beryl_channels.child_spec(
+      beryl.config(wire.phoenix_codec()),
+      handlers: [room()],
+    )
+
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(spec)
+    |> static_supervisor.start()
 }
 ```
 
@@ -44,10 +56,15 @@ message type, and neither escapes: handlers seal both in closures, so a
 single `List(channel.Handler)` holds channels that agree on nothing. No
 value is erased to `Dynamic` and no unchecked coercion is involved.
 
-The supervised socket entry point that builds a child specification from
-a handler table lands together with the dispatch adapter; until then this
-package provides the handler surface, the error surface, and handler-table
-validation.
+`child_spec` returns an ordinary `beryl.Sockets` handle plus a child
+specification for the application's supervision tree. The handle works
+with the `beryl_mist` and `beryl_ewe` transports, `beryl.broadcast`, and
+`beryl.stop`.
+
+Handlers are consulted in registration order and the first matching
+pattern owns the topic, so more specific patterns belong earlier in the
+list. A join for a topic no handler matches is refused explicitly with
+`{"reason": "unmatched topic"}` rather than left unanswered.
 
 ## Documentation
 

--- a/packages/beryl_channels/gleam.toml
+++ b/packages/beryl_channels/gleam.toml
@@ -16,6 +16,14 @@ gleam_otp = ">= 1.2.0 and < 2.0.0"
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
 glinter = ">= 2.19.0 and < 3.0.0"
+# Wire-contract parity matrix only: the same scenarios are driven over a real
+# WebSocket transport against `beryl.child_spec` and
+# `beryl_channels.child_spec`.
+beryl_mist = { path = "../beryl_mist" }
+mist = ">= 6.0.0 and < 7.0.0"
+gleam_http = ">= 4.3.0 and < 5.0.0"
+phoenix_channel_fixtures = { git = "https://github.com/tylerbutler/phoenix_channel_fixtures.git", ref = "7daccb856d17db6278980277237c201b2acdcdf1" }
+gluegun = { git = "https://github.com/tylerbutler/gluegun.git", ref = "532af1ac0308ff93c8a957467dbb638859593c93" }
 
 [tools.licence_audit]
 allow = ["Apache-2.0", "MIT"]

--- a/packages/beryl_channels/gleam.toml
+++ b/packages/beryl_channels/gleam.toml
@@ -11,10 +11,10 @@ beryl = { path = "../beryl" }
 gleam_stdlib = ">= 1.0.0 and < 2.0.0"
 gleam_erlang = ">= 1.3.0 and < 2.0.0"
 gleam_json = ">= 3.1.0 and < 4.0.0"
+gleam_otp = ">= 1.2.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
-gleam_otp = ">= 1.2.0 and < 2.0.0"
 glinter = ">= 2.19.0 and < 3.0.0"
 
 [tools.licence_audit]

--- a/packages/beryl_channels/manifest.toml
+++ b/packages/beryl_channels/manifest.toml
@@ -9,7 +9,10 @@
 packages = [
   { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
   { name = "beryl", version = "0.2.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../beryl" },
+  { name = "beryl_mist", version = "0.2.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../beryl_mist" },
+  { name = "cowlib", version = "2.19.0", build_tools = ["make", "rebar3"], requirements = [], otp_app = "cowlib", source = "hex", outer_checksum = "6DC66E3135B229193EA4DCB14294E79520C923D391315C9C962EF0B4BEA72356" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
+  { name = "exception", version = "2.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "6BDEA95248093599391C3B5DF1835C5C6A86C353C2F99CE539B450E3432FE117" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "glance", version = "7.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "EA52986965408D43003A1760E41457493EB96098DE193E6AD8646930EC190CB9" },
   { name = "gleam_crypto", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "2DE9E4EF53CF6FEE049D4F765731F7178F7A11AEFAE00EEE63BF7536B354AD3F" },
@@ -22,8 +25,16 @@ packages = [
   { name = "gleeunit", version = "1.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "EC31ABA74256AEA531EDF8169931D775BBB384FED0A8A1BDC4DD9354E3E21826" },
   { name = "glexer", version = "2.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "D423CF63B8D4F9654EF53D0AF4904B249EB0679BD41C63440170AC508C9CC65E" },
   { name = "glinter", version = "2.19.2", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "19CBB4D78E58E54D6B0E8554C389DC01071334FB11E9140C9487C9A4BBCA6158" },
+  { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
+  { name = "gluegun", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "gun"], source = "git", repo = "https://github.com/tylerbutler/gluegun.git", commit = "532af1ac0308ff93c8a957467dbb638859593c93" },
+  { name = "gramps", version = "6.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D55636072DEE173F6586A5679D3C02EC7A0DE3F8646B78C351B72908FF223DF7" },
+  { name = "gun", version = "2.5.0", build_tools = ["make", "rebar3"], requirements = ["cowlib"], otp_app = "gun", source = "hex", outer_checksum = "3839576181456F5553FC1BE006FD95681576B916CC9AD68D422A287ED4A770DD" },
+  { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
   { name = "lattice_presence", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "lattice_presence", source = "hex", outer_checksum = "4528FFC4B4DFCA076FAA0FA22D98CE4DF1B05BD0E9B4B90581DEA8799642C8B7" },
+  { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
+  { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
+  { name = "phoenix_channel_fixtures", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], source = "git", repo = "https://github.com/tylerbutler/phoenix_channel_fixtures.git", commit = "7daccb856d17db6278980277237c201b2acdcdf1" },
   { name = "simplifile", version = "2.7.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "A2727627B063E87351934C7F7F008F2D1FDB16F6DE0B8C79F9E46459CFC9C164" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
@@ -32,9 +43,14 @@ packages = [
 
 [requirements]
 beryl = { path = "../beryl" }
+beryl_mist = { path = "../beryl_mist" }
 gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
+gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
 gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_otp = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glinter = { version = ">= 2.19.0 and < 3.0.0" }
+gluegun = { git = "https://github.com/tylerbutler/gluegun.git", ref = "532af1ac0308ff93c8a957467dbb638859593c93" }
+mist = { version = ">= 6.0.0 and < 7.0.0" }
+phoenix_channel_fixtures = { git = "https://github.com/tylerbutler/phoenix_channel_fixtures.git", ref = "7daccb856d17db6278980277237c201b2acdcdf1" }

--- a/packages/beryl_channels/src/beryl_channels.gleam
+++ b/packages/beryl_channels/src/beryl_channels.gleam
@@ -10,17 +10,33 @@
 //// type.
 ////
 //// ```gleam
+//// import beryl
+//// import beryl/wire
 //// import beryl_channels
 //// import beryl_channels/channel
+//// import gleam/otp/static_supervisor
 ////
 //// pub fn handlers() -> List(channel.Handler) {
 ////   [rooms.channel(), documents.channel()]
 //// }
 ////
 //// pub fn main() {
-////   let assert Ok(Nil) = beryl_channels.validate_handlers(handlers())
+////   let assert Ok(#(sockets, spec)) =
+////     beryl_channels.child_spec(
+////       beryl.config(wire.phoenix_codec()),
+////       handlers: handlers(),
+////     )
+////
+////   let assert Ok(_root) =
+////     static_supervisor.new(static_supervisor.OneForOne)
+////     |> static_supervisor.add(spec)
+////     |> static_supervisor.start()
 //// }
 //// ```
+////
+//// The returned `beryl.Sockets` is an ordinary core handle: pass it to a
+//// transport (`beryl_mist`, `beryl_ewe`), to `beryl.broadcast`, and to
+//// `beryl.stop`.
 ////
 //// ## Routing rules
 ////
@@ -31,17 +47,18 @@
 //// handlers registered with the *same* pattern string are rejected
 //// instead, because the second one could never be reached.
 ////
-//// ## Status
-////
-//// The handler surface, the error surface, and the validation below are
-//// complete. The supervised socket entry point that builds a child
-//// specification from a handler table lands together with the dispatch
-//// adapter; it is deliberately absent rather than present and inert.
+//// A join for a topic no handler matches is refused explicitly, with the
+//// reason payload `{"reason": "unmatched topic"}`, rather than left
+//// unanswered.
 
 import beryl
+import beryl/socket
 import beryl/topic
 import beryl_channels/channel
+import beryl_channels/internal/router
 import gleam/list
+import gleam/otp/static_supervisor
+import gleam/otp/supervision
 import gleam/result
 import gleam/set
 
@@ -62,7 +79,6 @@ pub type HandlerError {
   DuplicatePattern(pattern: String)
 }
 
-// nolint: unused_exports -- consumed by `child_spec`, which lands with the dispatch adapter
 /// Why building a channel-system child specification failed.
 ///
 /// Like `beryl.child_spec`, this reports only the failures that can be
@@ -84,7 +100,7 @@ pub type ChildSpecError {
 /// (`"room:lobby"` and `"room:*"`) are valid: routing resolves them by
 /// first match.
 ///
-/// The socket entry points run exactly this validation before starting
+/// [`child_spec`](#child_spec) runs exactly this validation before building
 /// anything, so a handler table that passes here is accepted there too.
 pub fn validate_handlers(
   handlers: List(channel.Handler),
@@ -92,6 +108,61 @@ pub fn validate_handlers(
   let patterns = list.map(handlers, channel.pattern)
   use _ <- result.try(list.try_each(patterns, validate_pattern))
   check_duplicates(patterns, set.new())
+}
+
+/// Build a channel system's supervision child specification for embedding
+/// in an application's supervision tree.
+///
+/// Like `beryl.child_spec`, this reports only what can be detected before
+/// the tree is started: the handler table is validated first, then the
+/// `beryl.Config`, whose error is returned nested in
+/// [`ChildSpecInvalidConfig`](#ChildSpecError). The returned
+/// `beryl.Sockets` is usable as soon as the owning tree is running.
+///
+/// ## Example
+///
+/// ```gleam
+/// let assert Ok(#(sockets, spec)) =
+///   beryl_channels.child_spec(
+///     beryl.config(wire.phoenix_codec()),
+///     handlers: [rooms.channel()],
+///   )
+///
+/// let assert Ok(_root) =
+///   static_supervisor.new(static_supervisor.OneForOne)
+///   |> static_supervisor.add(spec)
+///   |> static_supervisor.start()
+/// ```
+pub fn child_spec(
+  config: beryl.Config,
+  handlers handlers: List(channel.Handler),
+) -> Result(
+  #(beryl.Sockets, supervision.ChildSpecification(static_supervisor.Supervisor)),
+  ChildSpecError,
+) {
+  use table <- result.try(
+    compile(handlers) |> result.map_error(ChildSpecInvalidHandlers),
+  )
+
+  beryl.child_spec(config, init: initialise(table), update: router.update)
+  |> result.map_error(ChildSpecInvalidConfig)
+}
+
+/// Validate a handler table and parse its patterns once, before anything
+/// is started.
+fn compile(
+  handlers: List(channel.Handler),
+) -> Result(List(router.Registered), HandlerError) {
+  use _ <- result.map(validate_handlers(handlers))
+  router.table(handlers)
+}
+
+/// The core `init` for a compiled handler table: one router per socket.
+fn initialise(
+  table: List(router.Registered),
+) -> fn(socket.ConnectInfo(router.Envelope)) ->
+  #(router.Router, List(socket.Effect)) {
+  fn(info) { router.init(table, info) }
 }
 
 fn validate_pattern(pattern: String) -> Result(String, HandlerError) {

--- a/packages/beryl_channels/src/beryl_channels.gleam
+++ b/packages/beryl_channels/src/beryl_channels.gleam
@@ -2,7 +2,7 @@
 ////
 //// This package layers Phoenix-shaped channel modules on top of beryl's
 //// public app-side dispatch API. An application registers a list of
-//// [`channel.Handler`](./beryl_channels/channel.html#Handler) values —
+//// [`channel.Handler`](/reference/api/beryl_channels-channel/#handler) values —
 //// each a topic pattern plus a typed `join` callback — and the layer
 //// routes every socket event to the channel that owns its topic. No
 //// hand-written message union and no hand-written router are required,
@@ -116,7 +116,7 @@ pub fn validate_handlers(
 /// Like `beryl.child_spec`, this reports only what can be detected before
 /// the tree is started: the handler table is validated first, then the
 /// `beryl.Config`, whose error is returned nested in
-/// [`ChildSpecInvalidConfig`](#ChildSpecError). The returned
+/// [`ChildSpecInvalidConfig`](#childspecerror). The returned
 /// `beryl.Sockets` is usable as soon as the owning tree is running.
 ///
 /// ## Example

--- a/packages/beryl_channels/src/beryl_channels/channel.gleam
+++ b/packages/beryl_channels/src/beryl_channels/channel.gleam
@@ -43,7 +43,7 @@
 //// `info`, the type of server-side messages it accepts. Neither escapes:
 //// [`joined`](#joined) seals `state` inside the callback closures, and
 //// [`handler`](#handler) seals `info` inside the registration closure, so
-//// the resulting [`Handler`](#Handler) is not generic and handlers with
+//// the resulting [`Handler`](#handler) is not generic and handlers with
 //// unrelated `state` and `info` types compose in one list. No value is
 //// ever erased to `Dynamic` and no unchecked coercion is involved:
 //// typed `info` values travel inside a closure that only the join which
@@ -52,7 +52,7 @@
 ////
 //// ## Ordering
 ////
-//// [`Actions`](#Actions) are applied strictly in the order they were
+//// [`Actions`](#actions) are applied strictly in the order they were
 //// added, and they always target the channel's own topic. They lower onto
 //// beryl's core `Effect` values, which the runtime applies in list order
 //// inside a single actor turn — so action order is wire order.
@@ -72,7 +72,7 @@ import gleam/option
 
 /// A typed handle for sending server-side messages to one joined channel.
 ///
-/// Obtained from [`JoinInfo`](#JoinInfo) in the `join` callback and safe to
+/// Obtained from [`JoinInfo`](#joininfo) in the `join` callback and safe to
 /// share with any process. Messages sent through it are delivered to the
 /// channel's `on_info` callback with their type intact.
 ///
@@ -94,7 +94,7 @@ pub opaque type Sender(info) {
 /// This is a fire-and-forget send: it returns as soon as the message is
 /// enqueued, whether or not the channel is still joined. A message
 /// enqueued for a channel that has already ended is discarded on arrival
-/// (see [`Sender`](#Sender)).
+/// (see [`Sender`](#sender)).
 pub fn notify(sender: Sender(info), message: info) -> Nil {
   sender.send(message)
 }
@@ -103,7 +103,7 @@ pub fn notify(sender: Sender(info), message: info) -> Nil {
 ///
 /// `socket_id` and `seed` come straight from the transport's connect
 /// information; `self` is this channel's own generation-scoped
-/// [`Sender`](#Sender), which is the supported way to schedule work for
+/// [`Sender`](#sender), which is the supported way to schedule work for
 /// just after the join acknowledgment.
 pub type JoinInfo(info) {
   JoinInfo(
@@ -181,7 +181,7 @@ pub fn broadcast_from(
 }
 
 /// Reply successfully to a client message, using the `reply` handle from
-/// the [`Message`](#Message) that asked for it.
+/// the [`Message`](#message) that asked for it.
 pub fn reply_ok(
   actions: Actions,
   reply: socket.Ref,
@@ -191,7 +191,7 @@ pub fn reply_ok(
 }
 
 /// Reply with an error to a client message, using the `reply` handle from
-/// the [`Message`](#Message) that asked for it.
+/// the [`Message`](#message) that asked for it.
 pub fn reply_error(
   actions: Actions,
   reply: socket.Ref,
@@ -337,7 +337,7 @@ pub fn on_binary(
 }
 
 /// Handle typed server-side messages sent through this channel's
-/// [`Sender`](#Sender).
+/// [`Sender`](#sender).
 pub fn on_info(
   callbacks: Callbacks(state, info),
   handle: fn(state, info) -> Next(state),
@@ -460,7 +460,7 @@ pub opaque type Handler {
 /// `"room:*"`, `"document:*:ops"`, `"*"`) and is validated when the
 /// handler table is used; see `beryl_channels.validate_handlers`.
 ///
-/// `join` receives the connection's [`JoinInfo`](#JoinInfo), the concrete
+/// `join` receives the connection's [`JoinInfo`](#joininfo), the concrete
 /// topic that matched, and the client's join payload, and answers with
 /// [`accept`](#accept), [`accept_with`](#accept_with), or
 /// [`reject`](#reject).

--- a/packages/beryl_channels/src/beryl_channels/internal/router.gleam
+++ b/packages/beryl_channels/src/beryl_channels/internal/router.gleam
@@ -1,0 +1,354 @@
+//// The dispatch adapter: one handler table compiled into the
+//// `init`/`update` pair `beryl.child_spec` expects.
+////
+//// This module is internal to `beryl_channels` (Gleam hides
+//// `beryl_channels/internal/*` from other packages and from the generated
+//// docs). Applications use `beryl_channels.child_spec`.
+////
+//// ## The model
+////
+//// Each socket gets exactly one [`Router`](#Router): the ordered handler
+//// table, the core `socket.Sender(Envelope)` handed to `init`, a
+//// dictionary of the topics this socket currently has a live channel on,
+//// and a monotonically increasing generation counter.
+////
+//// A *generation* is allocated for every join attempt that reaches a
+//// handler and is never reused, so an instance is identified by
+//// `#(topic, generation)`. That pair is what makes a duplicate rejoin
+//// safe: the old instance's senders are bound to a generation that is no
+//// longer live, so their envelopes are dropped instead of being handed to
+//// the new instance.
+////
+//// ## Process affinity (load-bearing)
+////
+//// `channel.open` and `LiveChannel.on_mail` **must run in the same
+//// process**. `channel.handler` creates the join's typed hand-off subject
+//// while running `open`, and only the process that created a subject may
+//// receive from it; `on_mail` places the sealed value into that subject
+//// and reads it back in the same turn.
+////
+//// This adapter satisfies that by construction: `open` runs from the
+//// `Join` input and `on_mail` from the `Info` input, and beryl delivers
+//// every input for a socket to `update` inside its own runtime actor
+//// process. Nothing here may move either call onto another process — not
+//// into a spawned task, not into a transport process.
+//// `dispatch_test.join_and_info_run_in_the_same_runtime_process_test`
+//// pins this.
+
+import beryl/socket
+import beryl/topic
+import beryl_channels/channel
+import gleam/dict
+import gleam/dynamic
+import gleam/json
+import gleam/list
+import gleam/option
+
+/// The socket-level message type of a channel system.
+///
+/// It carries no channel state and no typed `info` value: a `Mail` is a
+/// sealed thunk that only the join which created it can open, and the
+/// topic/generation pair says which join that is.
+pub type Envelope {
+  ChannelMail(topic: String, generation: Int, mail: channel.Mail)
+}
+
+/// A handler with its topic pattern parsed once, at table build time.
+pub type Registered {
+  Registered(pattern: topic.TopicPattern, handler: channel.Handler)
+}
+
+/// One live channel instance and the generation it was opened at.
+pub type Instance {
+  Instance(generation: Int, channel: channel.LiveChannel)
+}
+
+/// The per-socket model.
+pub type Router {
+  Router(
+    handlers: List(Registered),
+    socket_id: String,
+    seed: socket.ConnectSeed,
+    self: socket.Sender(Envelope),
+    /// The last generation handed out; strictly increasing, never reused.
+    generation: Int,
+    /// The topics this socket currently has an accepted instance on.
+    live: dict.Dict(String, Instance),
+  )
+}
+
+/// Parse every handler's pattern once, preserving registration order —
+/// routing takes the first match, so order is the routing rule.
+pub fn table(handlers: List(channel.Handler)) -> List(Registered) {
+  list.map(handlers, fn(handler) {
+    Registered(
+      pattern: topic.parse_pattern(channel.pattern(handler)),
+      handler: handler,
+    )
+  })
+}
+
+/// The `init` half of the pair: a socket starts with no joined channels.
+pub fn init(
+  handlers: List(Registered),
+  info: socket.ConnectInfo(Envelope),
+) -> #(Router, List(socket.Effect)) {
+  let router =
+    Router(
+      handlers: handlers,
+      socket_id: info.socket_id,
+      seed: info.seed,
+      self: info.self,
+      generation: 0,
+      live: dict.new(),
+    )
+  #(router, [])
+}
+
+/// The `update` half of the pair.
+pub fn update(
+  router: Router,
+  input: socket.Input(Envelope),
+) -> socket.Next(Router, Envelope) {
+  case input {
+    socket.Join(topic: name, payload: payload, ref: ref) ->
+      join(router, name, payload, ref)
+
+    socket.Message(topic: name, event: event, payload: payload, ref: ref) ->
+      on_live(router, name, fn(instance) {
+        instance.channel.on_message(channel.Message(
+          topic: name,
+          event: event,
+          payload: payload,
+          reply: ref,
+        ))
+      })
+
+    socket.Binary(topic: name, data: data) ->
+      on_live(router, name, fn(instance) { instance.channel.on_binary(data) })
+
+    socket.Closed(topic: name, reason: reason) -> closed(router, name, reason)
+
+    socket.Info(ChannelMail(topic: name, generation: generation, mail: mail)) ->
+      deliver(router, name, generation, mail)
+  }
+}
+
+// --- joining ---------------------------------------------------------------
+
+/// First match wins. An unmatched topic is refused explicitly rather than
+/// left unanswered, so the client always learns why.
+fn join(
+  router: Router,
+  name: String,
+  payload: dynamic.Dynamic,
+  ref: socket.Ref,
+) -> socket.Next(Router, Envelope) {
+  case select(router.handlers, name) {
+    option.None ->
+      socket.Next(router, [socket.RejectJoin(ref, unmatched_topic())])
+    option.Some(handler) -> open(router, handler, name, payload, ref)
+  }
+}
+
+fn select(
+  handlers: List(Registered),
+  name: String,
+) -> option.Option(channel.Handler) {
+  case handlers {
+    [] -> option.None
+    [registered, ..rest] ->
+      case topic.matches(registered.pattern, name) {
+        True -> option.Some(registered.handler)
+        False -> select(rest, name)
+      }
+  }
+}
+
+fn unmatched_topic() -> json.Json {
+  json.object([#("reason", json.string("unmatched topic"))])
+}
+
+/// Allocate this join's generation, bind the channel's sends to it, and
+/// run the handler.
+///
+/// The generation is bound into `deliver` *before* `channel.open` runs,
+/// because a `join` callback may notify itself; its mail has to be
+/// addressed to the join being opened. The counter advances even when the
+/// handler rejects, so a rejected join's sender can never collide with a
+/// later accepted one.
+fn open(
+  router: Router,
+  handler: channel.Handler,
+  name: String,
+  payload: dynamic.Dynamic,
+  ref: socket.Ref,
+) -> socket.Next(Router, Envelope) {
+  let generation = router.generation + 1
+  let router = Router(..router, generation: generation)
+  let context =
+    channel.JoinContext(
+      socket_id: router.socket_id,
+      seed: router.seed,
+      topic: name,
+      payload: payload,
+      deliver: mailbox(router.self, name, generation),
+    )
+
+  case channel.open(handler, context) {
+    // Only accepted joins become instances; a rejection leaves the socket
+    // with no channel on this topic.
+    channel.Rejected(reason) ->
+      socket.Next(router, [socket.RejectJoin(ref, reason)])
+    channel.Accepted(reply: reply, channel: live) -> {
+      let instance = Instance(generation: generation, channel: live)
+      socket.Next(
+        Router(..router, live: dict.insert(router.live, name, instance)),
+        // The acknowledgment is ordered ahead of anything the join asked
+        // for, so a push can never precede its own join reply.
+        [socket.AcceptJoin(ref, reply)],
+      )
+    }
+  }
+}
+
+/// Bind one join's sends to its topic and generation. Every `notify`
+/// produces exactly one envelope; nothing is coalesced.
+fn mailbox(
+  self: socket.Sender(Envelope),
+  name: String,
+  generation: Int,
+) -> fn(channel.Mail) -> Nil {
+  fn(mail) {
+    socket.notify(
+      self,
+      ChannelMail(topic: name, generation: generation, mail: mail),
+    )
+  }
+}
+
+// --- routing to a live instance --------------------------------------------
+
+/// Run `callback` against the live instance for `name`, if there is one.
+///
+/// Inputs for a topic this socket has no accepted instance on are ignored:
+/// a rejected join starts nothing, and a closed channel is gone.
+fn on_live(
+  router: Router,
+  name: String,
+  callback: fn(Instance) -> channel.Step,
+) -> socket.Next(Router, Envelope) {
+  case dict.get(router.live, name) {
+    Error(Nil) -> socket.Next(router, [])
+    Ok(instance) -> advance(router, name, instance, callback(instance))
+  }
+}
+
+/// Deliver one sealed server-side message.
+///
+/// The envelope is checked against the live instance **before** the mail
+/// is handed over, so a stale envelope — one from a closed channel or a
+/// superseded generation — is dropped with its thunk still sealed and its
+/// payload reaches nothing.
+fn deliver(
+  router: Router,
+  name: String,
+  generation: Int,
+  mail: channel.Mail,
+) -> socket.Next(Router, Envelope) {
+  case dict.get(router.live, name) {
+    Error(Nil) -> socket.Next(router, [])
+    Ok(instance) ->
+      case instance.generation == generation {
+        False -> socket.Next(router, [])
+        True -> advance(router, name, instance, instance.channel.on_mail(mail))
+      }
+  }
+}
+
+/// Lower one callback result onto the core.
+fn advance(
+  router: Router,
+  name: String,
+  instance: Instance,
+  step: channel.Step,
+) -> socket.Next(Router, Envelope) {
+  case step {
+    // The next instance keeps this join's generation: it is the same join.
+    channel.StepContinue(next: next, actions: actions) -> {
+      let live =
+        dict.insert(router.live, name, Instance(..instance, channel: next))
+      socket.Next(Router(..router, live: live), effects(name, actions))
+    }
+
+    // Actions first, then the kick. The instance stays live until the
+    // `Closed` the kick produces arrives, so termination runs there — on
+    // the one path every ending channel takes.
+    channel.StepClose(actions: actions) ->
+      socket.Next(
+        router,
+        list.append(effects(name, actions), [socket.KickTopic(name)]),
+      )
+
+    // Stopping the socket carries no actions: every channel on it is
+    // going away, and each still receives `Closed`.
+    channel.StepStop(reason: reason) -> socket.Stop(reason)
+  }
+}
+
+// --- termination -----------------------------------------------------------
+
+/// A joined topic ended, for any reason.
+///
+/// The instance is removed *before* its termination callback runs, so the
+/// callback can neither be re-entered for this instance nor observe it as
+/// live, and `Closed` is the only place termination happens — exactly
+/// once per accepted join.
+fn closed(
+  router: Router,
+  name: String,
+  reason: socket.StopReason,
+) -> socket.Next(Router, Envelope) {
+  case dict.get(router.live, name) {
+    Error(Nil) -> socket.Next(router, [])
+    Ok(instance) -> {
+      let router = Router(..router, live: dict.delete(router.live, name))
+      instance.channel.on_terminate(reason)
+      // Termination produces no actions: the topic is already closing, so
+      // frames pushed to it would be dropped by the core anyway.
+      socket.Next(router, [])
+    }
+  }
+}
+
+// --- action lowering -------------------------------------------------------
+
+/// Lower a channel's actions onto core effects, in order, all scoped to
+/// the channel's own topic. Core applies effects in list order, so action
+/// order is wire order.
+fn effects(name: String, actions: List(channel.Action)) -> List(socket.Effect) {
+  list.map(actions, fn(action) { effect(name, action) })
+}
+
+fn effect(name: String, action: channel.Action) -> socket.Effect {
+  case action {
+    channel.PushAction(event: event, payload: payload) ->
+      socket.Push(topic: name, event: event, payload: payload)
+    channel.BroadcastAction(event: event, payload: payload) ->
+      socket.Broadcast(topic: name, event: event, payload: payload)
+    channel.BroadcastFromAction(event: event, payload: payload) ->
+      socket.BroadcastFrom(topic: name, event: event, payload: payload)
+    channel.ReplyOkAction(reply: reply, payload: payload) ->
+      socket.ReplyOk(ref: reply, payload: payload)
+    channel.ReplyErrorAction(reply: reply, payload: payload) ->
+      socket.ReplyError(ref: reply, payload: payload)
+    channel.PresenceTrackAction(key: key, meta: meta) ->
+      socket.PresenceTrack(topic: name, key: key, meta: meta)
+    channel.PresenceUntrackAction(key: key) ->
+      socket.PresenceUntrack(topic: name, key: key)
+    channel.PushPresenceAction(event: event, encode: encode) ->
+      socket.PushPresence(topic: name, event: event, encode: encode)
+    channel.BroadcastPresenceAction(event: event, encode: encode) ->
+      socket.BroadcastPresence(topic: name, event: event, encode: encode)
+  }
+}

--- a/packages/beryl_channels/test/crash_test.gleam
+++ b/packages/beryl_channels/test/crash_test.gleam
@@ -1,0 +1,327 @@
+//// The crash boundaries a channel system inherits from beryl's core.
+////
+//// App code that panics must never take the runtime down. The core's
+//// policy is attributed by *where* the panic happened, and this layer
+//// must not blunt it:
+////
+//// | Panic in | Effect |
+//// |---|---|
+//// | `join` | that join is rejected; the socket survives |
+//// | `on_message` / `on_binary` | that topic closes; other topics survive |
+//// | `on_info` | the whole socket is torn down |
+//// | `on_terminate` | teardown still completes |
+////
+//// Every assertion runs against a real system through beryl's public
+//// transport SPI.
+
+import beryl
+import beryl/wire
+import beryl_channels/channel
+import dispatch_helpers as helper
+import gleam/erlang/process
+import gleam/json
+import gleam/string
+import gleeunit/should
+
+/// The crashing channels' server-side message type.
+pub type Poke {
+  Poke
+}
+
+// --- test channels ---------------------------------------------------------
+
+/// A channel that works: it answers `"ping"` and traces its termination.
+fn ok_handler(trace: process.Subject(String)) -> channel.Handler {
+  channel.handler("room:*", fn(_info, topic, _payload) {
+    let callbacks =
+      channel.callbacks()
+      |> channel.on_message(fn(state, _message) {
+        channel.continue_with(
+          state,
+          channel.actions() |> channel.push("pong", json.int(1)),
+        )
+      })
+      |> channel.on_binary(fn(state, _data) {
+        channel.continue_with(
+          state,
+          channel.actions() |> channel.push("pong", json.int(2)),
+        )
+      })
+      |> channel.on_terminate(fn(_state, reason) {
+        process.send(
+          trace,
+          "terminate:" <> topic <> ":" <> helper.reason_name(reason),
+        )
+      })
+    channel.accept_with(
+      channel.joined(Nil, callbacks),
+      json.object([#("handler", json.string("room"))]),
+    )
+  })
+}
+
+/// A channel whose `join` callback panics before it can accept or reject.
+fn join_panics() -> channel.Handler {
+  channel.handler("crash_join:*", fn(_info, _topic, _payload) {
+    panic as "join exploded"
+  })
+}
+
+/// A channel whose `on_message` and `on_binary` callbacks panic.
+fn callback_panics(trace: process.Subject(String)) -> channel.Handler {
+  channel.handler("crash_msg:*", fn(_info, topic, _payload) {
+    let callbacks =
+      channel.callbacks()
+      |> channel.on_message(fn(_state, _message) { panic as "message exploded" })
+      |> channel.on_binary(fn(_state, _data) { panic as "binary exploded" })
+      |> channel.on_terminate(fn(_state, reason) {
+        process.send(
+          trace,
+          "terminate:" <> topic <> ":" <> helper.reason_name(reason),
+        )
+      })
+    channel.accept(channel.joined(Nil, callbacks))
+  })
+}
+
+/// A channel whose `on_info` callback panics.
+fn info_panics(
+  trace: process.Subject(String),
+  senders: process.Subject(channel.Sender(Poke)),
+) -> channel.Handler {
+  channel.handler("crash_info:*", fn(info, topic, _payload) {
+    process.send(senders, info.self)
+    let callbacks =
+      channel.callbacks()
+      |> channel.on_info(fn(_state, _note) { panic as "info exploded" })
+      |> channel.on_terminate(fn(_state, reason) {
+        process.send(
+          trace,
+          "terminate:" <> topic <> ":" <> helper.reason_name(reason),
+        )
+      })
+    channel.accept(channel.joined(Nil, callbacks))
+  })
+}
+
+/// A channel that closes itself and then panics while terminating.
+fn terminate_panics(trace: process.Subject(String)) -> channel.Handler {
+  channel.handler("crash_term:*", fn(_info, topic, _payload) {
+    let callbacks =
+      channel.callbacks()
+      |> channel.on_message(fn(_state, _message) {
+        channel.close_with(
+          channel.actions() |> channel.push("bye", json.int(0)),
+        )
+      })
+      |> channel.on_terminate(fn(_state, _reason) {
+        process.send(trace, "terminating:" <> topic)
+        panic as "terminate exploded"
+      })
+    channel.accept(channel.joined(Nil, callbacks))
+  })
+}
+
+// --- systems ---------------------------------------------------------------
+
+fn start(handlers: List(channel.Handler)) -> beryl.Sockets {
+  helper.start(beryl.config(wire.phoenix_codec()), handlers: handlers)
+}
+
+fn start_text_only(handlers: List(channel.Handler)) -> beryl.Sockets {
+  helper.start(beryl.config(helper.text_only_codec()), handlers: handlers)
+}
+
+// --- join --------------------------------------------------------------
+
+pub fn a_panic_in_join_rejects_that_join_test() {
+  let trace = process.new_subject()
+  let channels = start([join_panics(), ok_handler(trace)])
+  let frames = helper.connect(channels, "s1")
+
+  // A live channel on the same socket, so the trace has a writer that a
+  // wrongly-registered or wrongly-torn-down channel would show up in.
+  helper.join(channels, "s1", "room:b", "jr-1", "r-1")
+  let _join_b = helper.recv(frames)
+
+  helper.join(channels, "s1", "crash_join:a", "jr-2", "r-2")
+
+  let reply = helper.recv(frames)
+  reply |> string.contains("\"status\":\"error\"") |> should.be_true
+  reply
+  |> string.contains("{\"reason\":\"join crashed\"}")
+  |> should.be_true
+
+  // The crashed join never became an instance: nothing is joined on its
+  // topic, so a message there is answered as an unjoined topic...
+  helper.push(channels, "s1", "crash_join:a", "ping", "r-3")
+  helper.recv(frames)
+  |> string.contains("{\"reason\":\"unmatched topic\"}")
+  |> should.be_true
+
+  // ...and neither channel terminated because of the crash.
+  helper.no_trace(trace)
+}
+
+pub fn a_panic_in_join_leaves_the_socket_usable_test() {
+  let trace = process.new_subject()
+  let channels = start([join_panics(), ok_handler(trace)])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "crash_join:a", "jr-1", "r-1")
+  let _rejection = helper.recv(frames)
+
+  // Same socket, a different topic: the crash rejected one join, it did
+  // not tear the connection down.
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  helper.recv(frames)
+  |> string.contains("\"handler\":\"room\"")
+  |> should.be_true
+
+  helper.push(channels, "s1", "room:b", "ping", "r-3")
+  helper.recv(frames) |> string.contains("\"pong\"") |> should.be_true
+}
+
+// --- message and binary --------------------------------------------------
+
+pub fn a_panic_handling_a_message_closes_only_that_topic_test() {
+  let trace = process.new_subject()
+  let channels = start([callback_panics(trace), ok_handler(trace)])
+  let frames = helper.connect(channels, "s1")
+  helper.join(channels, "s1", "crash_msg:a", "jr-1", "r-1")
+  let _join_a = helper.recv(frames)
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  let _join_b = helper.recv(frames)
+
+  helper.push(channels, "s1", "crash_msg:a", "boom", "r-3")
+
+  // The crashing topic is closed with the crash as its reason, and its
+  // termination callback still runs exactly once.
+  let line = helper.next_trace(trace)
+  line
+  |> string.starts_with("terminate:crash_msg:a:errored:")
+  |> should.be_true
+  helper.no_trace(trace)
+
+  // An errored close is announced as `phx_error`, not `phx_close`.
+  let close = helper.recv(frames)
+  close |> string.contains("phx_error") |> should.be_true
+  close |> string.contains("crash_msg:a") |> should.be_true
+
+  // The other topic on the same socket is untouched.
+  helper.push(channels, "s1", "room:b", "ping", "r-4")
+  helper.recv(frames) |> string.contains("\"pong\"") |> should.be_true
+
+  // ...and the closed topic is gone, so a later message reaches no
+  // channel: the core answers it with Phoenix's unmatched-topic error and
+  // the crashed channel is never re-entered.
+  helper.push(channels, "s1", "crash_msg:a", "boom", "r-5")
+  helper.recv(frames)
+  |> string.contains("{\"reason\":\"unmatched topic\"}")
+  |> should.be_true
+  helper.no_trace(trace)
+}
+
+pub fn a_panic_handling_a_binary_frame_closes_only_that_topic_test() {
+  let trace = process.new_subject()
+  let channels = start_text_only([callback_panics(trace), ok_handler(trace)])
+  let frames = helper.connect(channels, "s1")
+  helper.join(channels, "s1", "crash_msg:a", "jr-1", "r-1")
+  let _join_a = helper.recv(frames)
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  let _join_b = helper.recv(frames)
+
+  // A binary frame fans out to every joined topic in sorted order, so the
+  // panicking topic is delivered to first.
+  helper.route_binary(channels, "s1", <<1, 2, 3>>)
+
+  let line = helper.next_trace(trace)
+  line
+  |> string.starts_with("terminate:crash_msg:a:errored:")
+  |> should.be_true
+  helper.no_trace(trace)
+
+  let close = helper.recv(frames)
+  close |> string.contains("phx_error") |> should.be_true
+  close |> string.contains("crash_msg:a") |> should.be_true
+
+  // The surviving topic received the very same frame and handled it.
+  helper.recv(frames) |> string.contains("\"pong\",2") |> should.be_true
+
+  // ...and still works afterwards.
+  helper.push(channels, "s1", "room:b", "ping", "r-3")
+  helper.recv(frames) |> string.contains("\"pong\",1") |> should.be_true
+}
+
+// --- info ------------------------------------------------------------------
+
+pub fn a_panic_handling_info_closes_the_whole_socket_test() {
+  let trace = process.new_subject()
+  let senders = process.new_subject()
+  let channels = start([info_panics(trace, senders), ok_handler(trace)])
+  let frames = helper.connect(channels, "s1")
+  helper.join(channels, "s1", "crash_info:a", "jr-1", "r-1")
+  let _join_a = helper.recv(frames)
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  let _join_b = helper.recv(frames)
+  let assert Ok(sender) = process.receive(senders, 500)
+    as "the join reported its sender"
+
+  channel.notify(sender, Poke)
+
+  // An `Info` has no topic to attribute the crash to, so the socket goes
+  // away — and *every* channel on it terminates, exactly once each.
+  let first = helper.next_trace(trace)
+  first
+  |> string.starts_with("terminate:crash_info:a:errored:")
+  |> should.be_true
+  let second = helper.next_trace(trace)
+  second |> string.starts_with("terminate:room:b:errored:") |> should.be_true
+  helper.no_trace(trace)
+
+  // The socket is gone: later frames reach nothing at all.
+  let _close_a = helper.recv(frames)
+  let _close_b = helper.recv(frames)
+  helper.push(channels, "s1", "room:b", "ping", "r-3")
+  helper.recv_none(frames)
+}
+
+// --- terminate -------------------------------------------------------------
+
+pub fn a_panic_while_terminating_does_not_prevent_teardown_test() {
+  let trace = process.new_subject()
+  let channels = start([terminate_panics(trace), ok_handler(trace)])
+  let frames = helper.connect(channels, "s1")
+  helper.join(channels, "s1", "crash_term:a", "jr-1", "r-1")
+  let _join_a = helper.recv(frames)
+
+  helper.push(channels, "s1", "crash_term:a", "leave", "r-2")
+
+  helper.recv(frames) |> string.contains("\"bye\"") |> should.be_true
+  helper.next_trace(trace) |> should.equal("terminating:crash_term:a")
+
+  // The terminal frame is still sent even though the callback panicked.
+  helper.recv(frames) |> string.contains("phx_close") |> should.be_true
+
+  // The socket survived, so the topic can be joined again.
+  helper.join(channels, "s1", "crash_term:a", "jr-2", "r-3")
+  helper.recv(frames) |> string.contains("\"status\":\"ok\"") |> should.be_true
+}
+
+pub fn a_panic_while_terminating_does_not_stop_other_channels_closing_test() {
+  let trace = process.new_subject()
+  let channels = start([terminate_panics(trace), ok_handler(trace)])
+  let frames = helper.connect(channels, "s1")
+  helper.join(channels, "s1", "crash_term:a", "jr-1", "r-1")
+  let _join_a = helper.recv(frames)
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  let _join_b = helper.recv(frames)
+
+  helper.disconnect(channels, "s1")
+
+  // Topics close in sorted order; the first one panics while terminating
+  // and the second still terminates.
+  helper.next_trace(trace) |> should.equal("terminating:crash_term:a")
+  helper.next_trace(trace) |> should.equal("terminate:room:b:normal")
+  helper.no_trace(trace)
+}

--- a/packages/beryl_channels/test/dispatch_helpers.gleam
+++ b/packages/beryl_channels/test/dispatch_helpers.gleam
@@ -1,0 +1,148 @@
+//// Shared helpers for the dispatch-adapter integration tests.
+////
+//// Sockets are driven through beryl's **public** transport SPI
+//// (`beryl/transport`), so these tests exercise exactly the path a real
+//// WebSocket transport uses: connect, decode a frame in the caller, route
+//// it, disconnect. Outbound frames are captured per socket.
+
+import beryl
+import beryl/socket
+import beryl/transport
+import beryl/wire/codec
+import beryl_channels
+import beryl_channels/channel
+import gleam/erlang/process
+import gleam/option.{None}
+import gleam/otp/static_supervisor
+import gleeunit/should
+
+/// Build and start a supervised channel system for integration tests.
+pub fn start(
+  config: beryl.Config,
+  handlers handlers: List(channel.Handler),
+) -> beryl.Sockets {
+  let assert Ok(#(sockets, spec)) =
+    beryl_channels.child_spec(config, handlers: handlers)
+    as "the handler table and config are valid"
+  let assert Ok(_) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(spec)
+    |> static_supervisor.start()
+    as "the channel supervision tree starts"
+  sockets
+}
+
+/// Connect a socket, returning the subject that captures its outbound
+/// text frames.
+pub fn connect(
+  channels: beryl.Sockets,
+  socket_id: String,
+) -> process.Subject(String) {
+  let sent = process.new_subject()
+  let assert Ok(owner) = transport.runtime_pid(channels)
+  transport.admit_socket(
+    sockets: channels,
+    owner: owner,
+    socket_id: socket_id,
+    send: fn(message) {
+      process.send(sent, message)
+      Ok(Nil)
+    },
+    send_binary: fn(_data) { Ok(Nil) },
+    codec: None,
+    seed: socket.empty_seed(),
+    close: fn() { Nil },
+  )
+  |> should.equal(Ok(Nil))
+  sent
+}
+
+/// Announce that a socket's connection closed.
+pub fn disconnect(channels: beryl.Sockets, socket_id: String) -> Nil {
+  transport.socket_disconnected(channels, socket_id)
+}
+
+/// Route a raw text frame the way a transport does: decode in the caller,
+/// then hand the decoded message to the runtime.
+pub fn route(channels: beryl.Sockets, socket_id: String, raw: String) -> Nil {
+  let assert Ok(decoded) =
+    codec.decode_text(transport.active_codec(channels))(raw)
+    as "the test frame is valid phoenix wire format"
+  transport.route_decoded(channels, socket_id, decoded)
+}
+
+/// Route a raw binary frame.
+pub fn route_binary(
+  channels: beryl.Sockets,
+  socket_id: String,
+  data: BitArray,
+) -> Nil {
+  transport.route_binary(channels, socket_id, data)
+}
+
+/// Send a `phx_join` for a topic with the given join_ref/ref.
+pub fn join(
+  channels: beryl.Sockets,
+  socket_id: String,
+  topic_name: String,
+  join_ref: String,
+  ref: String,
+) -> Nil {
+  route(
+    channels,
+    socket_id,
+    "[\""
+      <> join_ref
+      <> "\",\""
+      <> ref
+      <> "\",\""
+      <> topic_name
+      <> "\",\"phx_join\",{}]",
+  )
+}
+
+/// Send a user event on a topic with a reply ref.
+pub fn push(
+  channels: beryl.Sockets,
+  socket_id: String,
+  topic_name: String,
+  event_name: String,
+  ref: String,
+) -> Nil {
+  route(
+    channels,
+    socket_id,
+    "[null,\""
+      <> ref
+      <> "\",\""
+      <> topic_name
+      <> "\",\""
+      <> event_name
+      <> "\",{}]",
+  )
+}
+
+/// Receive the next captured frame, failing after 500ms.
+pub fn recv(frames: process.Subject(String)) -> String {
+  let assert Ok(frame) = process.receive(frames, 500) as "a frame was sent"
+  frame
+}
+
+/// Assert no frame arrives within 100ms.
+pub fn recv_none(frames: process.Subject(String)) -> Nil {
+  process.receive(frames, 100) |> should.be_error
+  Nil
+}
+
+/// Receive the next trace line recorded by a test channel, failing after
+/// 500ms.
+pub fn next_trace(trace: process.Subject(String)) -> String {
+  let assert Ok(line) = process.receive(trace, 500) as "a trace was recorded"
+  line
+}
+
+/// Assert no trace line is recorded within 100ms.
+pub fn no_trace(trace: process.Subject(String)) -> Nil {
+  process.receive(trace, 100) |> should.be_error
+  Nil
+}

--- a/packages/beryl_channels/test/dispatch_helpers.gleam
+++ b/packages/beryl_channels/test/dispatch_helpers.gleam
@@ -8,6 +8,7 @@
 import beryl
 import beryl/socket
 import beryl/transport
+import beryl/wire
 import beryl/wire/codec
 import beryl_channels
 import beryl_channels/channel
@@ -15,6 +16,10 @@ import gleam/erlang/process
 import gleam/option.{None}
 import gleam/otp/static_supervisor
 import gleeunit/should
+
+/// The captured outbound text frames of one connected socket.
+pub type Frames =
+  process.Subject(String)
 
 /// Build and start a supervised channel system for integration tests.
 pub fn start(
@@ -34,6 +39,9 @@ pub fn start(
 
 /// Connect a socket, returning the subject that captures its outbound
 /// text frames.
+///
+/// No settling delay is needed: admission is acknowledged by the exact
+/// runtime owner before this function returns.
 pub fn connect(
   channels: beryl.Sockets,
   socket_id: String,
@@ -55,6 +63,30 @@ pub fn connect(
   )
   |> should.equal(Ok(Nil))
   sent
+}
+
+/// The Phoenix framing minus its binary decoder, so raw binary frames take
+/// the per-topic fan-out path and arrive as `Binary` inputs instead of
+/// being rejected at decode.
+pub fn text_only_codec() -> codec.Codec {
+  codec.new(
+    decode_text: wire.decode_message,
+    encode_reply: wire.reply_json,
+    encode_push: wire.push,
+    encode_heartbeat_reply: wire.heartbeat_reply,
+  )
+  |> codec.with_close_encoder(wire.channel_close)
+  |> codec.with_error_encoder(wire.channel_error)
+}
+
+/// A stable string for a stop reason, for trace assertions.
+pub fn reason_name(reason: socket.StopReason) -> String {
+  case reason {
+    socket.Normal -> "normal"
+    socket.Shutdown -> "shutdown"
+    socket.HeartbeatTimeout -> "heartbeat_timeout"
+    socket.Errored(detail) -> "errored:" <> detail
+  }
 }
 
 /// Announce that a socket's connection closed.
@@ -88,6 +120,18 @@ pub fn join(
   join_ref: String,
   ref: String,
 ) -> Nil {
+  join_with(channels, socket_id, topic_name, join_ref, ref, "{}")
+}
+
+/// Send a `phx_join` carrying a raw JSON payload.
+pub fn join_with(
+  channels: beryl.Sockets,
+  socket_id: String,
+  topic_name: String,
+  join_ref: String,
+  ref: String,
+  payload: String,
+) -> Nil {
   route(
     channels,
     socket_id,
@@ -97,7 +141,30 @@ pub fn join(
       <> ref
       <> "\",\""
       <> topic_name
-      <> "\",\"phx_join\",{}]",
+      <> "\",\"phx_join\","
+      <> payload
+      <> "]",
+  )
+}
+
+/// Send a `phx_leave` for a topic.
+pub fn leave(
+  channels: beryl.Sockets,
+  socket_id: String,
+  topic_name: String,
+  join_ref: String,
+  ref: String,
+) -> Nil {
+  route(
+    channels,
+    socket_id,
+    "[\""
+      <> join_ref
+      <> "\",\""
+      <> ref
+      <> "\",\""
+      <> topic_name
+      <> "\",\"phx_leave\",{}]",
   )
 }
 

--- a/packages/beryl_channels/test/dispatch_test.gleam
+++ b/packages/beryl_channels/test/dispatch_test.gleam
@@ -8,7 +8,6 @@ import beryl/socket
 import beryl/transport
 import beryl/wire
 import beryl/wire/codec
-import beryl_channels
 import beryl_channels/channel
 import dispatch_helpers as helper
 import gleam/bit_array

--- a/packages/beryl_channels/test/dispatch_test.gleam
+++ b/packages/beryl_channels/test/dispatch_test.gleam
@@ -1,0 +1,542 @@
+//// Integration coverage for the dispatch adapter: `child_spec` compiles
+//// a handler table into beryl's `init`/`update` pair, and every
+//// assertion below is made through beryl's public transport SPI, on real
+//// wire frames, against a real running system.
+
+import beryl
+import beryl/socket
+import beryl/transport
+import beryl/wire
+import beryl/wire/codec
+import beryl_channels
+import beryl_channels/channel
+import dispatch_helpers as helper
+import gleam/bit_array
+import gleam/erlang/process
+import gleam/int
+import gleam/json
+import gleam/option
+import gleam/string
+import gleeunit/should
+
+/// The room channel's private server-side message type. It is never named
+/// by the router, the socket model, or the wire.
+pub type Note {
+  Announce(String)
+  Farewell
+  /// Report the process the `on_info` callback runs in.
+  WhereAmI(process.Subject(process.Pid))
+}
+
+/// Everything a test channel reports back to the test process.
+pub type Wiring {
+  Wiring(
+    /// Ordered lifecycle trace: `"join:<topic>"` and
+    /// `"terminate:<topic>:<reason>:<state>"`.
+    trace: process.Subject(String),
+    /// The typed sender of each accepted join, in join order.
+    senders: process.Subject(channel.Sender(Note)),
+    /// The process each `join` callback ran in.
+    pids: process.Subject(process.Pid),
+  )
+}
+
+pub fn new_wiring() -> Wiring {
+  Wiring(
+    trace: process.new_subject(),
+    senders: process.new_subject(),
+    pids: process.new_subject(),
+  )
+}
+
+// --- test channels ---------------------------------------------------------
+
+/// A channel that reports which handler owns the topic and nothing else.
+fn labelled_handler(pattern: String, label: String) -> channel.Handler {
+  channel.handler(pattern, fn(_info, _topic, _payload) {
+    channel.accept_with(
+      channel.joined(Nil, channel.callbacks()),
+      json.object([#("handler", json.string(label))]),
+    )
+  })
+}
+
+/// The main test channel: an `Int` counter with every callback wired up.
+fn room_handler(wiring: Wiring) -> channel.Handler {
+  channel.handler("room:*", fn(info, topic, _payload) {
+    process.send(wiring.trace, "join:" <> topic)
+    process.send(wiring.senders, info.self)
+    process.send(wiring.pids, process.self())
+
+    channel.accept_with(
+      channel.joined(0, room_callbacks(wiring, topic)),
+      json.object([#("handler", json.string("room"))]),
+    )
+  })
+}
+
+fn room_callbacks(
+  wiring: Wiring,
+  topic: String,
+) -> channel.Callbacks(Int, Note) {
+  channel.callbacks()
+  |> channel.on_message(on_message)
+  |> channel.on_binary(fn(count, data) {
+    channel.continue_with(
+      count,
+      channel.actions()
+        |> channel.push("binary", json.int(bit_array.byte_size(data))),
+    )
+  })
+  |> channel.on_info(on_info)
+  |> channel.on_terminate(fn(count, reason) {
+    process.send(
+      wiring.trace,
+      "terminate:"
+        <> topic
+        <> ":"
+        <> reason_name(reason)
+        <> ":"
+        <> int.to_string(count),
+    )
+  })
+}
+
+fn on_message(count: Int, message: channel.Message) -> channel.Next(Int) {
+  case message.event, message.reply {
+    "echo", option.Some(ref) ->
+      channel.continue_with(
+        count,
+        channel.actions()
+          |> channel.reply_ok(ref, json.object([#("echoed", json.bool(True))])),
+      )
+    "fail", option.Some(ref) ->
+      channel.continue_with(
+        count,
+        channel.actions()
+          |> channel.reply_error(ref, json.object([#("no", json.bool(True))])),
+      )
+    "burst", _ ->
+      channel.continue_with(
+        count,
+        channel.actions()
+          |> channel.push("one", json.int(1))
+          |> channel.push("two", json.int(2))
+          |> channel.broadcast_from("three", json.int(3))
+          |> channel.broadcast("four", json.int(4)),
+      )
+    "count", _ ->
+      channel.continue_with(
+        count + 1,
+        channel.actions() |> channel.push("count", json.int(count + 1)),
+      )
+    "leave", _ ->
+      channel.close_with(
+        channel.actions() |> channel.push("bye", json.int(count)),
+      )
+    "halt", _ -> channel.stop_socket(socket.Normal)
+    _, _ -> channel.continue(count)
+  }
+}
+
+fn on_info(count: Int, note: Note) -> channel.Next(Int) {
+  case note {
+    Announce(text) ->
+      channel.continue_with(
+        count + 1,
+        channel.actions()
+          |> channel.push(
+            "note",
+            json.string(text <> "#" <> int.to_string(count + 1)),
+          ),
+      )
+    Farewell ->
+      channel.close_with(
+        channel.actions() |> channel.push("farewell", json.int(count)),
+      )
+    WhereAmI(reply) -> {
+      process.send(reply, process.self())
+      channel.continue(count)
+    }
+  }
+}
+
+fn reason_name(reason: socket.StopReason) -> String {
+  case reason {
+    socket.Normal -> "normal"
+    socket.Shutdown -> "shutdown"
+    socket.HeartbeatTimeout -> "heartbeat_timeout"
+    socket.Errored(detail) -> "errored:" <> detail
+  }
+}
+
+// --- systems ---------------------------------------------------------------
+
+fn start(handlers: List(channel.Handler)) -> beryl.Sockets {
+  helper.start(beryl.config(wire.phoenix_codec()), handlers: handlers)
+}
+
+fn start_room() -> #(beryl.Sockets, Wiring, process.Subject(String)) {
+  let wiring = new_wiring()
+  let channels = start([room_handler(wiring)])
+  let frames = helper.connect(channels, "s1")
+  #(channels, wiring, frames)
+}
+
+fn joined_room(
+  topic_name: String,
+) -> #(beryl.Sockets, Wiring, process.Subject(String)) {
+  let #(channels, wiring, frames) = start_room()
+  helper.join(channels, "s1", topic_name, "jr-1", "r-1")
+  helper.recv(frames) |> string.contains("\"status\":\"ok\"") |> should.be_true
+  helper.next_trace(wiring.trace) |> should.equal("join:" <> topic_name)
+  #(channels, wiring, frames)
+}
+
+fn next_sender(wiring: Wiring) -> channel.Sender(Note) {
+  let assert Ok(sender) = process.receive(wiring.senders, 500)
+    as "a join reported its sender"
+  sender
+}
+
+// --- handler selection -----------------------------------------------------
+
+pub fn join_selects_the_first_matching_handler_test() {
+  let channels =
+    start([
+      labelled_handler("room:lobby", "lobby"),
+      labelled_handler("room:*", "room"),
+    ])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "room:lobby", "jr-1", "r-1")
+  helper.recv(frames)
+  |> string.contains("\"handler\":\"lobby\"")
+  |> should.be_true
+
+  helper.join(channels, "s1", "room:other", "jr-2", "r-2")
+  helper.recv(frames)
+  |> string.contains("\"handler\":\"room\"")
+  |> should.be_true
+}
+
+pub fn registration_order_decides_overlapping_patterns_test() {
+  let channels =
+    start([
+      labelled_handler("room:*", "room"),
+      labelled_handler("room:lobby", "lobby"),
+    ])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "room:lobby", "jr-1", "r-1")
+  helper.recv(frames)
+  |> string.contains("\"handler\":\"room\"")
+  |> should.be_true
+}
+
+pub fn unmatched_topic_is_rejected_with_the_documented_reason_test() {
+  let #(channels, wiring, frames) = start_room()
+
+  helper.join(channels, "s1", "other:1", "jr-1", "r-1")
+
+  let reply = helper.recv(frames)
+  reply |> string.contains("\"status\":\"error\"") |> should.be_true
+  reply
+  |> string.contains("{\"reason\":\"unmatched topic\"}")
+  |> should.be_true
+
+  // No handler ran, so no channel exists to terminate later.
+  helper.no_trace(wiring.trace)
+}
+
+pub fn a_rejecting_handler_reports_its_own_reason_test() {
+  let channels =
+    start([
+      channel.handler("room:*", fn(_info, _topic, _payload) {
+        channel.reject(json.object([#("reason", json.string("forbidden"))]))
+      }),
+    ])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+
+  let reply = helper.recv(frames)
+  reply |> string.contains("\"status\":\"error\"") |> should.be_true
+  reply |> string.contains("forbidden") |> should.be_true
+}
+
+// --- client messages -------------------------------------------------------
+
+pub fn client_messages_reach_the_live_channel_test() {
+  let #(channels, _wiring, frames) = joined_room("room:a")
+
+  helper.push(channels, "s1", "room:a", "echo", "r-2")
+  let reply = helper.recv(frames)
+  reply |> string.contains("\"status\":\"ok\"") |> should.be_true
+  reply |> string.contains("\"echoed\":true") |> should.be_true
+  reply |> string.contains("r-2") |> should.be_true
+
+  helper.push(channels, "s1", "room:a", "fail", "r-3")
+  let error_reply = helper.recv(frames)
+  error_reply |> string.contains("\"status\":\"error\"") |> should.be_true
+  error_reply |> string.contains("r-3") |> should.be_true
+}
+
+pub fn channel_state_advances_across_messages_test() {
+  let #(channels, _wiring, frames) = joined_room("room:a")
+
+  helper.push(channels, "s1", "room:a", "count", "r-2")
+  helper.recv(frames) |> string.contains("\"count\",1") |> should.be_true
+
+  helper.push(channels, "s1", "room:a", "count", "r-3")
+  helper.recv(frames) |> string.contains("\"count\",2") |> should.be_true
+}
+
+pub fn each_topic_keeps_its_own_state_test() {
+  let #(channels, wiring, frames) = start_room()
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _join_a = helper.recv(frames)
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  let _join_b = helper.recv(frames)
+  helper.next_trace(wiring.trace) |> should.equal("join:room:a")
+  helper.next_trace(wiring.trace) |> should.equal("join:room:b")
+
+  helper.push(channels, "s1", "room:a", "count", "r-3")
+  helper.recv(frames)
+  |> string.contains("\"room:a\",\"count\",1")
+  |> should.be_true
+
+  helper.push(channels, "s1", "room:b", "count", "r-4")
+  helper.recv(frames)
+  |> string.contains("\"room:b\",\"count\",1")
+  |> should.be_true
+}
+
+pub fn actions_are_applied_in_order_on_the_channel_topic_test() {
+  let #(channels, _wiring, frames) = joined_room("room:a")
+
+  helper.push(channels, "s1", "room:a", "burst", "r-2")
+
+  // `broadcast_from` excludes this socket, so only one, two and four
+  // reach it — in exactly the order they were added.
+  let first = helper.recv(frames)
+  first |> string.contains("\"room:a\",\"one\"") |> should.be_true
+  let second = helper.recv(frames)
+  second |> string.contains("\"room:a\",\"two\"") |> should.be_true
+  let third = helper.recv(frames)
+  third |> string.contains("\"room:a\",\"four\"") |> should.be_true
+}
+
+pub fn binary_frames_reach_the_live_channel_test() {
+  // The Phoenix framing minus its binary decoder, so raw binary frames
+  // take the per-topic fan-out path and arrive as `Binary` inputs.
+  let text_only =
+    codec.new(
+      decode_text: wire.decode_message,
+      encode_reply: wire.reply_json,
+      encode_push: wire.push,
+      encode_heartbeat_reply: wire.heartbeat_reply,
+    )
+    |> codec.with_close_encoder(wire.channel_close)
+    |> codec.with_error_encoder(wire.channel_error)
+
+  let wiring = new_wiring()
+  let channels =
+    helper.start(beryl.config(text_only), handlers: [room_handler(wiring)])
+  let frames = helper.connect(channels, "s1")
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _join_reply = helper.recv(frames)
+  helper.next_trace(wiring.trace) |> should.equal("join:room:a")
+
+  helper.route_binary(channels, "s1", <<1, 2, 3, 4, 5>>)
+
+  helper.recv(frames) |> string.contains("\"binary\",5") |> should.be_true
+}
+
+// --- termination -----------------------------------------------------------
+
+pub fn close_applies_actions_then_kicks_the_topic_test() {
+  let #(channels, wiring, frames) = joined_room("room:a")
+
+  helper.push(channels, "s1", "room:a", "leave", "r-2")
+
+  helper.recv(frames) |> string.contains("\"bye\"") |> should.be_true
+  helper.recv(frames) |> string.contains("phx_close") |> should.be_true
+  helper.next_trace(wiring.trace)
+  |> should.equal("terminate:room:a:shutdown:0")
+  helper.no_trace(wiring.trace)
+}
+
+pub fn a_client_leave_terminates_the_channel_once_test() {
+  let #(channels, wiring, frames) = joined_room("room:a")
+
+  helper.route(channels, "s1", "[\"jr-1\",\"r-2\",\"room:a\",\"phx_leave\",{}]")
+
+  let _leave_reply = helper.recv(frames)
+  helper.recv(frames) |> string.contains("phx_close") |> should.be_true
+  helper.next_trace(wiring.trace) |> should.equal("terminate:room:a:normal:0")
+  helper.no_trace(wiring.trace)
+}
+
+pub fn a_disconnect_terminates_every_channel_once_test() {
+  let #(channels, wiring, frames) = start_room()
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _join_a = helper.recv(frames)
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  let _join_b = helper.recv(frames)
+  helper.next_trace(wiring.trace) |> should.equal("join:room:a")
+  helper.next_trace(wiring.trace) |> should.equal("join:room:b")
+
+  helper.disconnect(channels, "s1")
+
+  helper.next_trace(wiring.trace) |> should.equal("terminate:room:a:normal:0")
+  helper.next_trace(wiring.trace) |> should.equal("terminate:room:b:normal:0")
+  helper.no_trace(wiring.trace)
+}
+
+pub fn stop_socket_tears_down_the_socket_test() {
+  let #(channels, wiring, frames) = joined_room("room:a")
+
+  helper.push(channels, "s1", "room:a", "halt", "r-2")
+
+  helper.next_trace(wiring.trace)
+  |> string.starts_with("terminate:room:a:")
+  |> should.be_true
+  helper.no_trace(wiring.trace)
+
+  // Terminal close frame for the joined topic, then nothing more: the
+  // socket is gone, so a later frame reaches no channel.
+  helper.recv(frames) |> string.contains("phx_close") |> should.be_true
+  helper.push(channels, "s1", "room:a", "count", "r-3")
+  helper.recv_none(frames)
+}
+
+// --- duplicate rejoin ------------------------------------------------------
+
+pub fn a_rejoin_terminates_the_previous_instance_first_test() {
+  let #(channels, wiring, frames) = joined_room("room:a")
+
+  helper.push(channels, "s1", "room:a", "count", "r-2")
+  let _count = helper.recv(frames)
+
+  helper.join(channels, "s1", "room:a", "jr-2", "r-2")
+
+  // Core order: the previous instance closes normally with the state it
+  // had reached, and only then does a fresh instance join.
+  helper.next_trace(wiring.trace) |> should.equal("terminate:room:a:normal:1")
+  helper.next_trace(wiring.trace) |> should.equal("join:room:a")
+
+  helper.recv(frames) |> string.contains("phx_close") |> should.be_true
+  helper.recv(frames) |> string.contains("\"status\":\"ok\"") |> should.be_true
+
+  // The fresh instance starts from its own initial state.
+  helper.push(channels, "s1", "room:a", "count", "r-3")
+  helper.recv(frames) |> string.contains("\"count\",1") |> should.be_true
+}
+
+// --- typed server-side sends -----------------------------------------------
+
+pub fn typed_info_reaches_the_channels_on_info_test() {
+  let #(_channels, wiring, frames) = joined_room("room:a")
+  let sender = next_sender(wiring)
+
+  channel.notify(sender, Announce("hello"))
+
+  helper.recv(frames) |> string.contains("\"hello#1\"") |> should.be_true
+}
+
+pub fn every_send_delivers_exactly_one_payload_in_order_test() {
+  let #(_channels, wiring, frames) = joined_room("room:a")
+  let sender = next_sender(wiring)
+
+  channel.notify(sender, Announce("a"))
+  channel.notify(sender, Announce("b"))
+
+  helper.recv(frames) |> string.contains("\"a#1\"") |> should.be_true
+  helper.recv(frames) |> string.contains("\"b#2\"") |> should.be_true
+  helper.recv_none(frames)
+}
+
+pub fn sends_from_another_process_are_delivered_test() {
+  let #(_channels, wiring, frames) = joined_room("room:a")
+  let sender = next_sender(wiring)
+  let done = process.new_subject()
+
+  process.spawn_unlinked(fn() {
+    channel.notify(sender, Announce("remote"))
+    process.send(done, Nil)
+  })
+
+  let assert Ok(Nil) = process.receive(done, 500) as "the sender process ran"
+  helper.recv(frames) |> string.contains("\"remote#1\"") |> should.be_true
+}
+
+pub fn a_stale_generations_send_is_never_delivered_test() {
+  let #(channels, wiring, frames) = joined_room("room:a")
+  let stale = next_sender(wiring)
+
+  helper.join(channels, "s1", "room:a", "jr-2", "r-2")
+  helper.next_trace(wiring.trace) |> should.equal("terminate:room:a:normal:0")
+  helper.next_trace(wiring.trace) |> should.equal("join:room:a")
+  let _close = helper.recv(frames)
+  let _rejoin_reply = helper.recv(frames)
+  let fresh = next_sender(wiring)
+
+  // The stale sender belongs to the closed generation: its envelope is
+  // dropped before the sealed thunk runs, so its payload reaches neither
+  // generation.
+  channel.notify(stale, Announce("stale"))
+  helper.recv_none(frames)
+
+  // ...and the live generation is unpolluted.
+  channel.notify(fresh, Announce("fresh"))
+  helper.recv(frames) |> string.contains("\"fresh#1\"") |> should.be_true
+}
+
+pub fn a_send_to_a_closed_channel_is_never_delivered_test() {
+  let #(channels, wiring, frames) = joined_room("room:a")
+  let sender = next_sender(wiring)
+
+  helper.push(channels, "s1", "room:a", "leave", "r-2")
+  let _bye = helper.recv(frames)
+  let _close = helper.recv(frames)
+  helper.next_trace(wiring.trace)
+  |> should.equal("terminate:room:a:shutdown:0")
+
+  channel.notify(sender, Announce("gone"))
+  helper.recv_none(frames)
+}
+
+pub fn an_info_result_can_close_the_channel_test() {
+  let #(_channels, wiring, frames) = joined_room("room:a")
+  let sender = next_sender(wiring)
+
+  channel.notify(sender, Farewell)
+
+  helper.recv(frames) |> string.contains("\"farewell\"") |> should.be_true
+  helper.recv(frames) |> string.contains("phx_close") |> should.be_true
+  helper.next_trace(wiring.trace)
+  |> should.equal("terminate:room:a:shutdown:0")
+}
+
+/// The join callback and `on_info` must run in the *same* process: the
+/// typed hand-off `channel.handler` creates is owned by whichever process
+/// ran the join, and only that process may read from it. This pins the
+/// process-affinity seam the adapter depends on.
+pub fn join_and_info_run_in_the_same_runtime_process_test() {
+  let #(channels, wiring, _frames) = joined_room("room:a")
+  let sender = next_sender(wiring)
+  let assert Ok(join_pid) = process.receive(wiring.pids, 500)
+    as "the join reported its process"
+  let answers = process.new_subject()
+
+  channel.notify(sender, WhereAmI(answers))
+
+  let assert Ok(info_pid) = process.receive(answers, 500)
+    as "on_info reported its process"
+  info_pid |> should.equal(join_pid)
+
+  let assert Ok(runtime) = transport.runtime_pid(channels)
+    as "the runtime is running"
+  join_pid |> should.equal(runtime)
+}

--- a/packages/beryl_channels/test/dispatch_test.gleam
+++ b/packages/beryl_channels/test/dispatch_test.gleam
@@ -7,10 +7,10 @@ import beryl
 import beryl/socket
 import beryl/transport
 import beryl/wire
-import beryl/wire/codec
 import beryl_channels/channel
 import dispatch_helpers as helper
 import gleam/bit_array
+import gleam/dynamic/decode
 import gleam/erlang/process
 import gleam/int
 import gleam/json
@@ -23,6 +23,8 @@ import gleeunit/should
 pub type Note {
   Announce(String)
   Farewell
+  /// Ask the channel to stop the whole socket from `on_info`.
+  Halt
   /// Report the process the `on_info` callback runs in.
   WhereAmI(process.Subject(process.Pid))
 }
@@ -82,7 +84,7 @@ fn room_callbacks(
   |> channel.on_message(on_message)
   |> channel.on_binary(fn(count, data) {
     channel.continue_with(
-      count,
+      count + 1,
       channel.actions()
         |> channel.push("binary", json.int(bit_array.byte_size(data))),
     )
@@ -153,6 +155,7 @@ fn on_info(count: Int, note: Note) -> channel.Next(Int) {
       channel.close_with(
         channel.actions() |> channel.push("farewell", json.int(count)),
       )
+    Halt -> channel.stop_socket(socket.Normal)
     WhereAmI(reply) -> {
       process.send(reply, process.self())
       channel.continue(count)
@@ -198,6 +201,22 @@ fn next_sender(wiring: Wiring) -> channel.Sender(Note) {
   sender
 }
 
+/// A system on the Phoenix framing *minus* its binary decoder, with one
+/// socket joined to `room:a`, so raw binary frames take the per-topic
+/// fan-out path and arrive as `Binary` inputs.
+fn joined_binary_room() -> #(beryl.Sockets, Wiring, process.Subject(String)) {
+  let wiring = new_wiring()
+  let channels =
+    helper.start(beryl.config(helper.text_only_codec()), handlers: [
+      room_handler(wiring),
+    ])
+  let frames = helper.connect(channels, "s1")
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _join_reply = helper.recv(frames)
+  helper.next_trace(wiring.trace) |> should.equal("join:room:a")
+  #(channels, wiring, frames)
+}
+
 // --- handler selection -----------------------------------------------------
 
 pub fn join_selects_the_first_matching_handler_test() {
@@ -233,6 +252,49 @@ pub fn registration_order_decides_overlapping_patterns_test() {
   |> should.be_true
 }
 
+pub fn a_multi_segment_pattern_only_matches_its_own_shape_test() {
+  let channels =
+    start([
+      labelled_handler("document:*:ops", "ops"),
+      labelled_handler("*", "catch_all"),
+    ])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "document:42:ops", "jr-1", "r-1")
+  helper.recv(frames)
+  |> string.contains("\"handler\":\"ops\"")
+  |> should.be_true
+
+  // A topic of a different shape falls through to the next pattern in
+  // registration order rather than being forced onto the first.
+  helper.join(channels, "s1", "document:42", "jr-2", "r-2")
+  helper.recv(frames)
+  |> string.contains("\"handler\":\"catch_all\"")
+  |> should.be_true
+
+  helper.join(channels, "s1", "anything", "jr-3", "r-3")
+  helper.recv(frames)
+  |> string.contains("\"handler\":\"catch_all\"")
+  |> should.be_true
+}
+
+pub fn a_join_can_be_accepted_without_a_reply_payload_test() {
+  let channels =
+    start([
+      channel.handler("room:*", fn(_info, _topic, _payload) {
+        channel.accept(channel.joined(Nil, channel.callbacks()))
+      }),
+    ])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+
+  // The join is still acknowledged; it simply carries no response body.
+  let reply = helper.recv(frames)
+  reply |> string.contains("\"status\":\"ok\"") |> should.be_true
+  reply |> string.contains("\"response\":{}") |> should.be_true
+}
+
 pub fn unmatched_topic_is_rejected_with_the_documented_reason_test() {
   let #(channels, wiring, frames) = start_room()
 
@@ -262,6 +324,30 @@ pub fn a_rejecting_handler_reports_its_own_reason_test() {
   let reply = helper.recv(frames)
   reply |> string.contains("\"status\":\"error\"") |> should.be_true
   reply |> string.contains("forbidden") |> should.be_true
+}
+
+pub fn a_rejected_join_leaves_no_live_channel_test() {
+  let events = process.new_subject()
+  let channels =
+    start([
+      channel.handler("room:*", fn(_info, _topic, _payload) {
+        process.send(events, "join")
+        channel.reject(json.object([#("reason", json.string("forbidden"))]))
+      }),
+    ])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _rejection = helper.recv(frames)
+  let assert Ok("join") = process.receive(events, 500) as "the handler ran"
+
+  // Nothing was stored for the topic, so a later message reaches no
+  // channel and the core answers it as an unjoined topic.
+  helper.push(channels, "s1", "room:a", "echo", "r-2")
+  helper.recv(frames)
+  |> string.contains("{\"reason\":\"unmatched topic\"}")
+  |> should.be_true
+  process.receive(events, 100) |> should.be_error
 }
 
 // --- client messages -------------------------------------------------------
@@ -327,29 +413,30 @@ pub fn actions_are_applied_in_order_on_the_channel_topic_test() {
 }
 
 pub fn binary_frames_reach_the_live_channel_test() {
-  // The Phoenix framing minus its binary decoder, so raw binary frames
-  // take the per-topic fan-out path and arrive as `Binary` inputs.
-  let text_only =
-    codec.new(
-      decode_text: wire.decode_message,
-      encode_reply: wire.reply_json,
-      encode_push: wire.push,
-      encode_heartbeat_reply: wire.heartbeat_reply,
-    )
-    |> codec.with_close_encoder(wire.channel_close)
-    |> codec.with_error_encoder(wire.channel_error)
-
-  let wiring = new_wiring()
-  let channels =
-    helper.start(beryl.config(text_only), handlers: [room_handler(wiring)])
-  let frames = helper.connect(channels, "s1")
-  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
-  let _join_reply = helper.recv(frames)
-  helper.next_trace(wiring.trace) |> should.equal("join:room:a")
+  let #(channels, _wiring, frames) = joined_binary_room()
 
   helper.route_binary(channels, "s1", <<1, 2, 3, 4, 5>>)
 
   helper.recv(frames) |> string.contains("\"binary\",5") |> should.be_true
+}
+
+pub fn channel_state_advances_across_binary_frames_test() {
+  let #(channels, wiring, frames) = joined_binary_room()
+
+  helper.push(channels, "s1", "room:a", "count", "r-2")
+  helper.recv(frames) |> string.contains("\"count\",1") |> should.be_true
+
+  // A binary frame evolves the same assigns every other callback sees.
+  helper.route_binary(channels, "s1", <<1, 2, 3>>)
+  helper.recv(frames) |> string.contains("\"binary\",3") |> should.be_true
+
+  helper.push(channels, "s1", "room:a", "count", "r-3")
+  helper.recv(frames) |> string.contains("\"count\",3") |> should.be_true
+
+  // ...and the state a binary frame produced is the state `on_terminate`
+  // is handed.
+  helper.disconnect(channels, "s1")
+  helper.next_trace(wiring.trace) |> should.equal("terminate:room:a:normal:3")
 }
 
 // --- termination -----------------------------------------------------------
@@ -369,7 +456,7 @@ pub fn close_applies_actions_then_kicks_the_topic_test() {
 pub fn a_client_leave_terminates_the_channel_once_test() {
   let #(channels, wiring, frames) = joined_room("room:a")
 
-  helper.route(channels, "s1", "[\"jr-1\",\"r-2\",\"room:a\",\"phx_leave\",{}]")
+  helper.leave(channels, "s1", "room:a", "jr-1", "r-2")
 
   let _leave_reply = helper.recv(frames)
   helper.recv(frames) |> string.contains("phx_close") |> should.be_true
@@ -389,6 +476,28 @@ pub fn a_disconnect_terminates_every_channel_once_test() {
   helper.disconnect(channels, "s1")
 
   helper.next_trace(wiring.trace) |> should.equal("terminate:room:a:normal:0")
+  helper.next_trace(wiring.trace) |> should.equal("terminate:room:b:normal:0")
+  helper.no_trace(wiring.trace)
+}
+
+pub fn a_disconnect_after_a_leave_does_not_terminate_twice_test() {
+  let #(channels, wiring, frames) = start_room()
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _join_a = helper.recv(frames)
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  let _join_b = helper.recv(frames)
+  helper.next_trace(wiring.trace) |> should.equal("join:room:a")
+  helper.next_trace(wiring.trace) |> should.equal("join:room:b")
+
+  helper.leave(channels, "s1", "room:a", "jr-1", "r-3")
+  let _leave_reply = helper.recv(frames)
+  let _close = helper.recv(frames)
+  helper.next_trace(wiring.trace) |> should.equal("terminate:room:a:normal:0")
+
+  helper.disconnect(channels, "s1")
+
+  // Only the topic that is still joined terminates: termination happens
+  // exactly once per accepted join, never once per teardown path.
   helper.next_trace(wiring.trace) |> should.equal("terminate:room:b:normal:0")
   helper.no_trace(wiring.trace)
 }
@@ -492,6 +601,59 @@ pub fn a_stale_generations_send_is_never_delivered_test() {
   helper.recv(frames) |> string.contains("\"fresh#1\"") |> should.be_true
 }
 
+/// A rejected join still consumes a generation. If it did not, the next
+/// join on the same topic would reuse the rejected join's generation and
+/// its `Sender` would deliver into a channel that never admitted it.
+pub fn a_rejected_joins_sender_cannot_reach_a_later_accepted_join_test() {
+  let senders = process.new_subject()
+  let channels =
+    start([
+      channel.handler("room:*", fn(info, _topic, payload) {
+        process.send(senders, info.self)
+        case decode.run(payload, decode.at(["admit"], decode.bool)) {
+          Ok(True) ->
+            channel.accept(channel.joined(
+              0,
+              channel.callbacks()
+                |> channel.on_info(fn(count, note) {
+                  let assert Announce(text) = note as "only announcements"
+                  channel.continue_with(
+                    count + 1,
+                    channel.actions() |> channel.push("note", json.string(text)),
+                  )
+                }),
+            ))
+          _ -> channel.reject(json.object([#("reason", json.string("no"))]))
+        }
+      }),
+    ])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join_with(channels, "s1", "room:a", "jr-1", "r-1", "{\"admit\":false}")
+  helper.recv(frames)
+  |> string.contains("\"status\":\"error\"")
+  |> should.be_true
+  let rejected_sender = next_sender_of(senders)
+
+  helper.join_with(channels, "s1", "room:a", "jr-2", "r-2", "{\"admit\":true}")
+  helper.recv(frames) |> string.contains("\"status\":\"ok\"") |> should.be_true
+  let live_sender = next_sender_of(senders)
+
+  channel.notify(rejected_sender, Announce("ghost"))
+  helper.recv_none(frames)
+
+  channel.notify(live_sender, Announce("real"))
+  helper.recv(frames) |> string.contains("\"real\"") |> should.be_true
+}
+
+fn next_sender_of(
+  senders: process.Subject(channel.Sender(Note)),
+) -> channel.Sender(Note) {
+  let assert Ok(sender) = process.receive(senders, 500)
+    as "a join reported its sender"
+  sender
+}
+
 pub fn a_send_to_a_closed_channel_is_never_delivered_test() {
   let #(channels, wiring, frames) = joined_room("room:a")
   let sender = next_sender(wiring)
@@ -516,6 +678,30 @@ pub fn an_info_result_can_close_the_channel_test() {
   helper.recv(frames) |> string.contains("phx_close") |> should.be_true
   helper.next_trace(wiring.trace)
   |> should.equal("terminate:room:a:shutdown:0")
+}
+
+pub fn an_info_result_can_stop_the_socket_test() {
+  let #(channels, wiring, frames) = start_room()
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _join_a = helper.recv(frames)
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  let _join_b = helper.recv(frames)
+  helper.next_trace(wiring.trace) |> should.equal("join:room:a")
+  helper.next_trace(wiring.trace) |> should.equal("join:room:b")
+  let sender = next_sender(wiring)
+
+  channel.notify(sender, Halt)
+
+  // `stop_socket` from `on_info` ends every channel on the socket, not
+  // just the one that asked.
+  helper.next_trace(wiring.trace) |> should.equal("terminate:room:a:normal:0")
+  helper.next_trace(wiring.trace) |> should.equal("terminate:room:b:normal:0")
+  helper.no_trace(wiring.trace)
+
+  let _close_a = helper.recv(frames)
+  let _close_b = helper.recv(frames)
+  helper.push(channels, "s1", "room:a", "count", "r-3")
+  helper.recv_none(frames)
 }
 
 /// The join callback and `on_info` must run in the *same* process: the

--- a/packages/beryl_channels/test/doc_example_test.gleam
+++ b/packages/beryl_channels/test/doc_example_test.gleam
@@ -1,8 +1,13 @@
-//// Compiles the module-doc example from `beryl_channels/channel` so the
-//// documented shape cannot drift from the real API.
+//// Compiles the module-doc examples from `beryl_channels` and
+//// `beryl_channels/channel` so the documented shapes cannot drift from
+//// the real API.
 
+import beryl
+import beryl/wire
+import beryl_channels
 import beryl_channels/channel
 import gleam/json
+import gleam/otp/static_supervisor
 import gleeunit
 import gleeunit/should
 
@@ -40,4 +45,24 @@ pub fn room() -> channel.Handler {
 
 pub fn documented_example_compiles_and_joins_test() {
   room() |> channel.pattern |> should.equal("room:*")
+}
+
+/// The `beryl_channels` module-doc entry-point example, compiled and run
+/// so the documented shape cannot drift from the real API either.
+pub fn documented_child_spec_example_compiles_and_starts_test() {
+  let handlers = [room()]
+
+  let assert Ok(#(sockets, spec)) =
+    beryl_channels.child_spec(
+      beryl.config(wire.phoenix_codec()),
+      handlers: handlers,
+    )
+    as "the documented handler table builds"
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(spec)
+    |> static_supervisor.start()
+    as "the documented supervision tree starts"
+
+  beryl.stop(sockets) |> should.equal(Ok(Nil))
 }

--- a/packages/beryl_channels/test/entry_point_test.gleam
+++ b/packages/beryl_channels/test/entry_point_test.gleam
@@ -58,7 +58,7 @@ pub fn child_spec_rejects_an_invalid_handler_table_test() {
 pub fn child_spec_nests_the_core_config_error_verbatim_test() {
   let config =
     beryl.config(wire.phoenix_codec())
-    |> beryl.with_heartbeat(interval_ms: 1000, timeout_ms: 1)
+    |> beryl.with_heartbeat(timeout_ms: 1)
 
   beryl_channels.child_spec(config, handlers: [ok_handler("room:*")])
   |> should.equal(

--- a/packages/beryl_channels/test/entry_point_test.gleam
+++ b/packages/beryl_channels/test/entry_point_test.gleam
@@ -1,0 +1,92 @@
+//// Coverage for the package entry points: handler validation runs before
+//// anything is started, core errors are nested verbatim, and a
+//// `child_spec` system really dispatches once its supervisor is running.
+
+import beryl
+import beryl/wire
+import beryl_channels
+import beryl_channels/channel
+import dispatch_helpers as helper
+import gleam/json
+import gleam/otp/static_supervisor
+import gleam/string
+import gleeunit/should
+
+fn ok_handler(pattern: String) -> channel.Handler {
+  channel.handler(pattern, fn(_info, _topic, _payload) {
+    channel.accept_with(
+      channel.joined(Nil, channel.callbacks()),
+      json.object([#("handler", json.string(pattern))]),
+    )
+  })
+}
+
+// --- validation happens first ----------------------------------------------
+
+pub fn child_spec_rejects_an_invalid_pattern_before_building_test() {
+  beryl_channels.child_spec(beryl.config(wire.phoenix_codec()), handlers: [
+    ok_handler("room:*"),
+    ok_handler(""),
+  ])
+  |> should.equal(
+    Error(
+      beryl_channels.ChildSpecInvalidHandlers(beryl_channels.InvalidPattern(
+        "",
+        "pattern cannot be empty",
+      )),
+    ),
+  )
+}
+
+pub fn child_spec_rejects_an_invalid_handler_table_test() {
+  let result =
+    beryl_channels.child_spec(beryl.config(wire.phoenix_codec()), handlers: [
+      ok_handler("room:*"),
+      ok_handler("room:*"),
+    ])
+
+  result
+  |> should.equal(
+    Error(
+      beryl_channels.ChildSpecInvalidHandlers(beryl_channels.DuplicatePattern(
+        "room:*",
+      )),
+    ),
+  )
+}
+
+pub fn child_spec_nests_the_core_config_error_verbatim_test() {
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_heartbeat(interval_ms: 1000, timeout_ms: 1)
+
+  beryl_channels.child_spec(config, handlers: [ok_handler("room:*")])
+  |> should.equal(
+    Error(
+      beryl_channels.ChildSpecInvalidConfig(beryl.HeartbeatTimeoutTooLow(2)),
+    ),
+  )
+}
+
+// --- a supervised system dispatches ----------------------------------------
+
+pub fn child_spec_dispatches_once_its_supervisor_runs_test() {
+  let assert Ok(#(channels, spec)) =
+    beryl_channels.child_spec(beryl.config(wire.phoenix_codec()), handlers: [
+      ok_handler("room:*"),
+    ])
+    as "the handler table and config are valid"
+
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(spec)
+    |> static_supervisor.start()
+    as "the supervision tree starts"
+
+  let frames = helper.connect(channels, "s1")
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+
+  helper.recv(frames)
+  |> string.contains("\"handler\":\"room:*\"")
+  |> should.be_true
+}

--- a/packages/beryl_channels/test/entry_point_test.gleam
+++ b/packages/beryl_channels/test/entry_point_test.gleam
@@ -7,6 +7,7 @@ import beryl/wire
 import beryl_channels
 import beryl_channels/channel
 import dispatch_helpers as helper
+import gleam/erlang/process
 import gleam/json
 import gleam/otp/static_supervisor
 import gleam/string
@@ -89,4 +90,77 @@ pub fn child_spec_dispatches_once_its_supervisor_runs_test() {
   helper.recv(frames)
   |> string.contains("\"handler\":\"room:*\"")
   |> should.be_true
+}
+
+/// The explicit child-spec path and the shared supervised test helper must
+/// produce the same channel lifecycle.
+pub fn child_spec_runs_the_same_lifecycle_through_both_supervised_paths_test() {
+  let helper_started = process.new_subject()
+  let supervised = process.new_subject()
+
+  let direct =
+    helper.start(beryl.config(wire.phoenix_codec()), handlers: [
+      lifecycle_handler(helper_started),
+    ])
+
+  let assert Ok(#(channels, spec)) =
+    beryl_channels.child_spec(beryl.config(wire.phoenix_codec()), handlers: [
+      lifecycle_handler(supervised),
+    ])
+    as "the handler table and config are valid"
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(spec)
+    |> static_supervisor.start()
+    as "the supervision tree starts"
+
+  let direct_frames = drive_lifecycle(direct)
+  let supervised_frames = drive_lifecycle(channels)
+
+  supervised_frames |> should.equal(direct_frames)
+  collect(supervised) |> should.equal(collect(helper_started))
+}
+
+/// Join, exchange a message, then disconnect — the whole lifecycle, as a
+/// list of the frame shapes it produced.
+fn drive_lifecycle(channels: beryl.Sockets) -> List(String) {
+  let frames = helper.connect(channels, "s1")
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let join_reply = helper.recv(frames)
+  helper.push(channels, "s1", "room:a", "ping", "r-2")
+  let pong = helper.recv(frames)
+  helper.disconnect(channels, "s1")
+  let close = helper.recv(frames)
+  helper.recv_none(frames)
+  [join_reply, pong, close]
+}
+
+/// A channel that traces its whole lifecycle.
+fn lifecycle_handler(trace: process.Subject(String)) -> channel.Handler {
+  channel.handler("room:*", fn(_info, topic, _payload) {
+    let callbacks =
+      channel.callbacks()
+      |> channel.on_message(fn(state, message) {
+        process.send(trace, "message:" <> message.event)
+        channel.continue_with(
+          state,
+          channel.actions() |> channel.push("pong", json.int(1)),
+        )
+      })
+      |> channel.on_terminate(fn(_state, reason) {
+        process.send(trace, "terminate:" <> helper.reason_name(reason))
+      })
+    process.send(trace, "join:" <> topic)
+    channel.accept_with(
+      channel.joined(Nil, callbacks),
+      json.object([#("handler", json.string("room:*"))]),
+    )
+  })
+}
+
+fn collect(trace: process.Subject(String)) -> List(String) {
+  case process.receive(trace, 100) {
+    Error(Nil) -> []
+    Ok(line) -> [line, ..collect(trace)]
+  }
 }

--- a/packages/beryl_channels/test/fanout_test.gleam
+++ b/packages/beryl_channels/test/fanout_test.gleam
@@ -1,0 +1,107 @@
+//// Fan-out scope: `push` is for the socket that asked, `broadcast`
+//// reaches every socket on the topic, and `broadcast_from` reaches every
+//// socket *except* the one whose callback ran — all on the channel's own
+//// topic, and all in the order the actions were added.
+////
+//// The single-socket action tests can only observe an absence for
+//// `broadcast_from`; these run two sockets, so the exclusion is proved by
+//// what the other socket actually receives.
+
+import beryl
+import beryl/wire
+import beryl_channels/channel
+import dispatch_helpers as helper
+import gleam/json
+import gleam/string
+import gleeunit/should
+
+/// A channel that fans one message out through all three send scopes.
+fn fanout_handler() -> channel.Handler {
+  channel.handler("room:*", fn(_info, _topic, _payload) {
+    let callbacks =
+      channel.callbacks()
+      |> channel.on_message(fn(state, _message) {
+        channel.continue_with(
+          state,
+          channel.actions()
+            |> channel.push("mine", json.int(1))
+            |> channel.broadcast_from("others", json.int(2))
+            |> channel.broadcast("everyone", json.int(3)),
+        )
+      })
+    channel.accept(channel.joined(Nil, callbacks))
+  })
+}
+
+fn start_two_sockets() -> #(beryl.Sockets, helper.Frames, helper.Frames) {
+  let channels =
+    helper.start(beryl.config(wire.phoenix_codec()), handlers: [
+      fanout_handler(),
+    ])
+
+  let first = helper.connect(channels, "s1")
+  let second = helper.connect(channels, "s2")
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  helper.recv(first) |> string.contains("\"status\":\"ok\"") |> should.be_true
+  helper.join(channels, "s2", "room:a", "jr-2", "r-2")
+  helper.recv(second) |> string.contains("\"status\":\"ok\"") |> should.be_true
+
+  #(channels, first, second)
+}
+
+pub fn push_reaches_only_the_socket_whose_callback_ran_test() {
+  let #(channels, first, second) = start_two_sockets()
+
+  helper.push(channels, "s1", "room:a", "go", "r-3")
+
+  helper.recv(first) |> string.contains("\"mine\",1") |> should.be_true
+
+  // The other socket sees the two fan-out sends and never the push.
+  let others = helper.recv(second)
+  others |> string.contains("\"others\",2") |> should.be_true
+  others |> string.contains("\"mine\"") |> should.be_false
+}
+
+pub fn broadcast_from_excludes_the_sender_and_reaches_the_rest_test() {
+  let #(channels, first, second) = start_two_sockets()
+
+  helper.push(channels, "s1", "room:a", "go", "r-3")
+
+  // Sending socket: push, then the plain broadcast. The
+  // `broadcast_from` in between is not delivered back to it.
+  helper.recv(first) |> string.contains("\"mine\",1") |> should.be_true
+  helper.recv(first) |> string.contains("\"everyone\",3") |> should.be_true
+  helper.recv_none(first)
+
+  // Other socket: the excluded-sender broadcast *and* the plain one, in
+  // the order the actions were added.
+  helper.recv(second) |> string.contains("\"others\",2") |> should.be_true
+  helper.recv(second) |> string.contains("\"everyone\",3") |> should.be_true
+  helper.recv_none(second)
+}
+
+pub fn fan_out_is_scoped_to_the_channels_own_topic_test() {
+  let #(channels, first, second) = start_two_sockets()
+
+  // A second socket joins a *different* topic served by the same handler.
+  helper.join(channels, "s2", "room:b", "jr-3", "r-3")
+  helper.recv(second) |> string.contains("\"status\":\"ok\"") |> should.be_true
+
+  helper.push(channels, "s1", "room:a", "go", "r-4")
+
+  helper.recv(first) |> string.contains("\"room:a\",\"mine\"") |> should.be_true
+  helper.recv(first)
+  |> string.contains("\"room:a\",\"everyone\"")
+  |> should.be_true
+  helper.recv_none(first)
+
+  // Every frame the other socket receives is for `room:a`; nothing leaked
+  // onto `room:b`.
+  helper.recv(second)
+  |> string.contains("\"room:a\",\"others\"")
+  |> should.be_true
+  helper.recv(second)
+  |> string.contains("\"room:a\",\"everyone\"")
+  |> should.be_true
+  helper.recv_none(second)
+}

--- a/packages/beryl_channels/test/presence_actions_test.gleam
+++ b/packages/beryl_channels/test/presence_actions_test.gleam
@@ -1,0 +1,111 @@
+//// Presence actions lower onto core presence effects scoped to the
+//// channel's own topic, and keep the core's apply-time snapshot
+//// semantics.
+
+import beryl
+import beryl/presence
+import beryl/wire
+import beryl_channels
+import beryl_channels/channel
+import dispatch_helpers as helper
+import gleam/erlang/process
+import gleam/json
+import gleam/list
+import gleam/string
+import gleeunit/should
+
+fn encode_users(entries: List(presence.PresenceEntry)) -> json.Json {
+  json.object(list.map(entries, fn(entry) { #(entry.key, entry.meta) }))
+}
+
+/// A channel that tracks presence from its own `on_info` (right after the
+/// join acknowledgment) and untracks-then-snapshots on a client message —
+/// both in a single action list, and neither naming a topic.
+fn presence_handler() -> channel.Handler {
+  channel.handler("room:*", fn(info, _topic, _payload) {
+    let callbacks =
+      channel.callbacks()
+      |> channel.on_info(fn(state, _message) {
+        channel.continue_with(
+          state,
+          channel.actions()
+            |> channel.presence_track(
+              "alice",
+              json.object([#("status", json.string("online"))]),
+            )
+            |> channel.broadcast_presence("presence_list", encode_users),
+        )
+      })
+      |> channel.on_message(fn(state, _message) {
+        channel.continue_with(
+          state,
+          channel.actions()
+            |> channel.presence_untrack("alice")
+            |> channel.push_presence("presence_list", encode_users),
+        )
+      })
+
+    channel.notify(info.self, Nil)
+    channel.accept(channel.joined(Nil, callbacks))
+  })
+}
+
+fn start_system(handle: presence.Presence) -> beryl.Sockets {
+  helper.start(
+    beryl.config(wire.phoenix_codec()) |> beryl.with_presence_handle(handle),
+    handlers: [presence_handler()],
+  )
+}
+
+fn start_presence() -> presence.Presence {
+  let assert Ok(handle) = presence.start(presence.default_config("node1"))
+    as "presence starts"
+  handle
+}
+
+pub fn presence_actions_target_the_channels_own_topic_test() {
+  let handle = start_presence()
+  let channels = start_system(handle)
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _join_reply = helper.recv(frames)
+
+  // The tracked presence lands on `room:a` — the channel's own topic —
+  // even though no action named a topic.
+  let diff = helper.recv(frames)
+  diff |> string.contains("presence_diff") |> should.be_true
+  diff |> string.contains("\"room:a\"") |> should.be_true
+  let snapshot = helper.recv(frames)
+  snapshot |> string.contains("presence_list") |> should.be_true
+  snapshot |> string.contains("alice") |> should.be_true
+
+  process.sleep(20)
+  let assert [entry] = presence.list(handle, "room:a")
+    as "the presence actor holds one entry for the topic"
+  entry.key |> should.equal("alice")
+}
+
+pub fn presence_snapshots_see_earlier_actions_in_the_same_list_test() {
+  let handle = start_presence()
+  let channels = start_system(handle)
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _join_reply = helper.recv(frames)
+  let _join_diff = helper.recv(frames)
+  let _join_snapshot = helper.recv(frames)
+
+  helper.push(channels, "s1", "room:a", "part", "r-2")
+
+  // The untrack is applied before the snapshot in the same list, so the
+  // snapshot pushed to this socket is already empty.
+  let leave_diff = helper.recv(frames)
+  leave_diff |> string.contains("presence_diff") |> should.be_true
+  let snapshot = helper.recv(frames)
+  snapshot |> string.contains("presence_list") |> should.be_true
+  snapshot |> string.contains("alice") |> should.be_false
+
+  process.sleep(20)
+  presence.list(handle, "room:a") |> should.equal([])
+}

--- a/packages/beryl_channels/test/presence_actions_test.gleam
+++ b/packages/beryl_channels/test/presence_actions_test.gleam
@@ -5,7 +5,6 @@
 import beryl
 import beryl/presence
 import beryl/wire
-import beryl_channels
 import beryl_channels/channel
 import dispatch_helpers as helper
 import gleam/erlang/process

--- a/packages/beryl_channels/test/presence_actions_test.gleam
+++ b/packages/beryl_channels/test/presence_actions_test.gleam
@@ -7,7 +7,6 @@ import beryl/presence
 import beryl/wire
 import beryl_channels/channel
 import dispatch_helpers as helper
-import gleam/erlang/process
 import gleam/json
 import gleam/list
 import gleam/string
@@ -79,7 +78,9 @@ pub fn presence_actions_target_the_channels_own_topic_test() {
   snapshot |> string.contains("presence_list") |> should.be_true
   snapshot |> string.contains("alice") |> should.be_true
 
-  process.sleep(20)
+  // No settling delay is needed: the runtime applies presence effects with
+  // synchronous calls to the presence actor, and the snapshot frame above
+  // was encoded *after* the track committed.
   let assert [entry] = presence.list(handle, "room:a")
     as "the presence actor holds one entry for the topic"
   entry.key |> should.equal("alice")
@@ -105,6 +106,7 @@ pub fn presence_snapshots_see_earlier_actions_in_the_same_list_test() {
   snapshot |> string.contains("presence_list") |> should.be_true
   snapshot |> string.contains("alice") |> should.be_false
 
-  process.sleep(20)
+  // Same ordering argument as above: the snapshot frame is only sent once
+  // the untrack call has returned.
   presence.list(handle, "room:a") |> should.equal([])
 }

--- a/packages/beryl_channels/test/router_actor_test.gleam
+++ b/packages/beryl_channels/test/router_actor_test.gleam
@@ -4,11 +4,13 @@
 //// `select_other` handler that swallows and logs any message arriving in
 //// the process mailbox that its own selector does not match.
 ////
-//// The router below is a faithful miniature of the Task 3 router: its
-//// actor message type is the socket-level envelope, it owns the live
-//// channel and its generation, and every server-side send has to make the
-//// round trip out through `channel.notify` and back in as an envelope
-//// before `on_info` can run.
+//// The router below is a faithful miniature of the real adapter in
+//// `beryl_channels/internal/router`: its actor message type is the
+//// socket-level envelope, it owns the live channel and its generation,
+//// and every server-side send has to make the round trip out through
+//// `channel.notify` and back in as an envelope before `on_info` can run.
+//// It pins the seam in isolation; `dispatch_test` pins the same
+//// behaviour through a real running system.
 
 import beryl/socket
 import beryl_channels/channel

--- a/packages/beryl_channels/test/validation_test.gleam
+++ b/packages/beryl_channels/test/validation_test.gleam
@@ -96,7 +96,8 @@ pub fn validation_reports_the_first_repeated_pattern_in_order_test() {
   ])
   |> should.equal(Error(beryl_channels.DuplicatePattern("b")))
 }
-// Error-surface coverage deliberately stops here. `ChildSpecError` is
-// reachable only through the `child_spec` entry point, which lands with
-// the dispatch adapter; asserting on
-// hand-constructed values would test the compiler, not this package.
+// Error-surface coverage deliberately stops here. `ChildSpecError` is only
+// reachable through `child_spec`, so it is asserted end to end in
+// `entry_point_test`;
+// asserting on hand-constructed values here would test the compiler, not
+// this package.

--- a/packages/beryl_channels/test/wire_matrix.gleam
+++ b/packages/beryl_channels/test/wire_matrix.gleam
@@ -1,0 +1,668 @@
+//// One Phoenix wire-contract harness, run against two systems.
+////
+//// The point of this module is that there is exactly **one** copy of every
+//// moving part a contract scenario needs — the transport server, the wire
+//// codec, the WebSocket client, the frame builders, the frame decoder —
+//// and exactly **two** ways to build the system under test:
+////
+////   * `beryl.child_spec` with a hand-written `update`, and
+////   * `beryl_channels.child_spec` with a handler table.
+////
+//// Both implement the same application contract (see "The contract app"
+//// below), both are served by the same `beryl_mist` transport over a real
+//// WebSocket, and both are configured with the same `beryl.Config`.
+//// [`compare`](#compare) runs one scenario body against both and fails if
+//// the two systems are observably different, so no scenario has to be
+//// written twice.
+////
+//// Nothing here imports a beryl internal module or re-implements any part
+//// of the transport or the codec: the frames on the wire are produced and
+//// consumed by `beryl`, `beryl_mist` and `gluegun`.
+
+import beryl
+import beryl/presence
+import beryl/socket
+import beryl/topic
+import beryl/transport/server
+import beryl/wire
+import beryl/wire/codec
+import beryl_channels
+import beryl_channels/channel
+import beryl_mist
+import gleam/bit_array
+import gleam/bytes_tree
+import gleam/dynamic
+import gleam/dynamic/decode
+import gleam/erlang/atom
+import gleam/erlang/process
+import gleam/http/response
+import gleam/json
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/otp/static_supervisor
+import gleeunit/should
+import gluegun/connection
+import gluegun/message
+import gluegun/websocket
+import mist
+import phoenix_channel_fixtures/frame as fixtures
+
+/// The path both systems are served on.
+pub const socket_path = "/socket/websocket"
+
+/// The only topic pattern the contract app answers to.
+pub const room_pattern = "room:*"
+
+// ---------------------------------------------------------------------------
+// The contract app
+//
+// Two implementations of one observable behaviour:
+//
+//   join            accept with `{joined: true, topic: <topic>}`, unless the
+//                   join payload carries `{"deny": true}`, which is refused
+//                   with `{reason: "denied"}`
+//   join elsewhere  refused with `{reason: "unmatched topic"}`
+//   "ping"          reply ok `{pong: true}`
+//   "boom"          reply error `{reason: "nope"}`
+//   "push_me"       push `pushed` to the calling socket only
+//   "shout"         broadcast_from `shouted`, echoing the client payload
+//   "track"         presence-track "alice", then broadcast a snapshot
+//   "blob"          a codec-decoded binary payload: push its byte size
+//   raw binary      an undecoded binary frame: push its byte size
+// ---------------------------------------------------------------------------
+
+/// The hand-written `update` half of the matrix.
+pub fn raw_update() -> fn(Nil, socket.Input(Nil)) -> socket.Next(Nil, Nil) {
+  let pattern = topic.parse_pattern(room_pattern)
+  fn(model, input) { socket.Next(model, raw_effects(pattern, input)) }
+}
+
+fn raw_effects(
+  pattern: topic.TopicPattern,
+  input: socket.Input(Nil),
+) -> List(socket.Effect) {
+  case input {
+    socket.Join(name, payload, ref) -> raw_join(pattern, name, payload, ref)
+    socket.Message(_name, "ping", _payload, Some(ref)) -> [
+      socket.ReplyOk(ref, pong_payload()),
+    ]
+    socket.Message(_name, "boom", _payload, Some(ref)) -> [
+      socket.ReplyError(ref, boom_payload()),
+    ]
+    socket.Message(name, "push_me", _payload, _ref) -> [
+      socket.Push(name, pushed_event, pushed_payload()),
+    ]
+    socket.Message(name, "shout", payload, _ref) -> [
+      socket.BroadcastFrom(name, shouted_event, wire.dynamic_to_json(payload)),
+    ]
+    socket.Message(name, "track", _payload, _ref) -> [
+      socket.PresenceTrack(name, presence_key, presence_meta()),
+      socket.BroadcastPresence(name, presence_event, encode_presence),
+    ]
+    socket.Message(name, "blob", payload, _ref) -> [
+      socket.Push(name, binary_event, binary_payload("decoded", payload)),
+    ]
+    socket.Binary(name, data) -> [
+      socket.Push(
+        name,
+        binary_event,
+        binary_size_payload("raw", bit_array.byte_size(data)),
+      ),
+    ]
+    _ -> []
+  }
+}
+
+fn raw_join(
+  pattern: topic.TopicPattern,
+  name: String,
+  payload: dynamic.Dynamic,
+  ref: socket.Ref,
+) -> List(socket.Effect) {
+  use <- guard_reject(topic.matches(pattern, name), ref, unmatched_payload())
+  use <- guard_reject(!denied(payload), ref, denied_payload())
+  [socket.AcceptJoin(ref, Some(join_reply(name)))]
+}
+
+fn guard_reject(
+  allowed: Bool,
+  ref: socket.Ref,
+  reason: json.Json,
+  otherwise: fn() -> List(socket.Effect),
+) -> List(socket.Effect) {
+  case allowed {
+    True -> otherwise()
+    False -> [socket.RejectJoin(ref, reason)]
+  }
+}
+
+/// The handler-table half of the matrix.
+pub fn handlers() -> List(channel.Handler) {
+  [
+    channel.handler(room_pattern, fn(_info, name, payload) {
+      case denied(payload) {
+        True -> channel.reject(denied_payload())
+        False ->
+          channel.accept_with(
+            channel.joined(Nil, contract_callbacks()),
+            join_reply(name),
+          )
+      }
+    }),
+  ]
+}
+
+fn contract_callbacks() -> channel.Callbacks(Nil, Nil) {
+  channel.callbacks()
+  |> channel.on_message(fn(state, msg) {
+    channel.continue_with(state, message_actions(msg))
+  })
+  |> channel.on_binary(fn(state, data) {
+    channel.continue_with(
+      state,
+      channel.actions()
+        |> channel.push(
+          binary_event,
+          binary_size_payload("raw", bit_array.byte_size(data)),
+        ),
+    )
+  })
+}
+
+fn message_actions(msg: channel.Message) -> channel.Actions {
+  let actions = channel.actions()
+  case msg.event, msg.reply {
+    "ping", Some(ref) -> channel.reply_ok(actions, ref, pong_payload())
+    "boom", Some(ref) -> channel.reply_error(actions, ref, boom_payload())
+    "push_me", _ -> channel.push(actions, pushed_event, pushed_payload())
+    "shout", _ ->
+      channel.broadcast_from(
+        actions,
+        shouted_event,
+        wire.dynamic_to_json(msg.payload),
+      )
+    "track", _ ->
+      actions
+      |> channel.presence_track(presence_key, presence_meta())
+      |> channel.broadcast_presence(presence_event, encode_presence)
+    "blob", _ ->
+      channel.push(
+        actions,
+        binary_event,
+        binary_payload("decoded", msg.payload),
+      )
+    _, _ -> actions
+  }
+}
+
+// --- Shared payloads, so neither half can drift from the other ------------
+
+const pushed_event = "pushed"
+
+const shouted_event = "shouted"
+
+const binary_event = "binary_in"
+
+const presence_event = "presence_list"
+
+const presence_key = "alice"
+
+fn join_reply(name: String) -> json.Json {
+  json.object([#("joined", json.bool(True)), #("topic", json.string(name))])
+}
+
+fn denied_payload() -> json.Json {
+  json.object([#("reason", json.string("denied"))])
+}
+
+fn unmatched_payload() -> json.Json {
+  json.object([#("reason", json.string("unmatched topic"))])
+}
+
+fn pong_payload() -> json.Json {
+  json.object([#("pong", json.bool(True))])
+}
+
+fn boom_payload() -> json.Json {
+  json.object([#("reason", json.string("nope"))])
+}
+
+fn pushed_payload() -> json.Json {
+  json.object([#("from", json.string("server"))])
+}
+
+fn presence_meta() -> json.Json {
+  json.object([#("status", json.string("online"))])
+}
+
+fn binary_payload(kind: String, payload: dynamic.Dynamic) -> json.Json {
+  let size =
+    decode.run(payload, decode.bit_array)
+    |> result_size
+  binary_size_payload(kind, size)
+}
+
+fn result_size(decoded: Result(BitArray, a)) -> Int {
+  case decoded {
+    Ok(data) -> bit_array.byte_size(data)
+    Error(_) -> -1
+  }
+}
+
+fn binary_size_payload(kind: String, size: Int) -> json.Json {
+  json.object([#("kind", json.string(kind)), #("bytes", json.int(size))])
+}
+
+/// Presence snapshots are encoded as the tracked keys alone.
+///
+/// A snapshot that echoed `entry.meta` could not be compared across the
+/// two systems: beryl stamps every tracked entry with a random `phx_ref`,
+/// so the two runs would differ on a value neither dispatch layer
+/// controls. The metadata round-trip is still observed — the
+/// `presence_diff` the core broadcasts carries it verbatim.
+fn encode_presence(entries: List(presence.PresenceEntry)) -> json.Json {
+  json.preprocessed_array(
+    list.map(entries, fn(entry) { json.string(entry.key) }),
+  )
+}
+
+fn denied(payload: dynamic.Dynamic) -> Bool {
+  let decoder = {
+    use deny <- decode.optional_field("deny", False, decode.bool)
+    decode.success(deny)
+  }
+  case decode.run(payload, decoder) {
+    Ok(deny) -> deny
+    Error(_) -> False
+  }
+}
+
+// ---------------------------------------------------------------------------
+// System factory
+// ---------------------------------------------------------------------------
+
+/// One way of building a system that implements the contract app.
+pub type Variant {
+  Variant(name: String, start: fn(beryl.Config) -> beryl.Sockets)
+}
+
+/// A started system, served over a real WebSocket on `port`.
+pub type System {
+  System(variant: String, sockets: beryl.Sockets, port: Int)
+}
+
+/// The two systems every scenario is run against.
+pub fn variants() -> List(Variant) {
+  [
+    Variant(name: "beryl.child_spec", start: fn(config) {
+      let assert Ok(#(sockets, spec)) =
+        beryl.child_spec(
+          config,
+          init: fn(_info: socket.ConnectInfo(Nil)) { #(Nil, []) },
+          update: raw_update(),
+        )
+        as "the raw contract system builds"
+      let assert Ok(_) =
+        static_supervisor.new(static_supervisor.OneForOne)
+        |> static_supervisor.add(spec)
+        |> static_supervisor.start()
+        as "the raw contract supervision tree starts"
+      sockets
+    }),
+    Variant(name: "beryl_channels.child_spec", start: fn(config) {
+      let assert Ok(#(sockets, spec)) =
+        beryl_channels.child_spec(config, handlers: handlers())
+        as "the channel contract system builds"
+      let assert Ok(_) =
+        static_supervisor.new(static_supervisor.OneForOne)
+        |> static_supervisor.add(spec)
+        |> static_supervisor.start()
+        as "the channel contract supervision tree starts"
+      sockets
+    }),
+  ]
+}
+
+/// The default config both variants share: the stock Phoenix codec, which
+/// decodes binary frames into ordinary events.
+pub fn default_config() -> beryl.Config {
+  beryl.config(wire.phoenix_codec())
+}
+
+/// The Phoenix framing *without* its binary decoder, so raw binary frames
+/// reach the app undecoded instead of arriving as events.
+pub fn text_only_config() -> beryl.Config {
+  beryl.config(
+    codec.new(
+      decode_text: wire.decode_message,
+      encode_reply: wire.reply_json,
+      encode_push: wire.push,
+      encode_heartbeat_reply: wire.heartbeat_reply,
+    )
+    |> codec.with_close_encoder(wire.channel_close)
+    |> codec.with_error_encoder(wire.channel_error),
+  )
+}
+
+/// Run one scenario against both variants and require them to observe the
+/// same thing.
+///
+/// `setup` is called once per variant, so each run gets its own config and
+/// its own context value (a fresh presence actor, for example). The
+/// scenario's return value is the observation that is compared across the
+/// two systems; it is also returned, so a scenario can additionally assert
+/// what that shared observation must *be* rather than only that the two
+/// agree.
+pub fn compare(
+  setup setup: fn() -> #(beryl.Config, ctx),
+  scenario scenario: fn(System, ctx) -> observation,
+) -> observation {
+  let observations =
+    list.map(variants(), fn(variant) {
+      let #(config, context) = setup()
+      let sockets = variant.start(config)
+      let #(port, supervisor) = start_transport(sockets)
+      let observed = scenario(System(variant.name, sockets, port), context)
+      stop_transport(supervisor)
+      let assert Ok(Nil) = beryl.stop(sockets) as "the system stops cleanly"
+      observed
+    })
+
+  let assert [raw, layered] = observations
+    as "the matrix runs exactly two variants"
+  raw |> should.equal(layered)
+  raw
+}
+
+/// `compare` for scenarios that need no extra context.
+pub fn compare_with(
+  config config: fn() -> beryl.Config,
+  scenario scenario: fn(System) -> observation,
+) -> observation {
+  compare(setup: fn() { #(config(), Nil) }, scenario: fn(system, _context) {
+    scenario(system)
+  })
+}
+
+fn start_transport(sockets: beryl.Sockets) -> #(Int, process.Pid) {
+  let ports = process.new_subject()
+  let handler = fn(request) {
+    beryl_mist.upgrade(
+      request,
+      sockets,
+      server.default_config(socket_path),
+      fn() {
+        response.new(404)
+        |> response.set_body(mist.Bytes(bytes_tree.new()))
+      },
+    )
+  }
+
+  let assert Ok(started) =
+    handler
+    |> mist.new
+    |> mist.port(0)
+    |> mist.bind("127.0.0.1")
+    |> mist.after_start(fn(port, _scheme, _ip) { process.send(ports, port) })
+    |> mist.start
+    as "the mist server starts on a free port"
+  let assert Ok(port) = process.receive(ports, 1000)
+    as "the mist server reports its port"
+  #(port, started.pid)
+}
+
+fn stop_transport(supervisor: process.Pid) -> Nil {
+  // Unlink first: the test process started this supervisor, so an exit
+  // signal to a linked process would take the test down with it. `shutdown`
+  // (not `kill`) lets the supervisor terminate its acceptors gracefully
+  // instead of dumping a crash report for every one of them.
+  process.unlink(supervisor)
+  let watch = process.monitor(supervisor)
+  process.send_abnormal_exit(supervisor, atom.create("shutdown"))
+  let selector =
+    process.new_selector()
+    |> process.select_specific_monitor(watch, fn(_down) { Nil })
+  let assert Ok(Nil) = process.selector_receive(selector, 5000)
+    as "the transport server terminates"
+  Nil
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket client
+// ---------------------------------------------------------------------------
+
+/// A connected WebSocket client.
+pub type Client =
+  websocket.Socket
+
+/// Connect a client to a running system.
+pub fn connect(system: System) -> Client {
+  let assert Ok(client) =
+    websocket.connect(
+      host: "127.0.0.1",
+      port: system.port,
+      path: socket_path,
+      options: websocket.options()
+        |> websocket.with_timeout(connection.Milliseconds(500)),
+    )
+    as "the websocket client connects"
+  client
+}
+
+/// Send a raw text frame.
+pub fn send(client: Client, raw: String) -> Nil {
+  let assert Ok(Nil) = websocket.send_text(client, raw)
+    as "the text frame is sent"
+  Nil
+}
+
+/// Send a raw binary frame.
+pub fn send_binary(client: Client, data: BitArray) -> Nil {
+  let assert Ok(Nil) = websocket.send_binary(client, data)
+    as "the binary frame is sent"
+  Nil
+}
+
+/// Receive and decode the next server frame, failing if none arrives.
+pub fn next(client: Client) -> Frame {
+  let assert Ok(message.Text(raw)) = websocket.receive_app_frame(client)
+    as "a server text frame arrives"
+  decode_frame(raw)
+}
+
+/// Receive and decode exactly `count` server frames, in order.
+pub fn take(client: Client, count: Int) -> List(Frame) {
+  case count {
+    0 -> []
+    _ -> {
+      let frame = next(client)
+      [frame, ..take(client, count - 1)]
+    }
+  }
+}
+
+/// Receive exactly `count` frames and prove the server sent no more.
+///
+/// The proof is a fence rather than a timeout: a heartbeat travels the same
+/// path as the frames just read — one client connection into one runtime
+/// actor — so anything the server had already queued for this socket
+/// arrives *before* the heartbeat reply. An extra frame therefore fails
+/// the fence and is printed, instead of being silently discarded when the
+/// scenario ends. Absence that has to outlast a *different* path (a
+/// PubSub broadcast, say) still needs [`expect_silence`](#expect_silence).
+pub fn take_exactly(client: Client, count: Int) -> List(Frame) {
+  let frames = take(client, count)
+  fence(client)
+  frames
+}
+
+/// Assert that nothing is queued for this socket. See
+/// [`take_exactly`](#take_exactly).
+pub fn fence(client: Client) -> Nil {
+  send(client, heartbeat_frame(fence_ref))
+  next(client)
+  |> should.equal(Frame(
+    join_ref: None,
+    ref: Some(fence_ref),
+    topic: fixtures.heartbeat_topic,
+    event: fixtures.reply_event,
+    payload: "{\"response\":{},\"status\":\"ok\"}",
+  ))
+}
+
+const fence_ref = "fence"
+
+/// Assert the server sends nothing more.
+pub fn expect_silence(client: Client) -> Nil {
+  websocket.receive_app_frame(client) |> should.be_error
+  Nil
+}
+
+/// Close a client connection.
+pub fn close(client: Client) -> Nil {
+  let assert Ok(Nil) = websocket.close(client) as "the client closes"
+  Nil
+}
+
+// ---------------------------------------------------------------------------
+// Frames
+// ---------------------------------------------------------------------------
+
+/// A decoded server frame, with its payload canonicalised to JSON text so
+/// that two systems' observations compare structurally.
+pub type Frame {
+  Frame(
+    join_ref: Option(String),
+    ref: Option(String),
+    topic: String,
+    event: String,
+    payload: String,
+  )
+}
+
+/// A `phx_join` frame carrying `payload`.
+pub fn join_frame(
+  join_ref: String,
+  ref: String,
+  name: String,
+  payload: json.Json,
+) -> String {
+  encode_frame(Some(join_ref), Some(ref), name, fixtures.join_event, payload)
+}
+
+/// A `phx_leave` frame.
+pub fn leave_frame(join_ref: String, ref: String, name: String) -> String {
+  encode_frame(
+    Some(join_ref),
+    Some(ref),
+    name,
+    fixtures.leave_event,
+    json.object([]),
+  )
+}
+
+/// An application event frame that asks for a reply.
+pub fn event_frame(
+  join_ref: String,
+  ref: String,
+  name: String,
+  event: String,
+  payload: json.Json,
+) -> String {
+  encode_frame(Some(join_ref), Some(ref), name, event, payload)
+}
+
+/// An application event frame with no reply ref.
+pub fn unrefed_event_frame(
+  join_ref: String,
+  name: String,
+  event: String,
+  payload: json.Json,
+) -> String {
+  encode_frame(Some(join_ref), None, name, event, payload)
+}
+
+/// A client heartbeat on the reserved `phoenix` topic.
+pub fn heartbeat_frame(ref: String) -> String {
+  encode_frame(
+    None,
+    Some(ref),
+    fixtures.heartbeat_topic,
+    fixtures.heartbeat_event,
+    json.object([]),
+  )
+}
+
+/// A Phoenix V2 binary frame: `push` tag, then ref/topic/event lengths,
+/// then the bytes.
+pub fn binary_frame(
+  join_ref: String,
+  ref: String,
+  name: String,
+  event: String,
+  data: BitArray,
+) -> BitArray {
+  <<
+    0,
+    bit_array.byte_size(<<join_ref:utf8>>),
+    bit_array.byte_size(<<ref:utf8>>),
+    bit_array.byte_size(<<name:utf8>>),
+    bit_array.byte_size(<<event:utf8>>),
+    join_ref:utf8,
+    ref:utf8,
+    name:utf8,
+    event:utf8,
+    data:bits,
+  >>
+}
+
+fn encode_frame(
+  join_ref: Option(String),
+  ref: Option(String),
+  name: String,
+  event: String,
+  payload: json.Json,
+) -> String {
+  json.to_string(
+    json.preprocessed_array([
+      optional_json(join_ref),
+      optional_json(ref),
+      json.string(name),
+      json.string(event),
+      payload,
+    ]),
+  )
+}
+
+fn optional_json(value: Option(String)) -> json.Json {
+  case value {
+    Some(inner) -> json.string(inner)
+    None -> json.null()
+  }
+}
+
+fn decode_frame(raw: String) -> Frame {
+  let decoder = {
+    use join_ref <- decode.subfield([0], decode.optional(decode.string))
+    use ref <- decode.subfield([1], decode.optional(decode.string))
+    use name <- decode.subfield([2], decode.string)
+    use event <- decode.subfield([3], decode.string)
+    use payload <- decode.subfield([4], decode.dynamic)
+    decode.success(Frame(
+      join_ref: join_ref,
+      ref: ref,
+      topic: name,
+      event: event,
+      payload: json.to_string(wire.dynamic_to_json(payload)),
+    ))
+  }
+
+  let assert Ok(frame) = json.parse(from: raw, using: decoder)
+    as "the server frame is valid phoenix wire format"
+  frame
+}
+
+/// The `phx_reply` event name, from the shared Phoenix fixtures.
+pub fn reply_event() -> String {
+  fixtures.reply_event
+}

--- a/packages/beryl_channels/test/wire_matrix_test.gleam
+++ b/packages/beryl_channels/test/wire_matrix_test.gleam
@@ -1,0 +1,374 @@
+//// The Phoenix wire-contract parity matrix.
+////
+//// Every scenario in this module is written **once** and run by
+//// [`wire_matrix.compare`](./wire_matrix.html) against two systems that
+//// implement the same application contract: a raw `beryl.child_spec`
+//// with a hand-written `update`, and a `beryl_channels.child_spec` with a
+//// handler table. Both are served by the same `beryl_mist` transport over
+//// a real WebSocket and share one `beryl.Config`, so the only variable is
+//// the dispatch layer.
+////
+//// `compare` fails if the two systems observe different frames, and
+//// returns the shared observation so each scenario can also pin what that
+//// observation must be. A scenario therefore proves two things at once:
+//// the contract holds, and the channel layer is invisible on the wire.
+
+import beryl
+import beryl/presence
+import gleam/json
+import gleam/list
+import gleam/option.{None, Some}
+import gleam/string
+import gleeunit/should
+import wire_matrix as matrix
+
+const lobby = "room:lobby"
+
+/// Connect, join `room:lobby`, and return the join reply.
+fn join(system: matrix.System) -> #(matrix.Client, matrix.Frame) {
+  let client = matrix.connect(system)
+  matrix.send(client, matrix.join_frame("jr-1", "r-1", lobby, json.object([])))
+  let assert [reply] = matrix.take_exactly(client, 1)
+  #(client, reply)
+}
+
+// === Join ==================================================================
+
+pub fn a_join_is_accepted_with_the_same_reply_test() {
+  let reply =
+    matrix.compare_with(config: matrix.default_config, scenario: fn(system) {
+      let #(client, reply) = join(system)
+      matrix.close(client)
+      reply
+    })
+
+  reply.join_ref |> should.equal(Some("jr-1"))
+  reply.ref |> should.equal(Some("r-1"))
+  reply.topic |> should.equal(lobby)
+  reply.event |> should.equal(matrix.reply_event())
+  reply.payload
+  |> should.equal(
+    "{\"response\":{\"joined\":true,\"topic\":\"room:lobby\"},\"status\":\"ok\"}",
+  )
+}
+
+pub fn a_rejected_join_reports_the_same_reason_test() {
+  let reply =
+    matrix.compare_with(config: matrix.default_config, scenario: fn(system) {
+      let client = matrix.connect(system)
+      matrix.send(
+        client,
+        matrix.join_frame(
+          "jr-1",
+          "r-1",
+          lobby,
+          json.object([#("deny", json.bool(True))]),
+        ),
+      )
+      let assert [reply] = matrix.take_exactly(client, 1)
+      matrix.close(client)
+      reply
+    })
+
+  reply.event |> should.equal(matrix.reply_event())
+  reply.payload
+  |> should.equal("{\"response\":{\"reason\":\"denied\"},\"status\":\"error\"}")
+}
+
+pub fn a_join_for_an_unowned_topic_is_refused_the_same_way_test() {
+  let reply =
+    matrix.compare_with(config: matrix.default_config, scenario: fn(system) {
+      let client = matrix.connect(system)
+      matrix.send(
+        client,
+        matrix.join_frame("jr-1", "r-1", "other:topic", json.object([])),
+      )
+      let assert [reply] = matrix.take_exactly(client, 1)
+      matrix.close(client)
+      reply
+    })
+
+  reply.topic |> should.equal("other:topic")
+  reply.payload
+  |> should.equal(
+    "{\"response\":{\"reason\":\"unmatched topic\"},\"status\":\"error\"}",
+  )
+}
+
+// === Replies ===============================================================
+
+pub fn a_message_reply_is_identical_test() {
+  let reply =
+    matrix.compare_with(config: matrix.default_config, scenario: fn(system) {
+      let #(client, _join) = join(system)
+      matrix.send(
+        client,
+        matrix.event_frame("jr-1", "r-2", lobby, "ping", json.object([])),
+      )
+      let assert [reply] = matrix.take_exactly(client, 1)
+      matrix.close(client)
+      reply
+    })
+
+  // Phoenix echoes the channel's join_ref on event replies.
+  reply.join_ref |> should.equal(Some("jr-1"))
+  reply.ref |> should.equal(Some("r-2"))
+  reply.event |> should.equal(matrix.reply_event())
+  reply.payload
+  |> should.equal("{\"response\":{\"pong\":true},\"status\":\"ok\"}")
+}
+
+pub fn an_error_reply_is_identical_test() {
+  let reply =
+    matrix.compare_with(config: matrix.default_config, scenario: fn(system) {
+      let #(client, _join) = join(system)
+      matrix.send(
+        client,
+        matrix.event_frame("jr-1", "r-2", lobby, "boom", json.object([])),
+      )
+      let assert [reply] = matrix.take_exactly(client, 1)
+      matrix.close(client)
+      reply
+    })
+
+  reply.ref |> should.equal(Some("r-2"))
+  reply.payload
+  |> should.equal("{\"response\":{\"reason\":\"nope\"},\"status\":\"error\"}")
+}
+
+// === Push and fan-out ======================================================
+
+pub fn a_server_push_is_identical_test() {
+  let pushed =
+    matrix.compare_with(config: matrix.default_config, scenario: fn(system) {
+      let #(client, _join) = join(system)
+      matrix.send(
+        client,
+        matrix.unrefed_event_frame("jr-1", lobby, "push_me", json.object([])),
+      )
+      let assert [pushed] = matrix.take_exactly(client, 1)
+      matrix.close(client)
+      pushed
+    })
+
+  // A push is unsolicited: no join_ref and no ref, like Phoenix.
+  pushed.join_ref |> should.equal(None)
+  pushed.ref |> should.equal(None)
+  pushed.topic |> should.equal(lobby)
+  pushed.event |> should.equal("pushed")
+  pushed.payload |> should.equal("{\"from\":\"server\"}")
+}
+
+pub fn broadcast_from_excludes_the_sender_identically_test() {
+  let received =
+    matrix.compare_with(config: matrix.default_config, scenario: fn(system) {
+      let #(sender, _join) = join(system)
+      let listener = matrix.connect(system)
+      matrix.send(
+        listener,
+        matrix.join_frame("jr-2", "r-9", lobby, json.object([])),
+      )
+      let assert [_listener_join] = matrix.take_exactly(listener, 1)
+
+      matrix.send(
+        sender,
+        matrix.unrefed_event_frame(
+          "jr-1",
+          lobby,
+          "shout",
+          json.object([#("body", json.string("hi"))]),
+        ),
+      )
+      let assert [received] = matrix.take_exactly(listener, 1)
+      // The sender is excluded from its own broadcast_from.
+      matrix.expect_silence(sender)
+      matrix.close(sender)
+      matrix.close(listener)
+      received
+    })
+
+  received.event |> should.equal("shouted")
+  received.topic |> should.equal(lobby)
+  received.payload |> should.equal("{\"body\":\"hi\"}")
+}
+
+pub fn a_server_side_broadcast_reaches_both_systems_identically_test() {
+  let received =
+    matrix.compare_with(config: matrix.default_config, scenario: fn(system) {
+      let #(client, _join) = join(system)
+      beryl.broadcast(
+        system.sockets,
+        lobby,
+        "announcement",
+        json.object([#("body", json.string("hello"))]),
+      )
+      let assert [received] = matrix.take_exactly(client, 1)
+      matrix.close(client)
+      received
+    })
+
+  received.event |> should.equal("announcement")
+  received.payload |> should.equal("{\"body\":\"hello\"}")
+}
+
+// === Heartbeat and leave ===================================================
+
+pub fn a_heartbeat_is_answered_identically_test() {
+  let reply =
+    matrix.compare_with(config: matrix.default_config, scenario: fn(system) {
+      let #(client, _join) = join(system)
+      matrix.send(client, matrix.heartbeat_frame("hb-1"))
+      let assert [reply] = matrix.take_exactly(client, 1)
+      matrix.close(client)
+      reply
+    })
+
+  reply.join_ref |> should.equal(None)
+  reply.ref |> should.equal(Some("hb-1"))
+  reply.topic |> should.equal("phoenix")
+  reply.event |> should.equal(matrix.reply_event())
+  reply.payload |> should.equal("{\"response\":{},\"status\":\"ok\"}")
+}
+
+pub fn a_leave_ends_the_channel_identically_test() {
+  let frames =
+    matrix.compare_with(config: matrix.default_config, scenario: fn(system) {
+      let #(client, _join) = join(system)
+      matrix.send(client, matrix.leave_frame("jr-1", "r-3", lobby))
+      let frames = matrix.take_exactly(client, 2)
+
+      // The topic is gone: a later broadcast reaches nobody on this socket.
+      beryl.broadcast(system.sockets, lobby, "after_leave", json.object([]))
+      matrix.expect_silence(client)
+      matrix.close(client)
+      frames
+    })
+
+  // Phoenix answers the leave ref, then announces the channel is closed.
+  let assert [reply, closed] = frames
+  reply.ref |> should.equal(Some("r-3"))
+  reply.event |> should.equal(matrix.reply_event())
+  reply.payload |> should.equal("{\"response\":{},\"status\":\"ok\"}")
+  closed.event |> should.equal("phx_close")
+  closed.topic |> should.equal(lobby)
+  closed.join_ref |> should.equal(Some("jr-1"))
+  closed.payload |> should.equal("{}")
+}
+
+// === Binary ================================================================
+
+pub fn a_codec_decoded_binary_frame_is_handled_identically_test() {
+  let pushed =
+    matrix.compare_with(config: matrix.default_config, scenario: fn(system) {
+      let #(client, _join) = join(system)
+      matrix.send_binary(
+        client,
+        matrix.binary_frame("jr-1", "r-4", lobby, "blob", <<1, 2, 3, 4, 5>>),
+      )
+      let assert [pushed] = matrix.take_exactly(client, 1)
+      matrix.close(client)
+      pushed
+    })
+
+  pushed.event |> should.equal("binary_in")
+  pushed.payload |> should.equal("{\"bytes\":5,\"kind\":\"decoded\"}")
+}
+
+pub fn an_undecoded_binary_frame_is_handled_identically_test() {
+  let pushed =
+    matrix.compare_with(config: matrix.text_only_config, scenario: fn(system) {
+      let #(client, _join) = join(system)
+      matrix.send_binary(client, <<9, 9, 9>>)
+      let assert [pushed] = matrix.take_exactly(client, 1)
+      matrix.close(client)
+      pushed
+    })
+
+  pushed.event |> should.equal("binary_in")
+  pushed.payload |> should.equal("{\"bytes\":3,\"kind\":\"raw\"}")
+}
+
+// === Presence ==============================================================
+
+pub fn presence_tracking_produces_the_same_frames_test() {
+  let #(frames, entries) =
+    matrix.compare(
+      setup: fn() {
+        let assert Ok(handle) = presence.start(presence.default_config("node1"))
+          as "the presence actor starts"
+        #(matrix.default_config() |> beryl.with_presence_handle(handle), handle)
+      },
+      scenario: fn(system, handle) {
+        let #(client, _join) = join(system)
+        matrix.send(
+          client,
+          matrix.unrefed_event_frame("jr-1", lobby, "track", json.object([])),
+        )
+        let frames = matrix.take_exactly(client, 2)
+        let keys =
+          presence.list(handle, lobby)
+          |> list.map(fn(entry) { entry.key })
+        matrix.close(client)
+        #(frames, keys)
+      },
+    )
+
+  let assert [diff, snapshot] = frames
+  diff.event |> should.equal("presence_diff")
+  diff.payload |> string.contains("alice") |> should.be_true
+  diff.payload |> string.contains("online") |> should.be_true
+  snapshot.event |> should.equal("presence_list")
+  // The snapshot is encoded after the track in the same action list, so it
+  // already contains the key that was just tracked.
+  snapshot.payload |> should.equal("[\"alice\"]")
+  entries |> should.equal(["alice"])
+}
+
+// === Abuse controls ========================================================
+
+pub fn the_join_rate_limiter_answers_identically_test() {
+  let reply =
+    matrix.compare_with(
+      config: fn() {
+        matrix.default_config()
+        |> beryl.with_join_rate(per_second: 1, burst: 1)
+      },
+      scenario: fn(system) {
+        let #(client, _join) = join(system)
+        matrix.send(
+          client,
+          matrix.join_frame("jr-2", "r-2", "room:other", json.object([])),
+        )
+        let assert [reply] = matrix.take_exactly(client, 1)
+        matrix.close(client)
+        reply
+      },
+    )
+
+  reply.ref |> should.equal(Some("r-2"))
+  reply.payload |> string.contains("\"status\":\"error\"") |> should.be_true
+  reply.payload |> string.contains("rate_limited") |> should.be_true
+}
+
+pub fn the_topic_cap_answers_identically_test() {
+  let reply =
+    matrix.compare_with(
+      config: fn() {
+        matrix.default_config()
+        |> beryl.with_max_joined_topics_per_socket(1)
+      },
+      scenario: fn(system) {
+        let #(client, _join) = join(system)
+        matrix.send(
+          client,
+          matrix.join_frame("jr-2", "r-2", "room:other", json.object([])),
+        )
+        let assert [reply] = matrix.take_exactly(client, 1)
+        matrix.close(client)
+        reply
+      },
+    )
+
+  reply.payload |> string.contains("\"status\":\"error\"") |> should.be_true
+  reply.payload |> string.contains("too_many_topics") |> should.be_true
+}

--- a/packages/beryl_channels/test/wire_matrix_test.gleam
+++ b/packages/beryl_channels/test/wire_matrix_test.gleam
@@ -291,7 +291,7 @@ pub fn an_undecoded_binary_frame_is_handled_identically_test() {
 // === Presence ==============================================================
 
 pub fn presence_tracking_produces_the_same_frames_test() {
-  let #(frames, entries) =
+  let #(diff_shape, snapshot, entries) =
     matrix.compare(
       setup: fn() {
         let assert Ok(handle) = presence.start(presence.default_config("node1"))
@@ -309,14 +309,23 @@ pub fn presence_tracking_produces_the_same_frames_test() {
           presence.list(handle, lobby)
           |> list.map(fn(entry) { entry.key })
         matrix.close(client)
-        #(frames, keys)
+        let assert [diff, snapshot] = frames
+        #(
+          #(
+            diff.topic,
+            diff.event,
+            diff.payload |> string.contains("alice"),
+            diff.payload |> string.contains("online"),
+            diff.payload |> string.contains("\"leaves\":{}"),
+          ),
+          snapshot,
+          keys,
+        )
       },
     )
 
-  let assert [diff, snapshot] = frames
-  diff.event |> should.equal("presence_diff")
-  diff.payload |> string.contains("alice") |> should.be_true
-  diff.payload |> string.contains("online") |> should.be_true
+  diff_shape
+  |> should.equal(#(lobby, "presence_diff", True, True, True))
   snapshot.event |> should.equal("presence_list")
   // The snapshot is encoded after the track in the same action list, so it
   // already contains the key that was just tracked.

--- a/website/scripts/generate-reference.mjs
+++ b/website/scripts/generate-reference.mjs
@@ -155,7 +155,12 @@ function moduleSlug(moduleName) {
 function descriptionFromDocs(documentation, fallback) {
 	const text = normalizeDoc(documentation);
 	const firstLine = text.split("\n").find((line) => line.trim().length > 0);
-	return firstLine ? firstLine.replaceAll('"', '\\"') : fallback;
+	return firstLine ? firstLine.trim() : fallback;
+}
+
+/** Quote a scalar for safe embedding in YAML frontmatter. */
+function yamlQuote(value) {
+	return `"${String(value).replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
 }
 
 function normalizeDoc(documentation) {
@@ -341,7 +346,7 @@ function renderModulePage(moduleName, moduleInterface) {
 
 	return `---
 title: ${moduleName}
-description: ${description}
+description: ${yamlQuote(description)}
 ---
 
 ${GENERATED_MARKER}

--- a/website/src/content/docs/reference/api/beryl-bridge.md
+++ b/website/src/content/docs/reference/api/beryl-bridge.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/bridge
-description: Bridge - Forward an external OTP actor's message stream to a socket via
+description: "Bridge - Forward an external OTP actor's message stream to a socket via"
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl-error.md
+++ b/website/src/content/docs/reference/api/beryl-error.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/error
-description: Shared beryl-owned error helpers.
+description: "Shared beryl-owned error helpers."
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl-group.md
+++ b/website/src/content/docs/reference/api/beryl-group.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/group
-description: Channel Groups - Named collections of topics for multi-topic broadcasting
+description: "Channel Groups - Named collections of topics for multi-topic broadcasting"
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl-presence-wire.md
+++ b/website/src/content/docs/reference/api/beryl-presence-wire.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/presence/wire
-description: Phoenix-compatible wire encoding for presence diffs.
+description: "Phoenix-compatible wire encoding for presence diffs."
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/presence
-description: Presence - Distributed presence tracking backed by a CRDT
+description: "Presence - Distributed presence tracking backed by a CRDT"
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/pubsub
-description: PubSub - Distributed publish/subscribe using Erlang pg
+description: "PubSub - Distributed publish/subscribe using Erlang pg"
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl-socket-router.md
+++ b/website/src/content/docs/reference/api/beryl-socket-router.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/socket/router
-description: Topic-namespace routing for app-side dispatch.
+description: "Topic-namespace routing for app-side dispatch."
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl-socket.md
+++ b/website/src/content/docs/reference/api/beryl-socket.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/socket
-description: Types for building app-side dispatch systems with `beryl.child_spec`.
+description: "Types for building app-side dispatch systems with `beryl.child_spec`."
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl-stats.md
+++ b/website/src/content/docs/reference/api/beryl-stats.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/stats
-description: Local runtime statistics.
+description: "Local runtime statistics."
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl-topic.md
+++ b/website/src/content/docs/reference/api/beryl-topic.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/topic
-description: Pattern matching for topic routing.
+description: "Pattern matching for topic routing."
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl-transport-origin.md
+++ b/website/src/content/docs/reference/api/beryl-transport-origin.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/transport/origin
-description: Origin and handshake-version checks for WebSocket upgrades.
+description: "Origin and handshake-version checks for WebSocket upgrades."
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl-transport-server.md
+++ b/website/src/content/docs/reference/api/beryl-transport-server.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/transport/server
-description: Server-agnostic WebSocket transport infrastructure.
+description: "Server-agnostic WebSocket transport infrastructure."
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl-transport.md
+++ b/website/src/content/docs/reference/api/beryl-transport.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/transport
-description: Transport SPI — the contract between beryl core and WebSocket transport
+description: "Transport SPI — the contract between beryl core and WebSocket transport"
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl-wire-codec.md
+++ b/website/src/content/docs/reference/api/beryl-wire-codec.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/wire/codec
-description: Pluggable wire codec for beryl.
+description: "Pluggable wire codec for beryl."
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl-wire.md
+++ b/website/src/content/docs/reference/api/beryl-wire.md
@@ -1,6 +1,6 @@
 ---
 title: beryl/wire
-description: Phoenix Wire Protocol — encoding/decoding helpers and the canonical
+description: "Phoenix Wire Protocol — encoding/decoding helpers and the canonical"
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -1,6 +1,6 @@
 ---
 title: beryl
-description: Beryl - Type-safe real-time communication
+description: "Beryl - Type-safe real-time communication"
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl_channels-channel.md
+++ b/website/src/content/docs/reference/api/beryl_channels-channel.md
@@ -1,6 +1,6 @@
 ---
 title: beryl_channels/channel
-description: The channel composition surface: a channel is a topic pattern paired
+description: "The channel composition surface: a channel is a topic pattern paired"
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl_channels-channel.md
+++ b/website/src/content/docs/reference/api/beryl_channels-channel.md
@@ -54,7 +54,7 @@ The channel composition surface: a channel is a topic pattern paired
  `info`, the type of server-side messages it accepts. Neither escapes:
  [`joined`](#joined) seals `state` inside the callback closures, and
  [`handler`](#handler) seals `info` inside the registration closure, so
- the resulting [`Handler`](#Handler) is not generic and handlers with
+ the resulting [`Handler`](#handler) is not generic and handlers with
  unrelated `state` and `info` types compose in one list. No value is
  ever erased to `Dynamic` and no unchecked coercion is involved:
  typed `info` values travel inside a closure that only the join which
@@ -63,7 +63,7 @@ The channel composition surface: a channel is a topic pattern paired
 
  ## Ordering
 
- [`Actions`](#Actions) are applied strictly in the order they were
+ [`Actions`](#actions) are applied strictly in the order they were
  added, and they always target the channel's own topic. They lower onto
  beryl's core `Effect` values, which the runtime applies in list order
  inside a single actor turn — so action order is wire order.
@@ -124,7 +124,7 @@ Everything a `join` callback learns about the connection it is joining.
 
  `socket_id` and `seed` come straight from the transport's connect
  information; `self` is this channel's own generation-scoped
- [`Sender`](#Sender), which is the supported way to schedule work for
+ [`Sender`](#sender), which is the supported way to schedule work for
  just after the join acknowledgment.
 
 ```gleam
@@ -179,7 +179,7 @@ pub type Next(a)
 
 A typed handle for sending server-side messages to one joined channel.
 
- Obtained from [`JoinInfo`](#JoinInfo) in the `join` callback and safe to
+ Obtained from [`JoinInfo`](#joininfo) in the `join` callback and safe to
  share with any process. Messages sent through it are delivered to the
  channel's `on_info` callback with their type intact.
 
@@ -318,7 +318,7 @@ Register a channel for every topic matching `pattern`.
  `"room:*"`, `"document:*:ops"`, `"*"`) and is validated when the
  handler table is used; see `beryl_channels.validate_handlers`.
 
- `join` receives the connection's [`JoinInfo`](#JoinInfo), the concrete
+ `join` receives the connection's [`JoinInfo`](#joininfo), the concrete
  topic that matched, and the client's join payload, and answers with
  [`accept`](#accept), [`accept_with`](#accept_with), or
  [`reject`](#reject).
@@ -357,7 +357,7 @@ Send a typed server-side message to the channel that owns `sender`.
  This is a fire-and-forget send: it returns as soon as the message is
  enqueued, whether or not the channel is still joined. A message
  enqueued for a channel that has already ended is discarded on arrival
- (see [`Sender`](#Sender)).
+ (see [`Sender`](#sender)).
 
 ```gleam
 pub fn notify(
@@ -380,7 +380,7 @@ pub fn on_binary(
 ### `on_info`
 
 Handle typed server-side messages sent through this channel's
- [`Sender`](#Sender).
+ [`Sender`](#sender).
 
 ```gleam
 pub fn on_info(
@@ -487,7 +487,7 @@ pub fn reject(json.Json) -> JoinResult(a)
 ### `reply_error`
 
 Reply with an error to a client message, using the `reply` handle from
- the [`Message`](#Message) that asked for it.
+ the [`Message`](#message) that asked for it.
 
 ```gleam
 pub fn reply_error(
@@ -500,7 +500,7 @@ pub fn reply_error(
 ### `reply_ok`
 
 Reply successfully to a client message, using the `reply` handle from
- the [`Message`](#Message) that asked for it.
+ the [`Message`](#message) that asked for it.
 
 ```gleam
 pub fn reply_ok(

--- a/website/src/content/docs/reference/api/beryl_channels.md
+++ b/website/src/content/docs/reference/api/beryl_channels.md
@@ -21,17 +21,33 @@ Composable channels for beryl real-time sockets.
  type.
 
  ```gleam
+ import beryl
+ import beryl/wire
  import beryl_channels
  import beryl_channels/channel
+ import gleam/otp/static_supervisor
 
  pub fn handlers() -> List(channel.Handler) {
    [rooms.channel(), documents.channel()]
  }
 
  pub fn main() {
-   let assert Ok(Nil) = beryl_channels.validate_handlers(handlers())
+   let assert Ok(#(sockets, spec)) =
+     beryl_channels.child_spec(
+       beryl.config(wire.phoenix_codec()),
+       handlers: handlers(),
+     )
+
+   let assert Ok(_root) =
+     static_supervisor.new(static_supervisor.OneForOne)
+     |> static_supervisor.add(spec)
+     |> static_supervisor.start()
  }
  ```
+
+ The returned `beryl.Sockets` is an ordinary core handle: pass it to a
+ transport (`beryl_mist`, `beryl_ewe`), to `beryl.broadcast`, and to
+ `beryl.stop`.
 
  ## Routing rules
 
@@ -42,12 +58,9 @@ Composable channels for beryl real-time sockets.
  handlers registered with the *same* pattern string are rejected
  instead, because the second one could never be reached.
 
- ## Status
-
- The handler surface, the error surface, and the validation below are
- complete. The supervised socket entry point that builds a child
- specification from a handler table lands together with the dispatch
- adapter; it is deliberately absent rather than present and inert.
+ A join for a topic no handler matches is refused explicitly, with the
+ reason payload `{"reason": "unmatched topic"}`, rather than left
+ unanswered.
 
 ## Types
 
@@ -115,6 +128,39 @@ Two handlers were registered with the same pattern string. The
 
 ## Functions
 
+### `child_spec`
+
+Build a channel system's supervision child specification for embedding
+ in an application's supervision tree.
+
+ Like `beryl.child_spec`, this reports only what can be detected before
+ the tree is started: the handler table is validated first, then the
+ `beryl.Config`, whose error is returned nested in
+ [`ChildSpecInvalidConfig`](#ChildSpecError). The returned
+ `beryl.Sockets` is usable as soon as the owning tree is running.
+
+ ## Example
+
+ ```gleam
+ let assert Ok(#(sockets, spec)) =
+   beryl_channels.child_spec(
+     beryl.config(wire.phoenix_codec()),
+     handlers: [rooms.channel()],
+   )
+
+ let assert Ok(_root) =
+   static_supervisor.new(static_supervisor.OneForOne)
+   |> static_supervisor.add(spec)
+   |> static_supervisor.start()
+ ```
+
+```gleam
+pub fn child_spec(
+  beryl.Config,
+  handlers: List(channel.Handler)
+) -> Result(#(beryl.Sockets, supervision.ChildSpecification(static_supervisor.Supervisor)), ChildSpecError)
+```
+
 ### `validate_handlers`
 
 Validate a handler table without starting anything.
@@ -125,7 +171,7 @@ Validate a handler table without starting anything.
  (`"room:lobby"` and `"room:*"`) are valid: routing resolves them by
  first match.
 
- The socket entry points run exactly this validation before starting
+ [`child_spec`](#child_spec) runs exactly this validation before building
  anything, so a handler table that passes here is accepted there too.
 
 ```gleam

--- a/website/src/content/docs/reference/api/beryl_channels.md
+++ b/website/src/content/docs/reference/api/beryl_channels.md
@@ -13,7 +13,7 @@ Composable channels for beryl real-time sockets.
 
  This package layers Phoenix-shaped channel modules on top of beryl's
  public app-side dispatch API. An application registers a list of
- [`channel.Handler`](./beryl_channels/channel.html#Handler) values —
+ [`channel.Handler`](/reference/api/beryl_channels-channel/#handler) values —
  each a topic pattern plus a typed `join` callback — and the layer
  routes every socket event to the channel that owns its topic. No
  hand-written message union and no hand-written router are required,
@@ -136,7 +136,7 @@ Build a channel system's supervision child specification for embedding
  Like `beryl.child_spec`, this reports only what can be detected before
  the tree is started: the handler table is validated first, then the
  `beryl.Config`, whose error is returned nested in
- [`ChildSpecInvalidConfig`](#ChildSpecError). The returned
+ [`ChildSpecInvalidConfig`](#childspecerror). The returned
  `beryl.Sockets` is usable as soon as the owning tree is running.
 
  ## Example

--- a/website/src/content/docs/reference/api/beryl_channels.md
+++ b/website/src/content/docs/reference/api/beryl_channels.md
@@ -1,6 +1,6 @@
 ---
 title: beryl_channels
-description: Composable channels for beryl real-time sockets.
+description: "Composable channels for beryl real-time sockets."
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl_ewe.md
+++ b/website/src/content/docs/reference/api/beryl_ewe.md
@@ -1,6 +1,6 @@
 ---
 title: beryl_ewe
-description: Ewe WebSocket Transport - Direct Ewe integration for beryl
+description: "Ewe WebSocket Transport - Direct Ewe integration for beryl"
 ---
 
 <!--

--- a/website/src/content/docs/reference/api/beryl_mist.md
+++ b/website/src/content/docs/reference/api/beryl_mist.md
@@ -1,6 +1,6 @@
 ---
 title: beryl_mist
-description: Mist WebSocket Transport - Direct Mist integration for beryl
+description: "Mist WebSocket Transport - Direct Mist integration for beryl"
 ---
 
 <!--


### PR DESCRIPTION
## Purpose
Implement the channel dispatch adapter and Phoenix wire-contract coverage.

## Provenance and split notes
Source PR #250; source commit(s): `e7545f9f, 7a9a43cc, 2720e1af`. Combines adapter implementation, crash/fan-out tests, and the parity matrix with normalized presence wire semantics.
