### PR TITLE
docs(runtime): explain callback crash isolation

### DIFF
--- a/.changes/unreleased/beryl-document-why-app-callback.toml
+++ b/.changes/unreleased/beryl-document-why-app-callback.toml
@@ -1,3 +1,0 @@
-package = "beryl"
-kind = "Changed"
-body = "Document why app callback crashes are contained within the shared runtime instead of triggering a supervisor restart, and clarify that presence merge rescue is not a cluster security boundary."

--- a/.changes/unreleased/beryl-document-why-app-callback.toml
+++ b/.changes/unreleased/beryl-document-why-app-callback.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Changed"
+body = "Document why app callback crashes are contained within the shared runtime instead of triggering a supervisor restart, and clarify that presence merge rescue is not a cluster security boundary."

--- a/packages/beryl/src/beryl/internal.gleam
+++ b/packages/beryl/src/beryl/internal.gleam
@@ -49,9 +49,15 @@ pub fn result_error(error: e) -> Result(a, e) {
 }
 
 // nolint: stringly_typed_error -- the error is the formatted BEAM crash description; callers wrap or log it at use sites
+/// Crash boundary for work that runs inside a shared actor.
+///
 /// Run a callback, converting any BEAM crash (error/exit/throw) into an
-/// `Error(description)` so a faulty callback cannot take down the shared actor
-/// that invoked it.
+/// `Error(description)`. This is deliberately not left to OTP supervision:
+/// restarting the runtime or presence actor would discard every socket's or
+/// subscriber's state to recover from one scoped failure. Callers must discard
+/// the failed result and preserve or tear down only the affected scope; they
+/// must never continue with a partial result. Faults outside an explicit
+/// boundary still crash the actor and are handled by supervision.
 ///
 /// The description is depth-limited and truncated by the FFI so a
 /// client-triggered crash cannot bloat log metadata.

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -1281,15 +1281,10 @@ fn merge_remote_sync(
   sender: String,
   remote_state: State,
 ) -> actor.Next(ActorState, Message) {
-  // Merge, diff, on_diff, prune, and the read-model publication that follows
-  // all run inside a crash boundary. The remote state originates from
-  // another cluster node (possibly a mixed version, a compromised peer, or a
-  // malformed dynamic value coerced from the wire); an exception here must
-  // not terminate the shared presence actor. On failure we return the
-  // previous, unchanged `actor_state` so invalid sync input cannot partially
-  // mutate presence state or its read model: the read model is only
-  // republished once merge, on_diff, and prune have all completed
-  // successfully below.
+  // Crash boundary — see internal.rescue. Version skew or bugs can produce
+  // malformed sync state; Erlang distribution peers are fully trusted (see
+  // the production-hardening guide). Preserve the previous actor state unless
+  // merge, on_diff, prune, and read-model publication all complete.
   let processed =
     internal.rescue(fn() {
       let #(new_crdt, state_diff) =

--- a/packages/beryl/src/beryl/runtime.gleam
+++ b/packages/beryl/src/beryl/runtime.gleam
@@ -559,9 +559,8 @@ fn handle_message(
       actor.continue(state)
     }
     RemoteBroadcast(pubsub_msg) ->
-      // Delivered through the typed subscriber subject, but the payload's
-      // own shape is a frozen wire contract across nodes; a malformed frame
-      // from a mismatched peer must not crash the runtime.
+      // Crash boundary — see internal.rescue. The payload's own shape is a
+      // frozen wire contract; drop malformed frames from mismatched peers.
       case
         internal.rescue(fn() { handle_remote_broadcast(state, pubsub_msg) })
       {
@@ -748,6 +747,7 @@ fn register_socket(
   let sender = make_socket_sender(state, socket_id)
   let info = sock.ConnectInfo(socket_id: socket_id, seed: seed, self: sender)
   let init = state.init
+  // Crash boundary — see internal.rescue. A failed init never registers.
   case internal.rescue(fn() { init(info) }) {
     Error(crash) -> {
       state.logger
@@ -2112,6 +2112,8 @@ fn exec_input(
     Ok(socket) -> {
       let update = state.update
       let model = socket.model
+      // Crash boundary — see internal.rescue. The error path discards the
+      // callback result and tears down the narrowest safe scope.
       exec_update_result(
         state,
         socket_id,
@@ -3657,8 +3659,9 @@ fn begin_topic_cleanup(
 /// are already reflected: the presence actor publishes a topic's read-model
 /// snapshot before acknowledging the mutation that changed it, and the
 /// socket does not resume until that acknowledgement arrives. The encoder
-/// is app code and runs rescued: a crash drops the snapshot with an error
-/// log instead of taking down the runtime.
+/// is app code and runs inside the crash boundary (see `internal.rescue`):
+/// a crash drops the snapshot with an error log instead of taking down the
+/// runtime.
 fn presence_snapshot(
   state: State(model, msg),
   socket_id: String,

--- a/website/src/content/docs/architecture/runtime.md
+++ b/website/src/content/docs/architecture/runtime.md
@@ -51,6 +51,15 @@ Most lists are applied in a single actor turn. `PresenceTrack` and `PresenceUntr
 
 Crashes in app callbacks are rescued rather than allowed to take down the shared runtime. The blast radius is scoped to what crashed: a crashing `Join` is rejected; a crashing topic-scoped `Message` or `Binary` closes only that topic; a crashing `Info` tears down the whole socket because it has no topic to attribute; a crashing `Closed` is logged while teardown continues; and a crashing `init` leaves the socket unregistered. Crash descriptions are depth-limited and truncated before logging. Other sockets remain isolated.
 
+This is a deliberate trade-off with OTP's usual "let it crash" model. Every
+socket's model lives in the same runtime actor, so allowing one app callback
+crash to reach supervision would restart that actor, discard every socket's
+state, and close every connection on the handle. Beryl uses a crash boundary
+only where it can discard the callback result and reject or tear down the
+narrowest affected scope; it never continues with a partial result. Faults
+outside those explicit boundaries still crash the runtime and invoke
+supervision.
+
 For the channel layer, those scopes map to `join`, `on_message` /
 `on_binary`, `on_info`, and `on_terminate`. A terminate panic discards that
 router update, so its actions are lost and the old instance remains reachable

--- a/website/src/content/docs/guides/error-handling.md
+++ b/website/src/content/docs/guides/error-handling.md
@@ -131,6 +131,14 @@ Beryl rescues crashes in `init` and `update` rather than letting them take down 
 
 Crash descriptions are depth-limited and truncated before logging so client-triggered crashes cannot bloat log metadata.
 
+This is not a generic catch-and-continue policy. Because every socket shares
+one runtime actor, letting one callback crash reach supervision would restart
+the actor and disconnect every socket. Beryl instead discards the failed
+callback result and closes the narrowest safe scope; faults outside these
+explicit boundaries still invoke supervision. See
+[Runtime crash containment](/architecture/runtime/#crash-containment) for the
+trade-off.
+
 The channel layer maps those scopes to callbacks:
 
 | Channel callback | Effect |

--- a/website/src/content/docs/guides/supervision.md
+++ b/website/src/content/docs/guides/supervision.md
@@ -47,6 +47,14 @@ triggered them:
 | `update` on `Info` | The socket is torn down |
 | `update` on `Closed` | Logged; the close completes anyway |
 
+This boundary is intentional: all app callbacks run inside the one runtime
+actor, so a supervisor restart for one callback would discard every socket's
+model and close every connection on that `Sockets` handle. The boundary is
+used only when Beryl can discard the failed callback result and reject or tear
+down the narrowest safe scope. Other runtime faults still escape to the
+supervisor. See [Runtime crash containment](/architecture/runtime/#crash-containment)
+for the design trade-off.
+
 See the [Error Handling guide](/guides/error-handling/) for details.
 
 For channel callbacks, those rows map to `join`, `on_message`/`on_binary`,


### PR DESCRIPTION
Reviewers and operators need to understand why Beryl catches app callback
crashes instead of delegating them to OTP supervision. Because every socket
shares one runtime actor, restarting it for one callback failure would discard
all socket state and disconnect every connection on the handle.

## What changed

- Defines `internal.rescue` as an explicit shared-actor crash boundary: callers
  must discard failed or partial results and contain the narrowest safe scope,
  while unscoped runtime faults still reach supervision.
- Adds concise boundary pointers at runtime callback sites and corrects the
  presence merge comment so it no longer implies rescue protects against a
  compromised, fully trusted Erlang distribution peer.
- Documents the isolation-versus-restart trade-off in the runtime, supervision,
  and error-handling guides, with a Beryl changelog fragment.

Scope: 7 changed files, one concern.

## Validation

- `just format-check && just docs` - passed formatting, package documentation
  generation, and website API reference generation.
- `just pr` - passed the complete repository gate: formatting, checks, Gleam
  tests, strict builds, and Playwright example tests.
- Initial dependency restoration with `just deps` hit the external Hex API rate
  limit; `pnpm -C examples install` restored the missing lockfile-resolved
  JavaScript dependency, after which the final `just pr` passed.

## Run

Preview the documentation with `pnpm -C website dev` at
http://localhost:4321.

Closes #228

Authored with [Minions](https://icy-water-0224cc51e.2.azurestaticapps.net/minions).
