### PR TITLE
feat(core)!: make presence and groups supervised-only

### DIFF
--- a/.changes/unreleased/beryl-presence-and-groups-now.toml
+++ b/.changes/unreleased/beryl-presence-and-groups-now.toml
@@ -1,3 +1,3 @@
 package = "beryl"
 kind = "Changed"
-body = "Presence and groups now expose supervised child specifications with stable restart-safe handles instead of unsupervised start functions."
+body = "BREAKING: Presence and groups now expose supervised child specifications with stable restart-safe, node-affine handles instead of unsupervised start functions. Use each handle only on the node where its child runs: remote presence mutations and synchronous group operations panic as unavailable, remote presence reads return Error(Nil), and remote group broadcasts are not delivered."

--- a/.changes/unreleased/beryl-presence-and-groups-now.toml
+++ b/.changes/unreleased/beryl-presence-and-groups-now.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Changed"
+body = "Presence and groups now expose supervised child specifications with stable restart-safe handles instead of unsupervised start functions."

--- a/examples/chatrooms/src/chatrooms.gleam
+++ b/examples/chatrooms/src/chatrooms.gleam
@@ -19,12 +19,7 @@ import mist
 pub fn main() {
   let presence_tracker = session_presence.start()
 
-  // Start groups and create default room group.
-  let assert Ok(groups) = group.start()
-  let assert Ok(_) = group.create(groups, "public")
-  let assert Ok(_) = group.add(groups, "public", "room:general")
-  let assert Ok(_) = group.add(groups, "public", "room:random")
-  let assert Ok(_) = group.add(groups, "public", "room:help")
+  let #(groups, groups_spec) = group.child_spec()
   let assert Ok(hub) = broadcast_hub.start()
 
   let ctx = chat_app.Ctx(presence: presence_tracker, groups: groups, hub: hub)
@@ -45,8 +40,13 @@ pub fn main() {
   broadcast_hub.bind(hub, channels)
   let assert Ok(_root) =
     static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(groups_spec)
     |> static_supervisor.add(beryl_spec)
     |> static_supervisor.start()
+  let assert Ok(_) = group.create(groups, "public")
+  let assert Ok(_) = group.add(groups, "public", "room:general")
+  let assert Ok(_) = group.add(groups, "public", "room:random")
+  let assert Ok(_) = group.add(groups, "public", "room:help")
 
   io.println("💬 Chat Rooms Demo")
   io.println("   Open http://localhost:8001?token=beryl-demo")

--- a/examples/chatrooms/test/chatrooms_app_test.gleam
+++ b/examples/chatrooms/test/chatrooms_app_test.gleam
@@ -16,9 +16,7 @@ import gleeunit/should
 
 fn start() -> #(beryl.Sockets, session_presence.Tracker) {
   let presence = session_presence.start()
-  let assert Ok(groups) = group.start()
-  let assert Ok(_) = group.create(groups, "public")
-  let assert Ok(_) = group.add(groups, "public", "room:general")
+  let #(groups, groups_spec) = group.child_spec()
   let assert Ok(hub) = broadcast_hub.start()
   let ctx = app.Ctx(presence: presence, groups: groups, hub: hub)
   let assert Ok(#(sockets, spec)) =
@@ -28,8 +26,11 @@ fn start() -> #(beryl.Sockets, session_presence.Tracker) {
     )
   let assert Ok(_) =
     static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(groups_spec)
     |> static_supervisor.add(spec)
     |> static_supervisor.start()
+  let assert Ok(_) = group.create(groups, "public")
+  let assert Ok(_) = group.add(groups, "public", "room:general")
   broadcast_hub.bind(hub, sockets)
   #(sockets, presence)
 }

--- a/examples/showcase/src/showcase.gleam
+++ b/examples/showcase/src/showcase.gleam
@@ -85,11 +85,7 @@ pub fn main() {
   let presence_tracker = session_presence.start()
 
   // Chatrooms-specific state.
-  let assert Ok(groups) = group.start()
-  let assert Ok(_) = group.create(groups, "public")
-  let assert Ok(_) = group.add(groups, "public", "room:general")
-  let assert Ok(_) = group.add(groups, "public", "room:random")
-  let assert Ok(_) = group.add(groups, "public", "room:help")
+  let #(groups, groups_spec) = group.child_spec()
 
   // collab_docs-specific state.
   let docs_secret = docs_auth.new_secret()
@@ -129,8 +125,13 @@ pub fn main() {
   hub.bind(hub, channels)
   let assert Ok(_root) =
     static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(groups_spec)
     |> static_supervisor.add(beryl_spec)
     |> static_supervisor.start()
+  let assert Ok(_) = group.create(groups, "public")
+  let assert Ok(_) = group.add(groups, "public", "room:general")
+  let assert Ok(_) = group.add(groups, "public", "room:random")
+  let assert Ok(_) = group.add(groups, "public", "room:help")
 
   // Build per-example contexts pinned to their URL prefix.
   let cursors_ctx = cursors_router.Context(channels:, base_path: "/cursors")

--- a/examples/showcase/test/showcase_harness.gleam
+++ b/examples/showcase/test/showcase_harness.gleam
@@ -47,10 +47,7 @@ pub type Frames =
 /// the limiter rather than the channels.
 pub fn start(_replica: String) -> System {
   let presence_tracker = session_presence.start()
-  let assert Ok(groups) = group.start()
-  let assert Ok(_) = group.create(groups, "public")
-  let assert Ok(_) = group.add(groups, "public", "room:general")
-  let assert Ok(_) = group.add(groups, "public", "room:random")
+  let #(groups, groups_spec) = group.child_spec()
   let assert Ok(store) = doc_store.start()
   let assert Ok(broadcast_hub) = hub.start()
   let secret = auth.new_secret()
@@ -79,8 +76,12 @@ pub fn start(_replica: String) -> System {
   hub.bind(broadcast_hub, sockets)
   let assert Ok(_) =
     static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(groups_spec)
     |> static_supervisor.add(spec)
     |> static_supervisor.start()
+  let assert Ok(_) = group.create(groups, "public")
+  let assert Ok(_) = group.add(groups, "public", "room:general")
+  let assert Ok(_) = group.add(groups, "public", "room:random")
 
   System(sockets: sockets, secret: secret, presence: presence_tracker)
 }

--- a/packages/beryl/src/beryl/group.gleam
+++ b/packages/beryl/src/beryl/group.gleam
@@ -4,14 +4,17 @@
 //// Useful for scenarios like broadcasting to all channels in a "team" or
 //// sending a system-wide notification.
 ////
-//// Groups are independent of the Beryl runtime. Start the actor from a
-//// long-lived application process and include it in the application's
-//// supervision arrangement as appropriate.
+//// Groups are independent of the Beryl runtime and run under your
+//// application's supervision tree.
 ////
 //// ## Example
 ////
 //// ```gleam
-//// let assert Ok(groups) = group.start()
+//// let #(groups, groups_spec) = group.child_spec()
+//// let assert Ok(_root) =
+////   static_supervisor.new(static_supervisor.OneForOne)
+////   |> static_supervisor.add(groups_spec)
+////   |> static_supervisor.start()
 //// let assert Ok(Nil) = group.create(groups, "team:engineering")
 //// let assert Ok(Nil) = group.add(groups, "team:engineering", "room:frontend")
 //// let assert Ok(Nil) = group.add(groups, "team:engineering", "room:backend")
@@ -19,12 +22,12 @@
 //// ```
 
 import beryl
-import beryl/error as beryl_error
 import gleam/dict.{type Dict}
 import gleam/erlang/process.{type Subject}
 import gleam/json
 import gleam/list
 import gleam/otp/actor
+import gleam/otp/supervision
 import gleam/result
 import gleam/set.{type Set}
 
@@ -42,12 +45,6 @@ pub type GroupError {
   GroupAlreadyExists
   /// The group was not found
   GroupNotFound
-}
-
-/// Errors when starting the groups actor.
-pub type GroupStartError {
-  /// The actor failed to start
-  GroupActorStartFailed(beryl_error.StartFailure)
 }
 
 /// Messages the groups actor handles
@@ -79,14 +76,41 @@ type State {
   State(groups: Dict(String, Set(String)))
 }
 
-/// Start the groups actor
-pub fn start() -> Result(Groups, GroupStartError) {
+/// Build the supervised groups actor.
+///
+/// Add the returned child specification to your application's supervisor.
+/// The returned handle is name-backed, so it reaches the replacement actor
+/// after a supervised restart. Group definitions are in-memory state and are
+/// reset by a restart.
+pub fn child_spec() -> #(
+  Groups,
+  supervision.ChildSpecification(Subject(Message)),
+) {
+  let name = process.new_name("beryl_groups")
+  #(
+    Groups(subject: process.named_subject(name)),
+    supervision.worker(fn() { start_named(name) }),
+  )
+}
+
+@internal
+pub fn start() -> Result(Groups, actor.StartError) {
+  let name = process.new_name("beryl_groups")
+  start_named(name)
+  |> result.map(fn(_started) { Groups(subject: process.named_subject(name)) })
+}
+
+fn start_named(
+  name: process.Name(Message),
+) -> Result(actor.Started(Subject(Message)), actor.StartError) {
   build_groups()
+  |> actor.named(name)
   |> actor.start
-  |> result.map(fn(started) { Groups(subject: started.data) })
-  |> result.map_error(fn(error) {
-    GroupActorStartFailed(beryl_error.from_actor_start_error(error))
-  })
+}
+
+@internal
+pub fn subject(groups: Groups) -> Subject(Message) {
+  groups.subject
 }
 
 fn build_groups() -> actor.Builder(State, Message, Subject(Message)) {

--- a/packages/beryl/src/beryl/group.gleam
+++ b/packages/beryl/src/beryl/group.gleam
@@ -35,6 +35,13 @@ import gleam/set.{type Set}
 ///
 /// This handle is intentionally opaque so callers cannot forge the backing
 /// actor subject or depend on its runtime representation.
+///
+/// ## Node affinity
+///
+/// The stable registered subject is resolved on the caller's node. Keep a
+/// `Groups` handle on the node where its child specification runs. Calls from
+/// another BEAM node cannot reach the owning actor; synchronous operations
+/// panic as unavailable, and fire-and-forget broadcasts are not delivered.
 pub opaque type Groups {
   Groups(subject: Subject(Message))
 }

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -61,17 +61,13 @@ const sync_event = "presence_sync"
 ///
 /// ## Node affinity
 ///
-/// `list`, `get_by_key`, and `count` read the ETS read model directly
-/// in-process, which only works for ETS tables local to the calling node.
-/// Do not send this handle to, or otherwise use it from, a process on a
-/// different BEAM node: `track`/`untrack`/`untrack_all` would still reach
-/// the owning actor over distribution (they go through its `Subject`), but
-/// the read functions would be looking up a table name that names
-/// nothing on that node (or, if the identifier happens to collide with an
-/// unrelated local table, something else entirely), so they would fail or
-/// read the wrong data. Keep a Presence handle on the node where `child_spec`
-/// created it, and use PubSub replication (`with_pubsub`) to share presence
-/// state across nodes instead.
+/// The stable registered subject and ETS read model are resolved on the
+/// caller's node. Keep a `Presence` handle on the node where its child
+/// specification runs. From another BEAM node, synchronous mutations cannot
+/// reach the owning actor and panic as unavailable, while `list`, `get_by_key`,
+/// and `count` return `Error(Nil)` because the read model is unavailable.
+/// Use PubSub replication (`with_pubsub`) to share presence state across nodes
+/// instead of moving the handle itself.
 pub opaque type Presence {
   Presence(subject: Subject(Message), read_name: process.Name(Message))
 }

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -6,9 +6,8 @@
 //// - Receives remote state from PubSub and merges it internally
 //// - Invokes `on_diff` callback when merges produce non-empty diffs
 ////
-//// Presence is independent of the Beryl runtime. Start the actor from a
-//// long-lived application process and include it in the application's
-//// supervision arrangement as appropriate.
+//// Presence is independent of the Beryl runtime and runs under your
+//// application's supervision tree.
 ////
 //// ## Example
 ////
@@ -18,12 +17,15 @@
 ////   presence.default_config("node1")
 ////   |> presence.with_pubsub(ps)
 ////   |> presence.with_broadcast_interval(1500)
-//// let assert Ok(p) = presence.start(config)
+//// let #(p, presence_spec) = presence.child_spec(config)
+//// let assert Ok(_root) =
+////   static_supervisor.new(static_supervisor.OneForOne)
+////   |> static_supervisor.add(presence_spec)
+////   |> static_supervisor.start()
 //// let ref = presence.track(p, "room:lobby", "user:1", "socket-1", meta)
 //// let assert Ok(entries) = presence.list(p, "room:lobby")
 //// ```
 
-import beryl/error as beryl_error
 import beryl/internal
 import beryl/log
 import beryl/pubsub.{type PubSub}
@@ -39,6 +41,7 @@ import gleam/json
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/otp/actor
+import gleam/otp/supervision
 import gleam/result
 import gleam/set.{type Set}
 import gleam/string
@@ -53,10 +56,8 @@ const sync_event = "presence_sync"
 /// A running Presence instance.
 ///
 /// This handle is intentionally opaque so callers cannot forge actor subjects
-/// or depend on the runtime representation. It carries both the actor's
-/// subject (for the still-synchronous `track`/`untrack`/`untrack_all`) and a
-/// reference to the actor-owned ETS read model that `list`, `get_by_key`,
-/// and `count` read directly, without going through the actor mailbox.
+/// or depend on the runtime representation. It carries the actor's stable
+/// registered subject and the name of its actor-owned ETS read model.
 ///
 /// ## Node affinity
 ///
@@ -65,14 +66,14 @@ const sync_event = "presence_sync"
 /// Do not send this handle to, or otherwise use it from, a process on a
 /// different BEAM node: `track`/`untrack`/`untrack_all` would still reach
 /// the owning actor over distribution (they go through its `Subject`), but
-/// the read functions would be looking up a table reference that names
+/// the read functions would be looking up a table name that names
 /// nothing on that node (or, if the identifier happens to collide with an
 /// unrelated local table, something else entirely), so they would fail or
-/// read the wrong data. Keep a Presence handle on the node where `start`
+/// read the wrong data. Keep a Presence handle on the node where `child_spec`
 /// created it, and use PubSub replication (`with_pubsub`) to share presence
 /// state across nodes instead.
 pub opaque type Presence {
-  Presence(subject: Subject(Message), read_table: ReadTable)
+  Presence(subject: Subject(Message), read_name: process.Name(Message))
 }
 
 type State =
@@ -203,12 +204,6 @@ pub opaque type Config {
   )
 }
 
-/// Errors from presence operations
-pub type PresenceError {
-  /// The presence actor failed to start.
-  PresenceStartFailed(beryl_error.StartFailure)
-}
-
 /// Messages the presence actor handles
 pub opaque type Message {
   Track(
@@ -327,7 +322,7 @@ type CountLookup {
 type ReadTable
 
 @external(erlang, "beryl_presence_read_ffi", "new_table")
-fn ffi_new_read_table() -> ReadTable
+fn ffi_new_read_table(name: process.Name(Message)) -> ReadTable
 
 @external(erlang, "beryl_presence_read_ffi", "put_topic")
 fn ffi_put_topic(
@@ -341,10 +336,10 @@ fn ffi_put_topic(
 fn ffi_delete_topic(table: ReadTable, topic: String) -> Nil
 
 @external(erlang, "beryl_presence_read_ffi", "get_topic")
-fn ffi_get_topic(table: ReadTable, topic: String) -> TopicLookup
+fn ffi_get_topic(name: process.Name(Message), topic: String) -> TopicLookup
 
 @external(erlang, "beryl_presence_read_ffi", "get_count")
-fn ffi_get_count(table: ReadTable, topic: String) -> CountLookup
+fn ffi_get_count(name: process.Name(Message), topic: String) -> CountLookup
 
 /// Materialize a topic's current entries (and their count) from `crdt` into
 /// the read model, or remove its snapshot entirely once it has no entries
@@ -372,12 +367,12 @@ fn publish_topics(table: ReadTable, crdt: State, topics: List(String)) -> Nil {
 /// Returns `Error(Nil)` if the read model table is unavailable -- either
 /// because the presence actor that owns it is no longer running, or because
 /// this handle is being used from a process on a different BEAM node than
-/// the one `start` was called on (see the node affinity note on `Presence`).
+/// the one the child was started on (see the node affinity note on `Presence`).
 fn read_entries(
   presence: Presence,
   topic: String,
 ) -> Result(List(PresenceEntry), Nil) {
-  case ffi_get_topic(presence.read_table, topic) {
+  case ffi_get_topic(presence.read_name, topic) {
     Found(entries) -> Ok(entries)
     NotFound -> Ok([])
     TableGone -> Error(Nil)
@@ -483,22 +478,43 @@ pub fn subject(presence: Presence) -> Subject(Message) {
   presence.subject
 }
 
-/// Start the presence actor
-pub fn start(config: Config) -> Result(Presence, PresenceError) {
-  build_presence(config)
+/// Build the supervised presence actor.
+///
+/// Add the returned child specification to your application's supervisor.
+/// The returned handle is name-backed and resumes working after a supervised
+/// restart. Presence entries and tracking refs are in-memory state and are
+/// reset by a restart.
+pub fn child_spec(
+  config: Config,
+) -> #(Presence, supervision.ChildSpecification(Subject(Message))) {
+  let name = process.new_name("beryl_presence")
+  #(from_name(name), supervision.worker(fn() { start_named(config, name) }))
+}
+
+@internal
+pub fn start(config: Config) -> Result(Presence, actor.StartError) {
+  let name = process.new_name("beryl_presence")
+  start_named(config, name)
+  |> result.map(fn(_started) { from_name(name) })
+}
+
+fn from_name(name: process.Name(Message)) -> Presence {
+  Presence(subject: process.named_subject(name), read_name: name)
+}
+
+fn start_named(
+  config: Config,
+  name: process.Name(Message),
+) -> Result(actor.Started(Subject(Message)), actor.StartError) {
+  build_presence(config, name)
+  |> actor.named(name)
   |> actor.start
-  |> result.map(fn(started) {
-    let #(subject, read_table) = started.data
-    Presence(subject: subject, read_table: read_table)
-  })
-  |> result.map_error(fn(error) {
-    PresenceStartFailed(beryl_error.from_actor_start_error(error))
-  })
 }
 
 fn build_presence(
   config: Config,
-) -> actor.Builder(ActorState, Message, #(Subject(Message), ReadTable)) {
+  read_name: process.Name(Message),
+) -> actor.Builder(ActorState, Message, Subject(Message)) {
   // Each actor start is a fresh CRDT incarnation. Reusing the bare replica
   // name after a restart would reset its clocks while peers still remember
   // the old ones: new joins would be silently filtered as already-seen,
@@ -512,7 +528,7 @@ fn build_presence(
     // lifetime is tied to the actor: it is destroyed automatically if this
     // process stops or crashes, matching the "actor unavailable" failure
     // mode readers already get from a dead actor.
-    let read_table = ffi_new_read_table()
+    let read_table = ffi_new_read_table(read_name)
     let initial =
       ActorState(
         crdt: crdt,
@@ -546,7 +562,7 @@ fn build_presence(
 
         actor.initialised(initial)
         |> actor.selecting(selector)
-        |> actor.returning(#(subject, read_table))
+        |> actor.returning(subject)
         |> Ok
       }
       None -> {
@@ -560,7 +576,7 @@ fn build_presence(
             read_table: read_table,
           )
         actor.initialised(no_pubsub_initial)
-        |> actor.returning(#(subject, read_table))
+        |> actor.returning(subject)
         |> Ok
       }
     }
@@ -882,7 +898,7 @@ pub fn get_by_key(
 /// from a process on another BEAM node than the one it was started on (see
 /// the node affinity note on `Presence`).
 pub fn count(presence: Presence, topic: String) -> Result(Int, Nil) {
-  case ffi_get_count(presence.read_table, topic) {
+  case ffi_get_count(presence.read_name, topic) {
     CountFound(count) -> Ok(count)
     CountTableGone -> Error(Nil)
   }

--- a/packages/beryl/src/beryl_presence_read_ffi.erl
+++ b/packages/beryl/src/beryl_presence_read_ffi.erl
@@ -1,5 +1,5 @@
 -module(beryl_presence_read_ffi).
--export([new_table/0, put_topic/4, delete_topic/2, get_topic/2, get_count/2]).
+-export([new_table/1, put_topic/4, delete_topic/2, get_topic/2, get_count/2]).
 
 %% Create the materialized presence read-model table.
 %%
@@ -8,10 +8,12 @@
 %% automatically along with it, and any read attempted afterward observes a
 %% dead table rather than silently reading stale or empty data. The table is
 %% `protected` so any process can read it directly (no actor call), while
-%% only the owning (actor) process may write to it. Unnamed (no
-%% `named_table`), so repeated actor starts never collide on a shared name.
-new_table() ->
-    ets:new(beryl_presence_reads, [set, protected, {read_concurrency, true}]).
+%% only the owning (actor) process may write to it. The stable process name is
+%% also used as the table name (process registration and ETS use separate
+%% namespaces), so a name-backed Presence handle finds the replacement table
+%% after a supervised actor restart.
+new_table(Name) ->
+    ets:new(Name, [named_table, set, protected, {read_concurrency, true}]).
 
 %% Replace the materialized snapshot for a topic. Overwrites atomically:
 %% `ets:insert/2` replaces any prior entry for the same key in one step, so

--- a/packages/beryl/test/group_test.gleam
+++ b/packages/beryl/test/group_test.gleam
@@ -1,11 +1,43 @@
 import beryl/group
+import gleam/erlang/process
 import gleam/list
+import gleam/otp/static_supervisor
 import gleam/set
 import gleeunit/should
+import test_helpers
 
 pub fn group_start_test() {
-  let result = group.start()
-  should.be_ok(result)
+  let #(groups, spec) = group.child_spec()
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(spec)
+    |> static_supervisor.start()
+  group.list_groups(groups) |> should.equal([])
+}
+
+pub fn group_handle_survives_supervised_restart_test() {
+  let #(groups, spec) = group.child_spec()
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(spec)
+    |> static_supervisor.start()
+  let assert Ok(Nil) = group.create(groups, "before:restart")
+  let assert Ok(old_pid) = process.subject_owner(group.subject(groups))
+
+  process.kill(old_pid)
+  test_helpers.wait_until(
+    fn() {
+      case process.subject_owner(group.subject(groups)) {
+        Ok(pid) -> pid != old_pid
+        Error(Nil) -> False
+      }
+    },
+    2000,
+    10,
+  )
+
+  group.list_groups(groups) |> should.equal([])
+  group.create(groups, "after:restart") |> should.equal(Ok(Nil))
 }
 
 pub fn group_create_and_list_test() {

--- a/packages/beryl/test/presence_test.gleam
+++ b/packages/beryl/test/presence_test.gleam
@@ -2,6 +2,7 @@ import beryl/presence
 import gleam/erlang/process
 import gleam/json
 import gleam/list
+import gleam/otp/static_supervisor
 import gleam/string
 import gleeunit
 import gleeunit/should
@@ -16,8 +17,41 @@ fn test_config(replica: String) -> presence.Config {
 }
 
 pub fn presence_start_test() {
-  let result = presence.start(test_config("node1"))
-  should.be_ok(result)
+  let #(p, spec) = presence.child_spec(test_config("node1"))
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(spec)
+    |> static_supervisor.start()
+  presence.list(p, "room:lobby") |> should.equal(Ok([]))
+}
+
+pub fn presence_handle_and_reads_survive_supervised_restart_test() {
+  let #(p, spec) = presence.child_spec(test_config("node1"))
+  let assert Ok(_root) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(spec)
+    |> static_supervisor.start()
+  let _ref =
+    presence.track(p, "room:lobby", "user:old", "socket-old", json.null())
+  let assert Ok(old_pid) = process.subject_owner(presence.subject(p))
+
+  process.kill(old_pid)
+  test_helpers.wait_until(
+    fn() {
+      case process.subject_owner(presence.subject(p)) {
+        Ok(pid) -> pid != old_pid
+        Error(Nil) -> False
+      }
+    },
+    2000,
+    10,
+  )
+
+  presence.list(p, "room:lobby") |> should.equal(Ok([]))
+  let _ref =
+    presence.track(p, "room:lobby", "user:new", "socket-new", json.null())
+  let assert Ok([entry]) = presence.list(p, "room:lobby")
+  entry.key |> should.equal("user:new")
 }
 
 pub fn presence_track_and_list_test() {

--- a/website/src/content/docs/architecture/presence.md
+++ b/website/src/content/docs/architecture/presence.md
@@ -41,9 +41,11 @@ read-after-write behavior.
 |---|---|
 | `child_spec(config)` | Return a stable presence handle and its supervised child specification |
 
-The handle keeps working across actor restarts because both the process and
-its ETS read model use the same stable name. The replacement actor starts with
-fresh in-memory CRDT state and tracking refs.
+On the node where the child specification runs, the handle keeps working across
+actor restarts because both the process and its ETS read model use the same
+stable name. The replacement actor starts with fresh in-memory CRDT state and
+tracking refs. The handle itself is node-affine; PubSub replicates presence
+state between nodes.
 
 ### Configuration builders
 

--- a/website/src/content/docs/architecture/presence.md
+++ b/website/src/content/docs/architecture/presence.md
@@ -10,8 +10,9 @@ Every tracked entry is stamped with a **replica name** (the `replica` argument t
 
 ## How Beryl apps use it
 
-The presence actor is a standalone process that the application starts and
-supervises, then supplies to `beryl.Config` with `with_presence_handle`.
+The presence actor is a standalone supervised child that the application
+builds with `presence.child_spec`, adds to its supervision tree, and supplies
+to `beryl.Config` with `with_presence_handle`.
 
 App-side dispatch uses `PresenceTrack`, `PresenceUntrack`, `PushPresence`, and
 `BroadcastPresence` effects. Mutations are sent asynchronously to the presence
@@ -38,8 +39,11 @@ read-after-write behavior.
 
 | Function | Description |
 |---|---|
-| `start(config)` | Start an anonymous presence actor |
-| `start_named(config, name)` | Start a named presence actor |
+| `child_spec(config)` | Return a stable presence handle and its supervised child specification |
+
+The handle keeps working across actor restarts because both the process and
+its ETS read model use the same stable name. The replacement actor starts with
+fresh in-memory CRDT state and tracking refs.
 
 ### Configuration builders
 

--- a/website/src/content/docs/architecture/runtime.md
+++ b/website/src/content/docs/architecture/runtime.md
@@ -2,7 +2,7 @@
 title: Runtime & Supervision
 ---
 
-The runtime is the central OTP actor for app-side socket dispatch. Transports send admitted, decoded frames to it, and your application's `init`/`update` functions run inside it during event dispatch. Presence and groups are independent application-owned actors; PubSub is an Erlang `pg` wrapper rather than a child of the runtime.
+The runtime is the central OTP actor for app-side socket dispatch. Transports send admitted, decoded frames to it, and your application's `init`/`update` functions run inside it during event dispatch. Presence and groups are independent application-owned supervised children; PubSub is an Erlang `pg` wrapper rather than a child of the runtime.
 
 ## Role
 
@@ -78,7 +78,7 @@ flowchart TB
 - A restart drops per-socket state (models, joined topics); clients rejoin exactly as they would after any server restart.
 - The child is `Transient`, so a graceful `beryl.stop` is final.
 
-PubSub is **not** part of this tree; it is backed by Erlang's `pg` module, which manages its own lifecycle. Presence and groups are independent actors started by the application (see the [Supervision guide](/guides/supervision/)).
+PubSub is **not** part of this tree; it is backed by Erlang's `pg` module, which manages its own lifecycle. Presence and groups expose their own child specifications for the application's supervision tree (see the [Supervision guide](/guides/supervision/)).
 
 ## Where this lives
 

--- a/website/src/content/docs/guides/groups.md
+++ b/website/src/content/docs/guides/groups.md
@@ -147,4 +147,10 @@ a stable registered name and reaches the replacement actor after a supervised
 restart. Group definitions and topic memberships are in-memory state and reset
 when the actor restarts.
 
+The registered name is node-local. Keep a `Groups` handle on the node where its
+child specification runs. From another BEAM node, synchronous operations cannot
+reach the owning actor and panic as unavailable, while fire-and-forget
+`broadcast` calls are not delivered. Group definitions and memberships are not
+replicated between nodes.
+
 See the [Supervision guide](/guides/supervision) for the overall startup pattern.

--- a/website/src/content/docs/guides/groups.md
+++ b/website/src/content/docs/guides/groups.md
@@ -12,11 +12,17 @@ Groups are a server concern. Clients join individual topics via `phx_join`; they
 
 ```gleam
 import beryl/group
+import gleam/otp/static_supervisor
 
-let assert Ok(groups) = group.start()
+let #(groups, groups_spec) = group.child_spec()
+let assert Ok(_root) =
+  static_supervisor.new(static_supervisor.OneForOne)
+  |> static_supervisor.add(groups_spec)
+  |> static_supervisor.start()
 ```
 
-`group.start()` returns `Result(Groups, GroupStartError)`. The only failure case is `GroupActorStartFailed` — an OTP actor spawn failure.
+`group.child_spec()` returns the stable `Groups` handle immediately. Add its
+child specification to your application supervisor before using the handle.
 
 ## Creating and deleting groups
 
@@ -99,7 +105,6 @@ This is equivalent to calling `beryl.broadcast` on each topic in the group in se
 |-------|------|
 | `GroupAlreadyExists` | `create` called for a name already in use |
 | `GroupNotFound` | `delete`, `add`, `remove`, or `topics` called for an unknown group name |
-| `GroupActorStartFailed` | `group.start()` — the internal group actor failed to initialize |
 
 ## Full example: team rooms
 
@@ -107,9 +112,14 @@ This is equivalent to calling `beryl.broadcast` on each topic in the group in se
 import beryl
 import beryl/group
 import gleam/json
+import gleam/otp/static_supervisor
 
 // At startup
-let assert Ok(groups) = group.start()
+let #(groups, groups_spec) = group.child_spec()
+let assert Ok(_root) =
+  static_supervisor.new(static_supervisor.OneForOne)
+  |> static_supervisor.add(groups_spec)
+  |> static_supervisor.start()
 let assert Ok(Nil) = group.create(groups, "team:eng")
 let assert Ok(Nil) = group.add(groups, "team:eng", "room:frontend")
 let assert Ok(Nil) = group.add(groups, "team:eng", "room:backend")
@@ -132,6 +142,9 @@ let assert Ok(Nil) = group.delete(groups, "team:eng")
 
 ## Lifecycle
 
-The groups actor is a plain OTP actor linked to the process that calls `group.start()` — start it from your long-lived application process alongside `beryl.child_spec`. A `start_named` variant registers the actor under a `process.Name` for callers integrating it into their own supervision arrangements.
+The groups actor only starts through `group.child_spec`. Its handle is backed by
+a stable registered name and reaches the replacement actor after a supervised
+restart. Group definitions and topic memberships are in-memory state and reset
+when the actor restarts.
 
 See the [Supervision guide](/guides/supervision) for the overall startup pattern.

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -97,18 +97,18 @@ calling through the actor mailbox, so reads remain nonblocking while the actor
 is busy. Synchronous mutations publish before replying, giving immediate
 read-after-write consistency. `count` reads a materialized count in O(1).
 
-The table lifetime follows the actor: reads panic after that actor stops rather
-than returning a misleading empty result. Other presence actors own independent
-tables and remain unaffected.
+The table lifetime follows the actor. Before startup, after the actor stops, or
+during the brief window before a supervisor starts its replacement,
+`list`, `get_by_key`, and `count` return `Error(Nil)` rather than a misleading
+empty result. Other presence actors own independent tables and remain
+unaffected.
 
-The read model's ETS table is node-local: a `Presence` handle must stay on the
-node where its child specification runs. Sending the handle to (or otherwise
-calling `list`/`get_by_key`/`count` from) a process on a different BEAM node
-looks up a table name that names nothing on that node, so those calls fail
-there too (`track`/`untrack`/`untrack_all` still work remotely, since they only
-need to reach the owning actor's process). Use PubSub replication
-(`with_pubsub`) to share presence state across nodes instead of moving the
-handle itself.
+Both the stable actor name and the read model's ETS table are node-local, so a
+`Presence` handle must stay on the node where its child specification runs.
+From another BEAM node, `track`/`untrack`/`untrack_all` cannot reach the owning
+actor and panic as unavailable, while `list`/`get_by_key`/`count` return
+`Error(Nil)`. Use PubSub replication (`with_pubsub`) to share presence state
+across nodes instead of moving the handle itself.
 
 The handle is backed by stable process and ETS names, so it reaches the
 replacement actor and read model after a supervised restart. Presence entries

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -18,9 +18,11 @@ The presence system has two layers:
 ```gleam
 import beryl/presence
 import beryl/pubsub
+import gleam/otp/static_supervisor
 
 // Without PubSub (single-node only)
-let assert Ok(p) = presence.start(presence.default_config("node1"))
+let #(p, presence_spec) =
+  presence.child_spec(presence.default_config("node1"))
 
 // With PubSub for cross-node replication
 let ps = pubsub.start(pubsub.default_config())
@@ -28,7 +30,12 @@ let config =
   presence.default_config("node1")
   |> presence.with_pubsub(ps)
   |> presence.with_broadcast_interval(1500)
-let assert Ok(p) = presence.start(config)
+let #(p, presence_spec) = presence.child_spec(config)
+
+let assert Ok(_root) =
+  static_supervisor.new(static_supervisor.OneForOne)
+  |> static_supervisor.add(presence_spec)
+  |> static_supervisor.start()
 ```
 
 ## Tracking presences
@@ -94,7 +101,19 @@ The table lifetime follows the actor: reads panic after that actor stops rather
 than returning a misleading empty result. Other presence actors own independent
 tables and remain unaffected.
 
-The read model's ETS table is node-local: a `Presence` handle must stay on the node where `presence.start` created it. Sending the handle to (or otherwise calling `list`/`get_by_key`/`count` from) a process on a different BEAM node looks up a table reference that names nothing on that node, so those calls panic there too (`track`/`untrack`/`untrack_all` still work remotely, since they only need to reach the owning actor's process). Use PubSub replication (`with_pubsub`) to share presence state across nodes instead of moving the handle itself.
+The read model's ETS table is node-local: a `Presence` handle must stay on the
+node where its child specification runs. Sending the handle to (or otherwise
+calling `list`/`get_by_key`/`count` from) a process on a different BEAM node
+looks up a table name that names nothing on that node, so those calls fail
+there too (`track`/`untrack`/`untrack_all` still work remotely, since they only
+need to reach the owning actor's process). Use PubSub replication
+(`with_pubsub`) to share presence state across nodes instead of moving the
+handle itself.
+
+The handle is backed by stable process and ETS names, so it reaches the
+replacement actor and read model after a supervised restart. Presence entries
+and tracking refs are in-memory state and reset on restart; connected clients
+must re-track their presence.
 
 ## Diff callbacks
 

--- a/website/src/content/docs/guides/supervision.md
+++ b/website/src/content/docs/guides/supervision.md
@@ -56,9 +56,9 @@ but does not stop sibling-channel teardown; see
 
 ## Presence and groups
 
-`presence.start` and `group.start` return plain OTP actors linked to the
-calling process. Start them alongside `child_spec` from your long-lived
-application process:
+`presence.child_spec` and `group.child_spec` return stable handles and child
+specifications, just like the socket runtime. Add all three specifications to
+your application supervisor:
 
 ```gleam
 import beryl
@@ -68,11 +68,11 @@ import beryl/wire
 import gleam/otp/static_supervisor
 
 pub fn main() {
-  let assert Ok(presence_actor) =
-    presence.start(presence.default_config("node1"))
-  let assert Ok(groups) = group.start()
+  let #(presence_actor, presence_spec) =
+    presence.child_spec(presence.default_config("node1"))
+  let #(groups, groups_spec) = group.child_spec()
 
-  let assert Ok(#(channels, spec)) =
+  let assert Ok(#(channels, beryl_spec)) =
     beryl.child_spec(
       beryl.config(wire.phoenix_codec()),
       init: init,
@@ -80,7 +80,9 @@ pub fn main() {
     )
   let assert Ok(_root) =
     static_supervisor.new(static_supervisor.OneForOne)
-    |> static_supervisor.add(spec)
+    |> static_supervisor.add(presence_spec)
+    |> static_supervisor.add(groups_spec)
+    |> static_supervisor.add(beryl_spec)
     |> static_supervisor.start()
 
   // ... start the transport, run forever
@@ -93,9 +95,9 @@ actions. The runtime applies those mutations asynchronously and parks only the
 affected socket until completion. Do not call the synchronous public presence
 API directly from `init`, `update`, or a channel callback.
 
-Both also offer `start_named` variants that register the actor under a
-`process.Name` for callers integrating them into their own supervision
-arrangements.
+Both handles are name-backed and reach the replacement actor after a supervised
+restart. Presence entries and tracking refs, and group definitions and
+memberships, are in-memory state and reset when their actor restarts.
 
 :::note[PubSub is not supervised]
 `beryl/pubsub` is backed by Erlang's `pg` module, whose lifecycle is
@@ -128,7 +130,8 @@ quiet no-ops.
 ## Production checklist
 
 - Add the returned specification to your long-lived application supervisor.
-- Start application-owned presence and group actors alongside the Beryl child.
+- Add application-owned presence and group child specifications alongside the
+  Beryl child.
 - Configure PubSub when running more than one BEAM node.
 - Configure rate limits to protect against runaway clients — see
   [Production Hardening](/guides/production-hardening/).

--- a/website/src/content/docs/reference/api/beryl-group.md
+++ b/website/src/content/docs/reference/api/beryl-group.md
@@ -15,14 +15,17 @@ Channel Groups - Named collections of topics for multi-topic broadcasting
  Useful for scenarios like broadcasting to all channels in a "team" or
  sending a system-wide notification.
 
- Groups are independent of the Beryl runtime. Start the actor from a
- long-lived application process and include it in the application's
- supervision arrangement as appropriate.
+ Groups are independent of the Beryl runtime and run under your
+ application's supervision tree.
 
  ## Example
 
  ```gleam
- let assert Ok(groups) = group.start()
+ let #(groups, groups_spec) = group.child_spec()
+ let assert Ok(_root) =
+   static_supervisor.new(static_supervisor.OneForOne)
+   |> static_supervisor.add(groups_spec)
+   |> static_supervisor.start()
  let assert Ok(Nil) = group.create(groups, "team:engineering")
  let assert Ok(Nil) = group.add(groups, "team:engineering", "room:frontend")
  let assert Ok(Nil) = group.add(groups, "team:engineering", "room:backend")
@@ -63,22 +66,6 @@ A running Groups instance.
 pub type Groups
 ```
 
-### `GroupStartError`
-
-Errors when starting the groups actor.
-
-```gleam
-pub type GroupStartError {
-  GroupActorStartFailed(error.StartFailure)
-}
-```
-
-#### Constructors
-
-##### `GroupActorStartFailed(error.StartFailure)`
-
-The actor failed to start
-
 ### `Message`
 
 Messages the groups actor handles
@@ -118,6 +105,19 @@ pub fn broadcast(
   String,
   json.Json
 ) -> Nil
+```
+
+### `child_spec`
+
+Build the supervised groups actor.
+
+ Add the returned child specification to your application's supervisor.
+ The returned handle is name-backed, so it reaches the replacement actor
+ after a supervised restart. Group definitions are in-memory state and are
+ reset by a restart.
+
+```gleam
+pub fn child_spec() -> #(Groups, supervision.ChildSpecification(process.Subject(Message)))
 ```
 
 ### `create`
@@ -168,14 +168,6 @@ pub fn remove(
   String,
   String
 ) -> Result(Nil, GroupError)
-```
-
-### `start`
-
-Start the groups actor
-
-```gleam
-pub fn start() -> Result(Groups, GroupStartError)
 ```
 
 ### `topics`

--- a/website/src/content/docs/reference/api/beryl-group.md
+++ b/website/src/content/docs/reference/api/beryl-group.md
@@ -62,6 +62,13 @@ A running Groups instance.
  This handle is intentionally opaque so callers cannot forge the backing
  actor subject or depend on its runtime representation.
 
+ ## Node affinity
+
+ The stable registered subject is resolved on the caller's node. Keep a
+ `Groups` handle on the node where its child specification runs. Calls from
+ another BEAM node cannot reach the owning actor; synchronous operations
+ panic as unavailable, and fire-and-forget broadcasts are not delivered.
+
 ```gleam
 pub type Groups
 ```

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -79,17 +79,13 @@ A running Presence instance.
 
  ## Node affinity
 
- `list`, `get_by_key`, and `count` read the ETS read model directly
- in-process, which only works for ETS tables local to the calling node.
- Do not send this handle to, or otherwise use it from, a process on a
- different BEAM node: `track`/`untrack`/`untrack_all` would still reach
- the owning actor over distribution (they go through its `Subject`), but
- the read functions would be looking up a table name that names
- nothing on that node (or, if the identifier happens to collide with an
- unrelated local table, something else entirely), so they would fail or
- read the wrong data. Keep a Presence handle on the node where `child_spec`
- created it, and use PubSub replication (`with_pubsub`) to share presence
- state across nodes instead.
+ The stable registered subject and ETS read model are resolved on the
+ caller's node. Keep a `Presence` handle on the node where its child
+ specification runs. From another BEAM node, synchronous mutations cannot
+ reach the owning actor and panic as unavailable, while `list`, `get_by_key`,
+ and `count` return `Error(Nil)` because the read model is unavailable.
+ Use PubSub replication (`with_pubsub`) to share presence state across nodes
+ instead of moving the handle itself.
 
 ```gleam
 pub type Presence

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -17,9 +17,8 @@ Presence - Distributed presence tracking backed by a CRDT
  - Receives remote state from PubSub and merges it internally
  - Invokes `on_diff` callback when merges produce non-empty diffs
 
- Presence is independent of the Beryl runtime. Start the actor from a
- long-lived application process and include it in the application's
- supervision arrangement as appropriate.
+ Presence is independent of the Beryl runtime and runs under your
+ application's supervision tree.
 
  ## Example
 
@@ -29,7 +28,11 @@ Presence - Distributed presence tracking backed by a CRDT
    presence.default_config("node1")
    |> presence.with_pubsub(ps)
    |> presence.with_broadcast_interval(1500)
- let assert Ok(p) = presence.start(config)
+ let #(p, presence_spec) = presence.child_spec(config)
+ let assert Ok(_root) =
+   static_supervisor.new(static_supervisor.OneForOne)
+   |> static_supervisor.add(presence_spec)
+   |> static_supervisor.start()
  let ref = presence.track(p, "room:lobby", "user:1", "socket-1", meta)
  let assert Ok(entries) = presence.list(p, "room:lobby")
  ```
@@ -71,10 +74,8 @@ pub type Message
 A running Presence instance.
 
  This handle is intentionally opaque so callers cannot forge actor subjects
- or depend on the runtime representation. It carries both the actor's
- subject (for the still-synchronous `track`/`untrack`/`untrack_all`) and a
- reference to the actor-owned ETS read model that `list`, `get_by_key`,
- and `count` read directly, without going through the actor mailbox.
+ or depend on the runtime representation. It carries the actor's stable
+ registered subject and the name of its actor-owned ETS read model.
 
  ## Node affinity
 
@@ -83,10 +84,10 @@ A running Presence instance.
  Do not send this handle to, or otherwise use it from, a process on a
  different BEAM node: `track`/`untrack`/`untrack_all` would still reach
  the owning actor over distribution (they go through its `Subject`), but
- the read functions would be looking up a table reference that names
+ the read functions would be looking up a table name that names
  nothing on that node (or, if the identifier happens to collide with an
  unrelated local table, something else entirely), so they would fail or
- read the wrong data. Keep a Presence handle on the node where `start`
+ read the wrong data. Keep a Presence handle on the node where `child_spec`
  created it, and use PubSub replication (`with_pubsub`) to share presence
  state across nodes instead.
 
@@ -111,23 +112,20 @@ pub type PresenceEntry {
 }
 ```
 
-### `PresenceError`
+## Functions
 
-Errors from presence operations
+### `child_spec`
+
+Build the supervised presence actor.
+
+ Add the returned child specification to your application's supervisor.
+ The returned handle is name-backed and resumes working after a supervised
+ restart. Presence entries and tracking refs are in-memory state and are
+ reset by a restart.
 
 ```gleam
-pub type PresenceError {
-  PresenceStartFailed(error.StartFailure)
-}
+pub fn child_spec(Config) -> #(Presence, supervision.ChildSpecification(process.Subject(Message)))
 ```
-
-#### Constructors
-
-##### `PresenceStartFailed(error.StartFailure)`
-
-The presence actor failed to start.
-
-## Functions
 
 ### `count`
 
@@ -250,14 +248,6 @@ pub fn list(
   Presence,
   String
 ) -> Result(List(PresenceEntry), Nil)
-```
-
-### `start`
-
-Start the presence actor
-
-```gleam
-pub fn start(Config) -> Result(Presence, PresenceError)
 ```
 
 ### `track`


### PR DESCRIPTION
Beryl's socket runtime was supervised-only, but presence and groups still
started borrowed, unsupervised actors. This makes every process-backed Beryl
resource start through the application's OTP supervisor while keeping the
original handles usable after worker restarts.

## What changed

- Replace public `presence.start` and `group.start` with `child_spec` APIs that
  return stable, node-affine handles and application-owned child specifications.
- Recreate presence's actor-owned ETS read model under the same stable name on
  restart, preserving nonblocking reads without retaining stale state.
- Verify both original handles reach replacement workers and document that
  presence entries, tracking refs, group definitions, and memberships reset on
  restart.
- Migrate the chatrooms and showcase startup paths, guides, architecture docs,
  generated API references, and changelog.

## Breaking change

`presence.start`, `group.start`, `PresenceError`, and `GroupStartError` are no
longer public. Applications must add the specifications returned by
`presence.child_spec` and `group.child_spec` to their supervision tree.

The new stable handles are node-affine because their registered names resolve
on the caller's node. Use each handle only on the node where its child runs:
remote presence mutations and synchronous group operations panic as unavailable,
remote presence reads return `Error(Nil)`, and remote group broadcasts are not
delivered.

Closes #233
