### PR TITLE
feat(presence): keep keys visible during metadata updates

### DIFF
--- a/.changes/unreleased/beryl-add-presence-update-to.toml
+++ b/.changes/unreleased/beryl-add-presence-update-to.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Added"
+body = "Add presence.update to atomically replace one public presence meta in a single leave-plus-join diff without temporarily removing the key."

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -1,7 +1,7 @@
 //// Presence - Distributed presence tracking backed by a CRDT
 ////
 //// Wraps the pure `lattice_presence/presence_state` CRDT in an OTP actor that:
-//// - Handles track/untrack calls
+//// - Handles track/update/untrack calls
 //// - Periodically broadcasts state via PubSub for cross-node replication
 //// - Receives remote state from PubSub and merges it internally
 //// - Invokes `on_diff` callback when merges produce non-empty diffs
@@ -54,8 +54,8 @@ const sync_event = "presence_sync"
 ///
 /// This handle is intentionally opaque so callers cannot forge actor subjects
 /// or depend on the runtime representation. It carries both the actor's
-/// subject (for the still-synchronous `track`/`untrack`/`untrack_all`) and a
-/// reference to the actor-owned ETS read model that `list`, `get_by_key`,
+/// subject (for the still-synchronous `track`/`update`/`untrack`/`untrack_all`)
+/// and a reference to the actor-owned ETS read model that `list`, `get_by_key`,
 /// and `count` read directly, without going through the actor mailbox.
 ///
 /// ## Node affinity
@@ -63,14 +63,14 @@ const sync_event = "presence_sync"
 /// `list`, `get_by_key`, and `count` read the ETS read model directly
 /// in-process, which only works for ETS tables local to the calling node.
 /// Do not send this handle to, or otherwise use it from, a process on a
-/// different BEAM node: `track`/`untrack`/`untrack_all` would still reach
-/// the owning actor over distribution (they go through its `Subject`), but
-/// the read functions would be looking up a table reference that names
+/// different BEAM node: `track`/`update`/`untrack`/`untrack_all` would still
+/// reach the owning actor over distribution (they go through its `Subject`),
+/// but the read functions would be looking up a table reference that names
 /// nothing on that node (or, if the identifier happens to collide with an
-/// unrelated local table, something else entirely), so they would fail or
-/// read the wrong data. Keep a Presence handle on the node where `start`
-/// created it, and use PubSub replication (`with_pubsub`) to share presence
-/// state across nodes instead.
+/// unrelated local table, something else entirely), so they would fail or read
+/// the wrong data. Keep a Presence handle on the node where `start` created it,
+/// and use PubSub replication (`with_pubsub`) to share presence state across
+/// nodes instead.
 pub opaque type Presence {
   Presence(subject: Subject(Message), read_table: ReadTable)
 }
@@ -209,6 +209,12 @@ pub type PresenceError {
   PresenceStartFailed(beryl_error.StartFailure)
 }
 
+/// Errors from updating a tracked presence.
+pub type PresenceUpdateError {
+  /// The ref is unknown, already removed, or was not returned by `track`.
+  UnknownRef
+}
+
 /// Messages the presence actor handles
 pub opaque type Message {
   Track(
@@ -217,6 +223,11 @@ pub opaque type Message {
     session_id: String,
     meta: json.Json,
     reply: Subject(String),
+  )
+  Update(
+    ref: String,
+    meta: json.Json,
+    reply: Subject(Result(String, PresenceUpdateError)),
   )
   Untrack(ref: String, reply: Subject(Nil))
   UntrackAll(session_id: String, reply: Subject(Nil))
@@ -724,6 +735,25 @@ pub fn track(
   })
 }
 
