### PR TITLE
fix(ci): defer publish dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Setup environment
         uses: tylerbutler/actions/setup-gleam@77f80621309fc7443b628802e08a815d41dd4b47 # ratchet:tylerbutler/actions/setup-gleam@main
+        with:
+          run-deps: false
 
       - name: Setup mise tools
         uses: ./.github/actions/mise


### PR DESCRIPTION
## Summary

- prevent the publish job from downloading dependencies before mise installs trellis
- match the setup order used by the CI and release workflows
