### PR TITLE
refactor(core): tighten socket and transport APIs

### DIFF
--- a/.changes/unreleased/beryl-3.toml
+++ b/.changes/unreleased/beryl-3.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Changed"
+body = "BREAKING: socket.Next now carries only the model type, and distinct JoinRef and ReplyRef handles prevent join answers and message replies from being mixed. Connection permits and admission helpers now live exclusively under beryl/transport."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,21 +62,23 @@ runtime stores each socket's typed model and delivers `Join`, `Message`,
 `Binary`, `Closed`, and typed `Info` events without socket-dispatch casts or
 `Dynamic` round-trips. `Dynamic` is limited to decoded wire payloads.
 
-Join `Ref` values are single-pending-join capabilities with unique runtime
+`JoinRef` values are single-pending-join capabilities with unique runtime
 identity. Never reconstruct or compare their wire fields; return the exact ref
 in `AcceptJoin` or `RejectJoin`.
 
 ### Transport SPI Contract
 
 A transport implementation must follow this lifecycle:
-1. **Admit**: call `beryl.acquire_connection_slot` + `beryl.bind_connection_slot`
+1. **Admit**: call `transport.acquire_connection_slot` +
+   `transport.bind_connection_slot`
 2. **Own**: capture `transport.connection_owner` and monitor an `OwnerAlive` pid
 3. **Register atomically**: call `transport.admit_socket` with the captured
    owner and closer; close on failure
 4. **Route**: decode inbound frames with `transport.active_codec`, route via
    `transport.route_decoded` / `transport.route_binary`, shed over-rate frames
    with `transport.new_message_limiter` / `transport.take_token`
-5. **Disconnect**: `transport.socket_disconnected` + `beryl.release_connection_slot`
+5. **Disconnect**: `transport.socket_disconnected` +
+   `transport.release_connection_slot`
 
 ### Wire Protocol
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ fn init(info: socket.ConnectInfo(Msg)) -> #(Model, List(socket.Effect)) {
   #(Model(bridge: forwarder), [])
 }
 
