### PR TITLE
ci: use sticky-pull-request-comment for bot PR comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,26 +329,7 @@ jobs:
         run: node load/k6/render-smoke-comment.mjs smoke-artifacts "$RUN_URL" > smoke-comment.md
 
       - name: Update sticky PR comment
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          marker="<!-- beryl-protocol-smoke -->"
-          comment_id="$(
-            gh api \
-              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-              --paginate \
-              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$marker\"))) | .id" \
-              | head -n 1
-          )"
-          if [[ -n "$comment_id" ]]; then
-            gh api \
-              --method PATCH \
-              "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
-              --raw-field body="$(cat smoke-comment.md)"
-          else
-            gh api \
-              --method POST \
-              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-              --raw-field body="$(cat smoke-comment.md)"
-          fi
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # ratchet:marocchino/sticky-pull-request-comment@v3
+        with:
+          header: beryl-protocol-smoke
+          path: smoke-comment.md

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,39 +57,16 @@ jobs:
             --head ${{ github.event.pull_request.head.sha }} \
             --format github >> "$GITHUB_OUTPUT"
 
-      # Sticky comment keyed on an HTML marker: one comment per PR, rewritten
-      # on every push. `gh pr comment --edit-last` can't be used here — it
-      # edits the newest github-actions[bot] comment whatever its content, so
-      # it clobbers the protocol-smoke comment from ci.yml and both workflows
-      # then keep re-creating each other's comments.
+      # `header` scopes the sticky comment to this workflow. `gh pr comment
+      # --edit-last` can't be used here — it edits the newest
+      # github-actions[bot] comment whatever its content, so it clobbers the
+      # protocol-smoke comment from ci.yml and both then re-create each other.
       - name: Comment changelog preview
         if: steps.changelog.outputs.preview != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PREVIEW: ${{ steps.changelog.outputs.preview }}
-        run: |
-          marker="<!-- beryl-changelog-check -->"
-          body="$marker
-          $PREVIEW"
-          comment_id="$(
-            gh api \
-              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-              --paginate \
-              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$marker\"))) | .id" \
-              | head -n 1
-          )"
-          if [[ -n "$comment_id" ]]; then
-            gh api \
-              --method PATCH \
-              "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
-              --raw-field body="$body"
-          else
-            gh api \
-              --method POST \
-              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-              --raw-field body="$body"
-          fi
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # ratchet:marocchino/sticky-pull-request-comment@v3
+        with:
+          header: beryl-changelog-check
+          message: ${{ steps.changelog.outputs.preview }}
 
       - name: Fail on missing changelog fragments
         if: steps.changelog.outcome == 'failure'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,16 +57,39 @@ jobs:
             --head ${{ github.event.pull_request.head.sha }} \
             --format github >> "$GITHUB_OUTPUT"
 
-      # `--edit-last --create-if-none` makes this a sticky comment: one
-      # comment per PR, rewritten on every push.
+      # Sticky comment keyed on an HTML marker: one comment per PR, rewritten
+      # on every push. `gh pr comment --edit-last` can't be used here — it
+      # edits the newest github-actions[bot] comment whatever its content, so
+      # it clobbers the protocol-smoke comment from ci.yml and both workflows
+      # then keep re-creating each other's comments.
       - name: Comment changelog preview
         if: steps.changelog.outputs.preview != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PREVIEW: ${{ steps.changelog.outputs.preview }}
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} \
-            --edit-last --create-if-none --body "$PREVIEW"
+          marker="<!-- beryl-changelog-check -->"
+          body="$marker
+          $PREVIEW"
+          comment_id="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              --paginate \
+              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$marker\"))) | .id" \
+              | head -n 1
+          )"
+          if [[ -n "$comment_id" ]]; then
+            gh api \
+              --method PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
+              --raw-field body="$body"
+          else
+            gh api \
+              --method POST \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              --raw-field body="$body"
+          fi
 
       - name: Fail on missing changelog fragments
         if: steps.changelog.outcome == 'failure'

--- a/load/k6/render-smoke-comment.mjs
+++ b/load/k6/render-smoke-comment.mjs
@@ -73,8 +73,7 @@ export async function renderSmokeComment(directory, runUrl = "") {
     [...summaries.values()].every(passed);
   const runLink = runUrl ? ` [Workflow run](${runUrl}).` : "";
 
-  return `<!-- beryl-protocol-smoke -->
-## Protocol smoke
+  return `## Protocol smoke
 
 ${allPassed ? "✅ All protocol smoke checks passed." : "❌ One or more protocol smoke checks failed or produced no summary."}${runLink}
 


### PR DESCRIPTION
`gh pr comment --edit-last` edits the newest `github-actions[bot]` comment regardless of content, so the changelog step in `pr.yml` overwrote the protocol-smoke comment posted by `ci.yml`. That job then found its marker gone and posted a fresh one — leaving a duplicate changelog table behind on every push ([#314](https://github.com/tylerbutler/beryl/pull/314) has two).

Both jobs now use [`marocchino/sticky-pull-request-comment`](https://github.com/marocchino/sticky-pull-request-comment), whose `header` input scopes each sticky comment to its own workflow:

| workflow | job | header |
| --- | --- | --- |
| `pr.yml` | Changelog | `beryl-changelog-check` |
| `ci.yml` | Protocol smoke report | `beryl-protocol-smoke` |

This replaces the hand-rolled find-by-marker PATCH/POST block in `ci.yml` and the equivalent one added earlier in this branch — net −43 lines. `path: smoke-comment.md` reads the rendered report directly, so the smoke job's `GH_TOKEN`/`PR_NUMBER` env and `cat` go away too. The action is SHA-pinned with a `ratchet:` comment, matching `pnpm/action-setup` and `jdx/mise-action`.

`render-smoke-comment.mjs` no longer emits its own `<!-- beryl-protocol-smoke -->` line, since the action supplies the hidden marker. `node load/k6/check-smoke-comment.mjs` passes.

### Notes

- `pull_request` runs use the workflow from the PR's own branch, so open PRs keep the old behavior until they rebase onto this.
- Neither header matches the existing marker-less comments, so the first run after merge posts one fresh comment per job. The stale ones on #314 need deleting by hand.