### PR TITLE
docs(security): clarify frame limit is not a memory bound

### DIFF
--- a/.changes/unreleased/beryl-correct-the-production-hardening.toml
+++ b/.changes/unreleased/beryl-correct-the-production-hardening.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Correct the production-hardening guide to explain that inbound frame-size enforcement occurs after transport buffering and requires an edge limit to bound memory."

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -12,7 +12,8 @@ off; this guide explains what to turn on and why.
 
 Even with no configuration, beryl enforces:
 
-- **Frame size**: inbound WebSocket frames over 1 MiB close the connection
+- **Post-receipt frame size**: once the transport has assembled a complete
+  inbound WebSocket frame, Beryl closes the connection if it exceeds 1 MiB
   (`with_max_inbound_frame_bytes` to adjust).
 - **Topic and event lengths**: topics over 256 bytes and event names over 64
   bytes are rejected before reaching your app
@@ -23,6 +24,12 @@ Even with no configuration, beryl enforces:
   and messages carrying a stale `join_ref` are dropped.
 - **Heartbeat eviction**: sockets that stop sending heartbeats are evicted
   and their connections closed (60 s window by default, `with_heartbeat`).
+
+The frame-size check limits downstream decoding and routing work, but it does
+**not** bound transport-layer memory: buffering and reassembly happen before
+Beryl receives the frame. In production, configure a WebSocket frame/message
+size limit at or below Beryl's limit at your reverse proxy or load balancer,
+plus a matching request/body limit for the HTTP upgrade.
 
 ## What you should configure for production
 


### PR DESCRIPTION
Operators could read the production-hardening guide as promising that Beryl's
1 MiB inbound-frame cap protects transport memory. This clarifies that the cap
runs only after buffering and reassembly, and identifies the edge controls
needed for an actual memory boundary.

Closes #241.

## What changed

- Describe the always-on frame cap as post-receipt enforcement.
- Explain that it bounds downstream decode and routing work, not transport
  buffering.
- Direct production deployments to matching WebSocket and HTTP upgrade limits
  at the reverse proxy or load balancer.
- Add a Beryl `Fixed` changelog fragment.

Scope: 2 changed files, one concern.

Pre-edit estimate: 2 files (the production-hardening guide and its changelog
fragment). The implementation stayed within that scope.

## Validation

- `just changelog-check` - passed; Beryl has one valid fragment against
  `origin/main`.
- `pnpm -C website check:astro` - passed with 0 errors, 0 warnings, and 0
  hints.
- Runtime tests were not run because this changes documentation only.

To preview locally, run `pnpm -C website dev` and open
<http://localhost:4321/guides/production-hardening/>.

Authored with [Minions](https://icy-water-0224cc51e.2.azurestaticapps.net/minions).
