### PR TITLE
docs(rate-limit): preserve heartbeat flood eviction

### DIFF
--- a/.changes/unreleased/beryl-document-that-rate-limited.toml
+++ b/.changes/unreleased/beryl-document-that-rate-limited.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Document that rate-limited heartbeats do not refresh socket deadlines and sustained over-rate traffic is closed by heartbeat eviction."

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -372,6 +372,8 @@ pub fn with_payload_preview_bytes(
 /// Every complete inbound text or binary frame consumes this independent
 /// bucket before decoding. Configure it alongside `with_message_rate` to
 /// combine edge shedding with a runtime cap on decoded non-join traffic.
+/// An over-rate heartbeat is shed before it can refresh the socket's heartbeat
+/// deadline, so a sustained flood is eventually closed by heartbeat eviction.
 pub fn with_frame_rate(
   config: Config,
   per_second rate: Int,
@@ -384,7 +386,9 @@ pub fn with_frame_rate(
 ///
 /// Joins use `with_join_rate`; decoded leaves, heartbeats, events, decoded
 /// binary, and raw `Binary` inputs consume this bucket. It is independent of
-/// `with_frame_rate`.
+/// `with_frame_rate`. An over-rate heartbeat does not refresh the socket's
+/// heartbeat deadline, so a sustained flood is eventually closed by heartbeat
+/// eviction. Leave enough rate and burst headroom for legitimate heartbeats.
 pub fn with_message_rate(
   config: Config,
   per_second rate: Int,

--- a/packages/beryl/src/beryl/transport.gleam
+++ b/packages/beryl/src/beryl/transport.gleam
@@ -189,6 +189,11 @@ pub fn socket_disconnected(
 /// Route a transport-decoded inbound message to the runtime. Decode in
 /// the connection process (see `active_codec`) so parse cost and malformed
 /// input never reach the shared runtime.
+///
+/// Runtime message-rate limiting applies after routing. If it sheds a
+/// heartbeat, that heartbeat does not refresh the socket's deadline; sustained
+/// over-rate traffic therefore leads to heartbeat eviction and a call to the
+/// closer registered by `admit_socket`.
 pub fn route_decoded(
   sockets sockets: Sockets,
   socket_id socket_id: String,

--- a/packages/beryl/test/app_heartbeat_test.gleam
+++ b/packages/beryl/test/app_heartbeat_test.gleam
@@ -20,6 +20,17 @@ fn start_system(events: process.Subject(socket.Input(Nil))) -> beryl.Sockets {
   )
 }
 
+fn start_message_limited_system(
+  events: process.Subject(socket.Input(Nil)),
+) -> beryl.Sockets {
+  h.start_observed(
+    beryl.config(wire.phoenix_codec())
+      |> beryl.with_heartbeat(timeout_ms: 40)
+      |> beryl.with_message_rate(per_second: 1, burst: 1),
+    events,
+  )
+}
+
 fn connect_with_closer(
   channels: beryl.Sockets,
   socket_id: String,
@@ -94,6 +105,37 @@ pub fn active_socket_survives_while_stale_peer_is_evicted_test() {
   // The active socket still serves: it can join another topic.
   h.join(channels, "active", "room:b", "jr-3", "r-3")
   h.recv(active) |> string.contains("\"status\":\"ok\"") |> should.be_true
+}
+
+pub fn message_rate_limited_heartbeats_lead_to_eviction_test() {
+  let events = process.new_subject()
+  let channels = start_message_limited_system(events)
+  let closed = process.new_subject()
+  let frames = connect_with_closer(channels, "flooding", closed)
+
+  // Spend the only burst token on a heartbeat, then keep sending heartbeats
+  // faster than the bucket can refill. The shed heartbeats must not refresh
+  // last_heartbeat, so the normal timeout path closes the connection.
+  h.route(channels, "flooding", "[null,\"hb\",\"phoenix\",\"heartbeat\",{}]")
+  let _heartbeat_reply = h.recv(frames)
+  flood_heartbeats(channels, "flooding", 20)
+
+  process.receive(closed, 1000) |> should.equal(Ok(Nil))
+}
+
+fn flood_heartbeats(
+  channels: beryl.Sockets,
+  socket_id: String,
+  remaining: Int,
+) -> Nil {
+  case remaining <= 0 {
+    True -> Nil
+    False -> {
+      h.route(channels, socket_id, "[null,\"hb\",\"phoenix\",\"heartbeat\",{}]")
+      process.sleep(5)
+      flood_heartbeats(channels, socket_id, remaining - 1)
+    }
+  }
 }
 
 fn send_heartbeats(

--- a/packages/beryl/test/transport_server_rate_test.gleam
+++ b/packages/beryl/test/transport_server_rate_test.gleam
@@ -89,6 +89,17 @@ fn recv(conn: Conn) -> Result(String, Nil) {
   }
 }
 
+fn flood_heartbeats(conn: Conn, remaining: Int) -> Conn {
+  case remaining <= 0 {
+    True -> conn
+    False -> {
+      let conn = send_text(conn, heartbeat("flood"))
+      process.sleep(5)
+      flood_heartbeats(conn, remaining - 1)
+    }
+  }
+}
+
 // ── Frame-only ───────────────────────────────────────────────────────────
 
 pub fn frame_rate_alone_sheds_flood_before_decode_test() {
@@ -121,6 +132,26 @@ pub fn frame_rate_counts_malformed_frames_test() {
   // The single frame token was spent on the malformed frame, so the
   // following valid heartbeat is shed at the edge with no reply.
   recv(conn) |> should.equal(Error(Nil))
+}
+
+pub fn frame_rate_limited_heartbeats_lead_to_eviction_test() {
+  let config =
+    beryl.config(wire.phoenix_codec())
+    |> beryl.with_heartbeat(timeout_ms: 40)
+    |> beryl.with_frame_rate(per_second: 1, burst: 1)
+  let channels = start_system(config)
+  let conn = connect(channels, "10.10.10.6")
+
+  // Spend the only burst token on a heartbeat, then keep sending heartbeats
+  // faster than the edge bucket can refill. None of the shed frames reach the
+  // runtime, so the normal timeout path asks the transport to close.
+  let conn = send_text(conn, heartbeat("hb-1"))
+  let assert Ok(reply) = recv(conn)
+  reply |> string.contains("hb-1") |> should.be_true
+  let conn = flood_heartbeats(conn, 20)
+
+  process.selector_receive(from: conn.selector, within: 1000)
+  |> should.equal(Ok(server.Close))
 }
 
 // ── Message-only ─────────────────────────────────────────────────────────

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -48,7 +48,15 @@ let config =
 `with_frame_rate` and `with_message_rate` are independent. Joins consume frame
 and join quota, but not message quota; leaves and heartbeats consume both frame
 and message quota. Configure both, with frame capacity slightly higher for
-protocol traffic and malformed frames that never reach the runtime.
+protocol traffic and malformed frames that never reach the runtime. If either
+limiter sheds a heartbeat, the socket's heartbeat deadline is not refreshed.
+Sustained over-rate traffic is therefore terminated by heartbeat eviction
+rather than merely being shed forever.
+
+Size both rate and burst allowances with enough headroom for legitimate client
+traffic **plus heartbeats**. A limit that admits an application's normal events
+but leaves no heartbeat capacity can evict healthy clients during ordinary
+bursts.
 
 Optionally, `with_channel_rate` adds a per-socket-per-topic limit on top of
 the global per-socket message rate, useful when a single busy topic must not

--- a/website/src/content/docs/reference/api/beryl-transport.md
+++ b/website/src/content/docs/reference/api/beryl-transport.md
@@ -196,6 +196,11 @@ Route a transport-decoded inbound message to the runtime. Decode in
  the connection process (see `active_codec`) so parse cost and malformed
  input never reach the shared runtime.
 
+ Runtime message-rate limiting applies after routing. If it sheds a
+ heartbeat, that heartbeat does not refresh the socket's deadline; sustained
+ over-rate traffic therefore leads to heartbeat eviction and a call to the
+ closer registered by `admit_socket`.
+
 ```gleam
 pub fn route_decoded(
   sockets: beryl.Sockets,

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -410,6 +410,8 @@ Configure per-connection frame-rate limiting at the transport edge.
  Every complete inbound text or binary frame consumes this independent
  bucket before decoding. Configure it alongside `with_message_rate` to
  combine edge shedding with a runtime cap on decoded non-join traffic.
+ An over-rate heartbeat is shed before it can refresh the socket's heartbeat
+ deadline, so a sustained flood is eventually closed by heartbeat eviction.
 
 ```gleam
 pub fn with_frame_rate(
@@ -605,7 +607,9 @@ Configure per-socket decoded message-rate limiting in the runtime.
 
  Joins use `with_join_rate`; decoded leaves, heartbeats, events, decoded
  binary, and raw `Binary` inputs consume this bucket. It is independent of
- `with_frame_rate`.
+ `with_frame_rate`. An over-rate heartbeat does not refresh the socket's
+ heartbeat deadline, so a sustained flood is eventually closed by heartbeat
+ eviction. Leave enough rate and burst headroom for legitimate heartbeats.
 
 ```gleam
 pub fn with_message_rate(


### PR DESCRIPTION
Sustained client floods can shed the very heartbeats that would otherwise keep a socket alive. This makes the intended outcome explicit: rate-limited heartbeats do not refresh the deadline, so continued over-rate traffic ends in heartbeat eviction rather than an immortal connection.

## What changed

- Document the eviction interaction and legitimate-client headroom guidance for both frame and message limits.
- Pin both independent paths with runtime and `beryl/transport/server` regression tests.
- Regenerate the public API references and add a beryl changelog fragment.

**Scope: 8 changed files, one concern.** Two files are mechanically generated API reference pages.

Closes #244