+/// Replace the meta of a presence created by `track`.
+///
+/// The old ref's leave and the new ref's join are emitted together in one
+/// diff, so subscribers never observe an intermediate state without the
+/// presence key. Other tracked refs for the same key are left unchanged.
+///
+/// Returns the replacement ref, which must be used for subsequent `update`
+/// or `untrack` calls. Returns `Error(UnknownRef)` when `ref` is
+/// unknown, already removed, or belongs to the internal runtime.
+///
+/// Panics if the presence actor is unavailable or does not reply within 5 seconds.
+pub fn update(
+  presence: Presence,
+  ref: String,
+  meta: json.Json,
+) -> Result(String, PresenceUpdateError) {
+  process.call(presence.subject, 5000, fn(reply) { Update(ref, meta, reply) })
+}
+
 /// Untrack a specific presence using the ref returned by `track`.
 ///
 /// Removing an unknown or already-removed ref is a harmless no-op.
@@ -907,6 +937,29 @@ fn handle_message(
       actor.continue(new_state)
     }
 
+    Update(ref, meta, reply) -> {
+      case dict.get(actor_state.refs, ref) {
+        Ok(TrackedPresence(topic, key, session_id, _, _, PublicOwner)) -> {
+          let #(new_state, new_ref, _meta) =
+            do_track(
+              actor_state,
+              topic,
+              key,
+              session_id,
+              meta,
+              SupersedePublicRef(ref),
+            )
+          log_tracked(logger, topic, key, session_id, new_ref)
+          process.send(reply, Ok(new_ref))
+          actor.continue(new_state)
+        }
+        _ -> {
+          process.send(reply, Error(UnknownRef))
+          actor.continue(actor_state)
+        }
+      }
+    }
+
     TrackAsync(topic, key, session_id, meta, replace, tag, op_id, reply) -> {
       let #(new_state, ref, stored_meta) =
         do_track(
@@ -1056,6 +1109,9 @@ type Supersede {
   /// and several refs for one key (each with its own `phx_ref` meta) is a
   /// meaningful, supported shape there.
   SupersedeNothing
+  /// The public synchronous `update`: supersede exactly the ref supplied by
+  /// its owner, leaving every other public ref for the same key unchanged.
+  SupersedePublicRef(String)
   /// The runtime's asynchronous track: supersede `explicit` (the previous
   /// runtime ref, when the caller still knows it) and every other
   /// runtime-owned ref this actor holds for the same `(session_id, topic, key)`.
@@ -1080,6 +1136,7 @@ fn superseded_refs(
 ) -> List(String) {
   case supersede {
     SupersedeNothing -> []
+    SupersedePublicRef(ref) -> [ref]
     SupersedeSameKey(explicit) -> {
       let same_key =
         refs
@@ -1130,7 +1187,7 @@ fn do_track(
     )
   let new_crdt = state.join(removed.crdt, session_id, topic, key, stored_meta)
   let owner = case supersede {
-    SupersedeNothing -> PublicOwner
+    SupersedeNothing | SupersedePublicRef(_) -> PublicOwner
     SupersedeSameKey(_) -> RuntimeOwner
   }
   let replica = state.replica(new_crdt)

--- a/packages/beryl/test/presence_test.gleam
+++ b/packages/beryl/test/presence_test.gleam
@@ -2,6 +2,7 @@ import beryl/presence
 import gleam/erlang/process
 import gleam/json
 import gleam/list
+import gleam/option.{None}
 import gleam/string
 import gleeunit
 import gleeunit/should
@@ -131,6 +132,105 @@ pub fn presence_untrack_unknown_ref_is_noop_test() {
   presence.untrack(p, "does-not-exist")
 
   list.length(presence_entries(p, "room:lobby")) |> should.equal(1)
+}
+
+pub fn presence_update_replaces_one_ref_in_one_diff_test() {
+  let diff_subject = process.new_subject()
+  let config =
+    presence.default_config("node1")
+    |> presence.with_on_diff(fn(diff) { process.send(diff_subject, diff) })
+  let assert Ok(p) = presence.start(config)
+
+  let old_ref =
+    presence.track(
+      p,
+      "room:lobby",
+      "user:1",
+      "socket-1",
+      json.object([#("device", json.string("desktop"))]),
+    )
+  let other_ref =
+    presence.track(
+      p,
+      "room:lobby",
+      "user:1",
+      "socket-1",
+      json.object([#("device", json.string("mobile"))]),
+    )
+  let assert Ok(_) = process.receive(diff_subject, 1000)
+  let assert Ok(_) = process.receive(diff_subject, 1000)
+
+  let assert Ok(new_ref) =
+    presence.update(
+      p,
+      old_ref,
+      json.object([#("device", json.string("tablet"))]),
+    )
+  new_ref |> should.not_equal(old_ref)
+  new_ref |> should.not_equal(other_ref)
+
+  let assert Ok(diff) = process.receive(diff_subject, 1000)
+  process.receive(diff_subject, 0) |> should.be_error
+  let assert [joined] = presence.diff_joins(diff, "room:lobby")
+  let assert [left] = presence.diff_leaves(diff, "room:lobby")
+  json.to_string(joined.meta) |> string.contains("tablet") |> should.be_true
+  json.to_string(joined.meta) |> string.contains(new_ref) |> should.be_true
+  json.to_string(left.meta) |> string.contains("desktop") |> should.be_true
+  json.to_string(left.meta) |> string.contains(old_ref) |> should.be_true
+
+  presence_count(p, "room:lobby") |> should.equal(2)
+  let metas =
+    presence_metas(p, "room:lobby", "user:1")
+    |> list.map(fn(entry) { json.to_string(entry.1) })
+    |> string.join(",")
+  metas |> string.contains("tablet") |> should.be_true
+  metas |> string.contains("mobile") |> should.be_true
+  metas |> string.contains("desktop") |> should.be_false
+}
+
+pub fn presence_update_unknown_or_stale_ref_is_error_test() {
+  let diff_subject = process.new_subject()
+  let config =
+    presence.default_config("node1")
+    |> presence.with_on_diff(fn(diff) { process.send(diff_subject, diff) })
+  let assert Ok(p) = presence.start(config)
+  let ref = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
+  let assert Ok(_) = process.receive(diff_subject, 1000)
+
+  presence.update(p, "does-not-exist", json.null())
+  |> should.equal(Error(presence.UnknownRef))
+  process.receive(diff_subject, 0) |> should.be_error
+
+  let assert Ok(new_ref) = presence.update(p, ref, json.null())
+  let assert Ok(_) = process.receive(diff_subject, 1000)
+  presence.update(p, ref, json.null())
+  |> should.equal(Error(presence.UnknownRef))
+  presence.untrack(p, new_ref)
+}
+
+pub fn presence_update_rejects_runtime_owned_ref_test() {
+  let assert Ok(p) = presence.start(test_config("node1"))
+  let reply = process.new_subject()
+  presence.track_async(
+    p,
+    "room:lobby",
+    "user:1",
+    "socket-1",
+    json.object([#("status", json.string("online"))]),
+    None,
+    "test",
+    1,
+    reply,
+  )
+  let assert Ok(presence.MutationAck(
+    outcome: presence.Tracked(runtime_ref, _),
+    ..,
+  )) = process.receive(reply, 1000)
+
+  presence.update(p, runtime_ref, json.null())
+  |> should.equal(Error(presence.UnknownRef))
+  let assert [entry] = presence_entries(p, "room:lobby")
+  json.to_string(entry.meta) |> string.contains("online") |> should.be_true
 }
 
 pub fn presence_untrack_all_test() {

--- a/website/src/content/docs/guides/coming-from-phoenix.md
+++ b/website/src/content/docs/guides/coming-from-phoenix.md
@@ -75,6 +75,7 @@ Two practical consequences either way:
 | `MyAppWeb.Endpoint.broadcast/3` from anywhere | `beryl.broadcast(sockets, topic, event, payload)` | same |
 | `Phoenix.PubSub` | `beryl/pubsub`, also built on `pg` | same |
 | `Phoenix.Presence.track/3` / `untrack/3` | `channel.presence_track(key, meta)` / `channel.presence_untrack(key)` actions | `socket.PresenceTrack(topic, key, meta)` / `socket.PresenceUntrack(topic, key)` effects |
+| `Phoenix.Presence.update/4` | repeat `channel.presence_track(key, meta)`; for standalone refs, `presence.update(handle, ref, meta)` | repeat `socket.PresenceTrack(topic, key, meta)`; for standalone refs, `presence.update(handle, ref, meta)` |
 | `push(socket, "presence_state", Presence.list(socket))` | `channel.push_presence("presence_state", presence_wire.encode_state)` | `socket.PushPresence(topic, "presence_state", presence_wire.encode_state)` |
 | `intercept` / `handle_out` | no equivalent — shape payloads before `broadcast`, or per-socket with `push` | no equivalent — same advice |
 

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -54,11 +54,30 @@ let ref = presence.track(
 The **key** groups multiple connections from the same user. The **session ID**
 uniquely identifies each connection (typically the socket ID).
 
+## Updating metadata
+
+Replace one tracked presence's metadata without briefly removing its key from
+the roster:
+
+```gleam
+let assert Ok(new_ref) =
+  presence.update(
+    p,
+    ref,
+    json.object([#("status", json.string("away"))]),
+  )
+```
+
+`update` emits the old ref's leave and the new ref's join in one diff, while
+leaving other refs for the same key unchanged. Keep the returned ref for the
+next `update` or `untrack`; the previous ref becomes stale. An unknown, removed,
+or non-public ref returns `Error(presence.UnknownRef)`.
+
 ## Untracking
 
 ```gleam
 // Remove a specific presence, using the ref returned by `track`
-presence.untrack(p, ref)
+presence.untrack(p, new_ref)
 
 // Remove all presences for a session ID / socket (e.g., on disconnect)
 presence.untrack_all(p, socket_id)
@@ -94,7 +113,7 @@ The table lifetime follows the actor: reads panic after that actor stops rather
 than returning a misleading empty result. Other presence actors own independent
 tables and remain unaffected.
 
-The read model's ETS table is node-local: a `Presence` handle must stay on the node where `presence.start` created it. Sending the handle to (or otherwise calling `list`/`get_by_key`/`count` from) a process on a different BEAM node looks up a table reference that names nothing on that node, so those calls panic there too (`track`/`untrack`/`untrack_all` still work remotely, since they only need to reach the owning actor's process). Use PubSub replication (`with_pubsub`) to share presence state across nodes instead of moving the handle itself.
+The read model's ETS table is node-local: a `Presence` handle must stay on the node where `presence.start` created it. Sending the handle to (or otherwise calling `list`/`get_by_key`/`count` from) a process on a different BEAM node looks up a table reference that names nothing on that node, so those calls panic there too (`track`/`update`/`untrack`/`untrack_all` still work remotely, since they only need to reach the owning actor's process). Use PubSub replication (`with_pubsub`) to share presence state across nodes instead of moving the handle itself.
 
 ## Diff callbacks
 
@@ -210,6 +229,9 @@ The runtime owns refs created by `PresenceTrack` and automatically removes any
 remaining refs when the topic closes. Public synchronous `presence.track`
 calls remain available to application actors and other out-of-band workflows;
 their refs are independently addressable and are not part of runtime cleanup.
+Repeating `PresenceTrack` for the same topic and key replaces the runtime-owned
+meta atomically. Out-of-band workflows should use `presence.update` with the
+ref returned by `presence.track`.
 
 ## Next steps
 

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -12,7 +12,7 @@ description: "Presence - Distributed presence tracking backed by a CRDT"
 Presence - Distributed presence tracking backed by a CRDT
 
  Wraps the pure `lattice_presence/presence_state` CRDT in an OTP actor that:
- - Handles track/untrack calls
+ - Handles track/update/untrack calls
  - Periodically broadcasts state via PubSub for cross-node replication
  - Receives remote state from PubSub and merges it internally
  - Invokes `on_diff` callback when merges produce non-empty diffs
@@ -72,8 +72,8 @@ A running Presence instance.
 
  This handle is intentionally opaque so callers cannot forge actor subjects
  or depend on the runtime representation. It carries both the actor's
- subject (for the still-synchronous `track`/`untrack`/`untrack_all`) and a
- reference to the actor-owned ETS read model that `list`, `get_by_key`,
+ subject (for the still-synchronous `track`/`update`/`untrack`/`untrack_all`)
+ and a reference to the actor-owned ETS read model that `list`, `get_by_key`,
  and `count` read directly, without going through the actor mailbox.
 
  ## Node affinity
@@ -81,14 +81,14 @@ A running Presence instance.
  `list`, `get_by_key`, and `count` read the ETS read model directly
  in-process, which only works for ETS tables local to the calling node.
  Do not send this handle to, or otherwise use it from, a process on a
- different BEAM node: `track`/`untrack`/`untrack_all` would still reach
- the owning actor over distribution (they go through its `Subject`), but
- the read functions would be looking up a table reference that names
+ different BEAM node: `track`/`update`/`untrack`/`untrack_all` would still
+ reach the owning actor over distribution (they go through its `Subject`),
+ but the read functions would be looking up a table reference that names
  nothing on that node (or, if the identifier happens to collide with an
- unrelated local table, something else entirely), so they would fail or
- read the wrong data. Keep a Presence handle on the node where `start`
- created it, and use PubSub replication (`with_pubsub`) to share presence
- state across nodes instead.
+ unrelated local table, something else entirely), so they would fail or read
+ the wrong data. Keep a Presence handle on the node where `start` created it,
+ and use PubSub replication (`with_pubsub`) to share presence state across
+ nodes instead.
 
 ```gleam
 pub type Presence
@@ -126,6 +126,22 @@ pub type PresenceError {
 ##### `PresenceStartFailed(error.StartFailure)`
 
 The presence actor failed to start.
+
+### `PresenceUpdateError`
+
+Errors from updating a tracked presence.
+
+```gleam
+pub type PresenceUpdateError {
+  UnknownRef
+}
+```
+
+#### Constructors
+
+##### `UnknownRef`
+
+The ref is unknown, already removed, or was not returned by `track`.
 
 ## Functions
 
@@ -311,6 +327,28 @@ pub fn untrack_all(
   Presence,
   String
 ) -> Nil
+```
+
+### `update`
+
+Replace the meta of a presence created by `track`.
+
+ The old ref's leave and the new ref's join are emitted together in one
+ diff, so subscribers never observe an intermediate state without the
+ presence key. Other tracked refs for the same key are left unchanged.
+
+ Returns the replacement ref, which must be used for subsequent `update`
+ or `untrack` calls. Returns `Error(UnknownRef)` when `ref` is
+ unknown, already removed, or belongs to the internal runtime.
+
+ Panics if the presence actor is unavailable or does not reply within 5 seconds.
+
+```gleam
+pub fn update(
+  Presence,
+  String,
+  json.Json
+) -> Result(String, PresenceUpdateError)
 ```
 
 ### `with_broadcast_interval`


### PR DESCRIPTION
Presence consumers previously had to untrack and re-track a meta, making Phoenix-compatible clients briefly remove the key between two diffs. This adds a public atomic update path so cursor and status changes keep the presence continuously visible.

## What changed

- Add `presence.update`, which replaces exactly one public tracking ref and returns its replacement ref.
- Emit the old leave and new join in one diff while preserving other refs for the same key.
- Return `Error(presence.UnknownRef)` for unknown, stale, or runtime-owned refs without mutating presence state.
- Document the API in the presence guide, Phoenix migration map, generated reference, and changelog.

Closes #302
