### PR TITLE
fix(beryl_channels): adapt nested topic errors

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -40,6 +40,9 @@ needs_deps = true
 [tools.trellis.changelog]
 strictness = "warn"
 kinds = [
+  # `Initial Release` is a strict major bump: it plans 1.0.0 even for an
+  # unreleased 0.x package. Pre-1.0 packages use `Added` for their first
+  # release and describe that initial release in the fragment body.
   { label = "Initial Release", bump = "major" },
   { label = "Added", bump = "minor" },
   { label = "Changed", bump = "minor" },

--- a/packages/beryl_channels/src/beryl_channels.gleam
+++ b/packages/beryl_channels/src/beryl_channels.gleam
@@ -72,8 +72,13 @@ pub type HandlerError {
   /// A handler used a pattern string that is not a valid topic pattern.
   /// `pattern` is the offending pattern and `reason` is the
   /// [`beryl/topic`](https://beryl.tylerbutler.com/reference/api/beryl-topic/)
-  /// error
-  /// nested rather than flattened to a string, so it stays matchable.
+  /// error nested rather than flattened to a string, so it stays matchable.
+  ///
+  /// New
+  /// [`topic.TopicError`](https://beryl.tylerbutler.com/reference/api/beryl-topic/#topicerror)
+  /// variants may be added in a minor release. Match exact variants only when
+  /// you act on them differently, and otherwise keep a catch-all arm such as
+  /// `InvalidPattern(pattern, _)`.
   InvalidPattern(pattern: String, reason: topic.TopicError)
   /// Two handlers were registered with the same pattern string. The
   /// second one could never receive a join, because routing takes the

--- a/website/src/content/docs/guides/channels.md
+++ b/website/src/content/docs/guides/channels.md
@@ -226,6 +226,19 @@ pub fn check_handlers() -> Nil {
 flattened string, so the reason stays matchable. `ChildSpecError` likewise
 nests the core configuration error instead of flattening it.
 
+The example above matches every `TopicError` variant that exists today.
+New variants may be added in a minor release, so use a catch-all when the
+exact reason does not change your handling:
+
+```gleam
+Error(beryl_channels.InvalidPattern(pattern, _reason)) ->
+  panic as { "invalid channel pattern " <> pattern }
+```
+
+The same rule applies to
+`beryl.InvalidTopicPattern(pattern, reason)`, which nests the identical
+`topic.TopicError`.
+
 Validation is deterministic and two-phase: every pattern's syntax is
 checked in registration order first, then duplicate pattern strings are
 looked for in registration order. `child_spec` runs exactly this check

--- a/website/src/content/docs/reference/api/beryl_channels.md
+++ b/website/src/content/docs/reference/api/beryl_channels.md
@@ -119,8 +119,13 @@ pub type HandlerError {
 A handler used a pattern string that is not a valid topic pattern.
  `pattern` is the offending pattern and `reason` is the
  [`beryl/topic`](https://beryl.tylerbutler.com/reference/api/beryl-topic/)
- error
- nested rather than flattened to a string, so it stays matchable.
+ error nested rather than flattened to a string, so it stays matchable.
+
+ New
+ [`topic.TopicError`](https://beryl.tylerbutler.com/reference/api/beryl-topic/#topicerror)
+ variants may be added in a minor release. Match exact variants only when
+ you act on them differently, and otherwise keep a catch-all arm such as
+ `InvalidPattern(pattern, _)`.
 
 ##### `DuplicatePattern(pattern: String)`
 

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -73,8 +73,8 @@ This page lists common symptoms with targeted diagnosis steps. Start from your s
 ### `child_spec` returns `ChildSpecInvalidHandlers`
 
 - `InvalidPattern(pattern, reason)` means the pattern is not valid
-  `beryl/topic` syntax. `reason` is the nested `TopicError`; keep a catch-all
-  arm for future variants.
+  `beryl/topic` syntax. `reason` is the nested `TopicError` (`EmptyTopic` or
+  `InvalidFormat(detail)` today); keep a catch-all arm for future variants.
 - `DuplicatePattern(pattern)` means the same pattern string appears twice.
   Overlapping but different patterns are valid; first match wins.
 


### PR DESCRIPTION
## Purpose
Adapt beryl_channels documentation and matching guidance to nested topic errors.

## Provenance and split notes
Source PR #250; source commit(s): `610b1185`. Carries the dependent channel/docs half split from source commit 610b1185, retaining the pre-1.0 initial-release versioning rule.
