### PR TITLE
feat(codec): make downstream codecs testable

### DIFF
--- a/.changes/unreleased/beryl-expose-public-codec-operations.toml
+++ b/.changes/unreleased/beryl-expose-public-codec-operations.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Added"
+body = "Expose public codec operations so custom codecs can be tested without internal accessors"

--- a/packages/beryl/src/beryl/wire/codec.gleam
+++ b/packages/beryl/src/beryl/wire/codec.gleam
@@ -5,10 +5,9 @@
 //// the Phoenix array format (`[join_ref, ref, topic, event, payload]`).
 ////
 //// To run beryl over your own framing, build a `Codec` value and pass it
-//// to `beryl.config(codec)`. The runtime decodes inbound text via
-//// `codec.decode_text`, optionally decodes inbound binary via
-//// `codec.decode_binary`, dispatches based on the structural `InboundKind`,
-//// and produces outbound text or binary frames via `codec.encode_*` helpers.
+//// to `beryl.config(codec)`. The runtime decodes inbound frames and produces
+//// outbound frames using the configured callbacks. Codec authors can exercise
+//// those callbacks directly with the public `apply_*` functions.
 ////
 //// All codecs must normalise inbound traffic to the `Inbound` shape so
 //// the runtime can stay framing-agnostic.
@@ -222,6 +221,91 @@ pub fn with_error_encoder(
   Codec(..codec, encode_error: Some(encode_error))
 }
 