-fn update(model: Model, ev: socket.Input(Msg)) -> socket.Next(Model, Msg) {
+fn update(model: Model, ev: socket.Input(Msg)) -> socket.Next(Model) {
   case ev {
     Info(DocUpdated(version)) ->
       Next(model, [

--- a/docs/adr/0002-app-side-dispatch.md
+++ b/docs/adr/0002-app-side-dispatch.md
@@ -46,7 +46,7 @@ Replace the channel-module API entirely with app-side dispatch:
 - One supervised entry point, `beryl.child_spec(config, init, update)
   -> Result(#(Sockets, ChildSpecification(_)), ConfigError)`: the app
   supplies `init: fn(ConnectInfo(msg)) -> #(model, List(Effect))` and
-  `update: fn(model, Input(msg)) -> Next(model, msg)` per socket, and
+  `update: fn(model, Input(msg)) -> Next(model)` per socket, and
   routes topics itself.
 - Callback returns are an effects list (join acceptance/rejection, reply,
   push, broadcast, and topic kick), replacing the old channel API's

--- a/docs/adr/0003-layered-channel-api.md
+++ b/docs/adr/0003-layered-channel-api.md
@@ -23,7 +23,7 @@ router, third-party channels usable without app-side wiring. That trade
 was framed as either/or because both models competed to *be* the core.
 They need not: the core's entry-point shape — `init:
 fn(ConnectInfo(msg)) -> #(model, List(Effect))` and `update: fn(model,
-Input(msg)) -> Next(model, msg)` (`beryl.child_spec`) — is expressive
+Input(msg)) -> Next(model)` (`beryl.child_spec`) — is expressive
 enough to host a channel framework *above* the core, as ordinary data,
 using the closure-captured existential encoding ADR 0001 already
 validated ("Option B",

--- a/examples/chatrooms/src/chatrooms/app.gleam
+++ b/examples/chatrooms/src/chatrooms/app.gleam
@@ -14,7 +14,7 @@
 //// replies (an ok-status reply carrying an error payload).
 
 import beryl/group.{type Groups}
-import beryl/socket.{type Effect, type Ref}
+import beryl/socket.{type Effect, type JoinRef, type ReplyRef}
 import beryl/socket/router
 import example_helpers/color
 import example_helpers/payload
@@ -45,7 +45,7 @@ pub fn join(
   socket_id: String,
   match: router.Match,
   payload: Dynamic,
-  ref: Ref,
+  ref: JoinRef,
 ) -> #(Option(Model), List(Effect)) {
   let router.Match(topic:, params:) = match
   let room_name = case params {
@@ -113,7 +113,7 @@ pub fn update(
   model: Model,
   event_name: String,
   payload: Dynamic,
-  ref: Option(Ref),
+  ref: Option(ReplyRef),
 ) -> #(Model, List(Effect)) {
   case event_name {
     "new_msg" -> {
@@ -248,7 +248,7 @@ fn namespace(ctx: Ctx) -> router.Namespace(ChatRooms) {
 /// Build the socket-wide update once, sharing the app-owned model.
 pub fn chat_rooms_update(
   ctx: Ctx,
-) -> fn(ChatRooms, socket.Input(Nil)) -> socket.Next(ChatRooms, Nil) {
+) -> fn(ChatRooms, socket.Input(Nil)) -> socket.Next(ChatRooms) {
   let namespaces = [router.accept_only("lobby"), namespace(ctx)]
   fn(model, input) {
     router.route(namespaces, router.unknown_topic(), model, input)

--- a/examples/chatrooms/test/chatrooms_app_test.gleam
+++ b/examples/chatrooms/test/chatrooms_app_test.gleam
@@ -17,7 +17,7 @@ fn context() -> app.Ctx {
   app.Ctx(presence: presence_tracker, groups: groups)
 }
 
-fn lobby_ref() -> socket.Ref {
+fn lobby_ref() -> socket.JoinRef {
   socket.make_join_ref(
     topic: "lobby",
     join_ref: Some("lobby-join"),
@@ -25,7 +25,7 @@ fn lobby_ref() -> socket.Ref {
   )
 }
 
-fn room_ref(topic: String) -> socket.Ref {
+fn room_ref(topic: String) -> socket.JoinRef {
   socket.make_join_ref(
     topic: topic,
     join_ref: Some("room-join"),

--- a/examples/collab_docs/src/collab_docs/app.gleam
+++ b/examples/collab_docs/src/collab_docs/app.gleam
@@ -13,7 +13,7 @@
 //// Join-level tenant-token auth is preserved: the join payload must carry a
 //// `token` HMAC-signed for the tenant whose document is being joined.
 
-import beryl/socket.{type Effect, type Ref}
+import beryl/socket.{type Effect, type JoinRef, type ReplyRef}
 import beryl/socket/router
 import collab_docs/auth
 import collab_docs/doc_store.{type Store}
@@ -54,7 +54,7 @@ pub fn join(
   _socket_id: String,
   match: router.Match,
   payload: Dynamic,
-  ref: Ref,
+  ref: JoinRef,
 ) -> #(Option(Model), List(Effect)) {
   case match.params {
     [tenant, document] ->
@@ -107,7 +107,7 @@ pub fn update(
   model: Model,
   event_name: String,
   payload: Dynamic,
-  ref: Option(Ref),
+  ref: Option(ReplyRef),
 ) -> #(Model, List(Effect)) {
   case event_name {
     "sync_state" -> sync_state(ctx, topic_name, model, payload, ref)
@@ -202,7 +202,7 @@ fn namespace(ctx: Ctx) -> router.Namespace(OpenDocuments) {
 /// Build the socket-wide update once, sharing the app-owned model.
 pub fn open_documents_update(
   ctx: Ctx,
-) -> fn(OpenDocuments, socket.Input(Nil)) -> socket.Next(OpenDocuments, Nil) {
+) -> fn(OpenDocuments, socket.Input(Nil)) -> socket.Next(OpenDocuments) {
   let namespaces = [namespace(ctx)]
   fn(model, input) {
     router.route(namespaces, error_payload("invalid_topic"), model, input)
@@ -214,7 +214,7 @@ fn sync_state(
   topic_name: String,
   model: Model,
   payload: Dynamic,
-  ref: Option(Ref),
+  ref: Option(ReplyRef),
 ) -> #(Model, List(Effect)) {
   case payload.string_field(payload, "state") {
     Ok(state) ->
@@ -238,7 +238,7 @@ fn sync_state(
 
 /// The channel-module API sent state errors as an ok-status reply with an
 /// error payload (and dropped them without a ref); mirror that.
-fn reply_error(code: String, ref: Option(Ref)) -> List(Effect) {
+fn reply_error(code: String, ref: Option(ReplyRef)) -> List(Effect) {
   socket.reply_ok(ref, error_payload(code))
 }
 

--- a/examples/collab_docs/test/app_test.gleam
+++ b/examples/collab_docs/test/app_test.gleam
@@ -13,7 +13,7 @@ import gleam/json
 import gleam/option.{Some}
 import gleeunit/should
 
-fn document_ref() -> socket.Ref {
+fn document_ref() -> socket.JoinRef {
   socket.make_join_ref(
     topic: "document:demo:readme",
     join_ref: Some("jr"),

--- a/examples/cursors/src/cursors/app.gleam
+++ b/examples/cursors/src/cursors/app.gleam
@@ -15,7 +15,7 @@
 ////   `cursor_rooms_update` wrappers that drive the standalone cursors server
 ////   through a `beryl.child_spec` runtime, reusing that per-topic surface.
 
-import beryl/socket.{type Effect, type Ref}
+import beryl/socket.{type Effect, type JoinRef}
 import beryl/socket/router
 import example_helpers/color
 import example_helpers/payload
@@ -43,7 +43,7 @@ pub fn join(
   socket_id: String,
   topic: String,
   payload: Dynamic,
-  ref: Ref,
+  ref: JoinRef,
 ) -> #(Option(Model), List(Effect)) {
   let username = payload.string_or(payload, "username", "Anonymous")
   let color = color.pastel_for(socket_id)
@@ -196,7 +196,7 @@ fn namespace(ctx: Ctx) -> router.Namespace(CursorRooms) {
 /// Build the socket-wide update once, sharing the app-owned model.
 pub fn cursor_rooms_update(
   ctx: Ctx,
-) -> fn(CursorRooms, socket.Input(Nil)) -> socket.Next(CursorRooms, Nil) {
+) -> fn(CursorRooms, socket.Input(Nil)) -> socket.Next(CursorRooms) {
   let namespaces = [namespace(ctx)]
   fn(model, input) {
     router.route(namespaces, router.unknown_topic(), model, input)

--- a/examples/load_test/src/load_test/channel.gleam
+++ b/examples/load_test/src/load_test/channel.gleam
@@ -18,7 +18,7 @@ pub fn update(
   presence: session_presence.Tracker,
   model: Nil,
   input: Input(msg),
-) -> Next(Nil, msg) {
+) -> Next(Nil) {
   case input {
     Join("guardrail:forbidden", _, ref) ->
       socket.Next(model, [
@@ -43,7 +43,7 @@ pub fn message_effects(
   topic: String,
   event_name: String,
   payload: Dynamic,
-  ref: Option(socket.Ref),
+  ref: Option(socket.ReplyRef),
 ) -> List(Effect) {
   case event_name {
     "echo" ->
@@ -84,7 +84,7 @@ fn track(
   presence: session_presence.Tracker,
   topic: String,
   payload: Dynamic,
-  ref: Option(socket.Ref),
+  ref: Option(socket.ReplyRef),
 ) -> List(Effect) {
   case key_and_meta(payload) {
     Error(_) ->
@@ -103,7 +103,7 @@ fn untrack(
   presence: session_presence.Tracker,
   topic: String,
   payload: Dynamic,
-  ref: Option(socket.Ref),
+  ref: Option(socket.ReplyRef),
 ) -> List(Effect) {
   let decoder = {
     use key <- decode.field("key", decode.string)
@@ -122,14 +122,17 @@ fn untrack(
   }
 }
 
-fn reply_error(ref: Option(socket.Ref), payload: json.Json) -> List(Effect) {
+fn reply_error(
+  ref: Option(socket.ReplyRef),
+  payload: json.Json,
+) -> List(Effect) {
   case ref {
     Some(value) -> [ReplyError(value, payload)]
     None -> []
   }
 }
 
-fn reply_ok(ref: Option(socket.Ref), payload: json.Json) -> List(Effect) {
+fn reply_ok(ref: Option(socket.ReplyRef), payload: json.Json) -> List(Effect) {
   case ref {
     Some(value) -> [ReplyOk(value, payload)]
     None -> []

--- a/examples/showcase/src/showcase/channels/rooms.gleam
+++ b/examples/showcase/src/showcase/channels/rooms.gleam
@@ -11,7 +11,7 @@
 //// join cannot slip between them and overshoot the cap.
 
 import beryl/group.{type Groups}
-import beryl/socket.{type Ref}
+import beryl/socket.{type ReplyRef}
 import beryl_channels/channel
 import example_helpers/color
 import example_helpers/payload
@@ -149,7 +149,11 @@ fn callbacks(ctx: Ctx) -> channel.Callbacks(State, Note) {
 
 /// The message broadcast and its reply, in that order: the sender sees its
 /// own message before the acknowledgment, exactly as before.
-fn new_msg(state: State, raw: Dynamic, ref: Option(Ref)) -> channel.Actions {
+fn new_msg(
+  state: State,
+  raw: Dynamic,
+  ref: Option(ReplyRef),
+) -> channel.Actions {
   case string.trim(payload.string_or(raw, "text", "")) {
     "" ->
       channel.actions()

--- a/examples/showcase/src/showcase/reply.gleam
+++ b/examples/showcase/src/showcase/reply.gleam
@@ -4,13 +4,13 @@
 //// events are dropped, matching the example apps' raw-dispatch behavior
 //// (`example_helpers/reply`).
 
-import beryl/socket.{type Ref}
+import beryl/socket.{type ReplyRef}
 import beryl_channels/channel.{type Actions}
 import gleam/json.{type Json}
 import gleam/option.{type Option, None, Some}
 
 /// Add an ok-status reply when the client supplied a ref.
-pub fn ok(actions: Actions, reply: Option(Ref), payload: Json) -> Actions {
+pub fn ok(actions: Actions, reply: Option(ReplyRef), payload: Json) -> Actions {
   case reply {
     Some(ref) -> channel.reply_ok(actions, ref, payload)
     None -> actions

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -599,55 +599,15 @@ pub fn channels_telemetry_enabled(channels: Sockets) -> Bool {
   channels.config.telemetry
 }
 
-/// A held per-IP connection slot returned by `acquire_connection_slot`.
-///
-/// Opaque so Beryl can restructure the connection limiter without breaking
-/// transport authors. Hold it for the lifetime of the connection and pass it
-/// to `release_connection_slot` when the connection closes. When no per-IP
-/// limit is configured the permit is an admit-everything placeholder and
-/// releasing it is a no-op.
-pub opaque type ConnectionPermit {
-  ConnectionPermit(inner: Option(connection_limit.Permit))
-}
-
-/// Try to acquire a configured per-IP connection slot for transports.
-///
-/// Transports call this before admitting a connection, passing the **real
-/// socket peer IP**. Do not pass a client-supplied address (e.g. from
-/// `X-Forwarded-For`): a spoofed value would defeat the per-IP limit. Returns
-/// `Ok(permit)` when admitted (release the permit with
-/// `release_connection_slot` on close; when no limit is configured every
-/// connection is admitted), or `Error(Nil)` when the peer is already at its
-/// limit.
-pub fn acquire_connection_slot(
+@internal
+pub fn configured_connection_limiter(
   channels: Sockets,
-  ip: String,
-) -> Result(ConnectionPermit, Nil) {
-  connection_limit.acquire_optional(channels.connection_limiter, ip)
-  |> result.map(ConnectionPermit)
+) -> Option(connection_limit.ConnectionLimiter) {
+  channels.connection_limiter
 }
 
-/// Bind an acquired connection slot to the calling process.
-///
-/// Call this from the long-lived connection process (e.g. the WebSocket
-/// handler's init) after `acquire_connection_slot`. The limiter monitors the
-/// caller so the slot is reclaimed even if the connection process dies
-/// without running its close path — otherwise crashed connections would
-/// permanently exhaust their IP's slots.
-pub fn bind_connection_slot(permit: ConnectionPermit) -> Nil {
-  connection_limit.bind_optional(permit.inner)
-}
-
-/// Release a per-IP connection slot acquired by a transport.
-///
-/// Call from the process the permit was bound to (or from an unbound
-/// process when releasing before the connection was established).
-pub fn release_connection_slot(permit: ConnectionPermit) -> Nil {
-  connection_limit.release_optional(permit.inner)
-}
-
-/// Return the configured inbound frame size cap for transports.
-pub fn max_inbound_frame_bytes(channels: Sockets) -> Int {
+@internal
+pub fn configured_max_inbound_frame_bytes(channels: Sockets) -> Int {
   channels.config.max_inbound_frame_bytes
 }
 
@@ -839,7 +799,7 @@ fn await_down(monitor: process.Monitor) -> Result(Nil, Nil) {
 pub fn child_spec(
   config: Config,
   init init: fn(socket.ConnectInfo(msg)) -> #(model, List(socket.Effect)),
-  update update: fn(model, socket.Input(msg)) -> socket.Next(model, msg),
+  update update: fn(model, socket.Input(msg)) -> socket.Next(model),
 ) -> Result(
   #(Sockets, supervision.ChildSpecification(static_supervisor.Supervisor)),
   ConfigError,
@@ -887,7 +847,7 @@ type AppSubtree {
 fn build_app_subtree(
   config: Config,
   init: fn(socket.ConnectInfo(msg)) -> #(model, List(socket.Effect)),
-  update: fn(model, socket.Input(msg)) -> socket.Next(model, msg),
+  update: fn(model, socket.Input(msg)) -> socket.Next(model),
 ) -> Result(AppSubtree, ConfigError) {
   use _ <- result.map(validate_config(config))
   warn_if_unprotected(config)
@@ -932,7 +892,7 @@ fn child_spec_supervisor(
   runtime_name: process.Name(runtime.Msg(msg)),
   limiter_name: Option(process.Name(connection_limit.Message)),
   init: fn(socket.ConnectInfo(msg)) -> #(model, List(socket.Effect)),
-  update: fn(model, socket.Input(msg)) -> socket.Next(model, msg),
+  update: fn(model, socket.Input(msg)) -> socket.Next(model),
 ) -> Result(actor.Started(static_supervisor.Supervisor), actor.StartError) {
   let runtime_child =
     supervision.worker(fn() {

--- a/packages/beryl/src/beryl/runtime.gleam
+++ b/packages/beryl/src/beryl/runtime.gleam
@@ -21,8 +21,8 @@ import beryl/presence/wire as presence_wire
 import beryl/pubsub.{type PubSub}
 import beryl/rate_limit.{type RateLimitConfig}
 import beryl/socket.{
-  type ConnectInfo, type ConnectSeed, type Effect, type Input, type Next,
-  type Ref, type StopReason,
+  type ConnectInfo, type ConnectSeed, type Effect, type Input, type JoinRef,
+  type Next, type ReplyRef, type StopReason,
 } as sock
 import beryl/telemetry
 import beryl/topic.{type TopicPattern}
@@ -159,7 +159,7 @@ type State(model, msg) {
     logger: Logger,
     self_subject: Subject(Msg(msg)),
     init: fn(ConnectInfo(msg)) -> #(model, List(Effect)),
-    update: fn(model, Input(msg)) -> Next(model, msg),
+    update: fn(model, Input(msg)) -> Next(model),
     message_buckets: Dict(String, rate_limit.Bucket),
     join_buckets: Dict(String, rate_limit.Bucket),
     channel_buckets: Dict(String, Dict(String, rate_limit.Bucket)),
@@ -347,7 +347,7 @@ type SocketState(model, msg) {
     /// `Message` is delivered, removed when answered (so a reply is
     /// single-use), and pruned when its topic closes (so a stale ref stored
     /// across a leave/rejoin is not replied to).
-    pending_reply_refs: Set(Ref),
+    pending_reply_refs: Set(ReplyRef),
     last_heartbeat: Int,
     /// Native monotonic timestamp captured when the socket was accepted.
     connected_at: Int,
@@ -360,7 +360,7 @@ type Pending {
     topic: String,
     join_ref: Option(String),
     msg_ref: Option(String),
-    ref: Ref,
+    ref: JoinRef,
   )
 }
 
@@ -370,7 +370,7 @@ type Source {
     topic: String,
     join_ref: Option(String),
     msg_ref: Option(String),
-    ref: Ref,
+    ref: JoinRef,
     started_at: Int,
   )
   MessageSource(topic: String, kind: telemetry.MessageKind, started_at: Int)
@@ -441,7 +441,7 @@ pub fn start_named(
   name name: process.Name(Msg(msg)),
   pubsub pubsub_option: Option(PubSub(Json)),
   init init: fn(ConnectInfo(msg)) -> #(model, List(Effect)),
-  update update: fn(model, Input(msg)) -> Next(model, msg),
+  update update: fn(model, Input(msg)) -> Next(model),
 ) -> Result(actor.Started(Subject(Msg(msg))), actor.StartError) {
   internal.configure(config.logging)
 
@@ -1649,7 +1649,7 @@ fn route_message_with_ref(
   topic_name: String,
   event_name: String,
   payload: Dynamic,
-  message_ref: Ref,
+  message_ref: ReplyRef,
   started_at: Int,
   kind: telemetry.MessageKind,
 ) -> State(model, msg) {
@@ -1665,8 +1665,8 @@ fn route_message_with_ref(
         state,
         socket_id,
         topic_name,
-        sock.ref_join_ref(message_ref),
-        sock.ref_msg_ref(message_ref),
+        sock.reply_ref_join_ref(message_ref),
+        sock.reply_ref_msg_ref(message_ref),
         error_reason("duplicate_ref"),
       )
       emit_message_stop(
@@ -1698,7 +1698,7 @@ fn deliver_client_message(
   topic_name: String,
   event_name: String,
   payload: Dynamic,
-  message_ref: Option(Ref),
+  message_ref: Option(ReplyRef),
   started_at: Int,
   kind: telemetry.MessageKind,
 ) -> State(model, msg) {
@@ -2128,7 +2128,7 @@ fn exec_update_result(
   socket_id: String,
   source: Source,
   cont: Cont,
-  result: Result(Next(model, msg), String),
+  result: Result(Next(model), String),
 ) -> Exec(model, msg) {
   case result {
     Error(crash) -> exec_update_crash(state, socket_id, source, cont, crash)
@@ -2393,7 +2393,7 @@ fn exec_close_topic(
               ),
               join_refs: dict.delete(socket.join_refs, topic_name),
               pending_reply_refs: set.filter(socket.pending_reply_refs, fn(ref) {
-                sock.ref_topic(ref) != topic_name
+                sock.reply_ref_topic(ref) != topic_name
               }),
             )
           let state = store_socket(state, socket)
@@ -2705,7 +2705,7 @@ fn apply_kick_topic(
 fn apply_accept_join(
   state: State(model, msg),
   socket_id: String,
-  ref: Ref,
+  ref: JoinRef,
   reply: Option(Json),
   pending: Option(Pending),
   kicks: List(String),
@@ -2747,7 +2747,7 @@ fn apply_accept_join(
 fn apply_reject_join(
   state: State(model, msg),
   socket_id: String,
-  ref: Ref,
+  ref: JoinRef,
   reason: Json,
   pending: Option(Pending),
   kicks: List(String),
@@ -2770,12 +2770,12 @@ fn apply_reject_join(
 }
 
 fn matching_pending_join(
-  ref: Ref,
+  ref: JoinRef,
   pending: Option(Pending),
 ) -> Option(Pending) {
   case pending {
     Some(p) ->
-      case sock.ref_is_join(ref) && sock.refs_match(ref, p.ref) {
+      case sock.join_refs_match(ref, p.ref) {
         True -> Some(p)
         False -> None
       }
@@ -2786,13 +2786,13 @@ fn matching_pending_join(
 fn warn_unmatched_join_answer(
   state: State(model, msg),
   socket_id: String,
-  ref: Ref,
+  ref: JoinRef,
   effect_name: String,
 ) -> Nil {
   state.logger
   |> log.warn(effect_name <> " ignored: no matching pending join", [
     #("socket_id", socket_id),
-    #("topic", sock.ref_topic(ref)),
+    #("topic", sock.join_ref_topic(ref)),
   ])
 }
 
@@ -2840,60 +2840,50 @@ fn subscribe_socket(
   }
 }
 
-/// Send a reply for a stored `Ref`. Join refs must be answered with
-/// `AcceptJoin`/`RejectJoin`, so replies against them are dropped. Message
-/// refs are single-use and only valid while their topic is open: a ref that
-/// was already answered, or whose topic has since closed (including across a
-/// leave/rejoin), is dropped rather than sent as a stale/duplicate reply.
+/// Send a reply for a stored `ReplyRef`.
+///
+/// Reply refs are single-use and only valid while their topic is open: a ref
+/// that was already answered, or whose topic has since closed (including
+/// across a leave/rejoin), is dropped rather than sent as a stale/duplicate
+/// reply.
 fn apply_reply(
   state: State(model, msg),
   socket_id: String,
-  ref: Ref,
+  ref: ReplyRef,
   status: codec.ReplyStatus,
   payload: Json,
 ) -> State(model, msg) {
-  case sock.ref_is_join(ref) {
-    True -> {
-      state.logger
-      |> log.warn("Reply ignored: join refs require AcceptJoin/RejectJoin", [
-        #("socket_id", socket_id),
-        #("topic", sock.ref_topic(ref)),
-      ])
-      state
-    }
-    False ->
-      case dict.get(state.sockets, socket_id) {
-        Error(Nil) -> state
-        Ok(socket) ->
-          case set.contains(socket.pending_reply_refs, ref) {
-            False -> {
-              state.logger
-              |> log.warn("Reply ignored: unknown or already-answered ref", [
-                #("socket_id", socket_id),
-                #("topic", sock.ref_topic(ref)),
-              ])
-              state
-            }
-            True -> {
-              let frame =
-                codec.encode_reply(socket.codec)(
-                  sock.ref_join_ref(ref),
-                  sock.ref_msg_ref(ref),
-                  sock.ref_topic(ref),
-                  status,
-                  payload,
-                )
-              let _send_result =
-                send_frame_logged(state, socket, sock.ref_topic(ref), frame)
-              store_socket(
-                state,
-                SocketState(
-                  ..socket,
-                  pending_reply_refs: set.delete(socket.pending_reply_refs, ref),
-                ),
-              )
-            }
-          }
+  case dict.get(state.sockets, socket_id) {
+    Error(Nil) -> state
+    Ok(socket) ->
+      case set.contains(socket.pending_reply_refs, ref) {
+        False -> {
+          state.logger
+          |> log.warn("Reply ignored: unknown or already-answered ref", [
+            #("socket_id", socket_id),
+            #("topic", sock.reply_ref_topic(ref)),
+          ])
+          state
+        }
+        True -> {
+          let frame =
+            codec.encode_reply(socket.codec)(
+              sock.reply_ref_join_ref(ref),
+              sock.reply_ref_msg_ref(ref),
+              sock.reply_ref_topic(ref),
+              status,
+              payload,
+            )
+          let _send_result =
+            send_frame_logged(state, socket, sock.reply_ref_topic(ref), frame)
+          store_socket(
+            state,
+            SocketState(
+              ..socket,
+              pending_reply_refs: set.delete(socket.pending_reply_refs, ref),
+            ),
+          )
+        }
       }
   }
 }
@@ -2902,7 +2892,7 @@ fn apply_reply(
 fn register_reply_ref(
   state: State(model, msg),
   socket_id: String,
-  ref: Ref,
+  ref: ReplyRef,
 ) -> State(model, msg) {
   case dict.get(state.sockets, socket_id) {
     Error(Nil) -> state

--- a/packages/beryl/src/beryl/socket.gleam
+++ b/packages/beryl/src/beryl/socket.gleam
@@ -31,28 +31,28 @@ import gleam/erlang/reference.{type Reference}
 import gleam/json.{type Json}
 import gleam/option.{type Option, None, Some}
 
-/// A reply correlation handle.
+/// A pending join correlation handle.
 ///
-/// Carried by `Join` and (when the client requested a reply) `Message`
-/// inputs. Pass it back in `AcceptJoin`/`RejectJoin`/`ReplyOk`/`ReplyError`
-/// effects. Message refs may be stored in the model and answered from a later
-/// `update` turn (for example, after an async lookup completes). Join refs are
-/// valid only for their pending join and carry a unique runtime token, so a
-/// delayed completion for an older same-topic join cannot answer a replacement
-/// or retry.
-pub opaque type Ref {
-  Ref(
-    kind: RefKind,
+/// Pass it back in `AcceptJoin` or `RejectJoin`. A join ref is valid only for
+/// its pending join and carries a unique runtime token, so a delayed completion
+/// for an older same-topic join cannot answer a replacement or retry.
+pub opaque type JoinRef {
+  JoinRef(
     topic: String,
     join_ref: Option(String),
     msg_ref: Option(String),
-    join_token: Option(Reference),
+    token: Reference,
   )
 }
 
-type RefKind {
-  JoinRef
-  MessageRef
+/// A client message reply correlation handle.
+///
+/// Pass it back in `ReplyOk` or `ReplyError`. Reply refs may be stored in the
+/// model and answered from a later `update` turn (for example, after an async
+/// lookup completes). They are single-use and remain valid only while the
+/// topic instance that received the message stays open.
+pub opaque type ReplyRef {
+  ReplyRef(topic: String, join_ref: Option(String), msg_ref: Option(String))
 }
 
 @internal
@@ -60,13 +60,12 @@ pub fn make_join_ref(
   topic topic: String,
   join_ref join_ref: Option(String),
   msg_ref msg_ref: Option(String),
-) -> Ref {
-  Ref(
-    kind: JoinRef,
+) -> JoinRef {
+  JoinRef(
     topic: topic,
     join_ref: join_ref,
     msg_ref: msg_ref,
-    join_token: Some(reference.new()),
+    token: reference.new(),
   )
 }
 
@@ -75,38 +74,32 @@ pub fn make_message_ref(
   topic topic: String,
   join_ref join_ref: Option(String),
   msg_ref msg_ref: Option(String),
-) -> Ref {
-  Ref(
-    kind: MessageRef,
-    topic: topic,
-    join_ref: join_ref,
-    msg_ref: msg_ref,
-    join_token: None,
-  )
+) -> ReplyRef {
+  ReplyRef(topic: topic, join_ref: join_ref, msg_ref: msg_ref)
 }
 
 @internal
-pub fn ref_is_join(ref: Ref) -> Bool {
-  ref.kind == JoinRef
-}
-
-@internal
-pub fn refs_match(first: Ref, second: Ref) -> Bool {
+pub fn join_refs_match(first: JoinRef, second: JoinRef) -> Bool {
   first == second
 }
 
 @internal
-pub fn ref_topic(ref: Ref) -> String {
+pub fn join_ref_topic(ref: JoinRef) -> String {
   ref.topic
 }
 
 @internal
-pub fn ref_join_ref(ref: Ref) -> Option(String) {
+pub fn reply_ref_topic(ref: ReplyRef) -> String {
+  ref.topic
+}
+
+@internal
+pub fn reply_ref_join_ref(ref: ReplyRef) -> Option(String) {
   ref.join_ref
 }
 
 @internal
-pub fn ref_msg_ref(ref: Ref) -> Option(String) {
+pub fn reply_ref_msg_ref(ref: ReplyRef) -> Option(String) {
   ref.msg_ref
 }
 
@@ -132,10 +125,10 @@ pub type Input(msg) {
   /// A client asked to join a topic. Answer with `AcceptJoin` or
   /// `RejectJoin` in the returned effects; a `Join` left unanswered by the
   /// end of the update turn is rejected automatically (fail closed).
-  Join(topic: String, payload: Dynamic, ref: Ref)
+  Join(topic: String, payload: Dynamic, ref: JoinRef)
   /// A client message on a joined topic. `ref` is present for messages
   /// that expect a reply.
-  Message(topic: String, event: String, payload: Dynamic, ref: Option(Ref))
+  Message(topic: String, event: String, payload: Dynamic, ref: Option(ReplyRef))
   /// A binary frame on a joined topic (codecs without a binary decoder
   /// deliver the raw frame once per joined topic).
   Binary(topic: String, data: BitArray)
@@ -151,7 +144,7 @@ pub type Input(msg) {
 
 /// The result of one `update` call: the next model plus effects to apply,
 /// or an instruction to stop the whole socket.
-pub type Next(model, msg) {
+pub type Next(model) {
   /// Continue with the given model, applying the effects in order.
   Next(model: model, effects: List(Effect))
   /// Tear down the socket: every joined topic receives a `Closed` input,
@@ -165,13 +158,13 @@ pub type Effect {
   /// Accept a pending join. Subscribes the socket to the topic and sends
   /// the join acknowledgment (with an optional reply payload). Only valid
   /// while the `Join` input's ref is pending.
-  AcceptJoin(ref: Ref, reply: Option(Json))
+  AcceptJoin(ref: JoinRef, reply: Option(Json))
   /// Reject a pending join with an error payload.
-  RejectJoin(ref: Ref, reason: Json)
+  RejectJoin(ref: JoinRef, reason: Json)
   /// Reply successfully to a client message ref.
-  ReplyOk(ref: Ref, payload: Json)
+  ReplyOk(ref: ReplyRef, payload: Json)
   /// Reply with an error to a client message ref.
-  ReplyError(ref: Ref, payload: Json)
+  ReplyError(ref: ReplyRef, payload: Json)
   /// Push a server-initiated message to this socket on a joined topic.
   /// Pushes to topics this socket has not joined (yet) are dropped with a
   /// warning — order a `Push` after its topic's `AcceptJoin`.
@@ -230,10 +223,10 @@ pub type Effect {
 
 /// A `ReplyOk` when the client supplied a ref; no effects otherwise.
 ///
-/// `Message` inputs carry `Option(Ref)` (refless messages expect no
-/// reply) while the `ReplyOk` effect demands a `Ref`, so every handler
+/// `Message` inputs carry `Option(ReplyRef)` (refless messages expect no
+/// reply) while the `ReplyOk` effect demands a `ReplyRef`, so every handler
 /// that replies conditionally needs this gate.
-pub fn reply_ok(ref: Option(Ref), payload: Json) -> List(Effect) {
+pub fn reply_ok(ref: Option(ReplyRef), payload: Json) -> List(Effect) {
   case ref {
     Some(r) -> [ReplyOk(r, payload)]
     None -> []

--- a/packages/beryl/src/beryl/socket/router.gleam
+++ b/packages/beryl/src/beryl/socket/router.gleam
@@ -24,7 +24,8 @@
 //// rejected, while other inputs for unclaimed topics are ignored.
 
 import beryl/socket.{
-  type Effect, type Input, type Next, type Ref, type StopReason,
+  type Effect, type Input, type JoinRef, type Next, type ReplyRef,
+  type StopReason,
 }
 import beryl/topic.{type TopicPattern}
 import gleam/dynamic.{type Dynamic}
@@ -50,8 +51,8 @@ pub type Match {
 pub opaque type Namespace(model) {
   Namespace(
     pattern: TopicPattern,
-    join: fn(model, Match, Dynamic, Ref) -> #(model, List(Effect)),
-    message: fn(model, Match, String, Dynamic, Option(Ref)) ->
+    join: fn(model, Match, Dynamic, JoinRef) -> #(model, List(Effect)),
+    message: fn(model, Match, String, Dynamic, Option(ReplyRef)) ->
       #(model, List(Effect)),
     closed: fn(model, Match, StopReason) -> #(model, List(Effect)),
   )
@@ -62,8 +63,8 @@ pub opaque type Namespace(model) {
 /// socket-wide model.
 pub fn namespace(
   pattern pattern: String,
-  join join: fn(model, Match, Dynamic, Ref) -> #(model, List(Effect)),
-  message message: fn(model, Match, String, Dynamic, Option(Ref)) ->
+  join join: fn(model, Match, Dynamic, JoinRef) -> #(model, List(Effect)),
+  message message: fn(model, Match, String, Dynamic, Option(ReplyRef)) ->
     #(model, List(Effect)),
   closed closed: fn(model, Match, StopReason) -> #(model, List(Effect)),
 ) -> Namespace(model) {
@@ -98,7 +99,7 @@ pub fn route(
   reject_unknown: Json,
   model: model,
   input: Input(msg),
-) -> Next(model, msg) {
+) -> Next(model) {
   case input {
     socket.Join(topic_name, payload, ref) ->
       case owner(namespaces, topic_name) {
@@ -143,7 +144,7 @@ fn captured(ns: Namespace(model), topic_name: String) -> List(String) {
   |> result.unwrap([])
 }
 
-fn continue(result: #(model, List(Effect))) -> Next(model, msg) {
+fn continue(result: #(model, List(Effect))) -> Next(model) {
   let #(model, effects) = result
   socket.Next(model, effects)
 }

--- a/packages/beryl/src/beryl/transport.gleam
+++ b/packages/beryl/src/beryl/transport.gleam
@@ -3,24 +3,67 @@
 ////
 //// `beryl/transport/server` owns the shared admission, connection, rate,
 //// decode, and telemetry pipeline. This low-level SPI keeps only the hooks a
-//// transport implementation needs: exact-owner atomic admission, disconnect,
-//// text/binary routing, the configured codec, and transport telemetry.
+//// transport implementation needs: connection-capacity permits, exact-owner
+//// atomic admission, disconnect, text/binary routing, the configured codec,
+//// and transport telemetry.
 
 import beryl
+import beryl/connection_limit
 import beryl/socket
 import beryl/telemetry
 import beryl/wire/codec
 import gleam/bool
 import gleam/erlang/process
 import gleam/option.{type Option}
+import gleam/result
 
 /// Runtime handle accepted by transport implementations.
 pub type Sockets =
   beryl.Sockets
 
-/// Connection slot permit held by a transport connection.
-pub type ConnectionPermit =
-  beryl.ConnectionPermit
+/// A held connection slot returned by `acquire_connection_slot`.
+///
+/// Hold it for the lifetime of the connection and pass it to
+/// `release_connection_slot` when the connection closes. When no connection
+/// limit is configured the permit is an admit-everything placeholder and
+/// releasing it is a no-op.
+pub opaque type ConnectionPermit {
+  ConnectionPermit(inner: Option(connection_limit.Permit))
+}
+
+/// Try to acquire a configured connection slot for a transport.
+///
+/// Pass the real socket peer IP, never a client-supplied address such as
+/// `X-Forwarded-For`. Return `Error(Nil)` when the configured per-IP or
+/// node-wide limit is already reached.
+pub fn acquire_connection_slot(
+  sockets: Sockets,
+  ip: String,
+) -> Result(ConnectionPermit, Nil) {
+  connection_limit.acquire_optional(
+    beryl.configured_connection_limiter(sockets),
+    ip,
+  )
+  |> result.map(ConnectionPermit)
+}
+
+/// Bind an acquired connection slot to the calling connection process.
+///
+/// The limiter monitors the caller so the slot is reclaimed if the process
+/// dies without running its close path.
+pub fn bind_connection_slot(permit: ConnectionPermit) -> Nil {
+  connection_limit.bind_optional(permit.inner)
+}
+
+/// Release a connection slot acquired by a transport.
+pub fn release_connection_slot(permit: ConnectionPermit) -> Nil {
+  connection_limit.release_optional(permit.inner)
+}
+
+/// Return the configured inbound frame size cap for transports.
+pub fn max_inbound_frame_bytes(sockets: Sockets) -> Int {
+  beryl.configured_max_inbound_frame_bytes(sockets)
+}
 
 // --- Telemetry ---
 

--- a/packages/beryl/src/beryl/transport/server.gleam
+++ b/packages/beryl/src/beryl/transport/server.gleam
@@ -280,7 +280,7 @@ fn handle_matched_upgrade(
     )
   })
   let peer_ip = request_ip(request) |> result.unwrap("unknown")
-  case beryl.acquire_connection_slot(sockets, peer_ip) {
+  case transport.acquire_connection_slot(sockets, peer_ip) {
     Error(Nil) ->
       reject_upgrade(
         reject,
@@ -329,7 +329,7 @@ fn run_on_connect(
           accept(metadata, connection_permit)
           |> finish_upgrade(connection_permit, telemetry, started_at)
         Error(ConnectRejected) -> {
-          beryl.release_connection_slot(connection_permit)
+          transport.release_connection_slot(connection_permit)
           reject_upgrade(
             reject,
             telemetry,
@@ -378,7 +378,7 @@ fn finish_upgrade(
 ) -> Response(resp) {
   case response.status >= 400 {
     True -> {
-      beryl.release_connection_slot(connection_permit)
+      transport.release_connection_slot(connection_permit)
       transport.telemetry_upgrade_stop(
         telemetry,
         started_at,
@@ -472,9 +472,9 @@ pub fn init_connection(
   telemetry telemetry: transport.Telemetry,
   codec socket_codec: Option(Codec),
 ) -> #(ConnectionState, Selector(SendRequest)) {
-  // Bind the per-IP slot to this WebSocket process so it is reclaimed even
-  // if the process dies without running the transport's close callback.
-  beryl.bind_connection_slot(connection_permit)
+  // Bind the connection slot to this WebSocket process so it is reclaimed
+  // even if the process dies without running the transport's close callback.
+  transport.bind_connection_slot(connection_permit)
 
   let socket_id = generate_socket_id()
   let send_subject = process.new_subject()
@@ -523,7 +523,7 @@ pub fn init_connection(
       socket_id: socket_id,
       sockets: sockets,
       connection_permit: connection_permit,
-      max_inbound_frame_bytes: beryl.max_inbound_frame_bytes(sockets),
+      max_inbound_frame_bytes: transport.max_inbound_frame_bytes(sockets),
       codec: option.unwrap(socket_codec, beryl.configured_codec(sockets)),
       telemetry: telemetry,
       frame_limiter: beryl.frame_limits(sockets)
@@ -537,7 +537,7 @@ pub fn init_connection(
 /// Clean up when a connection closes: release the held connection slot and
 /// announce the disconnect to the runtime.
 pub fn close_connection(state: ConnectionState) -> Nil {
-  beryl.release_connection_slot(state.connection_permit)
+  transport.release_connection_slot(state.connection_permit)
   transport.socket_disconnected(state.sockets, state.socket_id)
 }
 

--- a/packages/beryl/test/app_dispatch_test.gleam
+++ b/packages/beryl/test/app_dispatch_test.gleam
@@ -5,7 +5,7 @@
 import app_test_helpers as h
 import beryl
 import beryl/socket.{
-  type Ref, AcceptJoin, Closed, Info, Join, Message, Next, RejectJoin,
+  type JoinRef, AcceptJoin, Closed, Info, Join, Message, Next, RejectJoin,
   ReplyError, ReplyOk,
 }
 import beryl/transport
@@ -27,7 +27,7 @@ type JoinRaceMode {
 }
 
 type JoinRaceModel {
-  JoinRaceModel(previous: Option(Ref), mode: JoinRaceMode)
+  JoinRaceModel(previous: Option(JoinRef), mode: JoinRaceMode)
 }
 
 fn start_join_race(mode: JoinRaceMode) -> beryl.Sockets {

--- a/packages/beryl/test/app_lifecycle_test.gleam
+++ b/packages/beryl/test/app_lifecycle_test.gleam
@@ -7,6 +7,7 @@
 import app_test_helpers as h
 import beryl
 import beryl/topic
+import beryl/transport
 import beryl/wire
 import gleam/otp/static_supervisor
 import gleam/string
@@ -183,6 +184,6 @@ pub fn child_spec_admission_fails_before_start_test() {
 
   // The limiter is supervised inside the not-yet-started subtree, so
   // admission fails cleanly rather than panicking.
-  beryl.acquire_connection_slot(sockets, "1.2.3.4")
+  transport.acquire_connection_slot(sockets, "1.2.3.4")
   |> should.be_error
 }

--- a/packages/beryl/test/app_presence_async_test.gleam
+++ b/packages/beryl/test/app_presence_async_test.gleam
@@ -163,7 +163,7 @@ fn app_update(
   model: String,
   event: socket.Input(Nil),
   events: Subject(String),
-) -> Next(String, Nil) {
+) -> Next(String) {
   case event {
     Join(topic, _payload, ref) ->
       case

--- a/packages/beryl/test/app_ref_test.gleam
+++ b/packages/beryl/test/app_ref_test.gleam
@@ -1,4 +1,4 @@
-//// `Ref` validity and single-use semantics for app-side dispatch. A message
+//// `ReplyRef` validity and single-use semantics for app-side dispatch. A
 //// reply ref is single-use (a second reply against it is dropped) and stops
 //// being valid once its topic closes — a stored ref replied to after the
 //// topic left, or after a leave+rejoin, is dropped rather than sent as a
@@ -7,7 +7,9 @@
 
 import app_test_helpers as h
 import beryl
-import beryl/socket.{type Ref, AcceptJoin, Info, Join, Message, Next, ReplyOk}
+import beryl/socket.{
+  type ReplyRef, AcceptJoin, Info, Join, Message, Next, ReplyOk,
+}
 import beryl/wire
 import gleam/erlang/process
 import gleam/json
@@ -20,7 +22,7 @@ pub type Msg {
 }
 
 type Model {
-  Model(stashed: Option(Ref))
+  Model(stashed: Option(ReplyRef))
 }
 
 /// - "double": reply to the same ref twice in one effects list (single-use).

--- a/packages/beryl/test/app_supervision_test.gleam
+++ b/packages/beryl/test/app_supervision_test.gleam
@@ -389,7 +389,7 @@ fn capturing_init(
   }
 }
 
-fn crashing_update(model: Nil, ev: socket.Input(Nil)) -> socket.Next(Nil, Nil) {
+fn crashing_update(model: Nil, ev: socket.Input(Nil)) -> socket.Next(Nil) {
   case ev {
     Join(_, _, ref) -> Next(model, [AcceptJoin(ref, None)])
     socket.Info(_) -> panic as "boom"
@@ -519,8 +519,8 @@ pub fn timed_out_admission_cannot_register_or_apply_init_effects_test() {
   let _connection =
     process.spawn(fn() {
       let assert Ok(permit) =
-        beryl.acquire_connection_slot(sockets, "203.0.113.10")
-      beryl.bind_connection_slot(permit)
+        transport.acquire_connection_slot(sockets, "203.0.113.10")
+      transport.bind_connection_slot(permit)
       let assert Ok(owner) = transport.runtime_pid(sockets)
       let result =
         transport.admit_socket(
@@ -535,7 +535,7 @@ pub fn timed_out_admission_cannot_register_or_apply_init_effects_test() {
           codec: None,
           seed: socket.empty_seed(),
           close: fn() {
-            beryl.release_connection_slot(permit)
+            transport.release_connection_slot(permit)
             process.send(connection_closed, Nil)
           },
         )
@@ -548,8 +548,8 @@ pub fn timed_out_admission_cannot_register_or_apply_init_effects_test() {
   process.receive(connection_closed, 1000) |> should.equal(Ok(Nil))
 
   let assert Ok(reclaimed) =
-    beryl.acquire_connection_slot(sockets, "203.0.113.10")
-  beryl.release_connection_slot(reclaimed)
+    transport.acquire_connection_slot(sockets, "203.0.113.10")
+  transport.release_connection_slot(reclaimed)
 
   release_gate(gate)
   let _fresh_frames = h.connect(sockets, "fresh")
@@ -708,5 +708,5 @@ pub fn stop_leaves_no_registered_name_or_process_test() {
   beryl.app_runtime_pid(sockets) |> should.be_error
   beryl.app_limiter_pid(sockets) |> should.be_error
   // The system is fully gone: a fresh connection cannot be admitted.
-  beryl.acquire_connection_slot(sockets, "1.2.3.4") |> should.be_error
+  transport.acquire_connection_slot(sockets, "1.2.3.4") |> should.be_error
 }

--- a/packages/beryl/test/app_test_helpers.gleam
+++ b/packages/beryl/test/app_test_helpers.gleam
@@ -27,7 +27,7 @@ pub fn accepting_init(
 pub fn accepting_update(
   model: Nil,
   input: socket.Input(Nil),
-) -> socket.Next(Nil, Nil) {
+) -> socket.Next(Nil) {
   case input {
     socket.Join(_, _, ref) -> socket.Next(model, [socket.AcceptJoin(ref, None)])
     _ -> socket.Next(model, [])
@@ -38,7 +38,7 @@ pub fn accepting_update(
 pub fn start_app(
   config: beryl.Config,
   init init: fn(socket.ConnectInfo(msg)) -> #(model, List(socket.Effect)),
-  update update: fn(model, socket.Input(msg)) -> socket.Next(model, msg),
+  update update: fn(model, socket.Input(msg)) -> socket.Next(model),
 ) -> Result(beryl.Sockets, beryl.ConfigError) {
   use #(sockets, spec) <- result.try(beryl.child_spec(config, init:, update:))
   let assert Ok(_) =

--- a/packages/beryl/test/connection_limit_test.gleam
+++ b/packages/beryl/test/connection_limit_test.gleam
@@ -1,13 +1,14 @@
 //// Per-IP connection limit enforcement tests.
 ////
 //// These exercise the public transport-facing API
-//// (`beryl.acquire_connection_slot` / `beryl.release_connection_slot`) which
-//// the Mist transport uses to admit or reject WebSocket upgrades based on the
+//// (`transport.acquire_connection_slot` / `transport.release_connection_slot`)
+//// which transports use to admit or reject WebSocket upgrades based on the
 //// real socket peer IP.
 
 import app_test_helpers as h
 import beryl
 import beryl/socket
+import beryl/transport
 import beryl/wire
 import gleam/erlang/process
 import gleeunit/should
@@ -28,11 +29,11 @@ fn start_with_limit(max_connections: Int) -> beryl.Sockets {
 pub fn zero_means_unlimited_test() {
   let channels = start_with_limit(0)
 
-  let assert Ok(first) = beryl.acquire_connection_slot(channels, "1.2.3.4")
-  should.be_ok(beryl.acquire_connection_slot(channels, "1.2.3.4"))
-  should.be_ok(beryl.acquire_connection_slot(channels, "1.2.3.4"))
+  let assert Ok(first) = transport.acquire_connection_slot(channels, "1.2.3.4")
+  should.be_ok(transport.acquire_connection_slot(channels, "1.2.3.4"))
+  should.be_ok(transport.acquire_connection_slot(channels, "1.2.3.4"))
 
-  beryl.release_connection_slot(first)
+  transport.release_connection_slot(first)
   |> should.equal(Nil)
 
   beryl.stop(channels)
@@ -42,8 +43,8 @@ pub fn zero_means_unlimited_test() {
 pub fn admits_connections_under_limit_test() {
   let channels = start_with_limit(2)
 
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.1"))
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.1"))
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.0.1"))
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.0.1"))
 
   beryl.stop(channels)
 }
@@ -52,8 +53,8 @@ pub fn admits_connections_under_limit_test() {
 pub fn rejects_connection_over_limit_test() {
   let channels = start_with_limit(1)
 
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.2"))
-  beryl.acquire_connection_slot(channels, "10.0.0.2")
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.0.2"))
+  transport.acquire_connection_slot(channels, "10.0.0.2")
   |> should.equal(Error(Nil))
 
   beryl.stop(channels)
@@ -64,14 +65,15 @@ pub fn rejects_connection_over_limit_test() {
 pub fn releasing_slot_frees_capacity_test() {
   let channels = start_with_limit(1)
 
-  let assert Ok(permit) = beryl.acquire_connection_slot(channels, "10.0.0.3")
+  let assert Ok(permit) =
+    transport.acquire_connection_slot(channels, "10.0.0.3")
   // At the limit now.
-  beryl.acquire_connection_slot(channels, "10.0.0.3")
+  transport.acquire_connection_slot(channels, "10.0.0.3")
   |> should.equal(Error(Nil))
 
   // Freeing the slot admits the next connection from the same IP.
-  beryl.release_connection_slot(permit)
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.3"))
+  transport.release_connection_slot(permit)
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.0.3"))
 
   beryl.stop(channels)
 }
@@ -80,13 +82,13 @@ pub fn releasing_slot_frees_capacity_test() {
 pub fn limit_is_per_ip_test() {
   let channels = start_with_limit(1)
 
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.4"))
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.5"))
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.0.4"))
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.0.5"))
 
   // Each IP is independently at its limit now.
-  beryl.acquire_connection_slot(channels, "10.0.0.4")
+  transport.acquire_connection_slot(channels, "10.0.0.4")
   |> should.equal(Error(Nil))
-  beryl.acquire_connection_slot(channels, "10.0.0.5")
+  transport.acquire_connection_slot(channels, "10.0.0.5")
   |> should.equal(Error(Nil))
 
   beryl.stop(channels)
@@ -101,8 +103,8 @@ pub fn slot_reclaimed_when_holder_dies_without_release_test() {
   let _pid =
     process.spawn_unlinked(fn() {
       let assert Ok(permit) =
-        beryl.acquire_connection_slot(channels, "10.0.0.7")
-      beryl.bind_connection_slot(permit)
+        transport.acquire_connection_slot(channels, "10.0.0.7")
+      transport.bind_connection_slot(permit)
       process.send(acquired, Nil)
     })
   let assert Ok(Nil) = process.receive(acquired, 500)
@@ -110,7 +112,7 @@ pub fn slot_reclaimed_when_holder_dies_without_release_test() {
   // Give the limiter time to observe the holder's exit.
   process.sleep(50)
 
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.7"))
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.0.7"))
   beryl.stop(channels)
 }
 
@@ -118,8 +120,9 @@ pub fn slot_reclaimed_when_holder_dies_without_release_test() {
 pub fn permit_can_be_released_test() {
   let channels = start_with_limit(1)
 
-  let assert Ok(permit) = beryl.acquire_connection_slot(channels, "10.0.0.6")
-  beryl.release_connection_slot(permit)
+  let assert Ok(permit) =
+    transport.acquire_connection_slot(channels, "10.0.0.6")
+  transport.release_connection_slot(permit)
 
   beryl.stop(channels)
 }

--- a/packages/beryl/test/global_connection_limit_test.gleam
+++ b/packages/beryl/test/global_connection_limit_test.gleam
@@ -1,8 +1,8 @@
 //// Node-wide (global) connection ceiling enforcement tests.
 ////
 //// These exercise the same public transport-facing API
-//// (`beryl.acquire_connection_slot` / `beryl.bind_connection_slot` /
-//// `beryl.release_connection_slot`) the Mist transport uses, but focus on the
+//// (`transport.acquire_connection_slot` / `transport.bind_connection_slot` /
+//// `transport.release_connection_slot`) the Mist transport uses, but focus on
 //// node-wide ceiling configured with `beryl.with_max_connections` — the limit
 //// that bounds concurrent connections across *all* source IPs, which a per-IP
 //// limit alone cannot enforce against distributed/rotating addresses.
@@ -10,6 +10,7 @@
 import app_test_helpers as h
 import beryl
 import beryl/socket
+import beryl/transport
 import beryl/wire
 import gleam/erlang/process
 import gleam/int
@@ -46,11 +47,11 @@ fn start_with_both_limits(
 pub fn global_zero_means_unlimited_test() {
   let channels = start_with_global_limit(0)
 
-  let assert Ok(first) = beryl.acquire_connection_slot(channels, "1.1.1.1")
-  should.be_ok(beryl.acquire_connection_slot(channels, "2.2.2.2"))
-  should.be_ok(beryl.acquire_connection_slot(channels, "3.3.3.3"))
+  let assert Ok(first) = transport.acquire_connection_slot(channels, "1.1.1.1")
+  should.be_ok(transport.acquire_connection_slot(channels, "2.2.2.2"))
+  should.be_ok(transport.acquire_connection_slot(channels, "3.3.3.3"))
 
-  beryl.release_connection_slot(first)
+  transport.release_connection_slot(first)
   |> should.equal(Nil)
 
   beryl.stop(channels)
@@ -61,9 +62,9 @@ pub fn global_zero_means_unlimited_test() {
 pub fn admits_connections_under_global_limit_test() {
   let channels = start_with_global_limit(3)
 
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.1"))
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.2"))
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.0.3"))
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.0.1"))
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.0.2"))
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.0.3"))
 
   beryl.stop(channels)
 }
@@ -74,11 +75,11 @@ pub fn admits_connections_under_global_limit_test() {
 pub fn rejects_connection_over_global_limit_test() {
   let channels = start_with_global_limit(2)
 
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.1.1"))
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.1.2"))
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.1.1"))
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.1.2"))
 
   // A third, unique source address is refused because the node is full.
-  beryl.acquire_connection_slot(channels, "10.0.1.3")
+  transport.acquire_connection_slot(channels, "10.0.1.3")
   |> should.equal(Error(Nil))
 
   beryl.stop(channels)
@@ -89,14 +90,15 @@ pub fn rejects_connection_over_global_limit_test() {
 pub fn releasing_slot_frees_global_capacity_test() {
   let channels = start_with_global_limit(1)
 
-  let assert Ok(permit) = beryl.acquire_connection_slot(channels, "10.0.2.1")
+  let assert Ok(permit) =
+    transport.acquire_connection_slot(channels, "10.0.2.1")
   // The node is at its ceiling now.
-  beryl.acquire_connection_slot(channels, "10.0.2.2")
+  transport.acquire_connection_slot(channels, "10.0.2.2")
   |> should.equal(Error(Nil))
 
   // Freeing the slot admits the next connection from a different IP.
-  beryl.release_connection_slot(permit)
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.2.2"))
+  transport.release_connection_slot(permit)
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.2.2"))
 
   beryl.stop(channels)
 }
@@ -111,8 +113,8 @@ pub fn global_slot_reclaimed_when_holder_dies_without_release_test() {
   let _pid =
     process.spawn_unlinked(fn() {
       let assert Ok(permit) =
-        beryl.acquire_connection_slot(channels, "10.0.3.1")
-      beryl.bind_connection_slot(permit)
+        transport.acquire_connection_slot(channels, "10.0.3.1")
+      transport.bind_connection_slot(permit)
       process.send(acquired, Nil)
       // Return immediately: the process exits without releasing, which must
       // still free the node-wide slot via the limiter's monitor.
@@ -124,7 +126,7 @@ pub fn global_slot_reclaimed_when_holder_dies_without_release_test() {
 
   // The reclaimed slot admits a connection from a *different* IP, proving the
   // global count (not just the per-IP count) was decremented.
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.3.2"))
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.3.2"))
   beryl.stop(channels)
 }
 
@@ -135,9 +137,9 @@ pub fn per_ip_and_global_compose_test() {
   // Per-IP allows 5 each, but the node as a whole allows only 1.
   let channels = start_with_both_limits(5, 1)
 
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.4.1"))
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.4.1"))
   // Different IP, well under its per-IP limit, but the node is full.
-  beryl.acquire_connection_slot(channels, "10.0.4.2")
+  transport.acquire_connection_slot(channels, "10.0.4.2")
   |> should.equal(Error(Nil))
 
   beryl.stop(channels)
@@ -148,12 +150,12 @@ pub fn per_ip_and_global_compose_test() {
 pub fn per_ip_limit_still_enforced_under_global_test() {
   let channels = start_with_both_limits(1, 10)
 
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.5.1"))
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.5.1"))
   // Same IP is at its per-IP limit even though the node has room.
-  beryl.acquire_connection_slot(channels, "10.0.5.1")
+  transport.acquire_connection_slot(channels, "10.0.5.1")
   |> should.equal(Error(Nil))
   // A different IP is admitted (node still under its global ceiling).
-  should.be_ok(beryl.acquire_connection_slot(channels, "10.0.5.2"))
+  should.be_ok(transport.acquire_connection_slot(channels, "10.0.5.2"))
 
   beryl.stop(channels)
 }
@@ -172,9 +174,9 @@ pub fn concurrent_opens_do_not_exceed_global_ceiling_test() {
       // Each attempt uses a unique IP so per-IP tracking cannot be what caps
       // the total — only the node-wide ceiling can.
       let ip = "10.9." <> int.to_string(i) <> ".1"
-      let outcome = case beryl.acquire_connection_slot(channels, ip) {
+      let outcome = case transport.acquire_connection_slot(channels, ip) {
         Ok(permit) -> {
-          beryl.bind_connection_slot(permit)
+          transport.bind_connection_slot(permit)
           True
         }
         Error(Nil) -> False

--- a/packages/beryl/test/socket_router_test.gleam
+++ b/packages/beryl/test/socket_router_test.gleam
@@ -24,11 +24,11 @@ fn init() -> Model {
   Model(socket_id: "socket-1", topics: dict.new())
 }
 
-fn join_ref(topic: String) -> socket.Ref {
+fn join_ref(topic: String) -> socket.JoinRef {
   socket.make_join_ref(topic:, join_ref: Some("j1"), msg_ref: Some("m1"))
 }
 
-fn message_ref(topic: String) -> socket.Ref {
+fn message_ref(topic: String) -> socket.ReplyRef {
   socket.make_message_ref(topic:, join_ref: Some("j1"), msg_ref: Some("m2"))
 }
 
@@ -99,7 +99,7 @@ fn vip_namespace() -> router.Namespace(Model) {
   )
 }
 
-fn update(model: Model, ev: socket.Input(Nil)) -> socket.Next(Model, Nil) {
+fn update(model: Model, ev: socket.Input(Nil)) -> socket.Next(Model) {
   router.route(
     [vip_namespace(), router.accept_only("lobby"), room_namespace()],
     router.unknown_topic(),

--- a/packages/beryl/test/transport_server_rate_test.gleam
+++ b/packages/beryl/test/transport_server_rate_test.gleam
@@ -51,7 +51,7 @@ type Conn {
 }
 
 fn connect(channels: beryl.Sockets, ip: String) -> Conn {
-  let assert Ok(permit) = beryl.acquire_connection_slot(channels, ip)
+  let assert Ok(permit) = transport.acquire_connection_slot(channels, ip)
   let #(state, selector) =
     server.init_connection(
       sockets: channels,

--- a/packages/beryl/test/transport_server_test.gleam
+++ b/packages/beryl/test/transport_server_test.gleam
@@ -41,7 +41,7 @@ pub fn shared_server_preserves_negotiated_socket_codec_test() {
     )
   let telemetry = transport.telemetry(sockets, transport.Mist)
   let assert Ok(connection_permit) =
-    beryl.acquire_connection_slot(sockets, "127.0.0.1")
+    transport.acquire_connection_slot(sockets, "127.0.0.1")
   let #(state, selector) =
     server.init_connection(
       sockets: sockets,

--- a/packages/beryl_channels/src/beryl_channels/channel.gleam
+++ b/packages/beryl_channels/src/beryl_channels/channel.gleam
@@ -179,7 +179,7 @@ pub type Message {
     /// The raw client payload, to decode with `gleam/dynamic/decode`.
     payload: dynamic.Dynamic,
     /// Reply correlation handle, when the client requested a reply.
-    reply: option.Option(socket.Ref),
+    reply: option.Option(socket.ReplyRef),
   )
 }
 
@@ -230,7 +230,7 @@ pub fn broadcast_from(
 /// the [`Message`](#message) that asked for it.
 pub fn reply_ok(
   actions: Actions,
-  reply: socket.Ref,
+  reply: socket.ReplyRef,
   payload: json.Json,
 ) -> Actions {
   add(actions, ReplyOkAction(reply, payload))
@@ -240,7 +240,7 @@ pub fn reply_ok(
 /// the [`Message`](#message) that asked for it.
 pub fn reply_error(
   actions: Actions,
-  reply: socket.Ref,
+  reply: socket.ReplyRef,
   payload: json.Json,
 ) -> Actions {
   add(actions, ReplyErrorAction(reply, payload))
@@ -636,8 +636,8 @@ pub type Action {
   PushAction(event: String, payload: json.Json)
   BroadcastAction(event: String, payload: json.Json)
   BroadcastFromAction(event: String, payload: json.Json)
-  ReplyOkAction(reply: socket.Ref, payload: json.Json)
-  ReplyErrorAction(reply: socket.Ref, payload: json.Json)
+  ReplyOkAction(reply: socket.ReplyRef, payload: json.Json)
+  ReplyErrorAction(reply: socket.ReplyRef, payload: json.Json)
   PresenceTrackAction(key: String, meta: json.Json)
   PresenceUntrackAction(key: String)
   PushPresenceAction(

--- a/packages/beryl_channels/src/beryl_channels/internal/router.gleam
+++ b/packages/beryl_channels/src/beryl_channels/internal/router.gleam
@@ -117,7 +117,7 @@ pub fn init(
 pub fn update(
   router: Router,
   input: socket.Input(Envelope),
-) -> socket.Next(Router, Envelope) {
+) -> socket.Next(Router) {
   case input {
     socket.Join(topic: name, payload: payload, ref: ref) ->
       join(router, name, payload, ref)
@@ -150,8 +150,8 @@ fn join(
   router: Router,
   name: String,
   payload: dynamic.Dynamic,
-  ref: socket.Ref,
-) -> socket.Next(Router, Envelope) {
+  ref: socket.JoinRef,
+) -> socket.Next(Router) {
   case select(router.handlers, name) {
     Error(Nil) ->
       socket.Next(router, [socket.RejectJoin(ref, unmatched_topic())])
@@ -190,8 +190,8 @@ fn open(
   handler: channel.Handler,
   name: String,
   payload: dynamic.Dynamic,
-  ref: socket.Ref,
-) -> socket.Next(Router, Envelope) {
+  ref: socket.JoinRef,
+) -> socket.Next(Router) {
   let generation = router.generation + 1
   let router = Router(..router, generation: generation)
   let context =
@@ -247,7 +247,7 @@ fn on_live(
   router: Router,
   name: String,
   callback: fn(Instance) -> channel.Step,
-) -> socket.Next(Router, Envelope) {
+) -> socket.Next(Router) {
   case dict.get(router.live, name) {
     Error(Nil) -> socket.Next(router, [])
     Ok(instance) -> advance(router, name, instance, callback(instance))
@@ -265,7 +265,7 @@ fn deliver(
   name: String,
   generation: Int,
   mail: channel.Mail,
-) -> socket.Next(Router, Envelope) {
+) -> socket.Next(Router) {
   case dict.get(router.live, name) {
     Error(Nil) -> socket.Next(router, [])
     Ok(instance) ->
@@ -282,7 +282,7 @@ fn advance(
   name: String,
   instance: Instance,
   step: channel.Step,
-) -> socket.Next(Router, Envelope) {
+) -> socket.Next(Router) {
   case step {
     // The next instance keeps this join's generation: it is the same join.
     channel.StepContinue(next: next, actions: actions) -> {
@@ -339,7 +339,7 @@ fn closed(
   router: Router,
   name: String,
   reason: socket.StopReason,
-) -> socket.Next(Router, Envelope) {
+) -> socket.Next(Router) {
   case dict.get(router.live, name) {
     Error(Nil) -> socket.Next(router, [])
     Ok(instance) -> {

--- a/packages/beryl_channels/test/wire_matrix.gleam
+++ b/packages/beryl_channels/test/wire_matrix.gleam
@@ -72,7 +72,7 @@ pub const room_pattern = "room:*"
 // ---------------------------------------------------------------------------
 
 /// The hand-written `update` half of the matrix.
-pub fn raw_update() -> fn(Nil, socket.Input(Nil)) -> socket.Next(Nil, Nil) {
+pub fn raw_update() -> fn(Nil, socket.Input(Nil)) -> socket.Next(Nil) {
   let pattern = topic.parse_pattern(room_pattern)
   fn(model, input) { socket.Next(model, raw_effects(pattern, input)) }
 }
@@ -118,7 +118,7 @@ fn raw_join(
   pattern: topic.TopicPattern,
   name: String,
   payload: dynamic.Dynamic,
-  ref: socket.Ref,
+  ref: socket.JoinRef,
 ) -> List(socket.Effect) {
   use <- guard_reject(topic.matches(pattern, name), ref, unmatched_payload())
   use <- guard_reject(!denied(payload), ref, denied_payload())
@@ -127,7 +127,7 @@ fn raw_join(
 
 fn guard_reject(
   allowed: Bool,
-  ref: socket.Ref,
+  ref: socket.JoinRef,
   reason: json.Json,
   otherwise: fn() -> List(socket.Effect),
 ) -> List(socket.Effect) {

--- a/packages/beryl_ewe/README.md
+++ b/packages/beryl_ewe/README.md
@@ -43,7 +43,7 @@ fn init(_info: ConnectInfo(msg)) -> #(Model, List(socket.Effect)) {
   #(Model, [])
 }
 
-fn update(model: Model, ev: socket.Input(msg)) -> socket.Next(Model, msg) {
+fn update(model: Model, ev: socket.Input(msg)) -> socket.Next(Model) {
   case ev {
     Join("room:" <> _, _payload, ref) -> Next(model, [AcceptJoin(ref, None)])
     _ -> Next(model, [])

--- a/packages/beryl_ewe/test/app_test_helpers.gleam
+++ b/packages/beryl_ewe/test/app_test_helpers.gleam
@@ -6,7 +6,7 @@ import gleam/result
 pub fn start(
   config: beryl.Config,
   init init: fn(socket.ConnectInfo(msg)) -> #(model, List(socket.Effect)),
-  update update: fn(model, socket.Input(msg)) -> socket.Next(model, msg),
+  update update: fn(model, socket.Input(msg)) -> socket.Next(model),
 ) -> Result(beryl.Sockets, beryl.ConfigError) {
   use #(sockets, spec) <- result.try(beryl.child_spec(config, init:, update:))
   let assert Ok(_) =

--- a/packages/beryl_mist/README.md
+++ b/packages/beryl_mist/README.md
@@ -43,7 +43,7 @@ fn init(_info: ConnectInfo(msg)) -> #(Model, List(socket.Effect)) {
   #(Model, [])
 }
 
-fn update(model: Model, ev: socket.Input(msg)) -> socket.Next(Model, msg) {
+fn update(model: Model, ev: socket.Input(msg)) -> socket.Next(Model) {
   case ev {
     Join("room:" <> _, _payload, ref) -> Next(model, [AcceptJoin(ref, None)])
     _ -> Next(model, [])

--- a/packages/beryl_mist/test/app_test_helpers.gleam
+++ b/packages/beryl_mist/test/app_test_helpers.gleam
@@ -6,7 +6,7 @@ import gleam/result
 pub fn start(
   config: beryl.Config,
   init init: fn(socket.ConnectInfo(msg)) -> #(model, List(socket.Effect)),
-  update update: fn(model, socket.Input(msg)) -> socket.Next(model, msg),
+  update update: fn(model, socket.Input(msg)) -> socket.Next(model),
 ) -> Result(beryl.Sockets, beryl.ConfigError) {
   use #(sockets, spec) <- result.try(beryl.child_spec(config, init:, update:))
   let assert Ok(_) =

--- a/packages/beryl_mist/test/client_contract_test.gleam
+++ b/packages/beryl_mist/test/client_contract_test.gleam
@@ -75,7 +75,7 @@ pub fn aquamarine_client_joins_real_beryl_server_test() {
 }
 
 fn start_test_server(
-  update: fn(Nil, socket.Input(Nil)) -> socket.Next(Nil, Nil),
+  update: fn(Nil, socket.Input(Nil)) -> socket.Next(Nil),
 ) -> Result(TestServer, Nil) {
   let assert Ok(channels) =
     h.start(
@@ -122,7 +122,7 @@ fn stop_test_server(server: TestServer) -> Nil {
 /// reporting join/close through the `events` observer.
 fn lobby_update(
   events: process.Subject(TestEvent),
-) -> fn(Nil, socket.Input(Nil)) -> socket.Next(Nil, Nil) {
+) -> fn(Nil, socket.Input(Nil)) -> socket.Next(Nil) {
   fn(model, ev) {
     case ev {
       socket.Join(topic, _payload, ref) -> {
@@ -272,7 +272,7 @@ pub fn gluegun_raw_malformed_frame_gets_error_reply_test() {
 }
 
 /// A `test:rejected` behaviour: reject every join with status `error`.
-fn rejected_update() -> fn(Nil, socket.Input(Nil)) -> socket.Next(Nil, Nil) {
+fn rejected_update() -> fn(Nil, socket.Input(Nil)) -> socket.Next(Nil) {
   fn(model, ev) {
     case ev {
       socket.Join(_topic, _payload, ref) ->
@@ -289,7 +289,7 @@ fn rejected_update() -> fn(Nil, socket.Input(Nil)) -> socket.Next(Nil, Nil) {
 
 /// A `test:echo` behaviour: accept joins and reply to any client message
 /// with `{body: <body>}` echoed from the request payload.
-fn echo_update() -> fn(Nil, socket.Input(Nil)) -> socket.Next(Nil, Nil) {
+fn echo_update() -> fn(Nil, socket.Input(Nil)) -> socket.Next(Nil) {
   fn(model, ev) {
     case ev {
       socket.Join(_topic, _payload, ref) ->

--- a/packages/beryl_mist/test/phoenix_contract_test.gleam
+++ b/packages/beryl_mist/test/phoenix_contract_test.gleam
@@ -209,7 +209,7 @@ fn assert_no_text_message(client: WebsocketClient) {
 /// sender, and topic close reports its reason to `terminated`.
 fn contract_update(
   terminated: process.Subject(socket.StopReason),
-) -> fn(Nil, socket.Input(Nil)) -> socket.Next(Nil, Nil) {
+) -> fn(Nil, socket.Input(Nil)) -> socket.Next(Nil) {
   fn(model, ev) {
     case ev {
       socket.Join(_topic, _payload, ref) ->

--- a/website/src/content/docs/architecture/overview.md
+++ b/website/src/content/docs/architecture/overview.md
@@ -49,7 +49,7 @@ flowchart TB
 | `beryl` | Public entry-point: `config/1`, `child_spec/3`, `broadcast/4`, `broadcast_from/5`, `stop/1` | — |
 | `beryl_channels` | Recommended channel layer: handler validation, typed per-topic state, lifecycle callbacks, and lowering onto the public core | [Channels](/guides/channels/) |
 | `beryl_channels/channel` | Type-safe handler builders, callbacks, senders, actions, join results, and callback results | [Channels](/guides/channels/) |
-| `beryl/socket` | The app-facing dispatch types: `Input`, `Next`, `Effect`, `Ref`, `ConnectInfo`/`ConnectSeed`, typed `Sender`/`notify` | [Runtime](/architecture/runtime) |
+| `beryl/socket` | The app-facing dispatch types: `Input`, `Next`, `Effect`, `JoinRef`/`ReplyRef`, `ConnectInfo`/`ConnectSeed`, typed `Sender`/`notify` | [Runtime](/architecture/runtime) |
 | `beryl/runtime` | Central OTP actor: per-socket models, event dispatch, effect interpreter, heartbeat enforcement | [Runtime](/architecture/runtime) |
 | `beryl/pubsub` | Distributed pub-sub via Erlang `pg`; subscribe, broadcast, and broadcast_from | [PubSub & Distribution](/architecture/pubsub-and-distribution) |
 | `beryl/presence` | OTP actor wrapping an add-wins OR-set CRDT; track/untrack, cross-node diff broadcast, `on_diff` callbacks | [Presence](/architecture/presence) |

--- a/website/src/content/docs/guides/authentication.md
+++ b/website/src/content/docs/guides/authentication.md
@@ -158,7 +158,7 @@ and only needs to decide **authorization** — is this user allowed on *this*
 topic?
 
 ```gleam
-fn update(model: Model, ev: socket.Input(Msg)) -> socket.Next(Model, Msg) {
+fn update(model: Model, ev: socket.Input(Msg)) -> socket.Next(Model) {
   case ev {
     socket.Join(topic, _payload, ref) ->
       case model {

--- a/website/src/content/docs/guides/channels.md
+++ b/website/src/content/docs/guides/channels.md
@@ -431,7 +431,7 @@ immediately after the join acknowledgment.
 stay joined; override only what the channel cares about.
 
 A `channel.Message` carries `topic`, `event`, the raw `payload` as
-`Dynamic`, and `reply: Option(socket.Ref)` — present only when the client
+`Dynamic`, and `reply: Option(socket.ReplyRef)` — present only when the client
 asked for a reply:
 
 ```gleam

--- a/website/src/content/docs/guides/coming-from-phoenix.md
+++ b/website/src/content/docs/guides/coming-from-phoenix.md
@@ -63,7 +63,7 @@ Two practical consequences either way:
 | `handle_in/3` | `channel.on_message` | `socket.Message(topic, event, payload, ref)` |
 | `{:reply, {:ok, payload}, socket}` | `channel.reply_ok(ref, payload)` / `channel.reply_error(ref, payload)` action | `socket.ReplyOk(ref, payload)` / `socket.ReplyError(ref, payload)` |
 | `{:noreply, socket}` | `channel.continue(state)` | `socket.Next(model, [])` |
-| `socket_ref/1` + `Phoenix.Channel.reply/2` (reply later) | keep the `Ref` in the channel's state, `reply_ok` from a later callback (not from `on_terminate` — see below) | store the `Ref` in your model, `socket.ReplyOk` from a later `update` turn |
+| `socket_ref/1` + `Phoenix.Channel.reply/2` (reply later) | keep the `ReplyRef` in the channel's state, `reply_ok` from a later callback (not from `on_terminate` — see below) | store the `ReplyRef` in your model, `socket.ReplyOk` from a later `update` turn |
 | `push(socket, event, payload)` | `channel.push(event, payload)` action | `socket.Push(topic, event, payload)` effect |
 | `broadcast!/3` | `channel.broadcast(event, payload)` action | `socket.Broadcast(topic, event, payload)` effect |
 | `broadcast_from!/3` | `channel.broadcast_from(event, payload)` action | `socket.BroadcastFrom(topic, event, payload)` effect |
@@ -186,7 +186,7 @@ fn init(_info: socket.ConnectInfo(Msg)) -> #(Model, List(socket.Effect)) {
   #(Model(room_id: ""), [])
 }
 
-fn update(model: Model, ev: socket.Input(Msg)) -> socket.Next(Model, Msg) {
+fn update(model: Model, ev: socket.Input(Msg)) -> socket.Next(Model) {
   case ev {
     socket.Join("room:" <> room_id, _payload, ref) ->
       socket.Next(Model(room_id: room_id), [

--- a/website/src/content/docs/guides/dispatch.md
+++ b/website/src/content/docs/guides/dispatch.md
@@ -95,7 +95,7 @@ fn init(info: socket.ConnectInfo(Msg)) -> #(Model, List(socket.Effect)) {
   #(Model(joined_topics: [], self: info.self), [])
 }
 
-fn update(model: Model, ev: socket.Input(Msg)) -> socket.Next(Model, Msg) {
+fn update(model: Model, ev: socket.Input(Msg)) -> socket.Next(Model) {
   let room_pattern = topic.parse_pattern("room:*")
 
   case ev {
@@ -253,7 +253,7 @@ fn rooms(ctx: Ctx) -> router.Namespace(Model) {
   )
 }
 
-fn update(ctx: Ctx) -> fn(Model, socket.Input(Msg)) -> socket.Next(Model, Msg) {
+fn update(ctx: Ctx) -> fn(Model, socket.Input(Msg)) -> socket.Next(Model) {
   let namespaces = [router.accept_only("lobby"), rooms(ctx)]
   fn(model, input) {
     router.route(namespaces, router.unknown_topic(), model, input)

--- a/website/src/content/docs/guides/error-handling.md
+++ b/website/src/content/docs/guides/error-handling.md
@@ -9,7 +9,7 @@ This guide covers how beryl surfaces errors to your app and to connected clients
 Return a `RejectJoin` effect to reject a client. The error payload is sent back as a `phx_reply` with `status: "error"`:
 
 ```gleam
-fn update(model: Model, ev: Input(Msg)) -> Next(Model, Msg) {
+fn update(model: Model, ev: Input(Msg)) -> Next(Model) {
   case ev {
     socket.Join(topic, payload, ref) ->
       case authenticate(payload) {
@@ -89,7 +89,7 @@ socket.Message(_topic, "create_item", payload, option.Some(ref)) ->
 ```
 
 :::note[Refless messages cannot be answered]
-`ReplyOk`/`ReplyError` need the message's `Ref`, which is `Some` only when the client expects a reply. A `Message` whose ref is `None` has nothing to correlate an answer with — the type system makes an unanswerable reply unrepresentable. Use `Push` for server-initiated messages with your own event name.
+`ReplyOk`/`ReplyError` need the message's `ReplyRef`, which is `Some` only when the client expects a reply. A `Message` whose ref is `None` has nothing to correlate an answer with — the type system makes an unanswerable reply unrepresentable. Use `Push` for server-initiated messages with your own event name.
 :::
 
 ## Unmatched topics

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -78,7 +78,7 @@ pub type Model {
   Model(user_id: String, room_id: String)
 }
 
-fn update(model: Model, ev: socket.Input(Nil)) -> socket.Next(Model, Nil) {
+fn update(model: Model, ev: socket.Input(Nil)) -> socket.Next(Model) {
   case ev {
     socket.Join("room:" <> room_id, _payload, ref) ->
       socket.Next(Model(..model, room_id: room_id), [socket.AcceptJoin(ref, None)])

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -296,7 +296,7 @@ pub fn init(info: socket.ConnectInfo(Msg)) -> #(Model, List(socket.Effect)) {
   #(Model(socket_id: info.socket_id), [])
 }
 
-pub fn update(model: Model, ev: socket.Input(Msg)) -> socket.Next(Model, Msg) {
+pub fn update(model: Model, ev: socket.Input(Msg)) -> socket.Next(Model) {
   case ev {
     socket.Join("room:" <> _, payload, ref) ->
       socket.Next(

--- a/website/src/content/docs/reference/api/beryl-socket-router.md
+++ b/website/src/content/docs/reference/api/beryl-socket-router.md
@@ -85,8 +85,8 @@ Build a namespace from a topic pattern (`beryl/topic` syntax, e.g.
 ```gleam
 pub fn namespace(
   pattern: String,
-  join: fn(a, Match, dynamic.Dynamic, socket.Ref) -> #(a, List(socket.Effect)),
-  message: fn(a, Match, String, dynamic.Dynamic, option.Option(socket.Ref)) -> #(a, List(socket.Effect)),
+  join: fn(a, Match, dynamic.Dynamic, socket.JoinRef) -> #(a, List(socket.Effect)),
+  message: fn(a, Match, String, dynamic.Dynamic, option.Option(socket.ReplyRef)) -> #(a, List(socket.Effect)),
   closed: fn(a, Match, socket.StopReason) -> #(a, List(socket.Effect))
 ) -> Namespace(a)
 ```
@@ -105,7 +105,7 @@ pub fn route(
   json.Json,
   a,
   socket.Input(b)
-) -> socket.Next(a, b)
+) -> socket.Next(a)
 ```
 
 ### `unknown_topic`

--- a/website/src/content/docs/reference/api/beryl-socket.md
+++ b/website/src/content/docs/reference/api/beryl-socket.md
@@ -76,19 +76,19 @@ One update may return several effects, applied strictly in list order
 ```gleam
 pub type Effect {
   AcceptJoin(
-    ref: Ref,
+    ref: JoinRef,
     reply: option.Option(json.Json)
   )
   RejectJoin(
-    ref: Ref,
+    ref: JoinRef,
     reason: json.Json
   )
   ReplyOk(
-    ref: Ref,
+    ref: ReplyRef,
     payload: json.Json
   )
   ReplyError(
-    ref: Ref,
+    ref: ReplyRef,
     payload: json.Json
   )
   Push(
@@ -132,7 +132,7 @@ pub type Effect {
 #### Constructors
 
 ##### `AcceptJoin(
-  ref: Ref,
+  ref: JoinRef,
   reply: option.Option(json.Json)
 )`
 
@@ -141,21 +141,21 @@ Accept a pending join. Subscribes the socket to the topic and sends
  while the `Join` input's ref is pending.
 
 ##### `RejectJoin(
-  ref: Ref,
+  ref: JoinRef,
   reason: json.Json
 )`
 
 Reject a pending join with an error payload.
 
 ##### `ReplyOk(
-  ref: Ref,
+  ref: ReplyRef,
   payload: json.Json
 )`
 
 Reply successfully to a client message ref.
 
 ##### `ReplyError(
-  ref: Ref,
+  ref: ReplyRef,
   payload: json.Json
 )`
 
@@ -259,13 +259,13 @@ pub type Input(a) {
   Join(
     topic: String,
     payload: dynamic.Dynamic,
-    ref: Ref
+    ref: JoinRef
   )
   Message(
     topic: String,
     event: String,
     payload: dynamic.Dynamic,
-    ref: option.Option(Ref)
+    ref: option.Option(ReplyRef)
   )
   Binary(
     topic: String,
@@ -284,7 +284,7 @@ pub type Input(a) {
 ##### `Join(
   topic: String,
   payload: dynamic.Dynamic,
-  ref: Ref
+  ref: JoinRef
 )`
 
 A client asked to join a topic. Answer with `AcceptJoin` or
@@ -295,7 +295,7 @@ A client asked to join a topic. Answer with `AcceptJoin` or
   topic: String,
   event: String,
   payload: dynamic.Dynamic,
-  ref: option.Option(Ref)
+  ref: option.Option(ReplyRef)
 )`
 
 A client message on a joined topic. `ref` is present for messages
@@ -324,13 +324,25 @@ A joined topic ended (client leave, kick, crash, or socket close).
 A typed server-side message, sent via the socket's `Sender` (see
  `ConnectInfo.self` and `notify`).
 
+### `JoinRef`
+
+A pending join correlation handle.
+
+ Pass it back in `AcceptJoin` or `RejectJoin`. A join ref is valid only for
+ its pending join and carries a unique runtime token, so a delayed completion
+ for an older same-topic join cannot answer a replacement or retry.
+
+```gleam
+pub type JoinRef
+```
+
 ### `Next`
 
 The result of one `update` call: the next model plus effects to apply,
  or an instruction to stop the whole socket.
 
 ```gleam
-pub type Next(a, b) {
+pub type Next(a) {
   Next(
     model: a,
     effects: List(Effect)
@@ -353,20 +365,17 @@ Continue with the given model, applying the effects in order.
 Tear down the socket: every joined topic receives a `Closed` input,
  terminal frames are sent, and the transport connection is closed.
 
-### `Ref`
+### `ReplyRef`
 
-A reply correlation handle.
+A client message reply correlation handle.
 
- Carried by `Join` and (when the client requested a reply) `Message`
- inputs. Pass it back in `AcceptJoin`/`RejectJoin`/`ReplyOk`/`ReplyError`
- effects. Message refs may be stored in the model and answered from a later
- `update` turn (for example, after an async lookup completes). Join refs are
- valid only for their pending join and carry a unique runtime token, so a
- delayed completion for an older same-topic join cannot answer a replacement
- or retry.
+ Pass it back in `ReplyOk` or `ReplyError`. Reply refs may be stored in the
+ model and answered from a later `update` turn (for example, after an async
+ lookup completes). They are single-use and remain valid only while the
+ topic instance that received the message stays open.
 
 ```gleam
-pub type Ref
+pub type ReplyRef
 ```
 
 ### `Sender`
@@ -444,13 +453,13 @@ pub fn notify(
 
 A `ReplyOk` when the client supplied a ref; no effects otherwise.
 
- `Message` inputs carry `Option(Ref)` (refless messages expect no
- reply) while the `ReplyOk` effect demands a `Ref`, so every handler
+ `Message` inputs carry `Option(ReplyRef)` (refless messages expect no
+ reply) while the `ReplyOk` effect demands a `ReplyRef`, so every handler
  that replies conditionally needs this gate.
 
 ```gleam
 pub fn reply_ok(
-  option.Option(Ref),
+  option.Option(ReplyRef),
   json.Json
 ) -> List(Effect)
 ```

--- a/website/src/content/docs/reference/api/beryl-transport-server.md
+++ b/website/src/content/docs/reference/api/beryl-transport-server.md
@@ -213,7 +213,7 @@ Initialize a newly upgraded WebSocket connection in its connection
 pub fn init_connection(
   sockets: beryl.Sockets,
   seed: socket.ConnectSeed,
-  connection_permit: beryl.ConnectionPermit,
+  connection_permit: transport.ConnectionPermit,
   base_selector: process.Selector(SendRequest),
   logger_name: String,
   telemetry: transport.Telemetry,
@@ -285,7 +285,7 @@ pub fn upgrade(
   telemetry: transport.Telemetry,
   request_ip: fn(request.Request(a)) -> Result(String, Nil),
   reject: fn(Int) -> response.Response(b),
-  accept: fn(List(#(String, String)), beryl.ConnectionPermit) -> response.Response(b),
+  accept: fn(List(#(String, String)), transport.ConnectionPermit) -> response.Response(b),
   next: fn() -> response.Response(b)
 ) -> response.Response(b)
 ```

--- a/website/src/content/docs/reference/api/beryl-transport.md
+++ b/website/src/content/docs/reference/api/beryl-transport.md
@@ -14,10 +14,24 @@ Transport SPI — the contract between beryl core and WebSocket transport
 
  `beryl/transport/server` owns the shared admission, connection, rate,
  decode, and telemetry pipeline. This low-level SPI keeps only the hooks a
- transport implementation needs: exact-owner atomic admission, disconnect,
- text/binary routing, the configured codec, and transport telemetry.
+ transport implementation needs: connection-capacity permits, exact-owner
+ atomic admission, disconnect, text/binary routing, the configured codec,
+ and transport telemetry.
 
 ## Types
+
+### `ConnectionPermit`
+
+A held connection slot returned by `acquire_connection_slot`.
+
+ Hold it for the lifetime of the connection and pass it to
+ `release_connection_slot` when the connection closes. When no connection
+ limit is configured the permit is an admit-everything placeholder and
+ releasing it is a no-op.
+
+```gleam
+pub type ConnectionPermit
+```
 
 ### `FrameKind`
 
@@ -80,14 +94,6 @@ pub type UpgradeOutcome {
 
 ## Type aliases
 
-### `ConnectionPermit`
-
-Connection slot permit held by a transport connection.
-
-```gleam
-pub type ConnectionPermit = beryl.ConnectionPermit
-```
-
 ### `Sockets`
 
 Runtime handle accepted by transport implementations.
@@ -97,6 +103,21 @@ pub type Sockets = beryl.Sockets
 ```
 
 ## Functions
+
+### `acquire_connection_slot`
+
+Try to acquire a configured connection slot for a transport.
+
+ Pass the real socket peer IP, never a client-supplied address such as
+ `X-Forwarded-For`. Return `Error(Nil)` when the configured per-IP or
+ node-wide limit is already reached.
+
+```gleam
+pub fn acquire_connection_slot(
+  beryl.Sockets,
+  String
+) -> Result(ConnectionPermit, Nil)
+```
 
 ### `active_codec`
 
@@ -127,6 +148,33 @@ pub fn admit_socket(
   seed: socket.ConnectSeed,
   close: fn() -> Nil
 ) -> Result(Nil, Nil)
+```
+
+### `bind_connection_slot`
+
+Bind an acquired connection slot to the calling connection process.
+
+ The limiter monitors the caller so the slot is reclaimed if the process
+ dies without running its close path.
+
+```gleam
+pub fn bind_connection_slot(ConnectionPermit) -> Nil
+```
+
+### `max_inbound_frame_bytes`
+
+Return the configured inbound frame size cap for transports.
+
+```gleam
+pub fn max_inbound_frame_bytes(beryl.Sockets) -> Int
+```
+
+### `release_connection_slot`
+
+Release a connection slot acquired by a transport.
+
+```gleam
+pub fn release_connection_slot(ConnectionPermit) -> Nil
 ```
 
 ### `route_binary`

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -125,20 +125,6 @@ A per-topic-pattern rate limit used a pattern string that is not a valid
  when you act on them differently, and otherwise keep a catch-all arm
  such as `InvalidTopicPattern(pattern, _)`.
 
-### `ConnectionPermit`
-
-A held per-IP connection slot returned by `acquire_connection_slot`.
-
- Opaque so Beryl can restructure the connection limiter without breaking
- transport authors. Hold it for the lifetime of the connection and pass it
- to `release_connection_slot` when the connection closes. When no per-IP
- limit is configured the permit is an admit-everything placeholder and
- releasing it is a no-op.
-
-```gleam
-pub type ConnectionPermit
-```
-
 ### `LoggingConfig`
 
 Logging configuration for Beryl diagnostics.
@@ -211,39 +197,6 @@ The runtime did not acknowledge the stop request within the shutdown
  window. The system may still be terminating.
 
 ## Functions
-
-### `acquire_connection_slot`
-
-Try to acquire a configured per-IP connection slot for transports.
-
- Transports call this before admitting a connection, passing the **real
- socket peer IP**. Do not pass a client-supplied address (e.g. from
- `X-Forwarded-For`): a spoofed value would defeat the per-IP limit. Returns
- `Ok(permit)` when admitted (release the permit with
- `release_connection_slot` on close; when no limit is configured every
- connection is admitted), or `Error(Nil)` when the peer is already at its
- limit.
-
-```gleam
-pub fn acquire_connection_slot(
-  Sockets,
-  String
-) -> Result(ConnectionPermit, Nil)
-```
-
-### `bind_connection_slot`
-
-Bind an acquired connection slot to the calling process.
-
- Call this from the long-lived connection process (e.g. the WebSocket
- handler's init) after `acquire_connection_slot`. The limiter monitors the
- caller so the slot is reclaimed even if the connection process dies
- without running its close path — otherwise crashed connections would
- permanently exhaust their IP's slots.
-
-```gleam
-pub fn bind_connection_slot(ConnectionPermit) -> Nil
-```
 
 ### `broadcast`
 
@@ -360,7 +313,7 @@ Build the app-side dispatch supervision child specification.
 pub fn child_spec(
   Config,
   init: fn(socket.ConnectInfo(a)) -> #(b, List(socket.Effect)),
-  update: fn(b, socket.Input(a)) -> socket.Next(b, a)
+  update: fn(b, socket.Input(a)) -> socket.Next(b)
 ) -> Result(#(Sockets, supervision.ChildSpecification(static_supervisor.Supervisor)), ConfigError)
 ```
 
@@ -389,25 +342,6 @@ pub fn logging_config(
   level: LogLevel,
   include_payloads: Bool
 ) -> LoggingConfig
-```
-
-### `max_inbound_frame_bytes`
-
-Return the configured inbound frame size cap for transports.
-
-```gleam
-pub fn max_inbound_frame_bytes(Sockets) -> Int
-```
-
-### `release_connection_slot`
-
-Release a per-IP connection slot acquired by a transport.
-
- Call from the process the permit was bound to (or from an unbound
- process when releasing before the connection was established).
-
-```gleam
-pub fn release_connection_slot(ConnectionPermit) -> Nil
 ```
 
 ### `stop`

--- a/website/src/content/docs/reference/api/beryl_channels-channel.md
+++ b/website/src/content/docs/reference/api/beryl_channels-channel.md
@@ -184,7 +184,7 @@ pub type Message {
     topic: String,
     event: String,
     payload: dynamic.Dynamic,
-    reply: option.Option(socket.Ref)
+    reply: option.Option(socket.ReplyRef)
   )
 }
 ```
@@ -566,7 +566,7 @@ Reply with an error to a client message, using the `reply` handle from
 ```gleam
 pub fn reply_error(
   Actions,
-  socket.Ref,
+  socket.ReplyRef,
   json.Json
 ) -> Actions
 ```
@@ -579,7 +579,7 @@ Reply successfully to a client message, using the `reply` handle from
 ```gleam
 pub fn reply_ok(
   Actions,
-  socket.Ref,
+  socket.ReplyRef,
   json.Json
 ) -> Actions
 ```


### PR DESCRIPTION
- Make `socket.Next` model-only and split `JoinRef` from `ReplyRef`.
- Move connection permits and admission helpers under `beryl/transport`.
- Preserve delayed reply and pending join behavior while migrating callers and docs.
- Part of #311