### PR TITLE
refactor(beryl)!: nest topic pattern errors

### DIFF
--- a/.changes/unreleased/beryl-config-error-topic-error.toml
+++ b/.changes/unreleased/beryl-config-error-topic-error.toml
@@ -1,0 +1,3 @@
+project = "beryl"
+kind = "Changed"
+body = "beryl.ConfigError's InvalidTopicPattern now nests the beryl/topic.TopicError in its reason field instead of flattening it to a String, matching the layer contract used by beryl_channels.HandlerError. New TopicError variants may be added in a minor release, so match with a catch-all unless you need the exact variant."

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -656,9 +656,16 @@ pub type ConfigError {
   /// smallest accepted timeout.
   HeartbeatTimeoutTooLow(minimum: Int)
   /// A per-topic-pattern rate limit used a pattern string that is not a valid
-  /// topic pattern. `pattern` is the offending pattern and `reason` describes
-  /// the problem.
-  InvalidTopicPattern(pattern: String, reason: String)
+  /// topic pattern. `pattern` is the offending pattern and `reason` is the
+  /// [`beryl/topic`](https://beryl.tylerbutler.com/reference/api/beryl-topic/)
+  /// error nested rather than flattened to a string, so it stays matchable.
+  ///
+  /// New
+  /// [`topic.TopicError`](https://beryl.tylerbutler.com/reference/api/beryl-topic/#topicerror)
+  /// variants may be added in a minor release. Match exact variants only
+  /// when you act on them differently, and otherwise keep a catch-all arm
+  /// such as `InvalidTopicPattern(pattern, _)`.
+  InvalidTopicPattern(pattern: String, reason: topic.TopicError)
 }
 
 /// Errors when stopping a Beryl system with [`stop`](#stop).
@@ -685,17 +692,8 @@ pub fn validate_config(config: Config) -> Result(Nil, ConfigError) {
   list.try_each(config.topic_rates, fn(entry) {
     let #(pattern, _limits) = entry
     topic.validate_pattern(pattern)
-    |> result.map_error(fn(error) {
-      InvalidTopicPattern(pattern, topic_error_reason(error))
-    })
+    |> result.map_error(fn(error) { InvalidTopicPattern(pattern, error) })
   })
-}
-
-fn topic_error_reason(error: topic.TopicError) -> String {
-  case error {
-    topic.EmptyTopic -> "pattern cannot be empty"
-    topic.InvalidFormat(reason) -> reason
-  }
 }
 
 /// Stop a Beryl system.

--- a/packages/beryl/src/beryl/topic.gleam
+++ b/packages/beryl/src/beryl/topic.gleam
@@ -314,6 +314,11 @@ fn has_control_characters(value: String) -> Bool {
 }
 
 /// Errors returned when validating a topic or topic pattern.
