### PR TITLE
feat: add APM dependency management and skills

### DIFF
--- a/.agents/skills/caveman-commit/README.md
+++ b/.agents/skills/caveman-commit/README.md
@@ -1,0 +1,44 @@
+# caveman-commit
+
+Terse Conventional Commits. Why over what.
+
+## What it does
+
+Generates commit messages in Conventional Commits format. Subject ≤50 chars, hard cap 72. Imperative mood. Body only when the *why* is non-obvious or there are breaking changes. No AI attribution, no "this commit does X", no emoji unless the project uses them. Body always required for breaking changes, security fixes, data migrations, and reverts — future debuggers need the context.
+
+Outputs only the message. Does not stage, commit, or amend.
+
+## How to invoke
+
+```
+/caveman-commit
+```
+
+Also triggers on phrases like "write a commit", "commit message", "generate commit".
+
+## Example output
+
+Diff: new endpoint for user profile.
+
+```
+feat(api): add GET /users/:id/profile
+
+Mobile client needs profile data without the full user payload
+to reduce LTE bandwidth on cold-launch screens.
+
+Closes #128
+```
+
+Diff: breaking API rename.
+
+```
+feat(api)!: rename /v1/orders to /v1/checkout
+
+BREAKING CHANGE: clients on /v1/orders must migrate to /v1/checkout
+before 2026-06-01. Old route returns 410 after that date.
+```
+
+## See also
+
+- [`SKILL.md`](./SKILL.md) — full LLM-facing instructions
+- [Caveman README](../../README.md) — repo overview

--- a/.agents/skills/caveman-commit/SKILL.md
+++ b/.agents/skills/caveman-commit/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: caveman-commit
+description: >
+  Ultra-compressed commit message generator. Cuts noise from commit messages while preserving
+  intent and reasoning. Conventional Commits format. Subject ≤50 chars, body only when "why"
+  isn't obvious. Use when user says "write a commit", "commit message", "generate commit",
+  "/commit", or invokes /caveman-commit. Auto-triggers when staging changes.
+---
+
+Write commit messages terse and exact. Conventional Commits format. No fluff. Why over what.
+
+## Rules
+
+**Subject line:**
+- `<type>(<scope>): <imperative summary>` — `<scope>` optional
+- Types: `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`, `style`, `revert`
+- Imperative mood: "add", "fix", "remove" — not "added", "adds", "adding"
+- ≤50 chars when possible, hard cap 72
+- No trailing period
+- Match project convention for capitalization after the colon
+
+**Body (only if needed):**
+- Skip entirely when subject is self-explanatory
+- Add body only for: non-obvious *why*, breaking changes, migration notes, linked issues
+- Wrap at 72 chars
+- Bullets `-` not `*`
+- Reference issues/PRs at end: `Closes #42`, `Refs #17`
+
+**What NEVER goes in:**
+- "This commit does X", "I", "we", "now", "currently" — the diff says what
+- "As requested by..." — use Co-authored-by trailer
+- "Generated with Claude Code" or any AI attribution — unless the user's own rule requires an `Assisted-by`/AI-attribution trailer, then add it as a trailer
+- Emoji (unless project convention requires)
+- Restating the file name when scope already says it
+
+## Examples
+
+Diff: new endpoint for user profile with body explaining the why
+- ❌ "feat: add a new endpoint to get user profile information from the database"
+- ✅
+  ```
+  feat(api): add GET /users/:id/profile
+
+  Mobile client needs profile data without the full user payload
+  to reduce LTE bandwidth on cold-launch screens.
+
+  Closes #128
+  ```
+
+Diff: breaking API change
+- ✅
+  ```
+  feat(api)!: rename /v1/orders to /v1/checkout
+
+  BREAKING CHANGE: clients on /v1/orders must migrate to /v1/checkout
+  before 2026-06-01. Old route returns 410 after that date.
+  ```
+
+## Auto-Clarity
+
+Always include body for: breaking changes, security fixes, data migrations, anything reverting a prior commit. Never compress these into subject-only — future debuggers need the context.
+
+## Boundaries
+
+Only generates the commit message. Does not run `git commit`, does not stage files, does not amend. Output the message as a code block ready to paste. "stop caveman-commit" or "normal mode": revert to verbose commit style.

--- a/.agents/skills/ponytail-audit/SKILL.md
+++ b/.agents/skills/ponytail-audit/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: ponytail-audit
+description: >
+  Whole-repo audit for over-engineering. Like ponytail-review, but scans the
+  entire codebase instead of a diff: a ranked list of what to delete, simplify,
+  or replace with stdlib/native equivalents. Use when the user says "audit this
+  codebase", "audit for over-engineering", "what can I delete from this repo",
+  "find bloat", "ponytail-audit", or "/ponytail-audit". One-shot report, does
+  not apply fixes.
+---
+
+ponytail-review, repo-wide. Scan the whole tree instead of a diff. Rank
+findings biggest cut first.
+
+## Tags
+
+Same as ponytail-review:
+
+- `delete:` dead code, unused flexibility, speculative feature. Replacement: nothing.
+- `stdlib:` hand-rolled thing the standard library ships. Name the function.
+- `native:` dependency or code doing what the platform already does. Name the feature.
+- `yagni:` abstraction with one implementation, config nobody sets, layer with one caller.
+- `shrink:` same logic, fewer lines. Show the shorter form.
+
+## Hunt
+
+Deps the stdlib or platform already ships, single-implementation interfaces,
+factories with one product, wrappers that only delegate, files exporting one
+thing, dead flags and config, hand-rolled stdlib.
+
+## Output
+
+One line per finding, ranked: `<tag> <what to cut>. <replacement>. [path]`.
+End with `net: -<N> lines, -<M> deps possible.` Nothing to cut: `Lean already. Ship.`
+
+## Boundaries
+
+Scope: over-engineering and complexity only. Correctness bugs, security holes,
+and performance are explicitly out of scope. Route them to a normal review
+pass. Lists findings, applies nothing. One-shot.
+"stop ponytail-audit" or "normal mode" to revert.

--- a/.agents/skills/ponytail-debt/SKILL.md
+++ b/.agents/skills/ponytail-debt/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: ponytail-debt
+description: >
+  Harvest every `ponytail:` comment in the codebase into a debt ledger, so the
+  deliberate shortcuts and deferrals ponytail leaves behind get tracked instead
+  of rotting into "later means never". Use when the user says "ponytail debt",
+  "/ponytail-debt", "what did ponytail defer", "list the shortcuts", "ponytail
+  ledger", or "what did we mark to do later". One-shot report, changes nothing.
+---
+
+Every deliberate ponytail shortcut is marked with a `ponytail:` comment naming
+its ceiling and upgrade path. This collects them into one ledger so a deferral
+can't quietly become permanent.
+
+## Scan
+
+Grep the repo for comment markers, skipping `node_modules`, `.git`, and build
+output:
+
+`grep -rnE '(#|//) ?ponytail:' .`  (add other comment prefixes if your stack uses them)
+
+Each hit is one ledger row. The comment prefix keeps prose that merely mentions
+the convention out of the ledger.
+
+## Output
+
+One row per marker, grouped by file:
+
+`<file>:<line>, <what was simplified>. ceiling: <the limit named>. upgrade: <the trigger to revisit>.`
+
+The convention is `ponytail: <ceiling>, <upgrade path>`, so pull the ceiling
+and the trigger straight from the comment. Want an owner per row too? add
+`git blame -L<line>,<line>`.
+
+Flag the rot risk: any `ponytail:` comment that names no upgrade path or
+trigger gets a `no-trigger` tag, those are the ones that silently rot.
+
+End with `<N> markers, <M> with no trigger.` Nothing found: `No ponytail: debt. Clean ledger.`
+
+## Boundaries
+
+Reads and reports only, changes nothing. To persist it, ask and it writes the
+ledger to a file (e.g. `PONYTAIL-DEBT.md`). One-shot. "stop ponytail-debt" or
+"normal mode" to revert.

--- a/.agents/skills/ponytail-gain/SKILL.md
+++ b/.agents/skills/ponytail-gain/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: ponytail-gain
+description: >
+  Show ponytail's measured impact as a compact scoreboard: less code, less
+  cost, more speed, from the benchmark medians. One-shot display, not a
+  persistent mode, and not a per-repo number. Trigger: /ponytail-gain,
+  "ponytail gain", "what does ponytail save", "show ponytail impact",
+  "ponytail scoreboard".
+---
+
+# Ponytail Gain
+
+Display this scoreboard when invoked. One-shot: do NOT change mode, write flag
+files, or persist anything.
+
+The figures are the published benchmark medians (5 everyday tasks: email
+validator, debounce, CSV sum, countdown timer, rate limiter; three models:
+Haiku, Sonnet, Opus). They are measured, not computed from the current repo.
+Source: `benchmarks/` and the README.
+
+## Scoreboard
+
+Render plain ASCII bars. The bar length shows the measured range; the label
+carries the exact figure:
+
+```
+  ponytail gain                     benchmark median · 5 tasks · 3 models
+
+  Lines of code   no-skill  ████████████████████  100%
+                  ponytail  ██▌·················    6–20%   ▼ 80–94%
+  Cost            no-skill  ████████████████████  100%
+                  ponytail  █████▌··············   23–53%  ▼ 47–77%
+  Speed           ponytail  ▸ 3–6× faster
+
+  This repo:  /ponytail-debt  (shortcuts you deferred)
+              /ponytail-audit (what's still cuttable)
+```
+
+## Honesty boundary
+
+These are benchmark medians, not this repo. NEVER print a per-repo savings
+number ("you saved X lines/tokens here"): the unbuilt version was never
+written, so there is no real baseline to subtract from in a live repo. The
+only real per-repo figures come from `/ponytail-debt` (a counted ledger), and
+this card points there instead of inventing one.
+
+## Boundaries
+
+One-shot display. Edits nothing, changes no mode.
+"stop ponytail" or "normal mode": revert.

