### PR TITLE
chore: bump trellis to 0.11.2

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-"github:tylerbutler/trellis" = "0.11.0"
+"github:tylerbutler/trellis" = "0.11.2"
 
 [env]
 LC_ALL = "en_US.UTF-8"


### PR DESCRIPTION
## Summary
- Bump pinned trellis version in `.mise.toml` from 0.11.0 to 0.11.2 for local development