+///
+/// New variants may be added in a minor release as validation gets stricter,
+/// so this type is not treated as closed for exhaustive matching. Match exact
+/// variants only where you act on them differently, and otherwise keep a
+/// catch-all arm (`_ -> ...`) so future variants do not break your code.
 pub type TopicError {
   /// The topic or pattern was an empty string.
   EmptyTopic

--- a/packages/beryl/test/app_lifecycle_test.gleam
+++ b/packages/beryl/test/app_lifecycle_test.gleam
@@ -6,6 +6,7 @@
 
 import app_test_helpers as h
 import beryl
+import beryl/topic
 import beryl/wire
 import gleam/otp/static_supervisor
 import gleam/string
@@ -44,16 +45,22 @@ pub fn validate_config_accepts_valid_topic_pattern_test() {
 
 pub fn validate_config_rejects_invalid_topic_pattern_test() {
   let bad = "room:" <> control_char
-  let result =
-    beryl.config(wire.phoenix_codec())
-    |> beryl.with_topic_rate(pattern: bad, per_second: 5, burst: 10)
-    |> beryl.validate_config
+  beryl.config(wire.phoenix_codec())
+  |> beryl.with_topic_rate(pattern: bad, per_second: 5, burst: 10)
+  |> beryl.validate_config
+  |> should.equal(
+    Error(beryl.InvalidTopicPattern(
+      bad,
+      topic.InvalidFormat("pattern contains control characters"),
+    )),
+  )
+}
 
-  case result {
-    Error(beryl.InvalidTopicPattern(pattern, _reason)) ->
-      pattern |> should.equal(bad)
-    _ -> should.fail()
-  }
+pub fn validate_config_rejects_empty_topic_pattern_test() {
+  beryl.config(wire.phoenix_codec())
+  |> beryl.with_topic_rate(pattern: "", per_second: 5, burst: 10)
+  |> beryl.validate_config
+  |> should.equal(Error(beryl.InvalidTopicPattern("", topic.EmptyTopic)))
 }
 
 // ── start / child_spec config validation parity ────────────────────────

--- a/website/src/content/docs/guides/error-handling.md
+++ b/website/src/content/docs/guides/error-handling.md
@@ -204,10 +204,19 @@ case beryl.child_spec(config, init: init, update: update) {
   Error(beryl.HeartbeatTimeoutTooLow(2)) ->
     // heartbeat_timeout_ms below 2 would silently disable eviction
     panic as "fix the heartbeat config"
-  Error(beryl.InvalidTopicPattern(pattern, reason)) ->
-    panic as pattern <> ": " <> reason
+  Error(beryl.InvalidTopicPattern(pattern, topic.EmptyTopic)) ->
+    panic as { pattern <> " is empty" }
+  Error(beryl.InvalidTopicPattern(pattern, topic.InvalidFormat(detail))) ->
+    panic as { pattern <> ": " <> detail }
+  Error(beryl.InvalidTopicPattern(pattern, _other)) ->
+    panic as { pattern <> " is invalid" }
 }
 ```
+
+`InvalidTopicPattern` nests `beryl/topic.TopicError` rather than flattening it
+to a string. New `TopicError` variants may be added in a minor release, so
+match exact variants only when your handling differs and keep a catch-all
+otherwise.
 
 `beryl_channels.child_spec` validates the handler table first and reports
 `ChildSpecInvalidHandlers(HandlerError)` or

--- a/website/src/content/docs/reference/api/beryl-topic.md
+++ b/website/src/content/docs/reference/api/beryl-topic.md
@@ -54,6 +54,11 @@ The topic does not match the pattern.
 
 Errors returned when validating a topic or topic pattern.
 
+ New variants may be added in a minor release as validation gets stricter,
+ so this type is not treated as closed for exhaustive matching. Match exact
+ variants only where you act on them differently, and otherwise keep a
+ catch-all arm (`_ -> ...`) so future variants do not break your code.
+
 ```gleam
 pub type TopicError {
   EmptyTopic

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -94,7 +94,7 @@ pub type ConfigError {
   HeartbeatTimeoutTooLow(minimum: Int)
   InvalidTopicPattern(
     pattern: String,
-    reason: String
+    reason: topic.TopicError
   )
 }
 ```
@@ -111,12 +111,19 @@ pub type ConfigError {
 
 ##### `InvalidTopicPattern(
   pattern: String,
-  reason: String
+  reason: topic.TopicError
 )`
 
 A per-topic-pattern rate limit used a pattern string that is not a valid
- topic pattern. `pattern` is the offending pattern and `reason` describes
- the problem.
+ topic pattern. `pattern` is the offending pattern and `reason` is the
+ [`beryl/topic`](https://beryl.tylerbutler.com/reference/api/beryl-topic/)
+ error nested rather than flattened to a string, so it stays matchable.
+
+ New
+ [`topic.TopicError`](https://beryl.tylerbutler.com/reference/api/beryl-topic/#topicerror)
+ variants may be added in a minor release. Match exact variants only
+ when you act on them differently, and otherwise keep a catch-all arm
+ such as `InvalidTopicPattern(pattern, _)`.
 
 ### `ConnectionPermit`
 


### PR DESCRIPTION
## Purpose
Nest topic.TopicError under InvalidTopicPattern in core.

## Provenance and split notes
Source PR #250; source commit(s): `610b1185`. Carries the core half of split source commit 610b1185; the dependent beryl_channels compatibility half follows separately.