--- a/.agents/skills/ponytail-help/SKILL.md
+++ b/.agents/skills/ponytail-help/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: ponytail-help
+description: >
+  Quick-reference card for all ponytail modes, skills, and commands.
+  One-shot display, not a persistent mode. Trigger: /ponytail-help,
+  "ponytail help", "what ponytail commands", "how do I use ponytail".
+---
+
+# Ponytail Help
+
+Display this reference card when invoked. One-shot, do NOT change mode,
+write flag files, or persist anything.
+
+## Levels
+
+| Level | Trigger | What change |
+|-------|---------|-------------|
+| **Lite** | `/ponytail lite` | Build what's asked, name the lazier alternative in one line. |
+| **Full** | `/ponytail` | The ladder enforced: YAGNI → stdlib → native → one line → minimum. Default. |
+| **Ultra** | `/ponytail ultra` | YAGNI extremist. Deletion before addition. Challenges requirements before building. |
+
+Level sticks until changed or session end.
+
+## Skills
+
+| Skill | Trigger | What it does |
+|-------|---------|--------------|
+| **ponytail** | `/ponytail` | Lazy mode itself. Simplest solution that works. |
+| **ponytail-review** | `/ponytail-review` | Over-engineering review: `L42: yagni: factory, one product. Inline.` |
+| **ponytail-audit** | `/ponytail-audit` | Whole-repo over-engineering audit: ranked list of what to delete. |
+| **ponytail-debt** | `/ponytail-debt` | Harvest `ponytail:` shortcut comments into a tracked ledger. |
+| **ponytail-gain** | `/ponytail-gain` | Measured-impact scoreboard: less code, less cost, more speed. |
+| **ponytail-help** | `/ponytail-help` | This card. |
+
+Codex uses `@ponytail`, `@ponytail-review`, and `@ponytail-help`; Claude Code
+and OpenCode use the slash-command forms above (OpenCode ships all six as
+slash commands).
+
+## Deactivate
+
+Say "stop ponytail" or "normal mode". Resume anytime with `/ponytail`.
+`/ponytail off` also works.
+
+## Configure Default Mode
+
+Default mode = `full`, auto-active every session. Change it:
+
+**Environment variable** (highest priority):
+```bash
+export PONYTAIL_DEFAULT_MODE=ultra
+```
+
+**Config file** (`~/.config/ponytail/config.json`, Windows: `%APPDATA%\ponytail\config.json`):
+```json
+{ "defaultMode": "lite" }
+```
+
+Set `"off"` to disable auto-activation on session start, activate manually
+with `/ponytail` when wanted.
+
+Resolution: env var > config file > `full`.
+
+## Update
+
+Enable auto-update once: open `/plugin`, go to Marketplaces, pick ponytail, Enable auto-update. Claude Code then pulls new versions at startup (run `/reload-plugins` when it prompts). Manual refresh: `/plugin marketplace update ponytail` then `/reload-plugins`.
+
+If `/plugin` is not recognized, your Claude Code is out of date. Update it (`npm install -g @anthropic-ai/claude-code@latest`, or `brew upgrade claude-code`) and restart. Other hosts use their own update flow.
+
+## More
+
+Full docs + examples: https://github.com/DietrichGebert/ponytail

--- a/.agents/skills/ponytail-review/SKILL.md
+++ b/.agents/skills/ponytail-review/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: ponytail-review
+description: >
+  Code review focused exclusively on over-engineering. Finds what to delete:
+  reinvented standard library, unneeded dependencies, speculative abstractions,
+  dead flexibility. One line per finding: location, what to cut, what replaces
+  it. Use when the user says "review for over-engineering", "what can we
+  delete", "is this over-engineered", "simplify review", or invokes
+  /ponytail-review. Complements correctness-focused review, this one only
+  hunts complexity.
+---
+
+Review diffs for unnecessary complexity. One line per finding: location, what
+to cut, what replaces it. The diff's best outcome is getting shorter.
+
+## Format
+
+`L<line>: <tag> <what>. <replacement>.`, or `<file>:L<line>: ...` for
+multi-file diffs.
+
+Tags:
+
+- `delete:` dead code, unused flexibility, speculative feature. Replacement: nothing.
+- `stdlib:` hand-rolled thing the standard library ships. Name the function.
+- `native:` dependency or code doing what the platform already does. Name the feature.
+- `yagni:` abstraction with one implementation, config nobody sets, layer with one caller.
+- `shrink:` same logic, fewer lines. Show the shorter form.
+
+## Examples
+
+❌ "This EmailValidator class might be more complex than necessary, have you
+considered whether all these validation rules are needed at this stage?"
+
+✅ `L12-38: stdlib: 27-line validator class. "@" in email, 1 line, real validation is the confirmation mail.`
+
+✅ `L4: native: moment.js imported for one format call. Intl.DateTimeFormat, 0 deps.`
+
+✅ `repo.py:L88: yagni: AbstractRepository with one implementation. Inline it until a second one exists.`
+
+✅ `L52-71: delete: retry wrapper around an idempotent local call. Nothing replaces it.`
+
+✅ `L30-44: shrink: manual loop builds dict. dict(zip(keys, values)), 1 line.`
+
+## Scoring
+
+End with the only metric that matters: `net: -<N> lines possible.`
+
+If there is nothing to cut, say `Lean already. Ship.` and stop.
+
+## Boundaries
+
+Scope: over-engineering and complexity only. Correctness bugs, security holes,
+and performance are explicitly out of scope. Route them to a normal review
+pass, not this one. A single smoke test or `assert`-based
+self-check is the ponytail minimum, not bloat, never flag it for deletion.
+Does not apply the fixes, only lists them.
+"stop ponytail-review" or "normal mode": revert to verbose review style.

