### PR TITLE
docs(security): clarify cookie limits and peer compromise

### DIFF
--- a/.changes/unreleased/beryl-clarify-that-erlang-cookies.toml
+++ b/.changes/unreleased/beryl-clarify-that-erlang-cookies.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Security"
+body = "Clarify that Erlang cookies prevent accidental cluster joins while network isolation and mutually verified TLS secure distribution peers."

--- a/.changes/unreleased/beryl-clarify-that-erlang-cookies.toml
+++ b/.changes/unreleased/beryl-clarify-that-erlang-cookies.toml
@@ -1,3 +1,0 @@
-package = "beryl"
-kind = "Security"
-body = "Clarify that Erlang cookies prevent accidental cluster joins while network isolation and mutually verified TLS secure distribution peers."

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,8 +38,11 @@ the standard, correct BEAM model, and it has one blunt consequence:
 Application- and socket-level authorization — `on_connect`, per-topic join
 checks in the app's `update`, rate limits — protects you against untrusted
 **WebSocket clients**. It
-does **not** protect you against a hostile **distribution peer**. A malicious or
-compromised node that has joined your cluster can:
+does **not** protect you against a hostile **distribution peer**. Distributed
+Erlang allows peers to execute arbitrary code on connected nodes, so a
+malicious or compromised peer means full node compromise that can extend
+across the cluster. Its beryl-specific capabilities are only a subset of that
+access:
 
 - Publish arbitrary internal beryl PubSub messages, including to reserved
   `beryl:*` topics that clients are never allowed to reach. Those messages are
@@ -61,31 +64,36 @@ If you run more than one node, you must secure Erlang distribution itself.
 None of the following is specific to beryl; it is the baseline for any
 distributed BEAM application, and beryl assumes you have done it.
 
-### Use a strong, protected Erlang cookie
+### Protect and randomize the Erlang cookie
 
