### PR TITLE
ci: grant publish CI permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,10 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
        github.event.pull_request.head.ref == 'release/pending')
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/ci.yml
 
   publish:


### PR DESCRIPTION
## Summary

- grant the reusable CI workflow the permissions it requests
- allow release PR merges to reach the tag and GitHub release job

## Why

The Publish workflow failed during startup because the called CI workflow requests `pull-requests: write`, while the caller inherited read-only repository permissions.