### PR TITLE
test(channel): prototype process-per-channel isolation

### DIFF
--- a/docs/spikes/0337-process-per-channel.md
+++ b/docs/spikes/0337-process-per-channel.md
@@ -1,0 +1,140 @@
+# Spike: process-per-channel isolation (#337)
+
+Prototype: `packages/beryl/test/spike_channel_worker.gleam`.
+Pinned behaviour: `packages/beryl/test/spike_channel_worker_test.gleam`.
+
+The prototype is built entirely on beryl's public core API, the way
+`beryl/channel` is. It reuses that layer's handlers, `join`, state sealing,
+callbacks, actions, and action lowering unchanged — `channel.open` returns
+the same non-generic `LiveChannel` — and changes only which process holds
+that value:
+
+```text
+shipped:  runtime actor ── LiveChannel per joined topic (in its model)
+spike:    runtime actor ── worker(topic) ── LiveChannel
+                        └─ worker(topic) ── LiveChannel
+```
+
+That is the whole difference, which is what makes the two comparable.
+No `Dynamic`, no coercion, and no core change was needed to build it.
+
+## The finding that reframes the issue
+
+**A socket is not a process, so the "socket session" in the issue's
+candidate shape does not exist and cannot be built from outside the core.**
+Everything the session was supposed to do lands on the router, which runs
+inside the one shared runtime actor:
+
+- It cannot monitor its workers. `DOWN` goes to the process that called
+  `monitor`, and the router does not own the runtime actor's selector. The
+  prototype pays for this with **one extra watcher process per channel**,
+  so the real cost is two processes per join, not one.
+- It cannot hold a per-socket in-flight budget, because there is nowhere
+  per-socket to hold one.
+- It cannot link workers to the connection. If the runtime actor dies, every
+  worker on every socket is orphaned until the factory supervisor goes down
+  with it.
+
+So #337 is downstream of [#334](https://github.com/tylerbutler/beryl/issues/334),
+not parallel to it. Process-per-channel on top of process-per-socket is a
+coherent design; process-per-channel on today's shared runtime buys callback
+concurrency and pays for it with a watcher process per channel and the two
+contract breaks below.
+
+## Answers to the questions the issue asked
+
+**Does the socket permit one in-flight callback, or can workers run
+concurrently?** Concurrently after join, serially during it. `join` and
+`on_terminate` are synchronous calls from the router; everything else is a
+cast, so N joined topics on one socket can be executing callbacks at once.
+
+**What ordering remains between actions from different topics on one
+socket?** Per topic, total order is preserved: one worker mailbox, FIFO, and
+the VM orders messages between one pair of processes. Across topics on one
+socket, nothing is preserved — two topics' replies can be interleaved in any
+order regardless of the order the client sent them. **This is a change from
+today**, where the shared runtime serialises the whole socket. Phoenix does
+not promise cross-topic ordering either, so the question is whether beryl
+wants to keep promising more than Phoenix does.
+
+**Does `join` execute during child startup or through an asynchronous
+handshake?** During child startup — an asynchronous handshake is not
+representable. Core rejects a `Join` that is unanswered when the update turn
+ends (fail-closed), so the router has to have the outcome before it returns.
+The prototype therefore runs `join` in the worker's initialiser and blocks
+the runtime on `factory_supervisor.start_child`. An async handshake needs a
+new core capability: a join that can be left pending across turns.
+
+**How are join timeout, worker startup failure, and worker death during an
+action batch represented?** All three are distinguishable. A join that overruns the initialiser timeout
+rejects with `join timeout` — a reason core has no equivalent for, because
+core cannot time a callback out at all, so it is a wire value this topology
+adds. A panicking join rejects with core's own `join crashed`. Worker death
+is a `Died` envelope from the watcher, which drops the topic from the router
+and kicks it; a batch in flight from that worker is then discarded by the
+generation check, since the topic is no longer live.
+
+**How does the session apply backpressure to worker mailboxes and pending
+action batches?** It does not. Worker mailboxes are unbounded and batches
+are applied as fast as they arrive. A budget needs a per-socket owner (#334).
+
+**Which process owns presence suspension while an asynchronous presence
+mutation is in flight?** Unchanged — the runtime. Workers emit actions;
+`PresenceTrack`/`PresenceUntrack` are core effects applied by the runtime,
+which is also what makes it necessary for the router, not the worker, to
+apply every batch.
+
+**How does socket shutdown terminate workers and preserve `on_terminate`?**
+Core delivers `Closed` for every joined topic on teardown, and the router
+answers each one with a synchronous `Finish` call before the turn ends —
+`on_terminate`'s actions have to be lowered inside that turn. Workers stop
+on the way out, and `a_disconnect_terminates_every_worker_test` pins that no
+worker outlives its socket.
+
+## Two contract breaks, both pinned by tests
+
+1. **A crashed worker cannot run `on_terminate`.** Today core rescues the
+   callback, keeps the model, and delivers `Closed`, so the channel's state
+   is still there to terminate. Here the state died with the process. This
+   matches Phoenix — a channel process crash skips `terminate/2` — but it is
+   a change from what beryl documents today.
+2. **A crashed channel closes as `phx_close`, not `phx_error`.** Core picks
+   the frame from the stop reason, and the only way a layer can close a topic
+   it no longer owns is `KickTopic`, which is `Shutdown`. Preserving this
+   needs a core effect that carries a reason.
+
+A third difference is arguably an improvement: a panic in `on_info` closes
+only its topic here, where today it tears down the whole socket.
+
+There is also a cost that is not a contract break but is worse
+operationally, and the prototype does not currently pay it down: **a panic
+inside `on_terminate` freezes every socket for a full second.** The worker
+dies before it can answer the router's synchronous `Finish`, so the `Closed`
+turn blocks in `process.receive` — inside the one shared runtime actor —
+until `terminate_timeout_ms` expires. Nothing else on that runtime moves in
+the meantime. It is fixable within this topology by selecting on the
+worker's `DOWN` alongside its reply, so a dead worker ends the wait at once;
+it is worth stating plainly because the shared runtime has no equivalent
+failure mode, and because a socket session (#334) would confine the stall to
+one connection instead of all of them.
+
+## What was not done
+
+- **No benchmarks.** The issue asks for thresholds to be set before final
+  numbers, and none are set. What can be said without measuring: two
+  processes per joined channel (worker plus watcher) against zero today,
+  plus one extra message hop for every reply, against the ability to run
+  callbacks on more than one scheduler. Whether that trade pays depends
+  entirely on callback cost, which is the thing to measure first.
+- **No cross-node, presence, or broadcast workloads**, and no binary frame
+  path — the binary path is `Deliver`'s shape exactly.
+- **The Phoenix contract matrix was not run against the spike.** It is wired
+  to `beryl.child_spec` and `channel.child_spec`; the two breaks above say
+  what it would report.
+
+## Recommendation
+
+Do not pursue process-per-channel before #334. Reassess afterwards, when a
+socket session actually exists to own monitoring, backpressure, and worker
+lifetime, and when the watcher process — currently half the per-channel cost
+— disappears.

--- a/packages/beryl/test/spike_channel_worker.gleam
+++ b/packages/beryl/test/spike_channel_worker.gleam
@@ -1,0 +1,602 @@
+//// Prototype for [#337](https://github.com/tylerbutler/beryl/issues/337):
+//// one temporary actor per accepted channel.
+////
+//// **This is a spike, not a second runtime.** It lives in `test/` because
+//// it exists to be measured and argued about, not shipped. Nothing in
+//// `src/` imports it.
+////
+//// ## What it reuses
+////
+//// Everything except the topology. Handlers, `join`, state sealing,
+//// callbacks, actions, and action lowering are `beryl/channel`'s own —
+//// `channel.open` produces the same non-generic `LiveChannel` the shipped
+//// router holds, and `channel.effects` lowers the same actions. The only
+//// difference is *which process* holds that `LiveChannel` and runs its
+//// callbacks:
+////
+//// ```text
+//// shipped:   runtime actor ── LiveChannel per topic (in its model)
+//// spike:     runtime actor ── Worker(topic) ── LiveChannel
+////                          └─ Worker(topic) ── LiveChannel
+//// ```
+////
+//// So a benchmark against `channel.child_spec` compares topology alone.
+////
+//// ## Shape
+////
+//// - A `factory_supervisor` starts one `Temporary` worker per accepted
+////   join. Temporary is the point: a worker whose join and authorization
+////   state died must not be restarted behind the client's back.
+//// - `join` runs **inside the worker's initialiser**, and the router waits
+////   for it, because the core rejects a `Join` that is unanswered when the
+////   update turn ends. There is no way to represent an asynchronous join
+////   handshake against today's core.
+//// - Everything after the join is asynchronous: the router casts work to
+////   the worker, and the worker reports an action batch back through the
+////   socket's own `Sender`, stamped with topic, generation, and sequence.
+////   The router validates the stamp before applying anything.
+//// - `on_terminate` is synchronous again, for the same reason `join` is:
+////   its actions have to be lowered inside the `Closed` turn.
+////
+//// ## Known ceilings
+////
+//// `ponytail:` spike-scope cuts — no backpressure, no binary frames, no
+//// pattern validation, workers not linked to their socket (nothing
+//// per-socket exists to link them to), and a panicking `on_terminate`
+//// stalling every socket for `terminate_timeout_ms` (see `finish`). Each
+//// one's upgrade path, and what the prototype found, is in
+//// `docs/spikes/0337-process-per-channel.md`.
+
+import beryl
+import beryl/channel
+import beryl/socket
+import beryl/topic
+import gleam/dict
+import gleam/dynamic
+import gleam/erlang/process
+import gleam/json
+import gleam/list
+import gleam/option.{type Option}
+import gleam/otp/actor
+import gleam/otp/factory_supervisor
+import gleam/otp/static_supervisor
+import gleam/otp/supervision
+import gleam/result
+
+/// How long a `join` callback has to finish before the worker's start is
+/// abandoned and the join rejected. The runtime actor is blocked for this
+/// long in the worst case — a real design would want it much lower than
+/// the supervisor's own call timeout, which is what actually bounds it.
+const join_timeout_ms = 1000
+
+/// How long the `Closed` turn waits for a worker's termination actions.
+const terminate_timeout_ms = 1000
+
+// ---------------------------------------------------------------------------
+// Worker
+// ---------------------------------------------------------------------------
+
+/// Work cast to one channel worker.
+type Work {
+  /// A client message for this channel's `on_message`.
+  Deliver(message: channel.Message)
+  /// One sealed server-side message for this channel's `on_info`.
+  ///
+  /// It arrives directly from the `Sender` that produced it, not by way of
+  /// the router: the join that sealed the mail *is* this process, so
+  /// process identity already carries the stamp the shipped router has to
+  /// check by hand. Mail for an ended join reaches a dead pid and is
+  /// dropped by the VM.
+  DeliverMail(mail: channel.Mail)
+  /// Run `on_terminate` and answer with its lowered actions, then stop.
+  Finish(reply: process.Subject(List(socket.Effect)), reason: socket.StopReason)
+  /// Stop without running any callback (a refused join has no channel).
+  Halt
+}
+
+/// What the factory supervisor hands back to the router when a worker
+/// starts.
+type Report {
+  /// The join was accepted. `effects` are its accept-time actions, already
+  /// lowered and in order; the router must apply them after the accept.
+  Opened(
+    work: process.Subject(Work),
+    reply: Option(json.Json),
+    effects: List(socket.Effect),
+  )
+  /// The join was refused. The worker stops itself.
+  Refused(reason: json.Json)
+}
+
+/// The factory supervisor's child argument: one join attempt.
+type Spawn {
+  Spawn(
+    handler: channel.Handler,
+    home: socket.Sender(Envelope),
+    socket_id: String,
+    seed: socket.ConnectSeed,
+    topic: String,
+    params: List(String),
+    payload: dynamic.Dynamic,
+    generation: Int,
+  )
+}
+
+/// An accepted channel, owned by exactly one worker process.
+type Channel {
+  Channel(
+    live: channel.LiveChannel,
+    topic: String,
+    generation: Int,
+    /// Batches this worker has reported, monotonic from 1.
+    sequence: Int,
+    home: socket.Sender(Envelope),
+  )
+}
+
+type State {
+  Running(Channel)
+  Refusing
+}
+
+/// Start one channel worker, running its `join` callback in the new
+/// process.
+///
+/// A panic in `join` fails the start, which the router turns into a
+/// rejection — the same observable outcome the shipped layer gets from
+/// core's rescue boundary, by a different mechanism.
+fn start_worker(spawn: Spawn) -> actor.StartResult(Report) {
+  actor.new_with_initialiser(join_timeout_ms, fn(work) {
+    let context =
+      channel.RoutedJoinContext(
+        socket_id: spawn.socket_id,
+        seed: spawn.seed,
+        topic: spawn.topic,
+        params: spawn.params,
+        payload: spawn.payload,
+        deliver: fn(mail) { process.send(work, DeliverMail(mail)) },
+      )
+
+    case channel.open(spawn.handler, context) {
+      channel.Rejected(reason) -> {
+        process.send(work, Halt)
+        Ok(actor.initialised(Refusing) |> actor.returning(Refused(reason)))
+      }
+      channel.Accepted(reply: reply, actions: actions, channel: live) ->
+        Ok(
+          actor.initialised(
+            Running(Channel(
+              live: live,
+              topic: spawn.topic,
+              generation: spawn.generation,
+              sequence: 0,
+              home: spawn.home,
+            )),
+          )
+          |> actor.returning(Opened(
+            work: work,
+            reply: reply,
+            effects: channel.effects(spawn.topic, actions),
+          )),
+        )
+    }
+  })
+  |> actor.on_message(handle)
+  |> actor.start
+}
+
+fn handle(state: State, work: Work) -> actor.Next(State, Work) {
+  case state {
+    Refusing -> actor.stop()
+    Running(active) ->
+      case work {
+        Deliver(message: message) ->
+          advance(active, active.live.on_message(message))
+        DeliverMail(mail: mail) -> advance(active, active.live.on_mail(mail))
+        Finish(reply: reply, reason: reason) -> {
+          process.send(
+            reply,
+            channel.effects(active.topic, active.live.on_terminate(reason)),
+          )
+          actor.stop()
+        }
+        Halt -> actor.stop()
+      }
+  }
+}
+
+/// Report one callback result to the router and keep the next channel.
+///
+/// A worker never closes its own topic: `Closing` and `StopSocket` are
+/// requests, and the worker stays alive until the router's `Closed` turn
+/// asks it for its termination actions.
+fn advance(current: Channel, step: channel.Step) -> actor.Next(State, Work) {
+  let next = Channel(..current, sequence: current.sequence + 1)
+  case step {
+    channel.StepContinue(next: live, actions: actions) -> {
+      report(next, Continue(channel.effects(next.topic, actions)))
+      actor.continue(Running(Channel(..next, live: live)))
+    }
+    channel.StepClose(actions: actions) -> {
+      report(next, Closing(channel.effects(next.topic, actions)))
+      actor.continue(Running(next))
+    }
+    channel.StepStop(reason: reason) -> {
+      report(next, StopSocket(reason))
+      actor.continue(Running(next))
+    }
+  }
+}
+
+fn report(active: Channel, outcome: Outcome) -> Nil {
+  socket.notify(
+    active.home,
+    Batch(
+      topic: active.topic,
+      generation: active.generation,
+      sequence: active.sequence,
+      outcome: outcome,
+    ),
+  )
+}
+
+/// Notify the socket when a worker exits, from a process that is allowed
+/// to receive `DOWN`.
+///
+/// The router runs inside beryl's shared runtime actor and does not own
+/// that actor's selector, so it cannot monitor anything itself. One
+/// short-lived watcher per worker is the price of that, and it doubles the
+/// per-channel process count — the first thing #334 would pay back.
+fn watch(
+  pid: process.Pid,
+  home: socket.Sender(Envelope),
+  name: String,
+  generation: Int,
+) -> Nil {
+  let _watcher =
+    process.spawn_unlinked(fn() {
+      let monitor = process.monitor(pid)
+      let selector =
+        process.new_selector()
+        |> process.select_specific_monitor(monitor, fn(down) { down })
+      let _down = process.selector_receive_forever(selector)
+      socket.notify(home, Died(topic: name, generation: generation))
+    })
+  Nil
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/// The socket-level message type: worker results coming home.
+///
+/// The stamp the issue proposed carries a socket id too. It is redundant
+/// here — an envelope travels through one socket's own `Sender`, so it can
+/// only arrive at the socket it belongs to.
+type Envelope {
+  Batch(topic: String, generation: Int, sequence: Int, outcome: Outcome)
+  Died(topic: String, generation: Int)
+}
+
+/// One worker's answer to one unit of work.
+type Outcome {
+  Continue(effects: List(socket.Effect))
+  Closing(effects: List(socket.Effect))
+  StopSocket(reason: socket.StopReason)
+}
+
+type Registered {
+  Registered(pattern: topic.TopicPattern, handler: channel.Handler)
+}
+
+type Worker {
+  Worker(
+    generation: Int,
+    work: process.Subject(Work),
+    /// The highest batch sequence applied for this join.
+    sequence: Int,
+  )
+}
+
+type Router {
+  Router(
+    handlers: List(Registered),
+    factory: process.Name(factory_supervisor.Message(Spawn, Report)),
+    socket_id: String,
+    seed: socket.ConnectSeed,
+    self: socket.Sender(Envelope),
+    generation: Int,
+    live: dict.Dict(String, Worker),
+  )
+}
+
+/// Build a spike channel system: a factory supervisor for channel workers,
+/// then beryl's runtime.
+///
+/// Start order matters — the runtime's first join looks the factory up by
+/// name.
+pub fn child_spec(
+  config: beryl.Config,
+  handlers handlers: List(channel.Handler),
+) -> Result(
+  #(beryl.Sockets, supervision.ChildSpecification(static_supervisor.Supervisor)),
+  beryl.ConfigError,
+) {
+  let factory = process.new_name("spike_channel_factory")
+  let table = table(handlers)
+
+  use #(sockets, runtime) <- result.map(beryl.child_spec(
+    config,
+    init: fn(info) { init(table, factory, info) },
+    update: update,
+  ))
+
+  let workers =
+    factory_supervisor.worker_child(start_worker)
+    |> factory_supervisor.restart_strategy(supervision.Temporary)
+    |> factory_supervisor.named(factory)
+    |> factory_supervisor.supervised()
+
+  let tree = fn() {
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(workers)
+    |> static_supervisor.add(runtime)
+    |> static_supervisor.start()
+  }
+
+  #(sockets, supervision.supervisor(tree))
+}
+
+fn table(handlers: List(channel.Handler)) -> List(Registered) {
+  list.map(handlers, fn(handler) {
+    Registered(
+      pattern: topic.parse_pattern(channel.pattern(handler)),
+      handler: handler,
+    )
+  })
+}
+
+fn init(
+  handlers: List(Registered),
+  factory: process.Name(factory_supervisor.Message(Spawn, Report)),
+  info: socket.ConnectInfo(Envelope),
+) -> #(Router, List(socket.Effect)) {
+  #(
+    Router(
+      handlers: handlers,
+      factory: factory,
+      socket_id: info.socket_id,
+      seed: info.seed,
+      self: info.self,
+      generation: 0,
+      live: dict.new(),
+    ),
+    [],
+  )
+}
+
+fn update(
+  router: Router,
+  input: socket.Input(Envelope),
+) -> socket.Next(Router) {
+  case input {
+    socket.Join(topic: name, payload: payload, ref: ref) ->
+      join(router, name, payload, ref)
+
+    socket.Message(topic: name, event: event, payload: payload, ref: ref) -> {
+      cast(
+        router,
+        name,
+        Deliver(channel.Message(
+          topic: name,
+          event: event,
+          payload: payload,
+          reply: ref,
+        )),
+      )
+      socket.Next(router, [])
+    }
+
+    // Out of spike scope: identical in shape to `Deliver`.
+    socket.Binary(topic: _, data: _) -> socket.Next(router, [])
+
+    socket.Closed(topic: name, reason: reason) -> finish(router, name, reason)
+
+    socket.Info(Batch(
+      topic: name,
+      generation: generation,
+      sequence: sequence,
+      outcome: outcome,
+    )) -> apply(router, name, generation, sequence, outcome)
+
+    socket.Info(Died(topic: name, generation: generation)) ->
+      died(router, name, generation)
+  }
+}
+
+/// Start a worker for an accepted topic, blocking the runtime until the
+/// join answers.
+fn join(
+  router: Router,
+  name: String,
+  payload: dynamic.Dynamic,
+  ref: socket.JoinRef,
+) -> socket.Next(Router) {
+  case select(router.handlers, name) {
+    Error(Nil) ->
+      socket.Next(router, [socket.RejectJoin(ref, refusal("unmatched topic"))])
+    Ok(#(handler, params)) -> {
+      let generation = router.generation + 1
+      let router = Router(..router, generation: generation)
+      let spawn =
+        Spawn(
+          handler: handler,
+          home: router.self,
+          socket_id: router.socket_id,
+          seed: router.seed,
+          topic: name,
+          params: params,
+          payload: payload,
+          generation: generation,
+        )
+
+      case
+        factory_supervisor.start_child(
+          factory_supervisor.get_by_name(router.factory),
+          spawn,
+        )
+      {
+        // A `join` that ran past `join_timeout_ms`. Core has no equivalent
+        // — it cannot time a callback out — so this reason is the
+        // prototype's own.
+        Error(actor.InitTimeout) ->
+          socket.Next(router, [socket.RejectJoin(ref, refusal("join timeout"))])
+
+        // A panicking join, which is what core reports as `join crashed`
+        // from its rescue boundary. `InitFailed` cannot happen here: the
+        // initialiser reports a refusal as data, never as an error.
+        Error(actor.InitExited(_)) | Error(actor.InitFailed(_)) ->
+          socket.Next(router, [socket.RejectJoin(ref, refusal("join crashed"))])
+
+        Ok(actor.Started(data: Refused(reason: reason), pid: _)) ->
+          socket.Next(router, [socket.RejectJoin(ref, reason)])
+
+        Ok(actor.Started(
+          pid: pid,
+          data: Opened(work: work, reply: reply, effects: accepted),
+        )) -> {
+          watch(pid, router.self, name, generation)
+          let live =
+            dict.insert(
+              router.live,
+              name,
+              Worker(generation: generation, work: work, sequence: 0),
+            )
+          socket.Next(Router(..router, live: live), [
+            socket.AcceptJoin(ref, reply),
+            ..accepted
+          ])
+        }
+      }
+    }
+  }
+}
+
+fn select(
+  handlers: List(Registered),
+  name: String,
+) -> Result(#(channel.Handler, List(String)), Nil) {
+  case handlers {
+    [] -> Error(Nil)
+    [registered, ..rest] ->
+      case topic.matches(registered.pattern, name) {
+        False -> select(rest, name)
+        True -> {
+          let params =
+            topic.extract_wildcards(registered.pattern, name)
+            |> result.unwrap([])
+          Ok(#(registered.handler, params))
+        }
+      }
+  }
+}
+
+fn refusal(reason: String) -> json.Json {
+  json.object([#("reason", json.string(reason))])
+}
+
+fn cast(router: Router, name: String, work: Work) -> Nil {
+  case dict.get(router.live, name) {
+    Error(Nil) -> Nil
+    Ok(worker) -> process.send(worker.work, work)
+  }
+}
+
+/// Apply one worker's action batch, after checking its stamp.
+///
+/// Generation rejects a batch from a superseded join; sequence rejects a
+/// replayed or reordered one. Locally the sequence check can never fire —
+/// the VM already orders messages between one pair of processes — so it is
+/// here for the distributed case and as a live assertion that the
+/// invariant holds.
+fn apply(
+  router: Router,
+  name: String,
+  generation: Int,
+  sequence: Int,
+  outcome: Outcome,
+) -> socket.Next(Router) {
+  case dict.get(router.live, name) {
+    Error(Nil) -> socket.Next(router, [])
+    Ok(worker) ->
+      case worker.generation == generation && sequence > worker.sequence {
+        False -> socket.Next(router, [])
+        True -> {
+          let live =
+            dict.insert(router.live, name, Worker(..worker, sequence: sequence))
+          let router = Router(..router, live: live)
+          case outcome {
+            Continue(effects: effects) -> socket.Next(router, effects)
+            // The worker stays live until the kick's `Closed` comes back,
+            // so termination runs on the one path every ending topic takes.
+            Closing(effects: effects) ->
+              socket.Next(
+                router,
+                list.append(effects, [socket.KickTopic(name)]),
+              )
+            StopSocket(reason: reason) -> socket.Stop(reason)
+          }
+        }
+      }
+  }
+}
+
+/// A worker exited.
+///
+/// Its state died with it, so there is no `on_terminate` to run and no way
+/// to rebuild the channel: the topic closes and the client must rejoin.
+/// Dropping the worker here also keeps the `Closed` this kick produces
+/// from waiting on a process that is already gone.
+fn died(router: Router, name: String, generation: Int) -> socket.Next(Router) {
+  case dict.get(router.live, name) {
+    Error(Nil) -> socket.Next(router, [])
+    Ok(worker) ->
+      case worker.generation == generation {
+        False -> socket.Next(router, [])
+        True ->
+          socket.Next(Router(..router, live: dict.delete(router.live, name)), [
+            socket.KickTopic(name),
+          ])
+      }
+  }
+}
+
+/// A topic ended: collect the worker's termination actions synchronously,
+/// because they have to be lowered inside this turn.
+///
+/// `ponytail:` a worker that panics in `on_terminate` never replies, so
+/// this blocks the shared runtime actor — and therefore every socket on it
+/// — for the full `terminate_timeout_ms`. The timeout is the only thing
+/// that ends the wait. Upgrade: monitor the worker and select on its
+/// `DOWN` alongside the reply, so a dead worker ends the wait immediately.
+fn finish(
+  router: Router,
+  name: String,
+  reason: socket.StopReason,
+) -> socket.Next(Router) {
+  case dict.get(router.live, name) {
+    Error(Nil) -> socket.Next(router, [])
+    Ok(worker) -> {
+      let router = Router(..router, live: dict.delete(router.live, name))
+      let reply = process.new_subject()
+      process.send(worker.work, Finish(reply: reply, reason: reason))
+      case process.receive(reply, terminate_timeout_ms) {
+        Ok(effects) -> socket.Next(router, effects)
+        // The worker died between the cast and the reply. Its termination
+        // actions are lost; the topic still closes.
+        Error(Nil) -> socket.Next(router, [])
+      }
+    }
+  }
+}

--- a/packages/beryl/test/spike_channel_worker_test.gleam
+++ b/packages/beryl/test/spike_channel_worker_test.gleam
@@ -1,0 +1,309 @@
+//// What the process-per-channel prototype (#337) actually does, pinned
+//// against the shipped shared-runtime layer.
+////
+//// The interesting assertions are the ones that *differ* from
+//// `channel_crash_test`: those are the parity costs of moving a channel
+//// into its own process, and they are the reason this spike exists.
+
+import beryl
+import beryl/channel
+import beryl/transport
+import beryl/wire
+import channel_dispatch_helper as helper
+import gleam/erlang/process
+import gleam/json
+import gleam/otp/static_supervisor
+import gleam/string
+import gleeunit/should
+import spike_channel_worker as spike
+
+/// A channel's server-side message type.
+pub type Note {
+  Announce(String)
+}
+
+// --- systems ---------------------------------------------------------------
+
+fn start(handlers: List(channel.Handler)) -> beryl.Sockets {
+  let assert Ok(#(sockets, spec)) =
+    spike.child_spec(beryl.config(wire.phoenix_codec()), handlers: handlers)
+    as "the spike config is valid"
+  let assert Ok(_) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(spec)
+    |> static_supervisor.start()
+    as "the spike supervision tree starts"
+  sockets
+}
+
+// --- test channels ---------------------------------------------------------
+
+/// A counting channel that reports the pid it runs in, replies to
+/// `"ping"`, and traces its termination.
+fn room(
+  pids: process.Subject(process.Pid),
+  trace: process.Subject(String),
+) -> channel.Handler {
+  channel.handler("room:*", fn(context) {
+    process.send(pids, process.self())
+    let callbacks =
+      channel.callbacks()
+      |> channel.on_message(fn(count, message) {
+        channel.next(count + 1, [
+          channel.reply_ok(message.reply, json.int(count + 1)),
+          channel.push("pong", json.int(count + 1)),
+        ])
+      })
+      |> channel.on_terminate(fn(_count, reason) {
+        process.send(
+          trace,
+          "terminate:" <> context.topic <> ":" <> helper.reason_name(reason),
+        )
+        []
+      })
+    channel.accept(0, callbacks)
+    |> channel.with_reply(json.object([#("handler", json.string("room"))]))
+  })
+}
+
+/// A channel that hands its typed sender out and pushes what it receives.
+fn mailbox(senders: process.Subject(channel.Sender(Note))) -> channel.Handler {
+  channel.handler("mail:*", fn(context) {
+    process.send(senders, context.self)
+    let callbacks =
+      channel.callbacks()
+      |> channel.on_info(fn(state, note) {
+        let Announce(text) = note
+        channel.next(state, [channel.push("announce", json.string(text))])
+      })
+    channel.accept(Nil, callbacks)
+  })
+}
+
+/// A channel whose `join` panics.
+fn join_panics() -> channel.Handler {
+  channel.handler("crash_join:*", fn(_context) { panic as "join exploded" })
+}
+
+/// A channel whose `on_message` panics, and which traces its termination
+/// so the test can prove it never runs.
+fn message_panics(trace: process.Subject(String)) -> channel.Handler {
+  channel.handler("crash_msg:*", fn(context) {
+    let callbacks =
+      channel.callbacks()
+      |> channel.on_message(fn(_state, _message) { panic as "message exploded" })
+      |> channel.on_terminate(fn(_state, _reason) {
+        process.send(trace, "terminate:" <> context.topic)
+        []
+      })
+    channel.accept(Nil, callbacks)
+  })
+}
+
+// --- helpers ---------------------------------------------------------------
+
+fn next_pid(pids: process.Subject(process.Pid)) -> process.Pid {
+  let assert Ok(pid) = process.receive(pids, 500) as "a channel opened"
+  pid
+}
+
+/// Wait for `pid` to exit, up to roughly a second.
+fn await_exit(pid: process.Pid, attempts: Int) -> Bool {
+  case process.is_alive(pid), attempts {
+    False, _ -> True
+    True, 0 -> False
+    True, _ -> {
+      process.sleep(20)
+      await_exit(pid, attempts - 1)
+    }
+  }
+}
+
+// --- topology --------------------------------------------------------------
+
+pub fn each_channel_runs_in_its_own_process_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([room(pids, trace)])
+  let frames = helper.connect(channels, "s1")
+  let assert Ok(runtime) = transport.runtime_pid(channels)
+    as "the runtime is running"
+
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  helper.recv(frames)
+  |> string.contains("\"handler\":\"room\"")
+  |> should.be_true
+  let channel_a = next_pid(pids)
+
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  let _join_b = helper.recv(frames)
+  let channel_b = next_pid(pids)
+
+  // Two joins on one socket: three distinct processes.
+  { channel_a == runtime } |> should.be_false
+  { channel_b == runtime } |> should.be_false
+  { channel_a == channel_b } |> should.be_false
+
+  // ...and the callbacks still work, through the same wire contract.
+  helper.push(channels, "s1", "room:a", "ping", "r-3")
+  helper.recv(frames) |> string.contains("\"status\":\"ok\"") |> should.be_true
+  helper.recv(frames) |> string.contains("\"pong\",1") |> should.be_true
+}
+
+pub fn a_typed_sender_reaches_its_own_worker_test() -> Nil {
+  let senders = process.new_subject()
+  let channels = start([mailbox(senders)])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "mail:a", "jr-1", "r-1")
+  let _join = helper.recv(frames)
+  let assert Ok(sender) = process.receive(senders, 500)
+    as "the channel handed out its sender"
+
+  channel.notify(sender, Announce("hello"))
+
+  // Mail goes straight to the worker that sealed it; the batch it
+  // produces comes back through the socket.
+  let push = helper.recv(frames)
+  push |> string.contains("\"announce\"") |> should.be_true
+  push |> string.contains("hello") |> should.be_true
+}
+
+pub fn a_rejoin_gets_a_fresh_worker_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([room(pids, trace)])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _join = helper.recv(frames)
+  let first = next_pid(pids)
+
+  helper.push(channels, "s1", "room:a", "ping", "r-2")
+  let _reply = helper.recv(frames)
+  helper.recv(frames) |> string.contains("\"pong\",1") |> should.be_true
+
+  helper.leave(channels, "s1", "room:a", "jr-1", "r-3")
+  helper.next_trace(trace) |> should.equal("terminate:room:a:normal")
+  { await_exit(first, 50) } |> should.be_true
+  let _leave_reply = helper.recv(frames)
+  let _close = helper.recv(frames)
+
+  helper.join(channels, "s1", "room:a", "jr-2", "r-4")
+  let _rejoin = helper.recv(frames)
+  let second = next_pid(pids)
+  { first == second } |> should.be_false
+
+  // A new worker means new state: the count starts over, and nothing the
+  // old worker held leaked into it.
+  helper.push(channels, "s1", "room:a", "ping", "r-5")
+  let _reply = helper.recv(frames)
+  helper.recv(frames) |> string.contains("\"pong\",1") |> should.be_true
+}
+
+// --- crash containment -----------------------------------------------------
+
+pub fn a_panic_in_join_rejects_that_join_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([join_panics(), room(pids, trace)])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "crash_join:a", "jr-1", "r-1")
+  let reply = helper.recv(frames)
+  reply |> string.contains("\"status\":\"error\"") |> should.be_true
+  reply |> string.contains("{\"reason\":\"join crashed\"}") |> should.be_true
+
+  // The socket is untouched: a worker that never started took nothing
+  // with it.
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  helper.recv(frames)
+  |> string.contains("\"handler\":\"room\"")
+  |> should.be_true
+}
+
+pub fn a_panic_handling_a_message_closes_only_that_topic_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([message_panics(trace), room(pids, trace)])
+  let frames = helper.connect(channels, "s1")
+  let assert Ok(runtime) = transport.runtime_pid(channels)
+    as "the runtime is running"
+
+  helper.join(channels, "s1", "crash_msg:a", "jr-1", "r-1")
+  let _join_a = helper.recv(frames)
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  let _join_b = helper.recv(frames)
+  let survivor = next_pid(pids)
+
+  helper.push(channels, "s1", "crash_msg:a", "boom", "r-3")
+
+  // The crash is contained by a process boundary, not a rescue: the
+  // runtime and the sibling channel are both untouched.
+  let close = helper.recv(frames)
+  close |> string.contains("crash_msg:a") |> should.be_true
+  { process.is_alive(runtime) } |> should.be_true
+  { process.is_alive(survivor) } |> should.be_true
+
+  helper.push(channels, "s1", "room:b", "ping", "r-4")
+  helper.recv(frames) |> string.contains("\"status\":\"ok\"") |> should.be_true
+  helper.recv(frames) |> string.contains("\"pong\",1") |> should.be_true
+}
+
+/// Both parity costs of the process boundary, pinned on one crash.
+///
+/// `on_terminate` is unreachable: the shipped layer runs it, because core
+/// rescues the callback and keeps the model, so the channel's state is
+/// still there to terminate. Here the state died with the process. This
+/// matches Phoenix, where a channel process crash skips `terminate/2`, but
+/// it is a change from what beryl does today.
+///
+/// And the close is announced as `phx_close`, not `phx_error`: core picks
+/// that from the stop reason, and the only way this layer can close a
+/// topic it no longer owns is `KickTopic`, which is `Shutdown`. Preserving
+/// the Phoenix contract needs a core effect that carries a reason.
+pub fn a_crashed_worker_loses_terminate_and_closes_as_shutdown_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([message_panics(trace), room(pids, trace)])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "crash_msg:a", "jr-1", "r-1")
+  let _join = helper.recv(frames)
+
+  helper.push(channels, "s1", "crash_msg:a", "boom", "r-2")
+
+  let close = helper.recv(frames)
+  close |> string.contains("phx_close") |> should.be_true
+  close |> string.contains("phx_error") |> should.be_false
+  helper.no_trace(trace)
+}
+
+// --- teardown --------------------------------------------------------------
+
+pub fn a_disconnect_terminates_every_worker_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([room(pids, trace)])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _join_a = helper.recv(frames)
+  let channel_a = next_pid(pids)
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  let _join_b = helper.recv(frames)
+  let channel_b = next_pid(pids)
+
+  helper.disconnect(channels, "s1")
+
+  // Both channels ran `on_terminate` and then stopped: no worker outlives
+  // the socket it belongs to.
+  helper.next_trace(trace)
+  |> string.starts_with("terminate:room:")
+  |> should.be_true
+  helper.next_trace(trace)
+  |> string.starts_with("terminate:room:")
+  |> should.be_true
+  { await_exit(channel_a, 50) } |> should.be_true
+  { await_exit(channel_b, 50) } |> should.be_true
+}