-Nodes authenticate to one another with a shared **Erlang cookie**. Any node
-that knows the cookie can join the cluster and is then fully trusted (see the
-trust boundary above).
+Nodes compare a shared **Erlang cookie** when connecting. Erlang
+[documents this mechanism](https://www.erlang.org/doc/system/distributed.html#security)
+as protection against accidental cross-cluster connections, not as
+cryptographically secure authentication against an adversary. Any node that
+knows the cookie and can reach a distribution port can join the cluster and is
+then fully trusted (see the trust boundary above).
 
 - Generate a long, high-entropy cookie; never ship the default `~/.erlang.cookie`
   that some tooling auto-generates, and never commit a cookie to source control.
+  This prevents accidental matches and makes offline guessing harder, but does
+  not make plain Erlang distribution secure.
 - Distribute it as a secret (secrets manager, orchestrator secret, restricted
   file with `0400` permissions owned by the runtime user) — not in an image
   layer, environment dump, or log.
 - Rotate it if it may have been exposed.
 
-The cookie is an authentication token, but it is transmitted and used in a way
-that provides **no confidentiality on its own**. It is not a substitute for
-transport encryption.
+The cookie is a cluster-membership tag, not a security boundary. Network
+isolation is always required, and TLS distribution with mutual certificate
+verification provides cryptographic peer authentication, confidentiality, and
+integrity.
 
-### Use TLS distribution across untrusted networks
+### Use mutually verified TLS distribution
 
-Plain Erlang distribution traffic is unencrypted and unauthenticated at the
-transport layer. For any distribution traffic that crosses a network you do not
-fully control — between availability zones, across a cloud VPC boundary, or over
-the public internet — enable **TLS distribution** (`inet_tls_dist`) with mutual
-certificate verification. This protects cookie exchange and inter-node payloads
-from eavesdropping and tampering. See the Erlang/OTP
+Plain Erlang distribution traffic is unencrypted and its handshake is not
+cryptographically secure. Use **TLS distribution** (`inet_tls_dist`) with
+mutual certificate verification for secure multi-node deployments, including
+traffic within private networks. This protects the handshake and inter-node
+payloads from eavesdropping, tampering, and peer impersonation. See the Erlang/OTP
 [Using TLS for Erlang Distribution](https://www.erlang.org/doc/apps/ssl/ssl_distribution.html)
 guide.
 

--- a/website/src/content/docs/architecture/pubsub-and-distribution.md
+++ b/website/src/content/docs/architecture/pubsub-and-distribution.md
@@ -75,8 +75,11 @@ When socket A sends a message on Node 1, its runtime calls `broadcast_from`, whi
 ## Trust Model
 
 All traffic arriving over Erlang distribution is treated as **fully trusted
-cluster input**. There is no additional authentication layer between nodes:
-the Erlang cookie and network controls are the security boundary.
+cluster input**. A peer can execute arbitrary code on connected nodes; the
+beryl-specific capabilities below are only a subset of that access. Network
+isolation and mutually verified TLS distribution enforce the security
+boundary. Erlang cookies prevent accidental cross-cluster connections but are
+not cryptographically secure peer authentication.
 
 A process on any peer node can:
 
@@ -92,8 +95,8 @@ applies only to inbound WebSocket frames. It does not screen messages that
 arrive via distribution.
 
 Refer to the [Production Hardening guide](/guides/production-hardening/#erlang-cluster-security-boundary)
-for the full cluster security requirements (cookie strength, TLS
-distribution, EPMD port restrictions, and cluster isolation).
+for the full cluster security requirements (network isolation, mutually
+verified TLS distribution, EPMD port restrictions, and cookie handling).
 
 ## Where this lives
 

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -107,31 +107,36 @@ attackers rotating connections.
 ## Erlang cluster security boundary
 
 Beryl's distributed PubSub and presence replication run over Erlang
-distribution. Every node in your Erlang cluster is **fully trusted**: a
-process on any peer node can subscribe to any topic, receive all
-broadcasts, and deliver messages that beryl's runtime will process as
-legitimate internal traffic. Channel authorization callbacks and
-WebSocket-layer controls do **not** apply to messages delivered over
-distribution — they protect only inbound WebSocket clients.
+distribution. Every connected peer is **fully trusted**: distributed Erlang
+allows peers to execute arbitrary code on connected nodes, so a hostile peer
+means full node compromise that can extend across the cluster. Subscribing to
+beryl topics, receiving broadcasts, injecting trusted internal traffic, and
+reading or corrupting presence state are only a subset of that access. Channel
+authorization callbacks and WebSocket-layer controls do **not** apply to
+messages delivered over distribution — they protect only inbound WebSocket
+clients.
 
 ### Internal vs. client messages
 
 | Source | Trust level | Gated by |
 |---|---|---|
 | WebSocket clients | Untrusted | `with_on_connect` authentication, `Join` authorization, and `Message` handling in `update` |
-| Erlang distribution peers | Fully trusted | Erlang cookie + network controls |
+| Erlang distribution peers | Fully trusted | Network isolation + mutually verified TLS distribution (cookies prevent accidental cross-cluster connections only) |
 
-A hostile distribution peer can broadcast arbitrary messages into any
-topic and read all presence state. Secure the cluster boundary **before**
-deploying multi-node beryl.
+This is not a beryl-specific deployment prerequisite. Network isolation and
+secure distribution are the baseline for every distributed BEAM application;
+beryl assumes that boundary is already enforced.
 
 ### Erlang cookie
 
 Set a long, randomly generated cookie in `vm.args` or the
-`RELEASE_COOKIE` environment variable. The cookie is the only
-authentication mechanism for distribution peers; a weak or default cookie
-(`CHANGE_ME`, the hostname, etc.) allows any process that can reach your
-distribution port to join the cluster.
+`RELEASE_COOKIE` environment variable. Erlang
+[uses the cookie to distinguish clusters](https://www.erlang.org/doc/system/distributed.html#security)
+and prevent accidental cross-cluster connections; its handshake is not
+cryptographically secure authentication against an adversary. A strong cookie
+prevents accidental matches and makes offline guessing harder, but it must
+never be the security boundary. Keep distribution ports isolated and use
+mutually verified TLS distribution.
 
 Generate a strong cookie with, for example:
 
@@ -141,9 +146,8 @@ openssl rand -base64 48
 
 ### TLS distribution
 
-When nodes communicate across networks you do not fully control — cloud
-subnets, VPNs, or any link that may traverse untrusted infrastructure —
-enable TLS distribution. See the
+Use TLS distribution with mutual certificate verification for secure
+multi-node deployments, including traffic within private networks. See the
 [Erlang TLS Distribution guide](https://www.erlang.org/doc/apps/ssl/ssl_distribution.html)
 for setup instructions.
 
@@ -165,10 +169,10 @@ and your chosen distribution port at the network layer.
 
 ### Do not share clusters with untrusted tenants
 
-Adding a node to an existing cluster grants it full visibility into all `pg`
-groups (PubSub topics) and all presence state on every node. Never connect
-beryl to a cluster that contains nodes owned or operated by parties outside
-your trust boundary.
+Adding a node to an existing cluster grants it arbitrary code execution on
+connected nodes; visibility into all `pg` groups (PubSub topics) and presence
+state is only part of that access. Never connect beryl to a cluster that
+contains nodes owned or operated by parties outside your trust boundary.
 
 See [SECURITY.md](https://github.com/tylerbutler/beryl/blob/main/SECURITY.md)
 for the full trust-boundary and distribution-hardening reference.


### PR DESCRIPTION
Operators could mistake Erlang cookies for adversarial peer authentication and
underestimate a distribution peer as only a beryl PubSub/presence risk. This
change documents the actual boundary: a hostile peer has arbitrary code
execution on connected nodes, potentially compromising the cluster.

## What changed

- Reframe Erlang cookies as accidental cross-cluster connection prevention,
  backed by Erlang's official security guidance.
- Make network isolation and mutually verified TLS distribution the security
  mechanisms for multi-node deployments.
- Lead with full node/cluster compromise and present beryl-specific PubSub and
  presence effects as a subset of that access.
- Align the production-hardening guide, security policy, and PubSub architecture
  page.

Scope: 3 changed files, one concern.

## Validation

- `just docs` — generated all package docs and 19 website API reference pages.
- `just site-build` — built 47 website pages and reported all internal links
  valid.

## Run locally

Run `just site-deps && just site-dev`, then open
<http://localhost:4321/guides/production-hardening/>.

Closes #231

Authored with [Minions](https://icy-water-0224cc51e.2.azurestaticapps.net/minions).
