### PR TITLE
docs(spikes): add #337 findings and #334 per-socket plan

### DIFF
--- a/docs/spikes/0334-per-socket-actor.md
+++ b/docs/spikes/0334-per-socket-actor.md
@@ -1,0 +1,217 @@
+# Spike plan: one actor per socket (#334)
+
+A plan, not a spike. Nothing has been prototyped or measured. Read against
+`main` at `d2acc2b`; every file and line reference below is that tree.
+
+[#337](https://github.com/tylerbutler/beryl/issues/337) was spiked first and
+concluded it is downstream of this issue — see
+[`0337-process-per-channel.md`](./0337-process-per-channel.md). Two of the
+three contract breaks it found trace back to the same root cause: a socket is
+not a process, so nothing can own per-socket monitoring, backpressure, or a
+drain. This issue is where that gets fixed, and the plan below is shaped by
+what #337 learned the expensive way.
+
+## The seam already exists
+
+`handle_message` (`runtime.gleam:517`) already partitions the runtime's own
+mailbox into exactly the two halves this issue asks for. Six variants are
+socket-scoped and dispatch through `dispatch_socket_msg`
+(`runtime.gleam:601`); the rest — `AdmitSocket`, `Broadcast`,
+`RemoteBroadcast`, `CheckHeartbeats`, `GetStats`, `Stop` — are router-scoped
+and never reach it. That function *is* the socket actor's `handle_message`,
+already written and already tested.
+
+The state splits along the same line. Every one of
+
+```text
+sockets  message_buckets  join_buckets  channel_buckets
+suspended  queued  unacked_tracks
+```
+
+is a `Dict(socket_id, _)`, and becomes a plain field on the socket actor.
+What is genuinely router-owned is `topics`, `pubsub`, `subscriber`, `config`,
+and `logger`.
+
+`Sender` is an opaque closure (`socket.gleam:263`) built at
+`runtime.gleam:801` as a send of `AppInfo(socket_id, message)` to the runtime
+subject. It captures the socket actor's subject instead. No signature
+changes, and it stops routing every server-side message through the router.
+
+So the rewrite is mostly a move, not a redesign. The design work is in the
+six decisions below, all of which are about what the router keeps.
+
+## Step 0: benchmarks, before any code
+
+The issue asks for thresholds set before final numbers. None are set, there
+is no bench harness in the repository, and #337 could not answer its own
+cost question without one. Both issues reduce to a single number:
+
+**Is app callback cost large enough to pay for a message hop?**
+
+Below some callback cost the shared actor wins and both issues close as
+"won't do". Above it, this issue is worth its complexity and #337 becomes
+worth reassessing.
+
+Build the harness against today's runtime, on `main`, before touching the
+topology. Workloads the issue names: connection churn, push round-trip,
+broadcast fan-out, presence. Report throughput, p95/p99, scheduler
+utilisation, mailbox depth, memory, process count. Sweep a synthetic
+callback cost across at least three orders of magnitude and find the
+crossover. That crossover is the decision.
+
+## Six decisions
+
+### 1. How a broadcast reaches a socket
+
+`local_broadcast` (`runtime.gleam:3730`) encodes the frame and calls each
+socket's `send` closure **from the router**, inside the router's turn. Keep
+that under per-socket actors and two processes write to one transport
+concurrently, so a broadcast can overtake a frame the socket actor has
+already decided to send. That is #337's third contract break in a new
+costume, and it would be just as unfixable from the router.
+
+The alternative is to route broadcasts through the socket actor: one extra
+hop per recipient, but per-socket encoding moves off the router onto N
+schedulers, which should pay for itself at fan-out.
+
+Recommend the hop. Measure it — this is the single largest performance
+question in the rewrite, because broadcast fan-out is the workload where the
+shared actor is currently at its best.
+
+### 2. Who owns the topic index
+
+Today `topics` is updated in the same turn as the join that caused it, which
+is why a broadcast issued immediately after a join can never miss that
+socket. Under per-socket actors the join happens somewhere else, and every
+option costs something:
+
+- **Router keeps the index, updated by synchronous call.** Every join on
+  every socket serialises through the router. This is precisely what the
+  #337 factory supervisor did, and it was the finding that survived that
+  spike unchanged.
+- **Router keeps the index, updated by cast.** Joins stay parallel, but a
+  window opens where the index lags the socket's real join state and a
+  broadcast misses a just-joined socket. New observable behaviour.
+- **Socket actors join `pg` groups directly.** `pubsub.gleam` already
+  supports per-process subscription — `subscriber` (`:194`), `join`
+  (`:202`), `leave` (`:207`), `subscribers` (`:304`),
+  `subscriber_count` (`:309`). The router would hold no topic index at all,
+  and remote broadcasts would reach socket actors with no router hop
+  whatsoever.
+
+The third is the most attractive and has the sharpest catch: `pubsub` is
+`Option` on the runtime config, so this means always starting a local `pg`
+scope, including for single-node deployments that configure no PubSub. That
+is a real cost to weigh, not a free reuse.
+
+### 3. Presence suspension is the deletion opportunity
+
+The `Step` / `Cont` / `Suspension` machinery — the interpreter at
+`runtime.gleam:1858`, its `Await` parking, `suspended`, and `queued` —
+exists for exactly one reason: one actor cannot block on the presence actor
+without stalling every socket. A per-socket actor can. A `process.try_call`
+bounded by `presence_op_timeout_ms` stalls only its own socket, which is
+already the behaviour suspension goes to great lengths to produce.
+
+If that holds, most of the step reification deletes. It should be validated
+against `app_presence_async_test` and `effect_ordering_test` before it is
+assumed, because the step machine also carries close-cleanup ordering, not
+just presence parking.
+
+One documented behaviour tightens rather than breaks. Today's architecture
+page says "an unrelated broadcast can land between two of the waiting
+socket's effects"
+(`website/src/content/docs/architecture/runtime.md:48`). Under a blocking
+call the broadcast queues in the socket actor's mailbox and lands after the
+effect list instead. That is a strictly stronger guarantee, so it is a
+documentation edit, not a contract break — but it is a behaviour change and
+belongs in the changelog.
+
+### 4. Admission must not become the new bottleneck
+
+`AdmitSocket` is a synchronous router call and has to stay atomic: the
+connection limit and the admission token are claimed together. But starting
+the socket actor *inside* that turn makes `supervisor:start_child` a
+serialised synchronous call per connection, which is #337's join
+serialisation transposed onto connections, and it would cap connection
+setup rate at one process.
+
+Prefer having the transport's connection process start the socket actor,
+then hand it to the router for an O(1) atomic admit. Startup stays parallel
+and the router turn stays short. This needs care around a socket actor that
+starts and is then refused admission — it must be stopped, and the
+admission token cancelled, without leaking either.
+
+### 5. Router failure semantics
+
+Transports monitor the router pid through `transport.runtime_pid`
+(`transport.gleam:243`), and the issue requires that router failure keeps
+its current connection-close and supervised-restart behaviour. So the router
+stays the named, stable owner, and its death has to take every socket actor
+with it — `one_for_all`, or `rest_for_one` with the router started first.
+
+#337 hit the orphan case directly: without `OneForAll`, a restarted runtime
+left every worker holding a `Sender` for a dead process with no termination
+message ever arriving. The same failure is available here at socket scale.
+
+### 6. Crash containment does not change
+
+Resist converting the `internal.rescue` boundaries to let-it-crash. Today a
+crashing topic-scoped `Message` closes only that topic; letting the socket
+actor die instead widens that to the whole socket, which the issue's own
+investigation criteria forbid. The *rationale* in the architecture page
+changes — per-socket state is no longer shared, so the original argument for
+rescuing weakens — but the behaviour must be preserved as-is and pinned by
+`app_crash_test` and `channel_crash_test` unchanged.
+
+## Phasing
+
+1. **Bench harness and thresholds** on today's runtime. Blocking; nothing
+   below is decidable without it.
+2. **Split the statistics API.** `stats.runtime_mailbox_length`
+   (`stats.gleam:69`) assumes one runtime mailbox and is a pre-1.0 leak the
+   issue already calls out. It is shippable on `main` independently of any
+   topology change, and it should ship first so the rewrite is not also an
+   API break.
+3. **Move heartbeat ownership to per-socket timers.** Deletes the O(N)
+   router sweep (`runtime.gleam:948`) and its awkward interaction with
+   suspended sockets. A strict improvement whether or not the rest of this
+   ever lands.
+4. **Prototype the socket actor** by lifting `dispatch_socket_msg` as-is,
+   wiring decisions 1 and 2 the cheap way first so the expensive options are
+   compared against something that works.
+5. **Run the whole suite unchanged.** 72 test files in
+   `packages/beryl/test`, plus `channel_wire_matrix` and the
+   `phoenix_channel_fixtures` matrix. Any test that needs editing to pass is
+   a contract break, and it gets written down here rather than edited away.
+6. **Benchmark against step 1's thresholds**, then decide.
+
+## What this adds and what it removes
+
+Removed: three per-socket rate-limit dicts, `suspended`, `queued`, the
+router heartbeat sweep, probably most of the step interpreter, and the
+router hop on every `Sender` send.
+
+Added: one supervisor, one hop per broadcast recipient, one hop per
+join/leave index update (unless decision 2 goes to `pg`), and the socket
+actor's own scaffolding.
+
+Net line count plausibly goes down. That is an argument for doing this even
+if the throughput case comes back weaker than hoped — but it is a guess
+until step 4 exists, and it should not be used to pre-empt step 1.
+
+## What this plan does not answer
+
+- **Whether it is worth doing.** That is step 1's job, and no number in this
+  document is measured.
+- **Cross-node behaviour.** If decision 2 goes to `pg`, remote broadcast
+  delivery changes shape and `presence_replication_test` becomes the
+  interesting suite. Not analysed here.
+- **The `except` / `from_socket` filtering path** under per-socket
+  subscription. `broadcast_from_socket` (`pubsub.gleam:270`) currently
+  filters at a single point in the router; where that filtering lands when
+  subscribers are separate processes is unresolved.
+- **Backpressure.** The issue does not ask for it and this plan does not add
+  it, but a per-socket process is the first place beryl could hold an
+  in-flight budget — which is what #337 found it was missing. Worth
+  designing for, not worth building yet.

--- a/docs/spikes/0337-process-per-channel.md
+++ b/docs/spikes/0337-process-per-channel.md
@@ -1,0 +1,191 @@
+# Spike: process-per-channel isolation (#337)
+
+The prototype and its tests are not merged. They live on the branch
+`feat/337-process-per-channel-spike` as
+`packages/beryl/test/spike_channel_worker.gleam` and
+`spike_channel_worker_test.gleam`; only these findings are merged here.
+
+The prototype reuses `beryl/channel`'s own router seam: handlers, `join`,
+state sealing, callbacks, actions, and action lowering are unchanged —
+`channel.open` returns the same non-generic `LiveChannel` — and only which
+process holds that value differs:
+
+```text
+shipped:  runtime actor ── LiveChannel per joined topic (in its model)
+spike:    runtime actor ── worker(topic) ── LiveChannel
+                        └─ worker(topic) ── LiveChannel
+```
+
+That is the whole difference, which is what makes the two comparable.
+No `Dynamic`, no coercion, and no core change was needed to build it.
+
+The seam it reuses (`channel.open`, `channel.effects`, `LiveChannel`,
+`Step`, `RoutedJoinContext`, `JoinOutcome`) is `@internal`, so the spike
+only compiles from inside the `beryl` package. **A transport package or a
+user application could not build this shape at all** — which is a finding in
+its own right, and sharpens the one below: this topology is not something a
+layer can reach for from outside the core.
+
+## The finding that reframes the issue
+
+**A socket is not a process, so the "socket session" in the issue's
+candidate shape does not exist and cannot be built from outside the core.**
+Everything the session was supposed to do lands on the router, which runs
+inside the one shared runtime actor:
+
+- It cannot monitor its workers. `DOWN` goes to the process that called
+  `monitor`, and the router does not own the runtime actor's selector. The
+  prototype pays for this with **one extra watcher process per channel**,
+  so the real cost is two processes per join, not one.
+- It cannot hold a per-socket in-flight budget, because there is nowhere
+  per-socket to hold one.
+- It cannot link workers to the connection. If the runtime actor dies, every
+  worker on every socket is orphaned. The prototype pins that with
+  `OneForAll`, so the factory restarts alongside the runtime; without it a
+  restarted runtime leaves every worker holding a `Sender` for a dead
+  process, with no `Finish` ever arriving to end them.
+- It cannot start its workers off the hot path. `supervisor:start_child` is
+  a `gen_server:call` handled synchronously in the factory supervisor, so
+  **every join on every socket queues behind one process**, each for up to
+  `join_timeout_ms`. Today the shared runtime already serialises joins, so
+  this is not a regression — but it survives #334 unchanged, and would be
+  the next thing to hit.
+
+So #337 is downstream of [#334](https://github.com/tylerbutler/beryl/issues/334),
+not parallel to it. Process-per-channel on top of process-per-socket is a
+coherent design; process-per-channel on today's shared runtime buys callback
+concurrency and pays for it with a watcher process per channel and the two
+contract breaks below.
+
+## Answers to the questions the issue asked
+
+**Does the socket permit one in-flight callback, or can workers run
+concurrently?** Concurrently after join, serially during it. `join` and
+`on_terminate` are synchronous calls from the router; everything else is a
+cast, so N joined topics on one socket can be executing callbacks at once.
+
+**What ordering remains between actions from different topics on one
+socket?** Per topic, order is preserved *between batches*: one worker
+mailbox, FIFO, and the VM orders messages between one pair of processes. It
+is **not** preserved between a batch and the topic's own close, which take
+different paths home and race — see the third contract break below. Across
+topics on one socket, nothing is preserved — two topics' replies can be interleaved in any
+order regardless of the order the client sent them. **This is a change from
+today**, where the shared runtime serialises the whole socket. Phoenix does
+not promise cross-topic ordering either, so the question is whether beryl
+wants to keep promising more than Phoenix does.
+
+**Does `join` execute during child startup or through an asynchronous
+handshake?** During child startup — an asynchronous handshake is not
+representable. Core rejects a `Join` that is unanswered when the update turn
+ends (fail-closed), so the router has to have the outcome before it returns.
+The prototype therefore runs `join` in the worker's initialiser and blocks
+the runtime on `factory_supervisor.start_child`. An async handshake needs a
+new core capability: a join that can be left pending across turns.
+
+**How are join timeout, worker startup failure, and worker death during an
+action batch represented?** All three are distinguishable. A join that overruns the initialiser timeout
+rejects with `join timeout` — a reason core has no equivalent for, because
+core cannot time a callback out at all, so it is a wire value this topology
+adds. A panicking join rejects with core's own `join crashed`. Worker death
+is a `Died` envelope from the watcher, which drops the topic from the router
+and kicks it; a batch in flight from that worker is then discarded by the
+generation check, since the topic is no longer live.
+
+**How does the session apply backpressure to worker mailboxes and pending
+action batches?** It does not. Worker mailboxes are unbounded and batches
+are applied as fast as they arrive. A budget needs a per-socket owner (#334).
+
+**Which process owns presence suspension while an asynchronous presence
+mutation is in flight?** Unchanged — the runtime. Workers emit actions;
+`PresenceTrack`/`PresenceUntrack` are core effects applied by the runtime,
+which is also what makes it necessary for the router, not the worker, to
+apply every batch.
+
+**How does socket shutdown terminate workers and preserve `on_terminate`?**
+Core delivers `Closed` for every joined topic on teardown, and the router
+answers each one with a synchronous `Finish` call before the turn ends —
+`on_terminate`'s actions have to be lowered inside that turn. Workers stop
+on the way out, and `a_disconnect_terminates_every_worker_test` pins that no
+worker outlives its socket.
+
+## Three contract breaks, all pinned by tests
+
+1. **A crashed worker cannot run `on_terminate`.** Today core rescues the
+   callback, keeps the model, and delivers `Closed`, so the channel's state
+   is still there to terminate. Here the state died with the process. This
+   matches Phoenix — a channel process crash skips `terminate/2` — but it is
+   a change from what beryl documents today.
+2. **A crashed channel closes as `phx_close`, not `phx_error`.** Core picks
+   the frame from the stop reason, and the only way a layer can close a topic
+   it no longer owns is `KickTopic`, which is `Shutdown`. Preserving this
+   needs a core effect that carries a reason.
+
+3. **A close discards the worker's in-flight batch.** A client that pushes
+   and then leaves loses the push's reply entirely: the batch travels the
+   slow path (worker → socket `Sender` → a later runtime turn) while the
+   close is answered on a direct subject, so the router drops the topic
+   before the batch gets home and then discards it. The client's `ref` is
+   never answered. `a_leave_discards_the_reply_it_raced_test` pins it; the
+   shipped shared runtime cannot lose this, because it runs `on_message` in
+   the same process that handles the leave.
+
+   **This one is not fixable from the router**, and that is the point. The
+   router would have to drain its socket's outstanding envelopes before
+   finishing, and it cannot: it is not a process, so it cannot selectively
+   receive from the mailbox its own batches arrive in. A per-socket process
+   (#334) can. This is the sharpest single piece of evidence that #337 is
+   downstream of #334 rather than parallel to it.
+
+A fourth difference is arguably an improvement: a panic in `on_info` closes
+only its topic here, where today it tears down the whole socket.
+
+There is also a cost that is not a contract break but is worse
+operationally. A worker that dies before answering the router's synchronous
+`Finish` would leave the `Closed` turn blocked — inside the one shared
+runtime actor, so every socket with it — until `terminate_timeout_ms`
+expired. That applies to a panicking `on_terminate` and, more commonly, to
+any close that overtakes a crash the router has not yet learned about. The
+prototype pays it down: `finish` selects on the worker's `DOWN` alongside
+its reply, so a dead worker ends the wait at once, and
+`a_dead_worker_does_not_stall_the_runtime_test` pins that.
+
+What remains is an `on_terminate` that *blocks* rather than dies, which
+still stalls every socket for up to `terminate_timeout_ms`. The shared
+runtime has the same exposure to a blocking callback, so it is not new; what
+a socket session (#334) adds is confinement of the stall to one connection.
+A worker that blocks in `on_terminate` forever also leaks itself and its
+watcher, since the router has already moved on — bounded in practice by the
+same thing that bounds an infinite callback today, which is nothing.
+
+## What was not done
+
+- **No benchmarks.** The issue asks for thresholds to be set before final
+  numbers, and none are set. What can be said without measuring: two
+  processes per joined channel (worker plus watcher) against zero today,
+  plus one extra message hop for every reply, against the ability to run
+  callbacks on more than one scheduler. Whether that trade pays depends
+  entirely on callback cost, which is the thing to measure first.
+- **No cross-node, presence, or broadcast workloads**, and no binary frame
+  path — the binary path is `Deliver`'s shape exactly.
+- **The Phoenix contract matrix was not run against the spike.** It is wired
+  to `beryl.child_spec` and `channel.child_spec`; the two breaks above say
+  what it would report.
+
+## Recommendation
+
+Do not pursue process-per-channel before #334. Reassess afterwards, when a
+socket session actually exists to own monitoring, backpressure, worker
+lifetime, and the drain that the third contract break needs, and when the
+watcher process — currently half the per-channel cost — disappears.
+
+Things to carry forward into a real implementation, none of which the spike
+resolves:
+
+- The close/batch drain (third contract break). Needs the per-socket process.
+- Join serialisation through the factory supervisor. Needs joins started off
+  the calling process, or a supervisor per socket.
+- A `Died` that arrives after a close, and a close that arrives after a
+  `Died`, are both handled here by deleting the topic first and letting the
+  other path miss. That works because a topic has exactly one ending; it
+  will not survive a design where a worker can be replaced in place.


### PR DESCRIPTION
Two documents, no code.

### `docs/spikes/0337-process-per-channel.md`

The process-per-channel spike findings, merged **without** the prototype —
`spike_channel_worker.gleam` and its tests stay on
`feat/337-process-per-channel-spike`. The doc's opening now says so.

Headline: a socket is not a process, so the "socket session" #337 assumed
does not exist and cannot be built from outside the core. Three contract
breaks are recorded, one of which (a close discarding the worker's in-flight
batch) is unfixable from the router. Recommendation: do not pursue #337
before #334.

### `docs/spikes/0334-per-socket-actor.md`

The plan that follows, read against `main` at `d2acc2b`.

- The split #334 asks for already exists at `runtime.gleam:601`
  (`dispatch_socket_msg`), and every per-socket dict is already keyed by
  socket id. The rewrite is mostly a move.
- Six decisions it turns on: broadcast delivery path, topic-index ownership,
  whether the presence step machine can be deleted, admission startup,
  router failure semantics, and leaving crash containment alone.
- Benchmarks are step 0 and blocking. There is no harness in the repo, and
  both issues reduce to one unmeasured number: is callback cost large enough
  to pay for a message hop?
- Two items ship independently of any topology change: splitting
  `stats.runtime_mailbox_length` (a pre-1.0 API leak) and moving heartbeats
  to per-socket timers.

Refs #334, #337.