### PR DESCRIPTION
Prototype for #337: one temporary actor per accepted channel.

Not a second runtime — the spike lives in `packages/beryl/test/` and nothing in `src/` imports it. It is built entirely on beryl's public core API, and reuses `beryl/channel`'s handlers, `join`, state sealing, callbacks, actions, and action lowering **unchanged** (`channel.open` returns the same non-generic `LiveChannel`). Only which process holds that value differs, which is what makes the two topologies comparable:

```text
shipped:  runtime actor ── LiveChannel per joined topic (in its model)
spike:    runtime actor ── worker(topic) ── LiveChannel
                        └─ worker(topic) ── LiveChannel
```

No `Dynamic`, no coercion, no core change was needed to build it.

## The finding that reframes the issue

**A socket is not a process, so the issue's "socket session" does not exist and cannot be built from outside the core.** Everything it was supposed to do lands on the router, which runs inside the one shared runtime actor: it cannot monitor its workers (`DOWN` goes to whoever called `monitor`, and the router does not own the runtime's selector), cannot hold a per-socket in-flight budget, and cannot link workers to the connection. The prototype pays for the first with **one watcher process per channel** — so the real cost is two processes per join, not one.

#337 is downstream of #334, not parallel to it.

## Answers to the questions the issue asked

Full write-up in [`docs/spikes/0337-process-per-channel.md`](docs/spikes/0337-process-per-channel.md). In brief:

- **Concurrency**: concurrent after join, serial during it. `join` and `on_terminate` are synchronous calls; everything else is a cast.
- **Ordering**: total per topic, none across topics on one socket. That is a change from today, where the shared runtime serialises the whole socket.
- **Join**: during child startup — an async handshake is *not representable*, because core fail-closes a `Join` left unanswered when the turn ends.
- **Failures**: a join that overruns the initialiser timeout rejects as `join timeout` (a reason core has no equivalent for — it cannot time a callback out); a panicking join rejects as core's own `join crashed`; worker death arrives as a watcher notification and the generation check discards any batch in flight.
- **Backpressure**: none. It needs a per-socket owner (#334).
- **Presence suspension**: unchanged, owned by the runtime — which is why the router, not the worker, must apply every batch.
- **Shutdown**: core's `Closed` per topic drives a synchronous `Finish`; no worker outlives its socket (pinned by a test).

## Two contract breaks, both pinned by tests

1. A crashed worker cannot run `on_terminate` — its state died with the process. (Matches Phoenix; changes beryl.)
2. Its topic closes as `phx_close`, not `phx_error` — `KickTopic` is the only close a layer has, and it is `Shutdown`. Preserving this needs a core effect that carries a reason.

A third difference is arguably an improvement: a panic in `on_info` closes only its topic here, where today it tears the socket down.

And one cost that is not a contract break but is worse operationally: **a panic inside `on_terminate` freezes every socket for a full second.** The worker dies before answering the router's synchronous `Finish`, so the `Closed` turn blocks in the shared runtime actor until the terminate timeout expires. Fixable within this topology by selecting on the worker's `DOWN` alongside its reply; worth stating because the shared runtime has no equivalent failure mode.

## Not done

No benchmarks — the issue asks for thresholds first, and none are set. No cross-node, presence, or broadcast workloads, no binary frame path, and the Phoenix contract matrix was not wired to the spike.

## Recommendation

Do not pursue process-per-channel before #334. Reassess when a socket session exists to own monitoring, backpressure, and worker lifetime — and when the watcher process, currently half the per-channel cost, disappears.

---

`gleam test`: 501 passing, 7 of them new. `just lint` clean, strict build clean.

Ponytail-reviewed (net −34 lines: dropped a lowering wrapper, made five types private, deduplicated the module doc against the spike doc, merged two parity tests) and gleam-reviewed against the official conventions guide (fixed a catch-all over `actor.StartError` — which is what surfaced the timeout/crash distinction above — and spelled out an abbreviated field name).

Closes #337 only in the sense that the prototype and its findings exist; the design decision itself belongs in a fault-boundary ADR.

