### PR TITLE
ci: post a sticky changelog comment on PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,8 +47,27 @@ jobs:
       # The release PR (branch release/pending) consumes all unreleased
       # fragments into the CHANGELOGs, so it can never satisfy this check.
       - name: Check changelog fragments
+        id: changelog
         if: github.head_ref != 'release/pending'
+        # Keep going on a failed check so the comment below still reports why.
+        continue-on-error: true
         run: |
           trellis changelog check \
             --base ${{ github.event.pull_request.base.sha }} \
-            --head ${{ github.event.pull_request.head.sha }}
+            --head ${{ github.event.pull_request.head.sha }} \
+            --format github >> "$GITHUB_OUTPUT"
+
+      # `--edit-last --create-if-none` makes this a sticky comment: one
+      # comment per PR, rewritten on every push.
+      - name: Comment changelog preview
+        if: steps.changelog.outputs.preview != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW: ${{ steps.changelog.outputs.preview }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --edit-last --create-if-none --body "$PREVIEW"
+
+      - name: Fail on missing changelog fragments
+        if: steps.changelog.outcome == 'failure'
+        run: exit 1

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-"github:tylerbutler/trellis" = "0.10.1"
+"github:tylerbutler/trellis" = "0.10.3"
 
 [env]
 LC_ALL = "en_US.UTF-8"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,8 +149,8 @@ resolution uses):
 CI matrix-tests Erlang 27 and 28. `.mise.toml` pins `erlang = "28"` for local
 development, deliberately overriding `.tool-versions` for mise users.
 
-trellis (0.4.1) is pinned in `.mise.toml` for local development and
-installed in CI via `.github/actions/install-trellis`.
+trellis (0.10.3) is pinned in `.mise.toml` for local development and
+installed in CI via `.github/actions/mise`.
 
 ## CI/CD
 

--- a/DEV.md
+++ b/DEV.md
@@ -11,7 +11,7 @@ Ensure you have the following installed:
 | Erlang/OTP | 27.2.1+ | BEAM runtime |
 | Gleam | 1.16.0+ | Compiler and tooling |
 | just | 1.50.0+ | Task runner |
-| [trellis](https://trellis.tylerbutler.com) | 0.4.1+ | Gleam workspace manager (tasks, versions, publishing) |
+| [trellis](https://trellis.tylerbutler.com) | 0.10.3+ | Gleam workspace manager (tasks, versions, publishing) |
 
 **Recommended:** Use [mise](https://mise.jdx.dev/) or [asdf](https://asdf-vm.com/) with the provided `.tool-versions` file. trellis is pinned in `.mise.toml` (mise's GitHub backend); it can also be installed via its shell installer or Homebrew. Note that `.mise.toml` also pins `erlang = "28"`, so mise users build on Erlang 28 while `.tool-versions` sets the 27.2.1 floor; CI matrix-tests both.
 


### PR DESCRIPTION
Use `trellis changelog check --format github` to emit the check result and its Markdown preview to $GITHUB_OUTPUT, then post it with `gh pr comment --edit-last --create-if-none` so each PR carries one comment that is rewritten on every push.

The check runs with continue-on-error and a separate failing step, so a missing fragment still fails the job but the comment explains why first.

Also bump the pinned trellis to 0.10.3 and correct the stale version and CI action references in CLAUDE.md and DEV.md.