### PR TITLE
feat: make actor call timeouts configurable

### DIFF
--- a/.changes/unreleased/beryl-synchronous-group-and-presence.toml
+++ b/.changes/unreleased/beryl-synchronous-group-and-presence.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Added"
+body = "Synchronous group and presence actor call timeouts are configurable. Group actors can be started with `group.start_with_config`, and both group and presence configs provide `with_call_timeout`; the existing 5-second default is unchanged."

--- a/packages/beryl/src/beryl/group.gleam
+++ b/packages/beryl/src/beryl/group.gleam
@@ -33,7 +33,14 @@ import gleam/set.{type Set}
 /// This handle is intentionally opaque so callers cannot forge the backing
 /// actor subject or depend on its runtime representation.
 pub opaque type Groups {
-  Groups(subject: Subject(Message))
+  Groups(subject: Subject(Message), call_timeout_ms: Int)
+}
+
+/// Configuration for starting a groups actor.
+///
+/// Build configs with `default_config` and the `with_*` functions.
+pub opaque type Config {
+  Config(call_timeout_ms: Int)
 }
 
 /// Errors from group operations
@@ -79,11 +86,32 @@ type State {
   State(groups: Dict(String, Set(String)))
 }
 
-/// Start the groups actor
+/// Build a groups configuration with a 5-second actor call timeout.
+pub fn default_config() -> Config {
+  Config(call_timeout_ms: 5000)
+}
+
+/// Set the timeout for synchronous group operations, in milliseconds.
+///
+/// This applies to `create`, `delete`, `add`, `remove`, `topics`, and
+/// `list_groups`. These functions panic if the actor does not reply within
+/// this timeout.
+pub fn with_call_timeout(_config: Config, timeout_ms: Int) -> Config {
+  Config(call_timeout_ms: timeout_ms)
+}
+
+/// Start the groups actor with the default configuration.
 pub fn start() -> Result(Groups, GroupStartError) {
+  start_with_config(default_config())
+}
+
+/// Start the groups actor with a custom configuration.
+pub fn start_with_config(config: Config) -> Result(Groups, GroupStartError) {
   build_groups()
   |> actor.start
-  |> result.map(fn(started) { Groups(subject: started.data) })
+  |> result.map(fn(started) {
+    Groups(subject: started.data, call_timeout_ms: config.call_timeout_ms)
+  })
   |> result.map_error(fn(error) {
     GroupActorStartFailed(beryl_error.from_actor_start_error(error))
   })
@@ -96,57 +124,73 @@ fn build_groups() -> actor.Builder(State, Message, Subject(Message)) {
 
 /// Create a new named group
 ///
-/// Panics if the groups actor is unavailable or does not reply within 5 seconds.
+/// Panics if the groups actor is unavailable or does not reply within the
+/// configured call timeout (5 seconds by default).
 pub fn create(groups: Groups, name: String) -> Result(Nil, GroupError) {
-  process.call(groups.subject, 5000, fn(reply) { Create(name, reply) })
+  process.call(groups.subject, groups.call_timeout_ms, fn(reply) {
+    Create(name, reply)
+  })
 }
 
 /// Delete a group
 ///
-/// Panics if the groups actor is unavailable or does not reply within 5 seconds.
+/// Panics if the groups actor is unavailable or does not reply within the
+/// configured call timeout (5 seconds by default).
 pub fn delete(groups: Groups, name: String) -> Result(Nil, GroupError) {
-  process.call(groups.subject, 5000, fn(reply) { Delete(name, reply) })
+  process.call(groups.subject, groups.call_timeout_ms, fn(reply) {
+    Delete(name, reply)
+  })
 }
 
 /// Add a topic to a group
 ///
-/// Panics if the groups actor is unavailable or does not reply within 5 seconds.
+/// Panics if the groups actor is unavailable or does not reply within the
+/// configured call timeout (5 seconds by default).
 pub fn add(
   groups: Groups,
   group_name: String,
   topic: String,
 ) -> Result(Nil, GroupError) {
-  process.call(groups.subject, 5000, fn(reply) { Add(group_name, topic, reply) })
+  process.call(groups.subject, groups.call_timeout_ms, fn(reply) {
+    Add(group_name, topic, reply)
+  })
 }
 
 /// Remove a topic from a group
 ///
-/// Panics if the groups actor is unavailable or does not reply within 5 seconds.
+/// Panics if the groups actor is unavailable or does not reply within the
+/// configured call timeout (5 seconds by default).
 pub fn remove(
   groups: Groups,
   group_name: String,
   topic: String,
 ) -> Result(Nil, GroupError) {
-  process.call(groups.subject, 5000, fn(reply) {
+  process.call(groups.subject, groups.call_timeout_ms, fn(reply) {
     Remove(group_name, topic, reply)
   })
 }
 
 /// Get all topics in a group
 ///
-/// Panics if the groups actor is unavailable or does not reply within 5 seconds.
+/// Panics if the groups actor is unavailable or does not reply within the
+/// configured call timeout (5 seconds by default).
 pub fn topics(
   groups: Groups,
   group_name: String,
 ) -> Result(Set(String), GroupError) {
-  process.call(groups.subject, 5000, fn(reply) { GetTopics(group_name, reply) })
+  process.call(groups.subject, groups.call_timeout_ms, fn(reply) {
+    GetTopics(group_name, reply)
+  })
 }
 
 /// List all group names
 ///
-/// Panics if the groups actor is unavailable or does not reply within 5 seconds.
+/// Panics if the groups actor is unavailable or does not reply within the
+/// configured call timeout (5 seconds by default).
 pub fn list_groups(groups: Groups) -> List(String) {
-  process.call(groups.subject, 5000, fn(reply) { ListGroups(reply) })
+  process.call(groups.subject, groups.call_timeout_ms, fn(reply) {
+    ListGroups(reply)
+  })
 }
 
 /// Broadcast a message to all topics in a group

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -72,7 +72,11 @@ const sync_event = "presence_sync"
 /// created it, and use PubSub replication (`with_pubsub`) to share presence
 /// state across nodes instead.
 pub opaque type Presence {
-  Presence(subject: Subject(Message), read_table: ReadTable)
+  Presence(
+    subject: Subject(Message),
+    read_table: ReadTable,
+    call_timeout_ms: Int,
+  )
 }
 
 type State =
@@ -195,6 +199,8 @@ pub opaque type Config {
     replica: String,
     /// How often to broadcast state for replication (ms). 0 = disabled.
     broadcast_interval_ms: Int,
+    /// Timeout for synchronous track and untrack calls (ms).
+    call_timeout_ms: Int,
     /// Optional callback invoked immediately when a merge produces a non-empty diff.
     /// This ensures no diffs are lost when multiple merges occur in rapid succession.
     /// Runs synchronously on the actor, strictly before the read model is
@@ -432,6 +438,7 @@ pub fn default_config(replica: String) -> Config {
     pubsub: None,
     replica: replica,
     broadcast_interval_ms: 1500,
+    call_timeout_ms: 5000,
     on_diff: None,
   )
 }
@@ -446,6 +453,14 @@ pub fn with_pubsub(config: Config, pubsub: PubSub(SyncPayload)) -> Config {
 /// Use `0` to disable periodic broadcasts.
 pub fn with_broadcast_interval(config: Config, interval_ms: Int) -> Config {
   Config(..config, broadcast_interval_ms: interval_ms)
+}
+
+/// Set the timeout for synchronous presence mutations, in milliseconds.
+///
+/// This applies to `track`, `untrack`, and `untrack_all`. These functions panic
+/// if the actor does not reply within this timeout. The default is 5000 ms.
+pub fn with_call_timeout(config: Config, timeout_ms: Int) -> Config {
+  Config(..config, call_timeout_ms: timeout_ms)
 }
 
 /// Set the callback invoked when local changes or remote merges produce a diff.
@@ -489,7 +504,11 @@ pub fn start(config: Config) -> Result(Presence, PresenceError) {
   |> actor.start
   |> result.map(fn(started) {
     let #(subject, read_table) = started.data
-    Presence(subject: subject, read_table: read_table)
+    Presence(
+      subject: subject,
+      read_table: read_table,
+      call_timeout_ms: config.call_timeout_ms,
+    )
   })
   |> result.map_error(fn(error) {
     PresenceStartFailed(beryl_error.from_actor_start_error(error))
@@ -711,7 +730,8 @@ fn meta_with_phx_ref(meta: json.Json, ref: String) -> json.Json {
 /// only meaningful to that actor. The ref is also merged into object metas as
 /// `phx_ref` for Phoenix client compatibility.
 ///
-/// Panics if the presence actor is unavailable or does not reply within 5 seconds.
+/// Panics if the presence actor is unavailable or does not reply within the
+/// configured call timeout (5 seconds by default).
 pub fn track(
   presence: Presence,
   topic: String,
@@ -719,7 +739,7 @@ pub fn track(
   session_id: String,
   meta: json.Json,
 ) -> String {
-  process.call(presence.subject, 5000, fn(reply) {
+  process.call(presence.subject, presence.call_timeout_ms, fn(reply) {
     Track(topic, key, session_id, meta, reply)
   })
 }
@@ -728,16 +748,20 @@ pub fn track(
 ///
 /// Removing an unknown or already-removed ref is a harmless no-op.
 ///
-/// Panics if the presence actor is unavailable or does not reply within 5 seconds.
+/// Panics if the presence actor is unavailable or does not reply within the
+/// configured call timeout (5 seconds by default).
 pub fn untrack(presence: Presence, ref: String) -> Nil {
-  process.call(presence.subject, 5000, fn(reply) { Untrack(ref, reply) })
+  process.call(presence.subject, presence.call_timeout_ms, fn(reply) {
+    Untrack(ref, reply)
+  })
 }
 
 /// Untrack all presences for a session (e.g., when a socket disconnects)
 ///
-/// Panics if the presence actor is unavailable or does not reply within 5 seconds.
+/// Panics if the presence actor is unavailable or does not reply within the
+/// configured call timeout (5 seconds by default).
 pub fn untrack_all(presence: Presence, session_id: String) -> Nil {
-  process.call(presence.subject, 5000, fn(reply) {
+  process.call(presence.subject, presence.call_timeout_ms, fn(reply) {
     UntrackAll(session_id, reply)
   })
 }

--- a/packages/beryl/test/group_test.gleam
+++ b/packages/beryl/test/group_test.gleam
@@ -1,11 +1,56 @@
 import beryl/group
+import gleam/erlang/process
 import gleam/list
 import gleam/set
 import gleeunit/should
 
+fn assert_crashes_within(op: fn() -> Nil, timeout_ms: Int) -> Nil {
+  let pid = process.spawn_unlinked(op)
+  let monitor = process.monitor(pid)
+  let selector =
+    process.new_selector()
+    |> process.select_specific_monitor(monitor, fn(down) { down })
+
+  case process.selector_receive(selector, timeout_ms) {
+    Ok(process.ProcessDown(reason: process.Normal, ..)) -> should.fail()
+    Ok(process.ProcessDown(..)) -> Nil
+    Ok(process.PortDown(..)) -> should.fail()
+    Error(Nil) -> should.fail()
+  }
+}
+
 pub fn group_start_test() {
   let result = group.start()
   should.be_ok(result)
+}
+
+pub fn configured_call_timeout_is_used_test() {
+  let groups_ready = process.new_subject()
+  let owner =
+    process.spawn_unlinked(fn() {
+      let config =
+        group.default_config()
+        |> group.with_call_timeout(20)
+      let assert Ok(groups) = group.start_with_config(config)
+      process.send(groups_ready, groups)
+      panic as "stop groups owner"
+    })
+  let monitor = process.monitor(owner)
+  let selector =
+    process.new_selector()
+    |> process.select_specific_monitor(monitor, fn(down) { down })
+  let assert Ok(groups) = process.receive(groups_ready, 1000)
+  let assert Ok(process.ProcessDown(..)) =
+    process.selector_receive(selector, 1000)
+
+  process.sleep(20)
+  assert_crashes_within(
+    fn() {
+      let _ = group.list_groups(groups)
+      Nil
+    },
+    1000,
+  )
 }
 
 pub fn group_create_and_list_test() {

--- a/packages/beryl/test/presence_test.gleam
+++ b/packages/beryl/test/presence_test.gleam
@@ -495,6 +495,19 @@ pub fn count_fails_after_presence_terminated_even_for_untouched_topic_test() {
   })
 }
 
+pub fn configured_call_timeout_is_used_test() {
+  let config =
+    presence.default_config("node1")
+    |> presence.with_call_timeout(20)
+  let assert Ok(p) = presence.start(config)
+  test_helpers.kill_presence(p)
+
+  assert_crashes(fn() {
+    let _ = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
+    Nil
+  })
+}
+
 // ── multiple presence actors: independent, unnamed read tables ─────────────
 //
 // The read-model ETS table is created unnamed (no `named_table`) so

--- a/website/src/content/docs/guides/groups.md
+++ b/website/src/content/docs/guides/groups.md
@@ -18,6 +18,20 @@ let assert Ok(groups) = group.start()
 
 `group.start()` returns `Result(Groups, GroupStartError)`. The only failure case is `GroupActorStartFailed` — an OTP actor spawn failure.
 
+Synchronous group operations wait up to 5 seconds for the actor by default.
+Configure a different timeout when starting the actor:
+
+```gleam
+let config =
+  group.default_config()
+  |> group.with_call_timeout(10_000)
+let assert Ok(groups) = group.start_with_config(config)
+```
+
+`create`, `delete`, `add`, `remove`, `topics`, and `list_groups` panic if the
+actor is unavailable or does not reply within this timeout. `broadcast` is
+fire-and-forget and does not use it.
+
 ## Creating and deleting groups
 
 ```gleam

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -31,6 +31,20 @@ let config =
 let assert Ok(p) = presence.start(config)
 ```
 
+Synchronous presence mutations wait up to 5 seconds for the actor by default.
+Use `with_call_timeout` to configure the timeout:
+
+```gleam
+let config =
+  presence.default_config("node1")
+  |> presence.with_call_timeout(10_000)
+let assert Ok(p) = presence.start(config)
+```
+
+`track`, `untrack`, and `untrack_all` panic if the actor is unavailable or does
+not reply within this timeout. Presence reads bypass the actor mailbox and do
+not use it.
+
 ## Tracking presences
 
 Track a user's presence when they join a channel:

--- a/website/src/content/docs/reference/api/beryl-group.md
+++ b/website/src/content/docs/reference/api/beryl-group.md
@@ -31,6 +31,16 @@ Channel Groups - Named collections of topics for multi-topic broadcasting
 
 ## Types
 
+### `Config`
+
+Configuration for starting a groups actor.
+
+ Build configs with `default_config` and the `with_*` functions.
+
+```gleam
+pub type Config
+```
+
 ### `GroupError`
 
 Errors from group operations
@@ -93,7 +103,8 @@ pub type Message
 
 Add a topic to a group
 
- Panics if the groups actor is unavailable or does not reply within 5 seconds.
+ Panics if the groups actor is unavailable or does not reply within the
+ configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn add(
@@ -124,7 +135,8 @@ pub fn broadcast(
 
 Create a new named group
 
- Panics if the groups actor is unavailable or does not reply within 5 seconds.
+ Panics if the groups actor is unavailable or does not reply within the
+ configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn create(
@@ -133,11 +145,20 @@ pub fn create(
 ) -> Result(Nil, GroupError)
 ```
 
+### `default_config`
+
+Build a groups configuration with a 5-second actor call timeout.
+
+```gleam
+pub fn default_config() -> Config
+```
+
 ### `delete`
 
 Delete a group
 
- Panics if the groups actor is unavailable or does not reply within 5 seconds.
+ Panics if the groups actor is unavailable or does not reply within the
+ configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn delete(
@@ -150,7 +171,8 @@ pub fn delete(
 
 List all group names
 
- Panics if the groups actor is unavailable or does not reply within 5 seconds.
+ Panics if the groups actor is unavailable or does not reply within the
+ configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn list_groups(Groups) -> List(String)
@@ -160,7 +182,8 @@ pub fn list_groups(Groups) -> List(String)
 
 Remove a topic from a group
 
- Panics if the groups actor is unavailable or does not reply within 5 seconds.
+ Panics if the groups actor is unavailable or does not reply within the
+ configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn remove(
@@ -172,21 +195,45 @@ pub fn remove(
 
 ### `start`
 
-Start the groups actor
+Start the groups actor with the default configuration.
 
 ```gleam
 pub fn start() -> Result(Groups, GroupStartError)
+```
+
+### `start_with_config`
+
+Start the groups actor with a custom configuration.
+
+```gleam
+pub fn start_with_config(Config) -> Result(Groups, GroupStartError)
 ```
 
 ### `topics`
 
 Get all topics in a group
 
- Panics if the groups actor is unavailable or does not reply within 5 seconds.
+ Panics if the groups actor is unavailable or does not reply within the
+ configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn topics(
   Groups,
   String
 ) -> Result(set.Set(String), GroupError)
+```
+
+### `with_call_timeout`
+
+Set the timeout for synchronous group operations, in milliseconds.
+
+ This applies to `create`, `delete`, `add`, `remove`, `topics`, and
+ `list_groups`. These functions panic if the actor does not reply within
+ this timeout.
+
+```gleam
+pub fn with_call_timeout(
+  Config,
+  Int
+) -> Config
 ```

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -273,7 +273,8 @@ Track a presence in a topic.
  only meaningful to that actor. The ref is also merged into object metas as
  `phx_ref` for Phoenix client compatibility.
 
- Panics if the presence actor is unavailable or does not reply within 5 seconds.
+ Panics if the presence actor is unavailable or does not reply within the
+ configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn track(
@@ -291,7 +292,8 @@ Untrack a specific presence using the ref returned by `track`.
 
  Removing an unknown or already-removed ref is a harmless no-op.
 
- Panics if the presence actor is unavailable or does not reply within 5 seconds.
+ Panics if the presence actor is unavailable or does not reply within the
+ configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn untrack(
@@ -304,7 +306,8 @@ pub fn untrack(
 
 Untrack all presences for a session (e.g., when a socket disconnects)
 
- Panics if the presence actor is unavailable or does not reply within 5 seconds.
+ Panics if the presence actor is unavailable or does not reply within the
+ configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn untrack_all(
@@ -321,6 +324,20 @@ Set how often presence state is broadcast for replication.
 
 ```gleam
 pub fn with_broadcast_interval(
+  Config,
+  Int
+) -> Config
+```
+
+### `with_call_timeout`
+
+Set the timeout for synchronous presence mutations, in milliseconds.
+
+ This applies to `track`, `untrack`, and `untrack_all`. These functions panic
+ if the actor does not reply within this timeout. The default is 5000 ms.
+
+```gleam
+pub fn with_call_timeout(
   Config,
   Int
 ) -> Config


### PR DESCRIPTION
Group and presence users can now tune how long synchronous actor operations wait, instead of being locked to a hard-coded five-second timeout.

## Changes

- Add `with_call_timeout` to group and presence configuration while preserving the five-second default.
- Keep `group.child_spec()` source-compatible and add `default_config()` plus `child_spec_with_config()` for customized group actors.
- Cover both actors with unavailable-actor timeout regressions and document the new configuration in guides, generated API reference, and the changelog.

Scope: 9 changed files, one concern.

Closes #168