### PR TITLE
refactor: simplify static warning text

### DIFF
--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -512,10 +512,7 @@ pub fn warn_if_unprotected(config: Config) -> Nil {
   |> log.warn("No abuse controls configured", [
     #(
       "hint",
-      "rate and connection limits are all disabled; fine for development, "
-        <> "but for production configure with_frame_rate, with_message_rate, "
-        <> "with_join_rate, with_max_connections_per_ip, and "
-        <> "with_max_connections (see the production hardening guide)",
+      "rate and connection limits are all disabled; fine for development, but for production configure with_frame_rate, with_message_rate, with_join_rate, with_max_connections_per_ip, and with_max_connections (see the production hardening guide)",
     ),
   ])
 }


### PR DESCRIPTION
## Summary

Replace the adjacent string-literal concatenation in `warn_if_unprotected` with one equivalent static literal. The emitted warning hint remains exactly unchanged; no API, presence invariant, suppression, or lint configuration changes are included.

Scope: 1 changed file, one concern.