--- a/.agents/skills/ponytail/SKILL.md
+++ b/.agents/skills/ponytail/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: ponytail
+description: >
+  Forces the laziest solution that actually works, simplest, shortest, most
+  minimal. Channels a senior dev who has seen everything: question whether the
+  task needs to exist at all (YAGNI), reach for the standard library before
+  custom code, native platform features before dependencies, one line before
+  fifty. Supports intensity levels: lite, full (default), ultra. Use on ANY
+  coding task: writing, adding, refactoring, fixing, reviewing, or designing
+  code, and choosing libraries or dependencies. Also use whenever the user
+  says "ponytail", "be lazy", "lazy mode", "simplest solution", "minimal
+  solution", "yagni", "do less", or "shortest path", or complains about
+  over-engineering, bloat, boilerplate, or unnecessary dependencies. Do NOT
+  use for non-coding requests (general knowledge, prose, translation,
+  summaries, recipes).
+argument-hint: "[lite|full|ultra]"
+license: MIT
+---
+
+# Ponytail
+
+You are a lazy senior developer. Lazy means efficient, not careless. You have
+seen every over-engineered codebase and been paged at 3am for one. The best
+code is the code never written.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
+unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
+Switch: `/ponytail lite|full|ultra`.
+
+## The ladder
+
+Stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)
+2. **Already in this codebase?** A helper, util, type, or pattern that already lives here → reuse it. Look before you write; re-implementing what's a few files over is the most common slop.
+3. **Stdlib does it?** Use it.
+4. **Native platform feature covers it?** `<input type="date">` over a picker lib, CSS over JS, DB constraint over app code.
+5. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.
+6. **Can it be one line?** One line.
+7. **Only then:** the minimum code that works.
+
+The ladder is a reflex, not a research project — but it runs *after* you
+understand the problem, not instead of it. Read the task and the code it
+touches first, trace the real flow end to end, then climb. Two rungs work →
+take the higher one and move on. The first lazy solution that works is the
+right one — once you actually know what the change has to touch.
+
+**Bug fix = root cause, not symptom.** A report names a symptom. Before you
+edit, grep every caller of the function you're about to touch. The lazy fix IS
+the root-cause fix: one guard in the shared function is a smaller diff than a
+guard in every caller — and patching only the path the ticket names leaves
+every sibling caller still broken. Fix it once, where all callers route through.
+
+## Rules
+
+- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- No boilerplate, no scaffolding "for later", later can scaffold for itself.
+- Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
+- Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
+- Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
+- Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path (`# ponytail: global lock, per-account locks if throughput matters`).
+
+## Output
+
+Code first. Then at most three short lines: what was skipped, when to add it.
+No essays, no feature tours, no design notes. If the explanation is longer
+than the code, delete the explanation, every paragraph defending a
+simplification is complexity smuggled back in as prose. Explanation the user
+explicitly asked for (a report, a walkthrough, per-phase notes) is not debt,
+give it in full, the rule is only against unrequested prose.
+
+Pattern: `[code] → skipped: [X], add when [Y].`
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
+| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
+| **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
+
+Example: "Add a cache for these API responses."
+- lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
+- full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
+- ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."
+
+## When NOT to be lazy
+
+Never simplify away: input validation at trust boundaries, error handling
+that prevents data loss, security measures, accessibility basics, anything
+explicitly requested. User insists on the full version → build it, no
+re-arguing.
+
+Never lazy about understanding the problem. The ladder shortens the
+solution, never the reading. Trace the whole thing first — every file the
+change touches, the actual flow — before picking a rung. Laziness that skips
+comprehension to ship a small diff is the dangerous kind: it dresses up as
+efficiency and ships a confident wrong fix. Read fully, then be lazy.
+
+Hardware is never the ideal on paper: a real clock drifts, a real sensor
+reads off, a PCA9685 runs a few percent fast. Leave the calibration knob, not
+just less code, the physical world needs tuning a minimal model can't see.
+
+Lazy code without its check is unfinished. Non-trivial logic (a branch, a
+loop, a parser, a money/security path) leaves ONE runnable check behind, the
+smallest thing that fails if the logic breaks: an `assert`-based
+`demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
+fixtures, no per-function suites unless asked. Trivial one-liners need no
+test, YAGNI applies to tests too.
+
+## Boundaries
+
+Ponytail governs what you build, not how you talk (pair with Caveman for
+terse prose). "stop ponytail" / "normal mode": revert. Level persists until
+changed or session end.
+
+The shortest path to done is the right path.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,48 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.js\" }",
+            "statusMessage": "Loading ponytail mode...",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/.claude/hooks/ponytail/hooks/ponytail-activate.js\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-subagent.js\" }",
+            "statusMessage": "Loading ponytail mode...",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/.claude/hooks/ponytail/hooks/ponytail-subagent.js\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-mode-tracker.js\" }",
+            "statusMessage": "Tracking ponytail mode...",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/.claude/hooks/ponytail/hooks/ponytail-mode-tracker.js\"",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/.github/hooks/ponytail-copilot-hooks.json
+++ b/.github/hooks/ponytail-copilot-hooks.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "node \".github/hooks/scripts/ponytail/hooks/ponytail-activate.js\"",
+        "powershell": "node \".github/hooks/scripts/ponytail/hooks/ponytail-activate.js\"",
+        "timeoutSec": 5
+      }
+    ],
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "node \".github/hooks/scripts/ponytail/hooks/ponytail-mode-tracker.js\"",
+        "powershell": "node \".github/hooks/scripts/ponytail/hooks/ponytail-mode-tracker.js\"",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/.github/hooks/scripts/ponytail/hooks/ponytail-activate.js
+++ b/.github/hooks/scripts/ponytail/hooks/ponytail-activate.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// ponytail — Claude Code SessionStart activation hook
+//
+// Runs on every session start:
+//   1. Writes flag file at $CLAUDE_CONFIG_DIR/.ponytail-active (defaults to ~/.claude; statusline reads this)
+//   2. Emits ponytail ruleset as hidden SessionStart context
+//   3. Detects missing statusline config and emits setup nudge
+
+const fs = require('fs');
+const path = require('path');
+const { getDefaultMode, getClaudeDir, isShellSafe } = require('./ponytail-config');
+const { getPonytailInstructions } = require('./ponytail-instructions');
+const {
+  clearMode,
+  isCodex,
+  isCopilot,
+  setMode,
+  writeHookOutput,
+} = require('./ponytail-runtime');
+
+const claudeDir = getClaudeDir();
+const settingsPath = path.join(claudeDir, 'settings.json');
+
+const mode = getDefaultMode();
+
+// "off" mode — skip activation entirely, don't write flag or emit rules
+if (mode === 'off') {
+  clearMode();
+  const hookOutput = (isCodex || isCopilot) ? '' : 'OK';
+  writeHookOutput('SessionStart', 'off', hookOutput);
+  process.exit(0);
+}
+
+// 1. Write flag file
+try {
+  setMode(mode);
+} catch (e) {
+  // Silent fail -- flag is best-effort, don't block the hook
+}
+
+// 2. Emit the ponytail ruleset, filtered to the active intensity level.
+let output = getPonytailInstructions(mode);
+
+// 3. Detect missing statusline config — nudge Claude to help set it up
+if (!isCodex && !isCopilot) try {
+  let hasStatusline = false;
+  if (fs.existsSync(settingsPath)) {
+    // Strip UTF-8 BOM some editors prepend on Windows (breaks JSON.parse)
+    const raw = fs.readFileSync(settingsPath, 'utf8').replace(/^\uFEFF/, '');
+    const settings = JSON.parse(raw);
+    if (settings.statusLine) {
+      hasStatusline = true;
+    }
+  }
+
+  // Nudge at most once — the flag file marks that the user has already seen
+  // (and implicitly declined) the statusline setup offer. Repeating it every
+  // session start turns a helpful hint into a nag.
+  const nudgeFlagPath = path.join(claudeDir, '.ponytail-statusline-nudged');
+  if (!hasStatusline && !fs.existsSync(nudgeFlagPath)) {
+    try { fs.writeFileSync(nudgeFlagPath, ''); } catch (e) { /* best-effort */ }
+    const isWindows = process.platform === 'win32';
+    const scriptName = isWindows ? 'ponytail-statusline.ps1' : 'ponytail-statusline.sh';
+    const scriptPath = path.join(__dirname, scriptName);
+    if (isShellSafe(scriptPath)) {
+      const command = isWindows
+        ? `powershell -ExecutionPolicy Bypass -File "${scriptPath}"`
+        : `bash "${scriptPath}"`;
+      const statusLineSnippet =
+        '"statusLine": { "type": "command", "command": ' + JSON.stringify(command) + ' }';
+      output += "\n\n" +
+        "STATUSLINE SETUP NEEDED: The ponytail plugin includes a statusline badge showing active mode " +
+        "(e.g. [PONYTAIL], [PONYTAIL:ULTRA]). It is not configured yet. " +
+        "To enable, add this to " + settingsPath + ": " +
+        statusLineSnippet + " " +
+        "Proactively offer to set this up for the user on first interaction.";
+    } else {
+      // ponytail: install path has shell metacharacters — don't embed it in a
+      // command snippet; have the agent wire it up by hand instead.
+      output += "\n\n" +
+        "STATUSLINE SETUP NEEDED: The ponytail plugin includes a statusline badge showing active mode. " +
+        "Its install path contains characters unsafe to embed in a shell command, so configure it manually: " +
+        "add a statusLine command of type \"command\" that runs " + scriptName +
+        " from the plugin's hooks directory to " + settingsPath + ", quoting/escaping the path for your shell. " +
+        "Proactively offer to set this up for the user on first interaction.";
+    }
+  }
+} catch (e) {
+  // Silent fail — don't block session start over statusline detection
+}
+
+try {
+  writeHookOutput('SessionStart', mode, output);
+} catch (e) {
+  // Silent fail — stdout closed/EPIPE at hook exit must not surface as a hook failure
+}

--- a/.github/hooks/scripts/ponytail/hooks/ponytail-config.js
+++ b/.github/hooks/scripts/ponytail/hooks/ponytail-config.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// ponytail — shared configuration resolver
+//
+// Resolution order for default mode:
+//   1. PONYTAIL_DEFAULT_MODE environment variable
+//   2. Config file defaultMode field:
+//      - $XDG_CONFIG_HOME/ponytail/config.json (any platform, if set)
+//      - ~/.config/ponytail/config.json (macOS / Linux fallback)
+//      - %APPDATA%\ponytail\config.json (Windows fallback)
+//   3. 'full'
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const DEFAULT_MODE = 'full';
+const VALID_MODES = ['off', 'lite', 'full', 'ultra', 'review'];
+const RUNTIME_MODES = ['off', 'lite', 'full', 'ultra'];
+
+function normalizeMode(mode) {
+  if (typeof mode !== 'string') return null;
+  const normalized = mode.trim().toLowerCase();
+  return RUNTIME_MODES.includes(normalized) ? normalized : null;
+}
+
+function normalizeConfigMode(mode) {
+  if (typeof mode !== 'string') return null;
+  const normalized = mode.trim().toLowerCase();
+  return VALID_MODES.includes(normalized) ? normalized : null;
+}
+
+function normalizePersistedMode(mode) {
+  return normalizeMode(mode) || normalizeConfigMode(mode);
+}
+
+// "stop ponytail" / "normal mode" turn ponytail off, but only as a standalone
+// command. Matching the phrase anywhere in the message turned it off mid-task
+// for ordinary requests like "add a normal mode toggle" — so require the whole
+// message to be the command, ignoring case and trailing punctuation.
+function isDeactivationCommand(text) {
+  const t = String(text || '').trim().toLowerCase().replace(/[.!?\s]+$/, '');
+  return t === 'stop ponytail' || t === 'normal mode';
+}
+
+// ponytail: only embed the plugin install path in a statusline shell command when
+// it's made of ordinary path characters. An allowlist beats escaping every shell's
+// metacharacters; a hostile clone path (quotes, &, $, backtick, ;, etc.) falls back
+// to manual setup instead. Allows : \ / for normal Windows and POSIX paths. Full
+// per-shell escaper only if a real need appears.
+function isShellSafe(p) {
+  return typeof p === 'string' && /^[A-Za-z0-9 _.\-:/\\~]+$/.test(p);
+}
+
+function getConfigDir() {
+  if (process.env.XDG_CONFIG_HOME) {
+    return path.join(process.env.XDG_CONFIG_HOME, 'ponytail');
+  }
+  if (process.platform === 'win32') {
+    return path.join(
+      process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'),
+      'ponytail'
+    );
+  }
+  return path.join(os.homedir(), '.config', 'ponytail');
+}
+
+function getConfigPath() {
+  return path.join(getConfigDir(), 'config.json');
+}
+
+function getClaudeDir() {
+  // ponytail: CLAUDE_CONFIG_DIR overrides ~/.claude, matching Claude Code.
+  return process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+}
+
+function getDefaultMode() {
+  // 1. Environment variable (highest priority)
+  const envMode = process.env.PONYTAIL_DEFAULT_MODE;
+  // ponytail: a default must be a runtime level (off/lite/full/ultra); review is
+  // a session-only mode, never a valid default (#377). Validate against
+  // RUNTIME_MODES so a stray env var or config can't make review the default.
+  if (envMode && RUNTIME_MODES.includes(envMode.toLowerCase())) {
+    return envMode.toLowerCase();
+  }
+
+  // 2. Config file
+  try {
+    const configPath = getConfigPath();
+    // Strip UTF-8 BOM (common on Windows-saved files) so JSON.parse doesn't choke
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8').replace(/^\uFEFF/, ''));
+    if (config.defaultMode && RUNTIME_MODES.includes(config.defaultMode.toLowerCase())) {
+      return config.defaultMode.toLowerCase();
+    }
+  } catch (e) {
+    // Config file doesn't exist or is invalid — fall through
+  }
+
+  // 3. Default
+  return DEFAULT_MODE;
+}
+
+// Silence the pi "Ponytail loaded" startup toast while keeping ponytail active.
+// PONYTAIL_QUIET_STARTUP=1 (or any truthy value; 0/false/empty mean "show it")
+// takes precedence, else config.quietStartup === true. Mirrors getHideStatus.
+function getQuietStartup() {
+  const env = process.env.PONYTAIL_QUIET_STARTUP;
+  if (env !== undefined) {
+    const v = env.trim().toLowerCase();
+    return v !== '' && v !== '0' && v !== 'false' && v !== 'no';
+  }
+  try {
+    const config = JSON.parse(fs.readFileSync(getConfigPath(), 'utf8').replace(/^\uFEFF/, ''));
+    return config.quietStartup === true;
+  } catch (_) {
+    return false;
+  }
+}
+
+// Hide the status-bar indicator while keeping ponytail active (#324).
+// PONYTAIL_HIDE_STATUS=1 (or any truthy value; 0/false/empty mean "don't hide")
+// takes precedence, else config.hideStatus === true.
+function getHideStatus() {
+  const env = process.env.PONYTAIL_HIDE_STATUS;
+  if (env !== undefined) {
+    const v = env.trim().toLowerCase();
+    return v !== '' && v !== '0' && v !== 'false' && v !== 'no';
+  }
+  try {
+    const config = JSON.parse(fs.readFileSync(getConfigPath(), 'utf8').replace(/^\uFEFF/, ''));
+    return config.hideStatus === true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function writeDefaultMode(mode) {
+  // ponytail: only a runtime level can be a default; review is session-only (#377).
+  const normalized = normalizeMode(mode);
+  if (!normalized) return null;
+
+  const configPath = getConfigPath();
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  let config = {};
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf8').replace(/^\uFEFF/, ''));
+    if (!config || typeof config !== 'object' || Array.isArray(config)) config = {};
+  } catch (_) {}
+  config.defaultMode = normalized;
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
+  return normalized;
+}
+
+module.exports = {
+  DEFAULT_MODE,
+  VALID_MODES,
+  RUNTIME_MODES,
+  getDefaultMode,
+  getConfigDir,
+  getConfigPath,
+  getClaudeDir,
+  getHideStatus,
+  getQuietStartup,
+  isShellSafe,
+  normalizeMode,
+  normalizeConfigMode,
+  normalizePersistedMode,
+  isDeactivationCommand,
+  writeDefaultMode,
+};

--- a/.github/hooks/scripts/ponytail/hooks/ponytail-instructions.js
+++ b/.github/hooks/scripts/ponytail/hooks/ponytail-instructions.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Shared Ponytail instruction builder for Claude hooks and Pi extension.
+
+const fs = require('fs');
+const path = require('path');
+const { DEFAULT_MODE, normalizeMode, normalizePersistedMode } = require('./ponytail-config');
+
+const INDEPENDENT_MODES = new Set(['review']);
+const SKILL_PATH = path.join(__dirname, '..', 'skills', 'ponytail', 'SKILL.md');
+
+function filterSkillBodyForMode(body, mode) {
+  const effectiveMode = normalizeMode(mode) || DEFAULT_MODE;
+  const withoutFrontmatter = String(body || '').replace(/^---[\s\S]*?---\s*/, '');
+
+  // Only the intensity table rows and worked examples are mode-specific, and
+  // both are keyed by a mode name (lite/full/ultra). A bullet whose label is
+  // not a mode — e.g. "No unrequested abstractions: ..." — is a normal rule
+  // and must be kept verbatim.
+  return withoutFrontmatter
+    .split(/\r?\n/)
+    .filter((line) => {
+      const tableLabel = line.match(/^\|\s*\*\*(.+?)\*\*\s*\|/);
+      if (tableLabel) {
+        const labelMode = normalizeMode(tableLabel[1].trim());
+        if (labelMode) return labelMode === effectiveMode;
+      }
+
+      // Require a quoted value: every worked example is `- lite: "..."`. Without
+      // this, an ordinary rule bullet that happens to start with a mode word
+      // (e.g. "- Full: ...") is silently dropped in every other mode — it looks
+      // like a worked example but is really prose meant to survive verbatim.
+      const exampleLabel = line.match(/^-\s*([^:]+):\s*"/);
+      if (exampleLabel) {
+        const labelMode = normalizeMode(exampleLabel[1].trim());
+        if (labelMode) return labelMode === effectiveMode;
+      }
+
+      return true;
+    })
+    .join('\n');
+}
+
+function getFallbackInstructions(mode) {
+  return 'PONYTAIL MODE ACTIVE — level: ' + mode + '\n\n' +
+    'You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.\n\n' +
+    '## Persistence\n\n' +
+    'ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if unsure. Off only: "stop ponytail" / "normal mode".\n\n' +
+    'Current level: **' + mode + '**. Switch: `/ponytail lite|full|ultra`.\n\n' +
+    '## The ladder\n\n' +
+    'Before any code, stop at the first rung that holds (the ladder runs after you understand the problem, not instead of it — read the code it touches and trace the real flow first):\n' +
+    '1. Does this need to be built at all? (YAGNI)\n' +
+    '2. Does it already exist in this codebase? Reuse what is already here, do not re-write it.\n' +
+    '3. Does the standard library do this? Use it.\n' +
+    '4. Does a native platform feature cover it? Use it.\n' +
+    '5. Does an already-installed dependency solve it? Use it.\n' +
+    '6. Can this be one line? Make it one line.\n' +
+    '7. Only then: write the minimum code that works.\n\n' +
+    'Bug fix = root cause, not symptom: grep every caller of the function you touch and fix the shared function once (a smaller diff than one guard per caller); patching only the path the ticket names leaves a sibling caller broken.\n\n' +
+    '## Rules\n\n' +
+    'No abstractions that were not requested. No avoidable dependencies. No boilerplate nobody asked for. ' +
+    'Deletion over addition. Boring over clever. Fewest files possible. ' +
+    'Ship the lazy version and question the complex request in the same response — never stall. ' +
+    'Between two same-size stdlib options, pick the one correct on edge cases. ' +
+    'Mark deliberate simplifications that cut a real corner with a known ceiling, using a `ponytail:` comment that names the ceiling and upgrade path.\n\n' +
+    '## Output\n\n' +
+    'Code first. Then at most three short lines: what was skipped, when to add it. ' +
+    'If the explanation is longer than the code, delete the explanation. ' +
+    'Explanation the user explicitly asked for is not debt, give it in full.\n\n' +
+    '## When NOT to be lazy\n\n' +
+    'Never simplify away: understanding the problem (read it fully and trace the real flow before picking a rung — a small diff you do not understand is just laziness dressed up as efficiency), input validation at trust boundaries, error handling that prevents data loss, ' +
+    'security measures, accessibility basics, the calibration real hardware needs (the platform is never the spec ideal), anything the user explicitly asked to keep. ' +
+    'Lazy code without its check is unfinished: non-trivial logic leaves ONE runnable check behind (assert-based demo/self-check or one small test file; no frameworks). Trivial one-liners need no test.\n\n' +
+    '## Boundaries\n\n' +
+    'Ponytail governs what you build, not how you talk. "stop ponytail" or "normal mode": revert. Level persists until changed or session end.';
+}
+
+function getPonytailInstructions(mode) {
+  const configuredMode = normalizePersistedMode(mode) || DEFAULT_MODE;
+
+  if (INDEPENDENT_MODES.has(configuredMode)) {
+    return 'PONYTAIL MODE ACTIVE — level: ' + configuredMode + '. Behavior defined by /ponytail-' + configuredMode + ' skill.';
+  }
+
+  const effectiveMode = normalizeMode(configuredMode) || DEFAULT_MODE;
+
+  try {
+    return 'PONYTAIL MODE ACTIVE — level: ' + effectiveMode + '\n\n' +
+      filterSkillBodyForMode(fs.readFileSync(SKILL_PATH, 'utf8'), effectiveMode);
+  } catch (e) {
+    return getFallbackInstructions(effectiveMode);
+  }
+}
+
+module.exports = {
+  filterSkillBodyForMode,
+  getFallbackInstructions,
+  getPonytailInstructions,
+};

--- a/.github/hooks/scripts/ponytail/hooks/ponytail-mode-tracker.js
+++ b/.github/hooks/scripts/ponytail/hooks/ponytail-mode-tracker.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// ponytail — UserPromptSubmit hook to track which ponytail mode is active
+// Inspects user input for /ponytail commands and writes mode to flag file
+
+const { getDefaultMode, isDeactivationCommand, writeDefaultMode } = require('./ponytail-config');
+const { clearMode, isQoder, readMode, setMode, writeHookOutput } = require('./ponytail-runtime');
+const { getPonytailInstructions } = require('./ponytail-instructions');
+
+let input = '';
+let done = false;
+
+function finish() {
+  if (done) return;
+  done = true;
+  try {
+    // Strip UTF-8 BOM some shells prepend when piping (breaks JSON.parse)
+    const data = JSON.parse(input.replace(/^\uFEFF/, ''));
+    const prompt = (data.prompt || '').trim().toLowerCase();
+
+    // Match /ponytail commands
+    let modeSwitched = false;
+    let deactivated = false;
+    if (/^[/@$]ponytail/.test(prompt)) {
+      const parts = prompt.split(/\s+/);
+      const cmd = parts[0].replace(/^[@$]/, '/');
+      const arg = parts[1] || '';
+
+      let mode = null;
+      let isReportOnly = false;
+
+      if (cmd === '/ponytail-review' || cmd === '/ponytail:ponytail-review') {
+        mode = 'review';
+      } else if (cmd === '/ponytail' || cmd === '/ponytail:ponytail') {
+        // `/ponytail default <mode>` persists the default to config (survives
+        // restarts). Plain switches stay session-scoped ("sticks until session
+        // end"), so this is the only path that writes config. review is not a
+        // valid default (#377), so only off/lite/full/ultra are accepted.
+        if (arg === 'default') {
+          const dmode = parts[2];
+          if (dmode === 'off' || dmode === 'lite' || dmode === 'full' || dmode === 'ultra') {
+            writeDefaultMode(dmode);
+            writeHookOutput('UserPromptSubmit', dmode, 'PONYTAIL DEFAULT SET — new sessions start in ' + dmode + '.');
+          }
+          return; // don't fall through to the session-mode switch
+        }
+        if (arg === 'lite') mode = 'lite';
+        else if (arg === 'full') mode = 'full';
+        else if (arg === 'ultra') mode = 'ultra';
+        else if (arg === 'off') mode = 'off';
+        else if (arg === '') {
+          isReportOnly = true;
+          mode = readMode() || getDefaultMode();
+        } else {
+          mode = getDefaultMode();
+        }
+      }
+
+      if (isReportOnly) {
+        writeHookOutput(
+          'UserPromptSubmit',
+          mode,
+          'PONYTAIL MODE ACTIVE — level: ' + mode,
+        );
+      } else if (mode && mode !== 'off') {
+        setMode(mode);
+        modeSwitched = true;
+        // ponytail: Qoder needs the full ruleset every turn, so when a mode
+        // switch happens we fold the confirmation into the ruleset output
+        // below (one JSON on stdout) instead of emitting two separate writes.
+        if (!isQoder) {
+          writeHookOutput(
+            'UserPromptSubmit',
+            mode,
+            'PONYTAIL MODE CHANGED — level: ' + mode,
+          );
+        }
+      } else if (mode === 'off') {
+        clearMode();
+        deactivated = true;
+        writeHookOutput('UserPromptSubmit', 'off', 'PONYTAIL MODE OFF');
+      }
+    }
+
+    // Detect deactivation
+    if (!modeSwitched && !deactivated && isDeactivationCommand(prompt)) {
+      clearMode();
+      deactivated = true;
+      writeHookOutput('UserPromptSubmit', 'off', 'PONYTAIL MODE OFF');
+    }
+
+    // Qoder has no SessionStart event, so UserPromptSubmit does double duty:
+    // activate the default mode on first prompt (if no flag exists yet), then
+    // inject the ruleset on every prompt. Claude Code/Codex do this in
+    // SessionStart via ponytail-activate.js; Qoder can't, so we do it here.
+    // Skip when deactivated — user just turned ponytail off.
+    if (isQoder && !deactivated) {
+      let currentMode = readMode();
+      if (!currentMode) {
+        // First prompt in session — initialize from config/env default
+        currentMode = getDefaultMode();
+        if (currentMode !== 'off') {
+          try { setMode(currentMode); } catch (e) {}
+        }
+      }
+      if (currentMode && currentMode !== 'off') {
+        // ponytail: one JSON per invocation — mode-switch confirmation is
+        // folded into the ruleset header so Qoder gets both in one write.
+        const header = modeSwitched
+          ? 'PONYTAIL MODE CHANGED — level: ' + currentMode + '\n\n'
+          : '';
+        writeHookOutput('UserPromptSubmit', currentMode, header + getPonytailInstructions(currentMode));
+      }
+    }
+  } catch (e) {
+    // Silent fail
+  }
+}
+
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', finish);
+
+// Never hang the session. On Windows, Claude Code runs this hook through a
+// PowerShell `if {}` wrapper that can swallow the piped prompt JSON, so stdin
+// 'end' never fires and the hook blocks forever — freezing the session (#443).
+// On error, or after a short fallback, process whatever arrived (recovering the
+// mode if data came without EOF) and exit. unref() keeps the timer from adding
+// latency to the normal path, where 'end' fires first. Mirrors the best-effort,
+// never-block contract the other lifecycle hooks already follow.
+process.stdin.on('error', () => { finish(); process.exit(0); });
+setTimeout(() => { finish(); process.exit(0); }, 1000).unref();

--- a/.github/hooks/scripts/ponytail/hooks/ponytail-runtime.js
+++ b/.github/hooks/scripts/ponytail/hooks/ponytail-runtime.js
@@ -1,0 +1,85 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { getClaudeDir, getConfigDir } = require('./ponytail-config');
+
+const STATE_FILE = '.ponytail-active';
+const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
+const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
+const isQoder = !isCopilot && !isCodex && Boolean(process.env.QODER_SESSION_ID);
+
+let stateDir = getClaudeDir();
+if (isCodex) stateDir = process.env.PLUGIN_DATA;
+if (isCopilot) stateDir = process.env.COPILOT_PLUGIN_DATA;
+if (isQoder) stateDir = path.join(os.homedir(), '.qoder');
+
+const statePath = path.join(stateDir, STATE_FILE);
+
+function setMode(mode) {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, mode);
+}
+
+function clearMode() {
+  try { fs.unlinkSync(statePath); } catch (e) {}
+}
+
+// Live mode written by activate/mode-tracker. Absent flag = ponytail off.
+function readMode() {
+  try {
+    return fs.readFileSync(statePath, 'utf8').trim() || null;
+  } catch (e) {
+    return null;
+  }
+}
+
+function writeHookOutput(event, mode, context = '') {
+  if (isCopilot) {
+    // Copilot reads additionalContext on SessionStart; ignores output elsewhere.
+    process.stdout.write(JSON.stringify(
+      event === 'SessionStart' && context ? { additionalContext: context } : {}));
+    return;
+  }
+  if (isCodex) {
+    const output = { systemMessage: `PONYTAIL:${mode.toUpperCase()}` };
+    if (context) {
+      output.hookSpecificOutput = {
+        hookEventName: event,
+        additionalContext: context,
+      };
+    }
+    process.stdout.write(JSON.stringify(output));
+    return;
+  }
+  if (isQoder) {
+    // Qoder: hookSpecificOutput JSON, same shape as Codex minus systemMessage.
+    // UserPromptSubmit additionalContext is injected into the Agent's conversation.
+    const output = {};
+    if (context) {
+      output.hookSpecificOutput = {
+        hookEventName: event,
+        additionalContext: context,
+      };
+    }
+    process.stdout.write(JSON.stringify(output));
+    return;
+  }
+  // Native Claude: SessionStart accepts raw stdout, but SubagentStart needs the
+  // hookSpecificOutput JSON form or the context is dropped.
+  if (event === 'SubagentStart') {
+    process.stdout.write(JSON.stringify(
+      { hookSpecificOutput: { hookEventName: event, additionalContext: context } }));
+    return;
+  }
+  process.stdout.write(context);
+}
+
+module.exports = {
+  clearMode,
+  isCodex,
+  isCopilot,
+  isQoder,
+  readMode,
+  setMode,
+  writeHookOutput,
+};

--- a/.github/hooks/scripts/ponytail/hooks/ponytail-statusline.ps1
+++ b/.github/hooks/scripts/ponytail/hooks/ponytail-statusline.ps1
@@ -1,0 +1,24 @@
+# CLAUDE_CONFIG_DIR overrides ~/.claude, matching where the hooks write the flag (issue #34)
+$ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }
+$Flag = Join-Path $ClaudeDir ".ponytail-active"
+if (-not (Test-Path $Flag)) {
+    exit 0
+}
+
+$Mode = ""
+try {
+    $Mode = (Get-Content $Flag -ErrorAction Stop | Select-Object -First 1).Trim()
+} catch {
+    exit 0
+}
+
+$Esc = [char]27
+# ultra is the high-intensity mode; flag it amber so it stands out from the
+# default green. The level is still in the text, so color is a redundant cue.
+$Color = if ($Mode -eq "ultra") { "173" } else { "108" }
+if ([string]::IsNullOrEmpty($Mode) -or $Mode -eq "full") {
+    [Console]::Write("${Esc}[38;5;${Color}m[PONYTAIL]${Esc}[0m")
+} else {
+    $Suffix = $Mode.ToUpperInvariant()
+    [Console]::Write("${Esc}[38;5;${Color}m[PONYTAIL:$Suffix]${Esc}[0m")
+}

--- a/.github/hooks/scripts/ponytail/hooks/ponytail-statusline.sh
+++ b/.github/hooks/scripts/ponytail/hooks/ponytail-statusline.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# CLAUDE_CONFIG_DIR overrides ~/.claude, matching where the hooks write the flag (issue #34)
+flag="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.ponytail-active"
+[ -f "$flag" ] || exit 0
+
+mode=$(head -n1 "$flag" | tr -d '[:space:]')
+
+# ultra is the high-intensity mode; flag it amber so it stands out from the
+# default green at a glance. The level is still in the text, so color is a
+# redundant cue, not the only one.
+color=108
+[ "$mode" = "ultra" ] && color=173
+
+if [ -z "$mode" ] || [ "$mode" = "full" ]; then
+    printf '\033[38;5;%sm[PONYTAIL]\033[0m' "$color"
+else
+    printf '\033[38;5;%sm[PONYTAIL:%s]\033[0m' "$color" "$(printf '%s' "$mode" | tr '[:lower:]' '[:upper:]')"
+fi

--- a/.github/hooks/scripts/ponytail/hooks/ponytail-subagent.js
+++ b/.github/hooks/scripts/ponytail/hooks/ponytail-subagent.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// ponytail — Claude Code SubagentStart hook
+//
+// SessionStart context is parent-thread only and never reaches subagents, so
+// without this every Task-spawned agent runs ponytail-unaware (issue #252).
+// When ponytail mode is active, inject the same ruleset into each subagent.
+//
+// Scoping (opt-in, issue #506): set PONYTAIL_SUBAGENT_MATCHER to a regex and
+// the ruleset is injected only into subagents whose agent_type matches. The
+// regex is unanchored and case-insensitive — "explore|general" matches either,
+// "^general$" is exact. Unset means inject into every subagent, as before.
+
+const { getPonytailInstructions } = require('./ponytail-instructions');
+const { readMode, writeHookOutput } = require('./ponytail-runtime');
+
+const mode = readMode();
+
+// Absent flag or off → ponytail isn't active; inject nothing.
+if (!mode || mode === 'off') {
+  process.exit(0);
+}
+
+function inject() {
+  try {
+    writeHookOutput('SubagentStart', mode, getPonytailInstructions(mode));
+  } catch (e) {
+    // Silent fail — a stdout error at hook exit must not surface as a hook failure.
+  }
+}
+
+// A bad regex must never crash the hook; treat it as "no matcher" and inject.
+let matcherRe = null;
+try {
+  if (process.env.PONYTAIL_SUBAGENT_MATCHER) {
+    matcherRe = new RegExp(process.env.PONYTAIL_SUBAGENT_MATCHER, 'i');
+  }
+} catch (e) {
+  matcherRe = null;
+}
+
+// No matcher → keep the original synchronous, stdin-independent path. On Windows
+// the PowerShell `if {}` wrapper can swallow the piped JSON so stdin 'end' never
+// fires (#443); the default path must not wait on stdin or it would stall every
+// subagent spawn.
+if (!matcherRe) {
+  inject();
+  process.exit(0);
+}
+
+// Matcher set → read agent_type from stdin and skip only on a definite
+// mismatch. Missing/unparseable agent_type, a stdin error, or the timeout all
+// fail open (inject), so scoping never silently drops the persona.
+let input = '';
+let done = false;
+
+function finish() {
+  if (done) return;
+  done = true;
+
+  let agentType = '';
+  try {
+    // Strip UTF-8 BOM some shells prepend when piping (breaks JSON.parse)
+    agentType = String(JSON.parse(input.replace(/^\uFEFF/, '')).agent_type || '').trim();
+  } catch (e) {
+    // Unparseable payload — fall through and inject to be safe.
+  }
+  if (agentType && !matcherRe.test(agentType)) {
+    process.exit(0);
+  }
+  inject();
+}
+
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', finish);
+// Never block the session (#443): recover on stdin error or a short fallback.
+process.stdin.on('error', () => { finish(); process.exit(0); });
+setTimeout(() => { finish(); process.exit(0); }, 1000).unref();

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ docs/architecture-deck.html
 
 # Local k6 load-test summaries
 /load/results/
+
+
+# APM dependencies
+apm_modules/

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,23 +1,31 @@
-# the name by which the project can be referenced within Serena
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
 project_name: "beryl"
 
-
-# list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
+# list of languages for which language servers are started (LSP backend only); choose from:
+#   ada                 al                  angular             ansible             bash
+#   bsl                 clojure             cpp                 cpp_ccls            crystal
+#   csharp              csharp_omnisharp    cue                 dart                elixir
+#   elm                 erlang              fortran             fsharp              gdscript
+#   go                  groovy              haskell             haxe                hlsl
+#   html                java                json                julia               kotlin
+#   latex               lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        php_phpantom        powershell
+#   python              python_jedi         python_pyrefly      python_ty           r
 #   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
-#   (This list may be outdated. For the current list, see values of Language enum here:
-#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
-#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+#   scss                solidity            svelte              swift               systemverilog
+#   terraform           toml                typescript          typescript_vts      vue
+#   yaml                zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -44,6 +52,13 @@ ignore_all_files_in_gitignore: true
 
 # list of additional paths to ignore in this project.
 # Same syntax as gitignore, so you can use * and **.
+# Important: quote patterns that start with `*`, otherwise YAML treats them as aliases.
+# Example:
+#   ignored_paths:
+#     - "examples/**"
+#     - ".worktrees/**"
+#     - "**/bin/**"
+#     - "**/obj/**"
 # Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
@@ -52,52 +67,19 @@ ignored_paths: []
 # Added on 2025-04-18
 read_only: false
 
-# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
-# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -108,11 +90,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -124,3 +109,67 @@ initial_prompt: ""
 # This overrides the corresponding setting in the global configuration; see the documentation there.
 # If null or missing, use the setting from the global configuration.
 symbol_info_budget:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
+ls_specific_settings: {}
+
+# list of workspace folder paths (LSP backend only).
+# These folders will be used to build up Serena's symbol index.
+# Paths must be within the project root and should thus be relative to the project root.
+# Furthermore, the paths should not be filtered by ignore settings.
+# Default setting: The entire project root folder (".") is considered.
+# In (large) monorepos, this can be used to index only subfolders of the project root, e.g.
+#   ls_workspace_folders:
+#     - "./subproject1"
+#     - "./subproject2"
+ls_workspace_folders:
+- .
+
+# list of additional workspace folder paths for cross-package reference support.
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries, but these folders are not indexed by Serena,
+# i.e. the respective symbols will not be found using Serena's symbol search tools.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+ls_additional_workspace_folders: []
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,0 +1,542 @@
+lockfile_version: '1'
+generated_at: '2026-08-07T20:56:25.818499+00:00'
+apm_version: 0.28.0
+dependencies:
+- repo_url: dietrichgebert/ponytail
+  materialization_repo_url: DietrichGebert/ponytail
+  name: ponytail
+  host: github.com
+  resolved_commit: 16f29800fd2681bdf24f3eb4ccffe38be3baec6b
+  version: 4.8.4
+  package_type: marketplace_plugin
+  deployed_files:
+  - .agents/skills/ponytail
+  - .agents/skills/ponytail-audit
+  - .agents/skills/ponytail-audit/SKILL.md
+  - .agents/skills/ponytail-debt
+  - .agents/skills/ponytail-debt/SKILL.md
+  - .agents/skills/ponytail-gain
+  - .agents/skills/ponytail-gain/SKILL.md
+  - .agents/skills/ponytail-help
+  - .agents/skills/ponytail-help/SKILL.md
+  - .agents/skills/ponytail-review
+  - .agents/skills/ponytail-review/SKILL.md
+  - .agents/skills/ponytail/SKILL.md
+  - .claude/hooks/ponytail/hooks/package.json
+  - .claude/hooks/ponytail/hooks/ponytail-activate.js
+  - .claude/hooks/ponytail/hooks/ponytail-config.js
+  - .claude/hooks/ponytail/hooks/ponytail-instructions.js
+  - .claude/hooks/ponytail/hooks/ponytail-mode-tracker.js
+  - .claude/hooks/ponytail/hooks/ponytail-runtime.js
+  - .claude/hooks/ponytail/hooks/ponytail-statusline.ps1
+  - .claude/hooks/ponytail/hooks/ponytail-statusline.sh
+  - .claude/hooks/ponytail/hooks/ponytail-subagent.js
+  - .claude/skills/ponytail
+  - .claude/skills/ponytail-audit
+  - .claude/skills/ponytail-audit/SKILL.md
+  - .claude/skills/ponytail-debt
+  - .claude/skills/ponytail-debt/SKILL.md
+  - .claude/skills/ponytail-gain
+  - .claude/skills/ponytail-gain/SKILL.md
+  - .claude/skills/ponytail-help
+  - .claude/skills/ponytail-help/SKILL.md
+  - .claude/skills/ponytail-review
+  - .claude/skills/ponytail-review/SKILL.md
+  - .claude/skills/ponytail/SKILL.md
+  - .github/hooks/ponytail-copilot-hooks.json
+  - .github/hooks/scripts/ponytail/hooks/ponytail-activate.js
+  - .github/hooks/scripts/ponytail/hooks/ponytail-config.js
+  - .github/hooks/scripts/ponytail/hooks/ponytail-instructions.js
+  - .github/hooks/scripts/ponytail/hooks/ponytail-mode-tracker.js
+  - .github/hooks/scripts/ponytail/hooks/ponytail-runtime.js
+  - .github/hooks/scripts/ponytail/hooks/ponytail-statusline.ps1
+  - .github/hooks/scripts/ponytail/hooks/ponytail-statusline.sh
+  - .github/hooks/scripts/ponytail/hooks/ponytail-subagent.js
+  deployed_file_hashes:
+    .agents/skills/ponytail-audit/SKILL.md: sha256:5560b8e383dbe2ddfddc873a1e2bf2e586e23e0cd7d995537482b2315331f6d1
+    .agents/skills/ponytail-debt/SKILL.md: sha256:c84fba75f0ca12bfe83f9a78ea02fd125c5dd3f1fbb18124105a489937f284e6
+    .agents/skills/ponytail-gain/SKILL.md: sha256:24e01d1c9715cb136ba1c4f1e52a95940c0193558b876828e537736480d6408b
+    .agents/skills/ponytail-help/SKILL.md: sha256:2264d1615117b02b0fd5a69ec84cd2757006471a78e4d6c22eed6d581c1d37a4
+    .agents/skills/ponytail-review/SKILL.md: sha256:40df33b58fc6ef889b93585733feb9566b76e9586efa7f376785c1e995197ac0
+    .agents/skills/ponytail/SKILL.md: sha256:1316a2f3f95741d2300b116fe0c2d81ce4a9568656ed0a62643f54aaf09957f2
+    .claude/hooks/ponytail/hooks/package.json: sha256:8005a3491db7d92f36ac66369861589f9c47123d3a7c71e643fc2c06168cd45a
+    .claude/hooks/ponytail/hooks/ponytail-activate.js: sha256:1c428c4ee9687c2f4321924109ee92e8f8b06fd6600cb6be9ec5b59633cafab1
+    .claude/hooks/ponytail/hooks/ponytail-config.js: sha256:0a8daf96cf9ac703dc4cb7b5065253567e513c951d60b8eb94a0fe727514aeca
+    .claude/hooks/ponytail/hooks/ponytail-instructions.js: sha256:23c050103f28dbe6bad953ae21d98cd06d720a20f33d4716e9de419f947d495e
+    .claude/hooks/ponytail/hooks/ponytail-mode-tracker.js: sha256:5d1a960ff01b73f651ec0242052a8cf1e064cb88147806bf6e13f92798aca251
+    .claude/hooks/ponytail/hooks/ponytail-runtime.js: sha256:80e4a13db4eca13f8cfca5237a46c34220c7c1f9ec841297191c0a46e49ca33e
+    .claude/hooks/ponytail/hooks/ponytail-statusline.ps1: sha256:6138f15bc7651ee7e5ced2a2a2280f5c810d58cad3e9f3252c628f4c923e48c9
+    .claude/hooks/ponytail/hooks/ponytail-statusline.sh: sha256:f1dbfa5997a5d4b5339619709053eff557ab16d71af75eb3041c3d3e3dca42ec
+    .claude/hooks/ponytail/hooks/ponytail-subagent.js: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e
+    .claude/skills/ponytail-audit/SKILL.md: sha256:5560b8e383dbe2ddfddc873a1e2bf2e586e23e0cd7d995537482b2315331f6d1
+    .claude/skills/ponytail-debt/SKILL.md: sha256:c84fba75f0ca12bfe83f9a78ea02fd125c5dd3f1fbb18124105a489937f284e6
+    .claude/skills/ponytail-gain/SKILL.md: sha256:24e01d1c9715cb136ba1c4f1e52a95940c0193558b876828e537736480d6408b
+    .claude/skills/ponytail-help/SKILL.md: sha256:2264d1615117b02b0fd5a69ec84cd2757006471a78e4d6c22eed6d581c1d37a4
+    .claude/skills/ponytail-review/SKILL.md: sha256:40df33b58fc6ef889b93585733feb9566b76e9586efa7f376785c1e995197ac0
+    .claude/skills/ponytail/SKILL.md: sha256:1316a2f3f95741d2300b116fe0c2d81ce4a9568656ed0a62643f54aaf09957f2
+    .github/hooks/ponytail-copilot-hooks.json: sha256:4ad52e6fd633e8fa1b73172da33e6b23d2b874fea94cd18a7def7a08037188a5
+    .github/hooks/scripts/ponytail/hooks/ponytail-activate.js: sha256:1c428c4ee9687c2f4321924109ee92e8f8b06fd6600cb6be9ec5b59633cafab1
+    .github/hooks/scripts/ponytail/hooks/ponytail-config.js: sha256:0a8daf96cf9ac703dc4cb7b5065253567e513c951d60b8eb94a0fe727514aeca
+    .github/hooks/scripts/ponytail/hooks/ponytail-instructions.js: sha256:23c050103f28dbe6bad953ae21d98cd06d720a20f33d4716e9de419f947d495e
+    .github/hooks/scripts/ponytail/hooks/ponytail-mode-tracker.js: sha256:5d1a960ff01b73f651ec0242052a8cf1e064cb88147806bf6e13f92798aca251
+    .github/hooks/scripts/ponytail/hooks/ponytail-runtime.js: sha256:80e4a13db4eca13f8cfca5237a46c34220c7c1f9ec841297191c0a46e49ca33e
+    .github/hooks/scripts/ponytail/hooks/ponytail-statusline.ps1: sha256:6138f15bc7651ee7e5ced2a2a2280f5c810d58cad3e9f3252c628f4c923e48c9
+    .github/hooks/scripts/ponytail/hooks/ponytail-statusline.sh: sha256:f1dbfa5997a5d4b5339619709053eff557ab16d71af75eb3041c3d3e3dca42ec
+    .github/hooks/scripts/ponytail/hooks/ponytail-subagent.js: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e
+  content_hash: sha256:44264185d4a65991e96fe785ab209f9c447f5878f675d294fe2e85ca61e711c3
+  declared_license: MIT
+- repo_url: juliusbrussee/caveman
+  materialization_repo_url: JuliusBrussee/caveman
+  name: caveman-commit
+  host: github.com
+  resolved_commit: ec83e5bace4c20484d704dea21e12fc4eb94e9aa
+  version: unknown
+  virtual_path: skills/caveman-commit
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .agents/skills/caveman-commit
+  - .agents/skills/caveman-commit/README.md
+  - .agents/skills/caveman-commit/SKILL.md
+  - .claude/skills/caveman-commit
+  - .claude/skills/caveman-commit/README.md
+  - .claude/skills/caveman-commit/SKILL.md
+  deployed_file_hashes:
+    .agents/skills/caveman-commit/README.md: sha256:a2e82924b487fc1845114c247b47c2d3c2d1bd60f90bbfa60e9831319eb964fa
+    .agents/skills/caveman-commit/SKILL.md: sha256:58db7b8efab911a629c26e7132517d9076e4e3645009eb604cb8c25663477841
+    .claude/skills/caveman-commit/README.md: sha256:a2e82924b487fc1845114c247b47c2d3c2d1bd60f90bbfa60e9831319eb964fa
+    .claude/skills/caveman-commit/SKILL.md: sha256:58db7b8efab911a629c26e7132517d9076e4e3645009eb604cb8c25663477841
+  content_hash: sha256:790a4eeace0be35c6691faf923518ba5bd50f1f1305d1101d09dd4971be94e00
+deployments:
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/package.json
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:8005a3491db7d92f36ac66369861589f9c47123d3a7c71e643fc2c06168cd45a
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-activate.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:1c428c4ee9687c2f4321924109ee92e8f8b06fd6600cb6be9ec5b59633cafab1
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-config.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:0a8daf96cf9ac703dc4cb7b5065253567e513c951d60b8eb94a0fe727514aeca
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-instructions.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:23c050103f28dbe6bad953ae21d98cd06d720a20f33d4716e9de419f947d495e
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-mode-tracker.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:5d1a960ff01b73f651ec0242052a8cf1e064cb88147806bf6e13f92798aca251
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-runtime.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:80e4a13db4eca13f8cfca5237a46c34220c7c1f9ec841297191c0a46e49ca33e
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-statusline.ps1
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:6138f15bc7651ee7e5ced2a2a2280f5c810d58cad3e9f3252c628f4c923e48c9
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-statusline.sh
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:f1dbfa5997a5d4b5339619709053eff557ab16d71af75eb3041c3d3e3dca42ec
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-subagent.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e
+- kind: project-relative
+  target: claude
+  value: .claude/skills/caveman-commit
+  runtime: null
+  scope: project
+  owners:
+  - juliusbrussee/caveman/skills/caveman-commit
+  active_owner: juliusbrussee/caveman/skills/caveman-commit
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/caveman-commit/README.md
+  runtime: null
+  scope: project
+  owners:
+  - juliusbrussee/caveman/skills/caveman-commit
+  active_owner: juliusbrussee/caveman/skills/caveman-commit
+  content_hash: sha256:a2e82924b487fc1845114c247b47c2d3c2d1bd60f90bbfa60e9831319eb964fa
+- kind: project-relative
+  target: claude
+  value: .claude/skills/caveman-commit/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - juliusbrussee/caveman/skills/caveman-commit
+  active_owner: juliusbrussee/caveman/skills/caveman-commit
+  content_hash: sha256:58db7b8efab911a629c26e7132517d9076e4e3645009eb604cb8c25663477841
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-audit
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-audit/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:5560b8e383dbe2ddfddc873a1e2bf2e586e23e0cd7d995537482b2315331f6d1
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-debt
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-debt/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:c84fba75f0ca12bfe83f9a78ea02fd125c5dd3f1fbb18124105a489937f284e6
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-gain
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-gain/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:24e01d1c9715cb136ba1c4f1e52a95940c0193558b876828e537736480d6408b
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-help
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-help/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:2264d1615117b02b0fd5a69ec84cd2757006471a78e4d6c22eed6d581c1d37a4
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-review
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-review/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:40df33b58fc6ef889b93585733feb9566b76e9586efa7f376785c1e995197ac0
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:1316a2f3f95741d2300b116fe0c2d81ce4a9568656ed0a62643f54aaf09957f2
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/caveman-commit
+  runtime: null
+  scope: project
+  owners:
+  - juliusbrussee/caveman/skills/caveman-commit
+  active_owner: juliusbrussee/caveman/skills/caveman-commit
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/caveman-commit/README.md
+  runtime: null
+  scope: project
+  owners:
+  - juliusbrussee/caveman/skills/caveman-commit
+  active_owner: juliusbrussee/caveman/skills/caveman-commit
+  content_hash: sha256:a2e82924b487fc1845114c247b47c2d3c2d1bd60f90bbfa60e9831319eb964fa
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/caveman-commit/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - juliusbrussee/caveman/skills/caveman-commit
+  active_owner: juliusbrussee/caveman/skills/caveman-commit
+  content_hash: sha256:58db7b8efab911a629c26e7132517d9076e4e3645009eb604cb8c25663477841
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/ponytail
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/ponytail-audit
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/ponytail-audit/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:5560b8e383dbe2ddfddc873a1e2bf2e586e23e0cd7d995537482b2315331f6d1
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/ponytail-debt
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/ponytail-debt/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:c84fba75f0ca12bfe83f9a78ea02fd125c5dd3f1fbb18124105a489937f284e6
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/ponytail-gain
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/ponytail-gain/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:24e01d1c9715cb136ba1c4f1e52a95940c0193558b876828e537736480d6408b
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/ponytail-help
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/ponytail-help/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:2264d1615117b02b0fd5a69ec84cd2757006471a78e4d6c22eed6d581c1d37a4
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/ponytail-review
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/ponytail-review/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:40df33b58fc6ef889b93585733feb9566b76e9586efa7f376785c1e995197ac0
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/ponytail/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:1316a2f3f95741d2300b116fe0c2d81ce4a9568656ed0a62643f54aaf09957f2
+- kind: project-relative
+  target: copilot
+  value: .github/hooks/ponytail-copilot-hooks.json
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:4ad52e6fd633e8fa1b73172da33e6b23d2b874fea94cd18a7def7a08037188a5
+- kind: project-relative
+  target: copilot
+  value: .github/hooks/scripts/ponytail/hooks/ponytail-activate.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:1c428c4ee9687c2f4321924109ee92e8f8b06fd6600cb6be9ec5b59633cafab1
+- kind: project-relative
+  target: copilot
+  value: .github/hooks/scripts/ponytail/hooks/ponytail-config.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:0a8daf96cf9ac703dc4cb7b5065253567e513c951d60b8eb94a0fe727514aeca
+- kind: project-relative
+  target: copilot
+  value: .github/hooks/scripts/ponytail/hooks/ponytail-instructions.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:23c050103f28dbe6bad953ae21d98cd06d720a20f33d4716e9de419f947d495e
+- kind: project-relative
+  target: copilot
+  value: .github/hooks/scripts/ponytail/hooks/ponytail-mode-tracker.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:5d1a960ff01b73f651ec0242052a8cf1e064cb88147806bf6e13f92798aca251
+- kind: project-relative
+  target: copilot
+  value: .github/hooks/scripts/ponytail/hooks/ponytail-runtime.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:80e4a13db4eca13f8cfca5237a46c34220c7c1f9ec841297191c0a46e49ca33e
+- kind: project-relative
+  target: copilot
+  value: .github/hooks/scripts/ponytail/hooks/ponytail-statusline.ps1
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:6138f15bc7651ee7e5ced2a2a2280f5c810d58cad3e9f3252c628f4c923e48c9
+- kind: project-relative
+  target: copilot
+  value: .github/hooks/scripts/ponytail/hooks/ponytail-statusline.sh
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:f1dbfa5997a5d4b5339619709053eff557ab16d71af75eb3041c3d3e3dca42ec
+- kind: project-relative
+  target: copilot
+  value: .github/hooks/scripts/ponytail/hooks/ponytail-subagent.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e

--- a/apm.yml
+++ b/apm.yml
@@ -1,0 +1,21 @@
+name: beryl
+version: 1.0.0
+description: APM project for beryl
+author: Tyler Butler
+# Which agent platforms to deploy to.
+# Resolution order: --target flag > this field > auto-detect from filesystem.
+# Accepted values: agent-skills, antigravity, claude, codex, copilot, cursor, gemini, grok-build, kiro, opencode, windsurf
+targets:
+- claude
+- copilot
+
+dependencies:
+  apm:
+    # - tylerbutler/agent-marketplace/plugins/repo-tools
+    # - tylerbutler/agent-marketplace/plugins/specialists
+    - JuliusBrussee/caveman/skills/caveman-commit
+    # - git: https://github.com/obra/superpowers
+    - DietrichGebert/ponytail
+  mcp: []
+includes: auto
+scripts: {}


### PR DESCRIPTION
## Summary
- Adopt APM (Agent Package Manager) to manage agent skills/hooks as declared dependencies (`apm.yml`, `apm.lock.yaml`) instead of manual copy-paste
- Add the ponytail skill set (audit, debt, gain, help, review) for lazy-first coding discipline
- Add the caveman-commit skill for compressed commit messages
- Wire up supporting Copilot hook scripts and Claude settings for ponytail mode activation/tracking
