### PR TITLE
docs(adr): define runtime scalability boundary

### DIFF
--- a/docs/adr/0002-app-side-dispatch.md
+++ b/docs/adr/0002-app-side-dispatch.md
@@ -11,6 +11,10 @@ remains the core programming model and the core still contains no erasure.
 ADR 0003 layers channel-module ergonomics above that API; co-locating the
 layer in `packages/beryl` does not move it into the runtime internals.
 
+Amended (2026-08-17) to record the scalability ceiling of the current shared
+runtime actor and the compatibility boundary for a post-1.0 process-topology
+rewrite. The public dispatch model is unchanged.
+
 ## Context
 
 ADR 0001 chose type erasure given library-side dispatch, and its analysis
@@ -86,8 +90,9 @@ the generated [API reference](https://beryl.tylerbutler.com/reference/api/);
   unreleased intermediate `beryl/socket/router` API was removed before
   release rather than becoming a third programming model.
 - The effects type carried the main join-ack ordering risk. Effects apply
-  strictly in list order within one runtime actor turn, so list order is
-  wire order. Presence integration is deliberately separate in Lane B:
+  strictly in list order, so list order is wire order. The current runtime
+  does this within one actor turn, but that topology is not part of the
+  guarantee. Presence integration is deliberately separate in Lane B:
   synchronous presence work stays outside the shared runtime, while the
   indivisible async read-model/effect bundle is deferred to a later slice.
 - Supervision is explicit through the sole runtime entry point:
@@ -99,3 +104,47 @@ the generated [API reference](https://beryl.tylerbutler.com/reference/api/);
   application's root or siblings. See
   [Supervision](/guides/supervision/) for the full contract, including what
   state is lost when the supervised runtime restarts.
+
+## Scalability and post-1.0 compatibility
+
+The current implementation runs every application's callbacks in one runtime
+actor. This keeps state ownership and ordering simple, but it also serializes
+all callback work for a channels system onto one BEAM process and therefore one
+scheduler at a time. That is a known throughput ceiling, not a required part
+of the public programming model.
+
+The public compatibility boundary is:
+
+- Each socket has one `model` and one `msg` type. Its `update` calls are
+  serialized, each call receives the model returned by the previous call, and
+  client inputs remain ordered for that socket.
+- Effects from one `Next` are applied in list order, and that order is
+  observable wire order. A join acknowledgement cannot be overtaken by a later
+  effect in the same list.
+- No execution ordering is guaranteed between different sockets.
+- Runtime process count, process identities, routing layout, and supervisor
+  shape are implementation details. Public handles remain opaque.
+
+These constraints permit a post-1.0 internal rewrite to a routing/registry
+process with one supervised actor per socket. Different sockets could then run
+callbacks on different schedulers while preserving the `init`/`update` API,
+per-socket model semantics, input order, effects, refs, and wire behavior. A
+busy individual socket would remain sequential by design. Topic-scoped crash
+containment could continue inside that socket actor without making the process
+layout observable.
+
+One actor per joined socket/topic pair is a different trade-off. It fits the
+private state owned by `beryl/channel`, but true parallel callback execution
+across two topics on the same socket would change observable callback ordering
+and cannot preserve raw dispatch's single per-socket model semantics. Such a
+change requires a separate decision and may require a major version unless the
+affected ordering is explicitly outside the relevant API's guarantees. One
+actor shared by all subscribers to a topic name is not a suitable substitute:
+it couples unrelated channel instances, makes a hot topic a bottleneck, and
+widens a crash to every local subscriber of that topic.
+
+The public `stats.runtime_mailbox_length` metric currently exposes the
+single-actor topology indirectly. Before 1.0 its meaning should be generalized
+to a topology-independent dispatch backlog, or replaced with separately named
+router and worker backlog metrics, so operational compatibility does not block
+this rewrite.


### PR DESCRIPTION
## Summary

- document the shared runtime actor throughput ceiling
- define the compatibility boundary for a post-1.0 per-socket actor rewrite
- record the ordering and statistics constraints around finer-grained actors