+/// Decode a text frame with a codec.
+///
+/// Codec authors can use this to test the decoder supplied to `new`.
+pub fn apply_decode_text(
+  codec: Codec,
+  text text: String,
+) -> Result(Inbound, DecodeError) {
+  codec.decode_text(text)
+}
+
+/// Decode a binary frame with a codec, if it has a binary decoder.
+///
+/// Returns `None` when the codec has no decoder configured with
+/// `with_binary_decoder`.
+pub fn apply_decode_binary(
+  codec: Codec,
+  data data: BitArray,
+) -> Option(Result(Inbound, DecodeError)) {
+  case codec.decode_binary {
+    Some(decode) -> Some(decode(data))
+    None -> None
+  }
+}
+
+/// Encode a reply with a codec.
+pub fn apply_encode_reply(
+  codec: Codec,
+  join_ref join_ref: Option(String),
+  ref ref: Option(String),
+  topic topic: String,
+  status status: ReplyStatus,
+  response response: json.Json,
+) -> Frame {
+  codec.encode_reply(join_ref, ref, topic, status, response)
+}
+
+/// Encode a server-initiated push with a codec.
+pub fn apply_encode_push(
+  codec: Codec,
+  topic topic: String,
+  event event: String,
+  payload payload: json.Json,
+) -> Frame {
+  codec.encode_push(topic, event, payload)
+}
+
+/// Encode a heartbeat reply with a codec.
+pub fn apply_encode_heartbeat_reply(
+  codec: Codec,
+  ref ref: Option(String),
+) -> Frame {
+  codec.encode_heartbeat_reply(ref)
+}
+
+/// Encode a graceful topic close with a codec, if it has a close encoder.
+///
+/// Returns `None` when the codec has no encoder configured with
+/// `with_close_encoder`.
+pub fn apply_encode_close(
+  codec: Codec,
+  join_ref join_ref: Option(String),
+  topic topic: String,
+) -> Option(Frame) {
+  case codec.encode_close {
+    Some(encode) -> Some(encode(join_ref, topic))
+    None -> None
+  }
+}
+
+/// Encode an abnormal topic termination with a codec, if it has an error
+/// encoder.
+///
+/// Returns `None` when the codec has no encoder configured with
+/// `with_error_encoder`.
+pub fn apply_encode_error(
+  codec: Codec,
+  join_ref join_ref: Option(String),
+  topic topic: String,
+) -> Option(Frame) {
+  case codec.encode_error {
+    Some(encode) -> Some(encode(join_ref, topic))
+    None -> None
+  }
+}
+
 /// Accessor for the codec's text decoder.
 @internal
 pub fn decode_text(codec: Codec) -> fn(String) -> Result(Inbound, DecodeError) {
@@ -273,6 +357,13 @@ pub fn encode_close(
 /// empty-topic frames are rejected instead of guessed at.
 pub fn with_topicless_events(codec: Codec) -> Codec {
   Codec(..codec, topicless_events: True)
+}
+
+/// Whether the codec routes events without an explicit topic.
+///
+/// Codec authors can use this to test `with_topicless_events`.
+pub fn uses_topicless_events(codec: Codec) -> Bool {
+  codec.topicless_events
 }
 
 /// Accessor for the codec's topicless-events flag.

--- a/packages/beryl/test/wire_codec_test.gleam
+++ b/packages/beryl/test/wire_codec_test.gleam
@@ -142,6 +142,81 @@ pub fn inbound_supports_optional_refs_test() {
   codec.inbound_ref(inbound) |> should.equal(None)
 }
 
+pub fn public_codec_operations_apply_configured_behaviour_test() {
+  let base =
+    codec.new(
+      decode_text: fn(text) {
+        Ok(codec.inbound(
+          join_ref: None,
+          ref: None,
+          topic: "text",
+          kind: codec.Event(text),
+          payload: dynamic.nil(),
+        ))
+      },
+      encode_reply: fn(_, _, _, _, _) { codec.TextFrame("reply") },
+      encode_push: fn(topic, event, _) {
+        codec.TextFrame(topic <> ":" <> event)
+      },
+      encode_heartbeat_reply: fn(_) { codec.TextFrame("heartbeat") },
+    )
+
+  let assert Ok(text_inbound) = codec.apply_decode_text(base, text: "decoded")
+  codec.inbound_kind(text_inbound) |> should.equal(codec.Event("decoded"))
+  codec.apply_decode_binary(base, data: <<1>>) |> should.equal(None)
+  codec.apply_encode_reply(
+    base,
+    join_ref: None,
+    ref: None,
+    topic: "room:1",
+    status: codec.StatusOk,
+    response: json.null(),
+  )
+  |> should.equal(codec.TextFrame("reply"))
+  codec.apply_encode_push(
+    base,
+    topic: "room:1",
+    event: "updated",
+    payload: json.null(),
+  )
+  |> should.equal(codec.TextFrame("room:1:updated"))
+  codec.apply_encode_heartbeat_reply(base, ref: None)
+  |> should.equal(codec.TextFrame("heartbeat"))
+  codec.apply_encode_close(base, join_ref: None, topic: "room:1")
+  |> should.equal(None)
+  codec.apply_encode_error(base, join_ref: None, topic: "room:1")
+  |> should.equal(None)
+  codec.uses_topicless_events(base) |> should.be_false()
+
+  let configured =
+    base
+    |> codec.with_binary_decoder(fn(_) {
+      Ok(codec.inbound(
+        join_ref: None,
+        ref: None,
+        topic: "binary",
+        kind: codec.Event("decoded"),
+        payload: dynamic.nil(),
+      ))
+    })
+    |> codec.with_close_encoder(fn(_, topic) {
+      codec.TextFrame("close:" <> topic)
+    })
+    |> codec.with_error_encoder(fn(_, topic) {
+      codec.TextFrame("error:" <> topic)
+    })
+    |> codec.with_topicless_events()
+
+  let assert Some(Ok(binary_inbound)) =
+    codec.apply_decode_binary(configured, data: <<1>>)
+  codec.inbound_topic(binary_inbound) |> should.equal("binary")
+  codec.apply_encode_close(configured, join_ref: None, topic: "room:1")
+  |> should.equal(Some(codec.TextFrame("close:room:1")))
+  codec.apply_encode_error(configured, join_ref: None, topic: "room:1")
+  |> should.equal(Some(codec.TextFrame("error:room:1")))
+  codec.uses_topicless_events(configured) |> should.be_true()
+}
+
 // === Reply status ===
 
 pub fn reply_status_round_trips_through_phoenix_codec_test() {

--- a/website/src/content/docs/reference/api/beryl-wire-codec.md
+++ b/website/src/content/docs/reference/api/beryl-wire-codec.md
@@ -16,10 +16,9 @@ Pluggable wire codec for beryl.
  the Phoenix array format (`[join_ref, ref, topic, event, payload]`).
 
  To run beryl over your own framing, build a `Codec` value and pass it
- to `beryl.config(codec)`. The runtime decodes inbound text via
- `codec.decode_text`, optionally decodes inbound binary via
- `codec.decode_binary`, dispatches based on the structural `InboundKind`,
- and produces outbound text or binary frames via `codec.encode_*` helpers.
+ to `beryl.config(codec)`. The runtime decodes inbound frames and produces
+ outbound frames using the configured callbacks. Codec authors can exercise
+ those callbacks directly with the public `apply_*` functions.
 
  All codecs must normalise inbound traffic to the `Inbound` shape so
  the runtime can stay framing-agnostic.
@@ -152,6 +151,103 @@ The handler failed (`"error"` in Phoenix framing).
 
 ## Functions
 
+### `apply_decode_binary`
+
+Decode a binary frame with a codec, if it has a binary decoder.
+
+ Returns `None` when the codec has no decoder configured with
+ `with_binary_decoder`.
+
+```gleam
+pub fn apply_decode_binary(
+  Codec,
+  data: BitArray
+) -> option.Option(Result(Inbound, DecodeError))
+```
+
+### `apply_decode_text`
+
+Decode a text frame with a codec.
+
+ Codec authors can use this to test the decoder supplied to `new`.
+
+```gleam
+pub fn apply_decode_text(
+  Codec,
+  text: String
+) -> Result(Inbound, DecodeError)
+```
+
+### `apply_encode_close`
+
+Encode a graceful topic close with a codec, if it has a close encoder.
+
+ Returns `None` when the codec has no encoder configured with
+ `with_close_encoder`.
+
+```gleam
+pub fn apply_encode_close(
+  Codec,
+  join_ref: option.Option(String),
+  topic: String
+) -> option.Option(Frame)
+```
+
+### `apply_encode_error`
+
+Encode an abnormal topic termination with a codec, if it has an error
+ encoder.
+
+ Returns `None` when the codec has no encoder configured with
+ `with_error_encoder`.
+
+```gleam
+pub fn apply_encode_error(
+  Codec,
+  join_ref: option.Option(String),
+  topic: String
+) -> option.Option(Frame)
+```
+
+### `apply_encode_heartbeat_reply`
+
+Encode a heartbeat reply with a codec.
+
+```gleam
+pub fn apply_encode_heartbeat_reply(
+  Codec,
+  ref: option.Option(String)
+) -> Frame
+```
+
+### `apply_encode_push`
+
+Encode a server-initiated push with a codec.
+
+```gleam
+pub fn apply_encode_push(
+  Codec,
+  topic: String,
+  event: String,
+  payload: json.Json
+) -> Frame
+```
+
+### `apply_encode_reply`
+
+Encode a reply with a codec.
+
+```gleam
+pub fn apply_encode_reply(
+  Codec,
+  join_ref: option.Option(String),
+  ref: option.Option(String),
+  topic: String,
+  status: ReplyStatus,
+  response: json.Json
+) -> Frame
+```
+
 ### `format_decode_error`
 
 Format a `DecodeError` as a human-readable string. Used by the
@@ -244,6 +340,16 @@ pub fn new(
   encode_push: fn(String, String, json.Json) -> Frame,
   encode_heartbeat_reply: fn(option.Option(String)) -> Frame
 ) -> Codec
+```
+
+### `uses_topicless_events`
+
+Whether the codec routes events without an explicit topic.
+
+ Codec authors can use this to test `with_topicless_events`.
+
+```gleam
+pub fn uses_topicless_events(Codec) -> Bool
 ```
 
 ### `with_binary_decoder`


### PR DESCRIPTION
Downstream `Codec` implementors could construct an opaque codec but had no
documented way to execute its callbacks in unit tests, forcing them to depend
on Beryl's `@internal` accessors. This adds a supported test seam without
exposing the codec's stored functions.

## What changed

- Add public `apply_*` operations for text and binary decoding plus reply,
  push, heartbeat, close, and error encoding.
- Preserve optional codec capabilities as `None` when a binary decoder or
  terminal encoder is not configured.
- Add `uses_topicless_events` so custom codecs can verify that builder setting.
- Cover the public operations and publish their generated API reference.

Scope: 4 changed files, one concern.

## Validation

- `cd packages/beryl && gleam test -- --filter "public_codec_operations_apply_configured_behaviour_test"` — 482 passed, no failures.
- `just lint` — no issues found.
- `just deps && just ci` — full format, check, docs, test, strict build, and example suites passed.
- `just doctor && just changelog-check` — passed; doctor retained five advisory dependency-range consistency warnings.

Run the full PR checks with `just ci`.

Closes #256

Authored with [Minions](https://icy-water-0224cc51e.2.azurestaticapps.net/minions).
