### PR TITLE
test(runtime): prototype per-socket actors and process-per-channel

### DIFF
--- a/docs/spikes/0334-per-socket-actor-findings.md
+++ b/docs/spikes/0334-per-socket-actor-findings.md
@@ -1,0 +1,156 @@
+# Spike: one actor per socket (#334) — prototype findings
+
+The prototype lives on the branch `feat/334-per-socket-actor-spike` as a
+single change to `packages/beryl/src/beryl/runtime.gleam` (+470/−63). It is a
+prototype: it wires each of the plan's six decisions the cheap way, and the
+shortcuts it takes are marked with `ponytail:` comments naming their ceiling
+and upgrade path. It has not been benchmarked, which is
+[the plan](./0334-per-socket-actor.md)'s step 1 and still the only thing that
+can decide whether any of this is worth shipping.
+
+## The lift was the whole trick
+
+The plan said the rewrite is "mostly a move, not a redesign". It is less than
+that: **the socket actor runs the same `handle_message` on the same `State`
+type as the router.** A socket actor is the runtime with `sockets` capped at
+one entry, `topics` holding only that socket's own memberships, no PubSub
+subscriber, and one new field set:
+
+```gleam
+router: Option(Subject(Msg(msg)))   // None in the router, Some(router) in a socket actor
+```
+
+Nothing in the ~3,000 lines of socket-scoped logic below `dispatch_socket_msg`
+was touched. `Sender` (`make_socket_sender`) captures `state.self_subject`, so
+it became the socket actor's subject with no edit at all. Every branch that
+had to change branches on that one field, in six places:
+
+| Function | Router | Socket actor |
+|---|---|---|
+| `handle_message` (socket-scoped variants) | forward to the socket's actor | dispatch as before |
+| `handle_admit_socket` | check owner, start the actor, hand it the registration | register |
+| `add_topic_subscriber` / `remove_topic_subscriber` | own the index and the pg subscription | keep its own copy, cast the change to the router |
+| `local_broadcast` | resolve recipients, one `Broadcast` per socket actor | encode and send for its own socket |
+| `broadcast_with_pubsub` | fan out locally, forward to PubSub | deliver inline to itself, then hand the rest to the router |
+| `Stop` | drain socket actors in two phases | tear down |
+
+`packages/beryl_mist` and `packages/beryl_ewe` were not touched and both
+suites pass unchanged (29 and 21 tests). The transport SPI never sees the
+topology, because `beryl.app_dispatch` was already a record of closures.
+
+## The whole suite runs: 487 passed, 3 failed
+
+All 60 test modules in `packages/beryl/test`, including `channel_wire_matrix`,
+`phoenix_binary_test`, `presence_replication_test`, and `pubsub_test`. No test
+was edited. The three failures are the contract breaks, and all three are ones
+the issue is asking for rather than accidents:
+
+1. **`channel_dispatch_test:join_and_info_run_in_the_same_runtime_process_test`**
+   — `join_pid == info_pid` still holds; both run in the socket actor. What
+   fails is the last line, `join_pid |> should.equal(runtime)`. App callbacks
+   no longer run in the runtime pid. That is #334's entire point, and this is
+   the only test that pins it.
+2. **`stats_test:snapshot_times_out_while_runtime_is_busy_test`** — expects
+   `Error(RequestTimedOut)` while an app callback is blocking; it now gets
+   `Ok(Snapshot(1, 1, 1, 0))`, because the router is not the process running
+   that callback. This is the plan's phasing step 2 (`stats.runtime_mailbox_length`)
+   arriving as a test failure.
+3. **`stats_test:snapshot_tracks_socket_lifecycle_test`** — reads
+   `connected_sockets` as 2 where 1 is expected. A disconnect is now
+   asynchronous: the socket actor tears itself down and the router learns from
+   a `SocketClosed` message that has not necessarily arrived when the snapshot
+   is taken. Stats are eventually consistent under this topology.
+
+Failures 2 and 3 are the same finding wearing two hats: **the statistics API
+has to be split before this topology can ship**, exactly as phasing step 2
+predicted, and it is the one piece that is shippable on `main` today.
+
+## Two orderings the plan did not name, both fixable
+
+Both were found by tests, and both cost real code to preserve. Neither is
+visible in the plan.
+
+### Effect-list order stops being wire order at the first broadcast
+
+Routing broadcasts through the router (decision 1) means a socket's *own* copy
+of a broadcast it originated takes a round trip, while the frames that follow
+it in the same effect list go out immediately. A `Broadcast` effect followed
+by a `Push` arrives in the wrong order. Five `app_presence_async_test` tests
+caught this.
+
+The fix is cheap and exact: the socket actor delivers to itself inline, then
+asks the router to fan out with itself excluded. It is exact because the only
+`except` a socket actor ever originates is its own id (`BroadcastFrom`), so
+one exclusion always suffices. Worth stating plainly in the plan, because a
+naive reading of decision 1 produces this bug.
+
+### Shutdown has to be two-phase
+
+`handle_stop` finalized every socket's in-flight presence mutation *before* it
+tore any socket down, so a socket's shutdown leaves reached the sockets still
+watching that topic. Told to stop concurrently, socket actors race: a watcher
+can be gone before the leave is fanned out to it. Two tests caught this
+(`shutdown_while_untrack_pending_…`, `shutdown_while_replacement_pending_…`).
+
+The prototype splits the old `handle_stop` at exactly the seam that already
+existed: `FinalizeForStop` to everyone, wait for all of them, then
+`StopSocketActor` to everyone, then wait for the last `SocketClosed`. The
+router must stay responsive throughout — a blocking `process.call` per socket
+actor deadlocks against the socket actors' own index updates and drops their
+teardown broadcasts. That is worth writing into the plan as a constraint: **the
+router can never make a blocking call into a socket actor.**
+
+## How each decision was wired, and what it cost
+
+- **1 (broadcast reaches a socket)** — the hop, as recommended, plus inline
+  self-delivery. Fan-out is now: router resolves the subscriber set, sends one
+  `Broadcast` per recipient, and each actor encodes its own frame. Broadcast
+  `send_failures` telemetry is dead in this topology — the router cannot see
+  the sends. Unmeasured; this is the number step 1 exists to produce.
+- **2 (topic index)** — the router keeps it, updated by cast. Not because cast
+  is better than call, but because a call cannot be made safely (see above).
+  The cast is sent from `subscribe_socket`, before the join reply leaves the
+  turn, so a client that acts on its own reply cannot beat its index entry to
+  the router. A broadcast originated by a *third* process can still race it;
+  no test caught that, and the window is real.
+- **3 (presence suspension)** — **not attempted.** `Step`/`Cont`/`Suspension`
+  is intact and all 22 `app_presence_async_test` tests pass with it. The
+  deletion opportunity is unevaluated, and the shutdown finding above suggests
+  the step machine's close-cleanup ordering is doing more load-bearing work
+  than the presence parking alone.
+- **4 (admission)** — the router starts the socket actor inside the admission
+  turn and waits for it to register. Serialised, exactly the bottleneck the
+  plan warned about; the transport-side start is the upgrade and was not built.
+- **5 (router failure)** — a monitor, not a supervisor. Socket actors are
+  unlinked from the router (so a socket crash cannot kill it) and stop on the
+  router's `Down`. This is a stand-in for `one_for_all`, not a substitute.
+- **6 (crash containment)** — unchanged. `internal.rescue` boundaries were not
+  touched and `app_crash_test` and `channel_crash_test` pass unedited.
+
+## What this is not
+
+- **Benchmarked.** No harness was built. Everything above is a correctness
+  result. The plan's step 1 is still blocking and still the decision.
+- **Nothing was deleted.** The plan predicted net line count might go down;
+  it went up by 407, because the prototype adds the split without taking any
+  of the removals (suspension, the router heartbeat sweep is gone, but the
+  three rate-limit dicts, `suspended`, `queued`, and the step interpreter all
+  remain). The deletion case is still a guess.
+- **Cross-node behaviour is untested beyond the existing suite.**
+  `presence_replication_test` and `pubsub_test` pass, but the router is still
+  the only pg member; decision 2's "socket actors join pg directly" option was
+  not built.
+- **Backpressure.** Not added, as the plan says.
+
+## Recommendation
+
+The topology works and the seam is real: one field, six branches, no change to
+the socket-scoped logic, no change to either transport. That is a much cheaper
+rewrite than the plan assumed, which strengthens the case for doing it.
+
+Ship phasing step 2 (the statistics split) on `main` now — two of the three
+failures are it, it is independent of the topology, and it is an API break
+that should not be bundled with one.
+
+Then build the benchmark harness. Nothing else here should be decided without
+it.

--- a/docs/spikes/0334-per-socket-actor-findings.md
+++ b/docs/spikes/0334-per-socket-actor-findings.md
@@ -38,9 +38,9 @@ had to change branches on that one field, in six places:
 suites pass unchanged (29 and 21 tests). The transport SPI never sees the
 topology, because `beryl.app_dispatch` was already a record of closures.
 
-## The whole suite runs: 487 passed, 3 failed
+## The whole suite runs: 496 passed, 3 failed
 
-All 60 test modules in `packages/beryl/test`, including `channel_wire_matrix`,
+All test modules in `packages/beryl/test`, including `channel_wire_matrix`,
 `phoenix_binary_test`, `presence_replication_test`, and `pubsub_test`. No test
 was edited. The three failures are the contract breaks, and all three are ones
 the issue is asking for rather than accidents:
@@ -64,6 +64,21 @@ the issue is asking for rather than accidents:
 Failures 2 and 3 are the same finding wearing two hats: **the statistics API
 has to be split before this topology can ship**, exactly as phasing step 2
 predicted, and it is the one piece that is shippable on `main` today.
+
+## #337's prototype runs on top of it unchanged
+
+`spike_channel_worker.gleam` and its 9 tests, written against the shared
+runtime on `feat/337-process-per-channel-spike`, pass without a single edit on
+top of the per-socket runtime — including
+`a_dead_worker_does_not_stall_the_runtime_test` and
+`a_disconnect_terminates_every_worker_test`, the two that exercise the
+monitoring and drain [#337](./0337-process-per-channel.md) found had no owner.
+
+That does not close #337 by itself: the prototype still supervises its workers
+from the runtime process, which is now the socket actor rather than the router,
+so the per-socket ownership those tests need is available but not yet claimed.
+It does confirm the "downstream of #334" conclusion concretely rather than by
+argument.
 
 ## Two orderings the plan did not name, both fixable
 

--- a/docs/spikes/0334-per-socket-actor.md
+++ b/docs/spikes/0334-per-socket-actor.md
@@ -3,6 +3,11 @@
 A plan, not a spike. Nothing has been prototyped or measured. Read against
 `main` at `d2acc2b`; every file and line reference below is that tree.
 
+**Update:** the prototype this plan describes has since been built on
+`feat/334-per-socket-actor-spike`. See
+[`0334-per-socket-actor-findings.md`](./0334-per-socket-actor-findings.md)
+for what it found. Still unmeasured — step 0 below remains blocking.
+
 [#337](https://github.com/tylerbutler/beryl/issues/337) was spiked first and
 concluded it is downstream of this issue — see
 [`0337-process-per-channel.md`](./0337-process-per-channel.md). Two of the

--- a/docs/spikes/0334-per-socket-actor.md
+++ b/docs/spikes/0334-per-socket-actor.md
@@ -1,0 +1,217 @@
+# Spike plan: one actor per socket (#334)
+
+A plan, not a spike. Nothing has been prototyped or measured. Read against
+`main` at `d2acc2b`; every file and line reference below is that tree.
+
+[#337](https://github.com/tylerbutler/beryl/issues/337) was spiked first and
+concluded it is downstream of this issue — see
+[`0337-process-per-channel.md`](./0337-process-per-channel.md). Two of the
+three contract breaks it found trace back to the same root cause: a socket is
+not a process, so nothing can own per-socket monitoring, backpressure, or a
+drain. This issue is where that gets fixed, and the plan below is shaped by
+what #337 learned the expensive way.
+
+## The seam already exists
+
+`handle_message` (`runtime.gleam:517`) already partitions the runtime's own
+mailbox into exactly the two halves this issue asks for. Six variants are
+socket-scoped and dispatch through `dispatch_socket_msg`
+(`runtime.gleam:601`); the rest — `AdmitSocket`, `Broadcast`,
+`RemoteBroadcast`, `CheckHeartbeats`, `GetStats`, `Stop` — are router-scoped
+and never reach it. That function *is* the socket actor's `handle_message`,
+already written and already tested.
+
+The state splits along the same line. Every one of
+
+```text
+sockets  message_buckets  join_buckets  channel_buckets
+suspended  queued  unacked_tracks
+```
+
+is a `Dict(socket_id, _)`, and becomes a plain field on the socket actor.
+What is genuinely router-owned is `topics`, `pubsub`, `subscriber`, `config`,
+and `logger`.
+
+`Sender` is an opaque closure (`socket.gleam:263`) built at
+`runtime.gleam:801` as a send of `AppInfo(socket_id, message)` to the runtime
+subject. It captures the socket actor's subject instead. No signature
+changes, and it stops routing every server-side message through the router.
+
+So the rewrite is mostly a move, not a redesign. The design work is in the
+six decisions below, all of which are about what the router keeps.
+
+## Step 0: benchmarks, before any code
+
+The issue asks for thresholds set before final numbers. None are set, there
+is no bench harness in the repository, and #337 could not answer its own
+cost question without one. Both issues reduce to a single number:
+
+**Is app callback cost large enough to pay for a message hop?**
+
+Below some callback cost the shared actor wins and both issues close as
+"won't do". Above it, this issue is worth its complexity and #337 becomes
+worth reassessing.
+
+Build the harness against today's runtime, on `main`, before touching the
+topology. Workloads the issue names: connection churn, push round-trip,
+broadcast fan-out, presence. Report throughput, p95/p99, scheduler
+utilisation, mailbox depth, memory, process count. Sweep a synthetic
+callback cost across at least three orders of magnitude and find the
+crossover. That crossover is the decision.
+
+## Six decisions
+
+### 1. How a broadcast reaches a socket
+
+`local_broadcast` (`runtime.gleam:3730`) encodes the frame and calls each
+socket's `send` closure **from the router**, inside the router's turn. Keep
+that under per-socket actors and two processes write to one transport
+concurrently, so a broadcast can overtake a frame the socket actor has
+already decided to send. That is #337's third contract break in a new
+costume, and it would be just as unfixable from the router.
+
+The alternative is to route broadcasts through the socket actor: one extra
+hop per recipient, but per-socket encoding moves off the router onto N
+schedulers, which should pay for itself at fan-out.
+
+Recommend the hop. Measure it — this is the single largest performance
+question in the rewrite, because broadcast fan-out is the workload where the
+shared actor is currently at its best.
+
+### 2. Who owns the topic index
+
+Today `topics` is updated in the same turn as the join that caused it, which
+is why a broadcast issued immediately after a join can never miss that
+socket. Under per-socket actors the join happens somewhere else, and every
+option costs something:
+
+- **Router keeps the index, updated by synchronous call.** Every join on
+  every socket serialises through the router. This is precisely what the
+  #337 factory supervisor did, and it was the finding that survived that
+  spike unchanged.
+- **Router keeps the index, updated by cast.** Joins stay parallel, but a
+  window opens where the index lags the socket's real join state and a
+  broadcast misses a just-joined socket. New observable behaviour.
+- **Socket actors join `pg` groups directly.** `pubsub.gleam` already
+  supports per-process subscription — `subscriber` (`:194`), `join`
+  (`:202`), `leave` (`:207`), `subscribers` (`:304`),
+  `subscriber_count` (`:309`). The router would hold no topic index at all,
+  and remote broadcasts would reach socket actors with no router hop
+  whatsoever.
+
+The third is the most attractive and has the sharpest catch: `pubsub` is
+`Option` on the runtime config, so this means always starting a local `pg`
+scope, including for single-node deployments that configure no PubSub. That
+is a real cost to weigh, not a free reuse.
+
+### 3. Presence suspension is the deletion opportunity
+
+The `Step` / `Cont` / `Suspension` machinery — the interpreter at
+`runtime.gleam:1858`, its `Await` parking, `suspended`, and `queued` —
+exists for exactly one reason: one actor cannot block on the presence actor
+without stalling every socket. A per-socket actor can. A `process.try_call`
+bounded by `presence_op_timeout_ms` stalls only its own socket, which is
+already the behaviour suspension goes to great lengths to produce.
+
+If that holds, most of the step reification deletes. It should be validated
+against `app_presence_async_test` and `effect_ordering_test` before it is
+assumed, because the step machine also carries close-cleanup ordering, not
+just presence parking.
+
+One documented behaviour tightens rather than breaks. Today's architecture
+page says "an unrelated broadcast can land between two of the waiting
+socket's effects"
+(`website/src/content/docs/architecture/runtime.md:48`). Under a blocking
+call the broadcast queues in the socket actor's mailbox and lands after the
+effect list instead. That is a strictly stronger guarantee, so it is a
+documentation edit, not a contract break — but it is a behaviour change and
+belongs in the changelog.
+
+### 4. Admission must not become the new bottleneck
+
+`AdmitSocket` is a synchronous router call and has to stay atomic: the
+connection limit and the admission token are claimed together. But starting
+the socket actor *inside* that turn makes `supervisor:start_child` a
+serialised synchronous call per connection, which is #337's join
+serialisation transposed onto connections, and it would cap connection
+setup rate at one process.
+
+Prefer having the transport's connection process start the socket actor,
+then hand it to the router for an O(1) atomic admit. Startup stays parallel
+and the router turn stays short. This needs care around a socket actor that
+starts and is then refused admission — it must be stopped, and the
+admission token cancelled, without leaking either.
+
+### 5. Router failure semantics
+
+Transports monitor the router pid through `transport.runtime_pid`
+(`transport.gleam:243`), and the issue requires that router failure keeps
+its current connection-close and supervised-restart behaviour. So the router
+stays the named, stable owner, and its death has to take every socket actor
+with it — `one_for_all`, or `rest_for_one` with the router started first.
+
+#337 hit the orphan case directly: without `OneForAll`, a restarted runtime
+left every worker holding a `Sender` for a dead process with no termination
+message ever arriving. The same failure is available here at socket scale.
+
+### 6. Crash containment does not change
+
+Resist converting the `internal.rescue` boundaries to let-it-crash. Today a
+crashing topic-scoped `Message` closes only that topic; letting the socket
+actor die instead widens that to the whole socket, which the issue's own
+investigation criteria forbid. The *rationale* in the architecture page
+changes — per-socket state is no longer shared, so the original argument for
+rescuing weakens — but the behaviour must be preserved as-is and pinned by
+`app_crash_test` and `channel_crash_test` unchanged.
+
+## Phasing
+
+1. **Bench harness and thresholds** on today's runtime. Blocking; nothing
+   below is decidable without it.
+2. **Split the statistics API.** `stats.runtime_mailbox_length`
+   (`stats.gleam:69`) assumes one runtime mailbox and is a pre-1.0 leak the
+   issue already calls out. It is shippable on `main` independently of any
+   topology change, and it should ship first so the rewrite is not also an
+   API break.
+3. **Move heartbeat ownership to per-socket timers.** Deletes the O(N)
+   router sweep (`runtime.gleam:948`) and its awkward interaction with
+   suspended sockets. A strict improvement whether or not the rest of this
+   ever lands.
+4. **Prototype the socket actor** by lifting `dispatch_socket_msg` as-is,
+   wiring decisions 1 and 2 the cheap way first so the expensive options are
+   compared against something that works.
+5. **Run the whole suite unchanged.** 72 test files in
+   `packages/beryl/test`, plus `channel_wire_matrix` and the
+   `phoenix_channel_fixtures` matrix. Any test that needs editing to pass is
+   a contract break, and it gets written down here rather than edited away.
+6. **Benchmark against step 1's thresholds**, then decide.
+
+## What this adds and what it removes
+
+Removed: three per-socket rate-limit dicts, `suspended`, `queued`, the
+router heartbeat sweep, probably most of the step interpreter, and the
+router hop on every `Sender` send.
+
+Added: one supervisor, one hop per broadcast recipient, one hop per
+join/leave index update (unless decision 2 goes to `pg`), and the socket
+actor's own scaffolding.
+
+Net line count plausibly goes down. That is an argument for doing this even
+if the throughput case comes back weaker than hoped — but it is a guess
+until step 4 exists, and it should not be used to pre-empt step 1.
+
+## What this plan does not answer
+
+- **Whether it is worth doing.** That is step 1's job, and no number in this
+  document is measured.
+- **Cross-node behaviour.** If decision 2 goes to `pg`, remote broadcast
+  delivery changes shape and `presence_replication_test` becomes the
+  interesting suite. Not analysed here.
+- **The `except` / `from_socket` filtering path** under per-socket
+  subscription. `broadcast_from_socket` (`pubsub.gleam:270`) currently
+  filters at a single point in the router; where that filtering lands when
+  subscribers are separate processes is unresolved.
+- **Backpressure.** The issue does not ask for it and this plan does not add
+  it, but a per-socket process is the first place beryl could hold an
+  in-flight budget — which is what #337 found it was missing. Worth
+  designing for, not worth building yet.

--- a/docs/spikes/0337-process-per-channel-round-2.md
+++ b/docs/spikes/0337-process-per-channel-round-2.md
@@ -1,0 +1,245 @@
+# Spike: process-per-channel isolation (#337), round 2
+
+Round 1 ([`0337-process-per-channel.md`](./0337-process-per-channel.md)) ran
+on the shared runtime actor and concluded: *do not pursue process-per-channel
+before [#334](./0334-per-socket-actor.md); reassess afterwards, when a socket
+session exists to own monitoring, backpressure, worker lifetime, and the drain
+the third contract break needs.*
+
+#334's prototype has since landed on this branch. Round 2 re-ran the same
+prototype on it and tried to claim each of those four things. Same files:
+`packages/beryl/test/spike_channel_worker.gleam` and its test module, now 12
+tests.
+
+**Result: one of the four was real, one was free, and two were never blocked
+on #334 at all.** The load-bearing one — the drain — turns out not to be a
+topology problem in the first place.
+
+## The finding that reframes round 1
+
+**The raced reply is core's rule, not the topology's.** Round 1's third
+contract break — a close discards the worker's in-flight batch, so a client
+that pushes and then leaves never gets its reply — was blamed on the router
+not being a process:
+
+> It is not fixable from the router... The router would have to drain its
+> socket's outstanding envelopes before finishing, and it cannot: it is not a
+> process, so it cannot selectively receive from the mailbox its own batches
+> arrive in. A per-socket process (#334) can. This is the sharpest single
+> piece of evidence that #337 is downstream of #334.
+
+That is wrong, and the evidence is
+`a_reply_ref_is_dead_by_the_closed_turn_test`: **one plain `beryl.child_spec`
+app, one socket, one process, no workers anywhere** — and the reply is still
+lost. `exec_close_topic` (`runtime.gleam:2686`) deletes the topic's
+`pending_reply_refs` *before* it delivers `Closed`, deliberately, so that
+pushes to a closing topic drop while broadcasts still reach its remaining
+subscribers. Any `ReplyOk` a layer returns from that turn names a ref core has
+already invalidated.
+
+### Why no drain rescues it
+
+The drain round 1 asked for is, as it happens, *buildable* — and still
+useless. Worth spelling out, because "we still cannot drain" and "draining
+does not help" lead to different next steps.
+
+It is buildable because `init` runs in the socket's own process, so a
+`process.Subject` created there is owned by the socket actor, and a worker
+sending its batches to that subject puts them in the socket actor's mailbox
+under a tag the layer can name. `process.selector_receive(sel, 0)` on a
+selector holding only that subject is an Erlang selective receive: it takes
+the pending batches and leaves everything else in the mailbox. Ordering even
+cooperates — `finish` calls the worker synchronously, the worker's mailbox is
+FIFO, so any `Deliver` it was given is processed and reported *before* the
+`Finish` reply comes back. By the time the layer would drain, the batch is
+reliably there.
+
+It is useless because the recovered effects are returned from the `Closed`
+turn, and that is the one turn in which the topic's refs are already gone. The
+drain hands the layer a `ReplyOk` for a ref core deleted a moment earlier.
+(Not implemented: the outcome is decided by the ref invalidation, which the
+no-workers test establishes on its own.)
+
+### The ordering is lost where beryl's core owns the leave
+
+Process-per-channel should *preserve* this ordering, not break it. In Phoenix
+the channel process receives both the push and the `phx_leave` in its own
+mailbox, in order, so the reply is produced before the leave is acted on —
+ordering falls out of the topology for free. beryl's shipped runtime preserves
+it for the same structural reason: one process handles `on_message` and the
+leave.
+
+The spike loses it because beryl's core, not the worker, receives the leave.
+Core closes the topic and only then tells the layer, so the worker's reply is
+already orphaned by the time anyone can act on it. The break is not "a channel
+lives in its own process"; it is "a channel lives in its own process that the
+leave never reaches". Nothing above `beryl.child_spec` can change who the
+leave reaches.
+
+This also makes the break a regression against beryl-today *and* against
+Phoenix, rather than the Phoenix-parity trade contract breaks 1 and 2 are. It
+is the one of the three that a real implementation should be expected to fix
+rather than document.
+
+## What #334 actually paid back
+
+### Free: a blocking `on_terminate` now stalls one connection
+
+Round 1's worst operational cost was a `Finish` that blocks — `finish` is a
+synchronous call, and on the shared runtime the socket it blocked was every
+socket. `a_blocking_terminate_stalls_only_its_own_socket_test` pins that it is
+now confined, and it **passes against round 1's prototype unmodified**. The
+`Finish` wait is unchanged; only the process it blocks is different.
+
+### Claimed: a supervisor per socket, so joins stop serialising
+
+Round 1 flagged this as the next thing to hit:
+
+> every join on every socket queues behind one process... it survives #334
+> unchanged.
+
+It survives #334, but not #334 plus one change: each socket now starts its own
+`factory_supervisor` in `init`, linked to its own socket actor.
+`a_slow_join_does_not_block_another_socket_test` pins it — a 700ms join on
+`s1` no longer delays `s2`'s join reply past a 500ms window. **Checked out
+against round 1's worker module, that test fails**, so it discriminates the
+topologies rather than merely passing.
+
+The link is the other half. Round 1 needed a globally named factory wrapped
+with the runtime in `OneForAll`, because a restarted runtime would otherwise
+leave every worker on every socket holding a `Sender` for a dead process. A
+socket-owned supervisor dies with its socket, so `child_spec` is now
+`beryl.child_spec` and nothing else: the tree, the global name, and the
+`OneForAll` coupling are all deleted.
+
+## What round 1 over-booked
+
+### The per-channel watcher was never a #334 cost
+
+Round 1:
+
+> The prototype pays for this with **one extra watcher process per channel**,
+> so the real cost is two processes per join, not one... the first thing #334
+> would pay back.
+
+`init` has always run once per socket, and `info.self` has always been that
+socket's own `Sender`. A single watcher holding one monitor per worker was
+available on the shared runtime too — `start_watcher` is that, and nothing in
+it depends on #334. Per-channel process cost is one worker, not two, and
+always was. What #334 adds is only that the watcher is started by the socket's
+own process and dies with it.
+
+### There was always somewhere to put a per-socket budget
+
+Round 1:
+
+> It cannot hold a per-socket in-flight budget, because there is nowhere
+> per-socket to hold one.
+
+The `Router` record *is* per-socket, and was before #334 — `init` returns one
+model per connection. A budget was always holdable. Not implemented here,
+because implementing it would have produced no finding; what #334 changes is
+what a budget would protect (one socket actor's own scheduler share) rather
+than whether one can exist.
+
+## What still has no owner
+
+- **Backpressure.** Still not built. Worker mailboxes are unbounded.
+- **An asynchronous join handshake.** Unchanged: core rejects a `Join` left
+  unanswered when the update turn ends, so `join` still runs in the worker's
+  initialiser with the socket actor blocked on it. The block is now confined
+  to one socket, which makes it survivable but not free.
+- **`on_terminate` after a crash**, and **`phx_error` vs `phx_close`** —
+  contract breaks 1 and 2, both unchanged and both needing core changes (a
+  rescued callback cannot exist across a dead process; `KickTopic` cannot
+  carry a reason).
+
+## Test status
+
+`packages/beryl` runs 503 passed / 3 failures. The three failures are #334's
+own contract breaks, unchanged and unrelated (see
+[`0334-per-socket-actor-findings.md`](./0334-per-socket-actor-findings.md)):
+the runtime-pid assertion in `channel_dispatch_test`, and two `stats_test`
+cases that the statistics split is meant to resolve.
+
+Still no benchmarks. That has not moved since round 1 and is still the only
+thing that can decide whether any of this is worth shipping.
+
+## Why a supervisor is still in the picture at all
+
+The obvious simplification — drop the supervisor, have the socket actor
+`actor.start` its own workers — does not work, and the reason constrains any
+real implementation.
+
+`actor.start` spawns **linked** to the caller
+(`gleam_otp/src/gleam/otp/actor.gleam:592`), and gleam_otp actors do not trap
+exits. A worker started that way would take its socket actor down when it
+panicked, turning round 1's one genuine improvement — a panic in `on_message`
+closes only its topic — into "a panic kills the connection". A supervisor is
+the only construct that gives an unlinked child whose initialiser you can
+still wait on synchronously, which the join handshake requires.
+
+So the supervisor stays, and per-socket is the cheapest place to put it: the
+socket actor is blocked on `start_child` for the duration of the join
+callback either way, so confining the queue to one socket costs nothing that
+was not already being paid. Linking that supervisor to the socket actor is
+what supplies worker lifetime — socket actor dies, supervisor dies, workers
+die — which is the piece of round 1's "socket session" that turned out to be
+real.
+
+## Recommendation
+
+Round 1's "do not pursue before #334" is discharged. Of the four things it
+wanted a socket session to own: worker lifetime and join serialisation were
+real and are now claimed; the blocking-callback stall was real and #334
+confines it for free; monitoring and the in-flight budget were never blocked
+on #334 at all.
+
+What replaces it is narrower and firmer: **process-per-channel cannot be built
+on top of `beryl.child_spec`, and should not be attempted there.** Round 1
+showed the seam it needs is `@internal`, so no transport or application can
+reach it. Round 2 shows that even with the seam opened, the ordering the
+design depends on is decided by who receives the leave — and that is core.
+
+### What a real implementation looks like
+
+Not a layer. A change to `beryl/runtime.gleam` in which the socket actor owns
+its channels directly:
+
+- The socket actor holds `Dict(topic, worker)` and monitors its workers on its
+  **own** selector. No watcher process at all — that cost disappears here, one
+  round later than round 1 expected and for a different reason.
+- A leave is routed *to the worker* and the topic closes on the worker's
+  outcome, rather than closing first and notifying after. This is the whole
+  fix for the raced reply, and it is only expressible from inside core.
+- Its supervisor is per-socket and linked, as prototyped here.
+- `join` still runs in the worker's initialiser until core grows a join that
+  can stay pending across turns. Confined to one socket, that is survivable.
+
+### What to settle before writing it
+
+1. **Benchmark.** Unchanged from round 1 and from #334's plan, and still the
+   only thing that can decide whether any of this ships. One process per
+   channel plus one extra message hop per reply, against callbacks running on
+   more than one scheduler. Whether that trades depends on callback cost,
+   which nobody has measured. A cheap callback makes this pure overhead; an
+   expensive one makes it the whole point.
+2. **Decide the close ordering as a documented semantic**, not as an
+   implementation detail: does a leave wait for the channel's in-flight work?
+   Round 1 read the answer as a bug to be drained away; it is a contract. Both
+   beryl-today and Phoenix answer yes, which is a strong argument for keeping
+   it — but keeping it is what forces the worker into core, so the cost of the
+   answer should be accepted deliberately.
+3. **Decide contract breaks 1 and 2** — `on_terminate` lost to a crash, and
+   `phx_close` where beryl documents `phx_error`. Both are unchanged by #334
+   and both are Phoenix-parity trades rather than regressions, so they are
+   candidates for documenting rather than fixing. Fixing break 2 needs a core
+   effect that carries a stop reason; break 1 cannot be fixed at all while the
+   channel's state lives in the process that died.
+
+## What round 2 did not do
+
+No benchmarks, no cross-node or presence-heavy workloads, no binary frame
+path, and the Phoenix contract matrix was still not run against the spike. The
+drain was argued rather than built, for the reason given above. Backpressure
+is still absent.

--- a/docs/spikes/0337-process-per-channel.md
+++ b/docs/spikes/0337-process-per-channel.md
@@ -3,11 +3,10 @@
 Prototype: `packages/beryl/test/spike_channel_worker.gleam`.
 Pinned behaviour: `packages/beryl/test/spike_channel_worker_test.gleam`.
 
-The prototype is built entirely on beryl's public core API, the way
-`beryl/channel` is. It reuses that layer's handlers, `join`, state sealing,
-callbacks, actions, and action lowering unchanged — `channel.open` returns
-the same non-generic `LiveChannel` — and changes only which process holds
-that value:
+The prototype reuses `beryl/channel`'s own router seam: handlers, `join`,
+state sealing, callbacks, actions, and action lowering are unchanged —
+`channel.open` returns the same non-generic `LiveChannel` — and only which
+process holds that value differs:
 
 ```text
 shipped:  runtime actor ── LiveChannel per joined topic (in its model)
@@ -17,6 +16,13 @@ spike:    runtime actor ── worker(topic) ── LiveChannel
 
 That is the whole difference, which is what makes the two comparable.
 No `Dynamic`, no coercion, and no core change was needed to build it.
+
+The seam it reuses (`channel.open`, `channel.effects`, `LiveChannel`,
+`Step`, `RoutedJoinContext`, `JoinOutcome`) is `@internal`, so the spike
+only compiles from inside the `beryl` package. **A transport package or a
+user application could not build this shape at all** — which is a finding in
+its own right, and sharpens the one below: this topology is not something a
+layer can reach for from outside the core.
 
 ## The finding that reframes the issue
 
@@ -32,8 +38,16 @@ inside the one shared runtime actor:
 - It cannot hold a per-socket in-flight budget, because there is nowhere
   per-socket to hold one.
 - It cannot link workers to the connection. If the runtime actor dies, every
-  worker on every socket is orphaned until the factory supervisor goes down
-  with it.
+  worker on every socket is orphaned. The prototype pins that with
+  `OneForAll`, so the factory restarts alongside the runtime; without it a
+  restarted runtime leaves every worker holding a `Sender` for a dead
+  process, with no `Finish` ever arriving to end them.
+- It cannot start its workers off the hot path. `supervisor:start_child` is
+  a `gen_server:call` handled synchronously in the factory supervisor, so
+  **every join on every socket queues behind one process**, each for up to
+  `join_timeout_ms`. Today the shared runtime already serialises joins, so
+  this is not a regression — but it survives #334 unchanged, and would be
+  the next thing to hit.
 
 So #337 is downstream of [#334](https://github.com/tylerbutler/beryl/issues/334),
 not parallel to it. Process-per-channel on top of process-per-socket is a
@@ -49,9 +63,11 @@ concurrently?** Concurrently after join, serially during it. `join` and
 cast, so N joined topics on one socket can be executing callbacks at once.
 
 **What ordering remains between actions from different topics on one
-socket?** Per topic, total order is preserved: one worker mailbox, FIFO, and
-the VM orders messages between one pair of processes. Across topics on one
-socket, nothing is preserved — two topics' replies can be interleaved in any
+socket?** Per topic, order is preserved *between batches*: one worker
+mailbox, FIFO, and the VM orders messages between one pair of processes. It
+is **not** preserved between a batch and the topic's own close, which take
+different paths home and race — see the third contract break below. Across
+topics on one socket, nothing is preserved — two topics' replies can be interleaved in any
 order regardless of the order the client sent them. **This is a change from
 today**, where the shared runtime serialises the whole socket. Phoenix does
 not promise cross-topic ordering either, so the question is whether beryl
@@ -91,7 +107,7 @@ answers each one with a synchronous `Finish` call before the turn ends —
 on the way out, and `a_disconnect_terminates_every_worker_test` pins that no
 worker outlives its socket.
 
-## Two contract breaks, both pinned by tests
+## Three contract breaks, all pinned by tests
 
 1. **A crashed worker cannot run `on_terminate`.** Today core rescues the
    callback, keeps the model, and delivers `Closed`, so the channel's state
@@ -103,20 +119,42 @@ worker outlives its socket.
    it no longer owns is `KickTopic`, which is `Shutdown`. Preserving this
    needs a core effect that carries a reason.
 
-A third difference is arguably an improvement: a panic in `on_info` closes
+3. **A close discards the worker's in-flight batch.** A client that pushes
+   and then leaves loses the push's reply entirely: the batch travels the
+   slow path (worker → socket `Sender` → a later runtime turn) while the
+   close is answered on a direct subject, so the router drops the topic
+   before the batch gets home and then discards it. The client's `ref` is
+   never answered. `a_leave_discards_the_reply_it_raced_test` pins it; the
+   shipped shared runtime cannot lose this, because it runs `on_message` in
+   the same process that handles the leave.
+
+   **This one is not fixable from the router**, and that is the point. The
+   router would have to drain its socket's outstanding envelopes before
+   finishing, and it cannot: it is not a process, so it cannot selectively
+   receive from the mailbox its own batches arrive in. A per-socket process
+   (#334) can. This is the sharpest single piece of evidence that #337 is
+   downstream of #334 rather than parallel to it.
+
+A fourth difference is arguably an improvement: a panic in `on_info` closes
 only its topic here, where today it tears down the whole socket.
 
 There is also a cost that is not a contract break but is worse
-operationally, and the prototype does not currently pay it down: **a panic
-inside `on_terminate` freezes every socket for a full second.** The worker
-dies before it can answer the router's synchronous `Finish`, so the `Closed`
-turn blocks in `process.receive` — inside the one shared runtime actor —
-until `terminate_timeout_ms` expires. Nothing else on that runtime moves in
-the meantime. It is fixable within this topology by selecting on the
-worker's `DOWN` alongside its reply, so a dead worker ends the wait at once;
-it is worth stating plainly because the shared runtime has no equivalent
-failure mode, and because a socket session (#334) would confine the stall to
-one connection instead of all of them.
+operationally. A worker that dies before answering the router's synchronous
+`Finish` would leave the `Closed` turn blocked — inside the one shared
+runtime actor, so every socket with it — until `terminate_timeout_ms`
+expired. That applies to a panicking `on_terminate` and, more commonly, to
+any close that overtakes a crash the router has not yet learned about. The
+prototype pays it down: `finish` selects on the worker's `DOWN` alongside
+its reply, so a dead worker ends the wait at once, and
+`a_dead_worker_does_not_stall_the_runtime_test` pins that.
+
+What remains is an `on_terminate` that *blocks* rather than dies, which
+still stalls every socket for up to `terminate_timeout_ms`. The shared
+runtime has the same exposure to a blocking callback, so it is not new; what
+a socket session (#334) adds is confinement of the stall to one connection.
+A worker that blocks in `on_terminate` forever also leaks itself and its
+watcher, since the router has already moved on — bounded in practice by the
+same thing that bounds an infinite callback today, which is nothing.
 
 ## What was not done
 
@@ -135,6 +173,17 @@ one connection instead of all of them.
 ## Recommendation
 
 Do not pursue process-per-channel before #334. Reassess afterwards, when a
-socket session actually exists to own monitoring, backpressure, and worker
-lifetime, and when the watcher process — currently half the per-channel cost
-— disappears.
+socket session actually exists to own monitoring, backpressure, worker
+lifetime, and the drain that the third contract break needs, and when the
+watcher process — currently half the per-channel cost — disappears.
+
+Things to carry forward into a real implementation, none of which the spike
+resolves:
+
+- The close/batch drain (third contract break). Needs the per-socket process.
+- Join serialisation through the factory supervisor. Needs joins started off
+  the calling process, or a supervisor per socket.
+- A `Died` that arrives after a close, and a close that arrives after a
+  `Died`, are both handled here by deleting the topic first and letting the
+  other path miss. That works because a topic has exactly one ending; it
+  will not survive a design where a worker can be replaced in place.

--- a/docs/spikes/0337-process-per-channel.md
+++ b/docs/spikes/0337-process-per-channel.md
@@ -1,0 +1,140 @@
+# Spike: process-per-channel isolation (#337)
+
+Prototype: `packages/beryl/test/spike_channel_worker.gleam`.
+Pinned behaviour: `packages/beryl/test/spike_channel_worker_test.gleam`.
+
+The prototype is built entirely on beryl's public core API, the way
+`beryl/channel` is. It reuses that layer's handlers, `join`, state sealing,
+callbacks, actions, and action lowering unchanged — `channel.open` returns
+the same non-generic `LiveChannel` — and changes only which process holds
+that value:
+
+```text
+shipped:  runtime actor ── LiveChannel per joined topic (in its model)
+spike:    runtime actor ── worker(topic) ── LiveChannel
+                        └─ worker(topic) ── LiveChannel
+```
+
+That is the whole difference, which is what makes the two comparable.
+No `Dynamic`, no coercion, and no core change was needed to build it.
+
+## The finding that reframes the issue
+
+**A socket is not a process, so the "socket session" in the issue's
+candidate shape does not exist and cannot be built from outside the core.**
+Everything the session was supposed to do lands on the router, which runs
+inside the one shared runtime actor:
+
+- It cannot monitor its workers. `DOWN` goes to the process that called
+  `monitor`, and the router does not own the runtime actor's selector. The
+  prototype pays for this with **one extra watcher process per channel**,
+  so the real cost is two processes per join, not one.
+- It cannot hold a per-socket in-flight budget, because there is nowhere
+  per-socket to hold one.
+- It cannot link workers to the connection. If the runtime actor dies, every
+  worker on every socket is orphaned until the factory supervisor goes down
+  with it.
+
+So #337 is downstream of [#334](https://github.com/tylerbutler/beryl/issues/334),
+not parallel to it. Process-per-channel on top of process-per-socket is a
+coherent design; process-per-channel on today's shared runtime buys callback
+concurrency and pays for it with a watcher process per channel and the two
+contract breaks below.
+
+## Answers to the questions the issue asked
+
+**Does the socket permit one in-flight callback, or can workers run
+concurrently?** Concurrently after join, serially during it. `join` and
+`on_terminate` are synchronous calls from the router; everything else is a
+cast, so N joined topics on one socket can be executing callbacks at once.
+
+**What ordering remains between actions from different topics on one
+socket?** Per topic, total order is preserved: one worker mailbox, FIFO, and
+the VM orders messages between one pair of processes. Across topics on one
+socket, nothing is preserved — two topics' replies can be interleaved in any
+order regardless of the order the client sent them. **This is a change from
+today**, where the shared runtime serialises the whole socket. Phoenix does
+not promise cross-topic ordering either, so the question is whether beryl
+wants to keep promising more than Phoenix does.
+
+**Does `join` execute during child startup or through an asynchronous
+handshake?** During child startup — an asynchronous handshake is not
+representable. Core rejects a `Join` that is unanswered when the update turn
+ends (fail-closed), so the router has to have the outcome before it returns.
+The prototype therefore runs `join` in the worker's initialiser and blocks
+the runtime on `factory_supervisor.start_child`. An async handshake needs a
+new core capability: a join that can be left pending across turns.
+
+**How are join timeout, worker startup failure, and worker death during an
+action batch represented?** All three are distinguishable. A join that overruns the initialiser timeout
+rejects with `join timeout` — a reason core has no equivalent for, because
+core cannot time a callback out at all, so it is a wire value this topology
+adds. A panicking join rejects with core's own `join crashed`. Worker death
+is a `Died` envelope from the watcher, which drops the topic from the router
+and kicks it; a batch in flight from that worker is then discarded by the
+generation check, since the topic is no longer live.
+
+**How does the session apply backpressure to worker mailboxes and pending
+action batches?** It does not. Worker mailboxes are unbounded and batches
+are applied as fast as they arrive. A budget needs a per-socket owner (#334).
+
+**Which process owns presence suspension while an asynchronous presence
+mutation is in flight?** Unchanged — the runtime. Workers emit actions;
+`PresenceTrack`/`PresenceUntrack` are core effects applied by the runtime,
+which is also what makes it necessary for the router, not the worker, to
+apply every batch.
+
+**How does socket shutdown terminate workers and preserve `on_terminate`?**
+Core delivers `Closed` for every joined topic on teardown, and the router
+answers each one with a synchronous `Finish` call before the turn ends —
+`on_terminate`'s actions have to be lowered inside that turn. Workers stop
+on the way out, and `a_disconnect_terminates_every_worker_test` pins that no
+worker outlives its socket.
+
+## Two contract breaks, both pinned by tests
+
+1. **A crashed worker cannot run `on_terminate`.** Today core rescues the
+   callback, keeps the model, and delivers `Closed`, so the channel's state
+   is still there to terminate. Here the state died with the process. This
+   matches Phoenix — a channel process crash skips `terminate/2` — but it is
+   a change from what beryl documents today.
+2. **A crashed channel closes as `phx_close`, not `phx_error`.** Core picks
+   the frame from the stop reason, and the only way a layer can close a topic
+   it no longer owns is `KickTopic`, which is `Shutdown`. Preserving this
+   needs a core effect that carries a reason.
+
+A third difference is arguably an improvement: a panic in `on_info` closes
+only its topic here, where today it tears down the whole socket.
+
+There is also a cost that is not a contract break but is worse
+operationally, and the prototype does not currently pay it down: **a panic
+inside `on_terminate` freezes every socket for a full second.** The worker
+dies before it can answer the router's synchronous `Finish`, so the `Closed`
+turn blocks in `process.receive` — inside the one shared runtime actor —
+until `terminate_timeout_ms` expires. Nothing else on that runtime moves in
+the meantime. It is fixable within this topology by selecting on the
+worker's `DOWN` alongside its reply, so a dead worker ends the wait at once;
+it is worth stating plainly because the shared runtime has no equivalent
+failure mode, and because a socket session (#334) would confine the stall to
+one connection instead of all of them.
+
+## What was not done
+
+- **No benchmarks.** The issue asks for thresholds to be set before final
+  numbers, and none are set. What can be said without measuring: two
+  processes per joined channel (worker plus watcher) against zero today,
+  plus one extra message hop for every reply, against the ability to run
+  callbacks on more than one scheduler. Whether that trade pays depends
+  entirely on callback cost, which is the thing to measure first.
+- **No cross-node, presence, or broadcast workloads**, and no binary frame
+  path — the binary path is `Deliver`'s shape exactly.
+- **The Phoenix contract matrix was not run against the spike.** It is wired
+  to `beryl.child_spec` and `channel.child_spec`; the two breaks above say
+  what it would report.
+
+## Recommendation
+
+Do not pursue process-per-channel before #334. Reassess afterwards, when a
+socket session actually exists to own monitoring, backpressure, and worker
+lifetime, and when the watcher process — currently half the per-channel cost
+— disappears.

--- a/docs/spikes/0337-process-per-channel.md
+++ b/docs/spikes/0337-process-per-channel.md
@@ -1,0 +1,191 @@
+# Spike: process-per-channel isolation (#337)
+
+The prototype and its tests are not merged. They live on the branch
+`feat/337-process-per-channel-spike` as
+`packages/beryl/test/spike_channel_worker.gleam` and
+`spike_channel_worker_test.gleam`; only these findings are merged here.
+
+The prototype reuses `beryl/channel`'s own router seam: handlers, `join`,
+state sealing, callbacks, actions, and action lowering are unchanged —
+`channel.open` returns the same non-generic `LiveChannel` — and only which
+process holds that value differs:
+
+```text
+shipped:  runtime actor ── LiveChannel per joined topic (in its model)
+spike:    runtime actor ── worker(topic) ── LiveChannel
+                        └─ worker(topic) ── LiveChannel
+```
+
+That is the whole difference, which is what makes the two comparable.
+No `Dynamic`, no coercion, and no core change was needed to build it.
+
+The seam it reuses (`channel.open`, `channel.effects`, `LiveChannel`,
+`Step`, `RoutedJoinContext`, `JoinOutcome`) is `@internal`, so the spike
+only compiles from inside the `beryl` package. **A transport package or a
+user application could not build this shape at all** — which is a finding in
+its own right, and sharpens the one below: this topology is not something a
+layer can reach for from outside the core.
+
+## The finding that reframes the issue
+
+**A socket is not a process, so the "socket session" in the issue's
+candidate shape does not exist and cannot be built from outside the core.**
+Everything the session was supposed to do lands on the router, which runs
+inside the one shared runtime actor:
+
+- It cannot monitor its workers. `DOWN` goes to the process that called
+  `monitor`, and the router does not own the runtime actor's selector. The
+  prototype pays for this with **one extra watcher process per channel**,
+  so the real cost is two processes per join, not one.
+- It cannot hold a per-socket in-flight budget, because there is nowhere
+  per-socket to hold one.
+- It cannot link workers to the connection. If the runtime actor dies, every
+  worker on every socket is orphaned. The prototype pins that with
+  `OneForAll`, so the factory restarts alongside the runtime; without it a
+  restarted runtime leaves every worker holding a `Sender` for a dead
+  process, with no `Finish` ever arriving to end them.
+- It cannot start its workers off the hot path. `supervisor:start_child` is
+  a `gen_server:call` handled synchronously in the factory supervisor, so
+  **every join on every socket queues behind one process**, each for up to
+  `join_timeout_ms`. Today the shared runtime already serialises joins, so
+  this is not a regression — but it survives #334 unchanged, and would be
+  the next thing to hit.
+
+So #337 is downstream of [#334](https://github.com/tylerbutler/beryl/issues/334),
+not parallel to it. Process-per-channel on top of process-per-socket is a
+coherent design; process-per-channel on today's shared runtime buys callback
+concurrency and pays for it with a watcher process per channel and the two
+contract breaks below.
+
+## Answers to the questions the issue asked
+
+**Does the socket permit one in-flight callback, or can workers run
+concurrently?** Concurrently after join, serially during it. `join` and
+`on_terminate` are synchronous calls from the router; everything else is a
+cast, so N joined topics on one socket can be executing callbacks at once.
+
+**What ordering remains between actions from different topics on one
+socket?** Per topic, order is preserved *between batches*: one worker
+mailbox, FIFO, and the VM orders messages between one pair of processes. It
+is **not** preserved between a batch and the topic's own close, which take
+different paths home and race — see the third contract break below. Across
+topics on one socket, nothing is preserved — two topics' replies can be interleaved in any
+order regardless of the order the client sent them. **This is a change from
+today**, where the shared runtime serialises the whole socket. Phoenix does
+not promise cross-topic ordering either, so the question is whether beryl
+wants to keep promising more than Phoenix does.
+
+**Does `join` execute during child startup or through an asynchronous
+handshake?** During child startup — an asynchronous handshake is not
+representable. Core rejects a `Join` that is unanswered when the update turn
+ends (fail-closed), so the router has to have the outcome before it returns.
+The prototype therefore runs `join` in the worker's initialiser and blocks
+the runtime on `factory_supervisor.start_child`. An async handshake needs a
+new core capability: a join that can be left pending across turns.
+
+**How are join timeout, worker startup failure, and worker death during an
+action batch represented?** All three are distinguishable. A join that overruns the initialiser timeout
+rejects with `join timeout` — a reason core has no equivalent for, because
+core cannot time a callback out at all, so it is a wire value this topology
+adds. A panicking join rejects with core's own `join crashed`. Worker death
+is a `Died` envelope from the watcher, which drops the topic from the router
+and kicks it; a batch in flight from that worker is then discarded by the
+generation check, since the topic is no longer live.
+
+**How does the session apply backpressure to worker mailboxes and pending
+action batches?** It does not. Worker mailboxes are unbounded and batches
+are applied as fast as they arrive. A budget needs a per-socket owner (#334).
+
+**Which process owns presence suspension while an asynchronous presence
+mutation is in flight?** Unchanged — the runtime. Workers emit actions;
+`PresenceTrack`/`PresenceUntrack` are core effects applied by the runtime,
+which is also what makes it necessary for the router, not the worker, to
+apply every batch.
+
+**How does socket shutdown terminate workers and preserve `on_terminate`?**
+Core delivers `Closed` for every joined topic on teardown, and the router
+answers each one with a synchronous `Finish` call before the turn ends —
+`on_terminate`'s actions have to be lowered inside that turn. Workers stop
+on the way out, and `a_disconnect_terminates_every_worker_test` pins that no
+worker outlives its socket.
+
+## Three contract breaks, all pinned by tests
+
+1. **A crashed worker cannot run `on_terminate`.** Today core rescues the
+   callback, keeps the model, and delivers `Closed`, so the channel's state
+   is still there to terminate. Here the state died with the process. This
+   matches Phoenix — a channel process crash skips `terminate/2` — but it is
+   a change from what beryl documents today.
+2. **A crashed channel closes as `phx_close`, not `phx_error`.** Core picks
+   the frame from the stop reason, and the only way a layer can close a topic
+   it no longer owns is `KickTopic`, which is `Shutdown`. Preserving this
+   needs a core effect that carries a reason.
+
+3. **A close discards the worker's in-flight batch.** A client that pushes
+   and then leaves loses the push's reply entirely: the batch travels the
+   slow path (worker → socket `Sender` → a later runtime turn) while the
+   close is answered on a direct subject, so the router drops the topic
+   before the batch gets home and then discards it. The client's `ref` is
+   never answered. `a_leave_discards_the_reply_it_raced_test` pins it; the
+   shipped shared runtime cannot lose this, because it runs `on_message` in
+   the same process that handles the leave.
+
+   **This one is not fixable from the router**, and that is the point. The
+   router would have to drain its socket's outstanding envelopes before
+   finishing, and it cannot: it is not a process, so it cannot selectively
+   receive from the mailbox its own batches arrive in. A per-socket process
+   (#334) can. This is the sharpest single piece of evidence that #337 is
+   downstream of #334 rather than parallel to it.
+
+A fourth difference is arguably an improvement: a panic in `on_info` closes
+only its topic here, where today it tears down the whole socket.
+
+There is also a cost that is not a contract break but is worse
+operationally. A worker that dies before answering the router's synchronous
+`Finish` would leave the `Closed` turn blocked — inside the one shared
+runtime actor, so every socket with it — until `terminate_timeout_ms`
+expired. That applies to a panicking `on_terminate` and, more commonly, to
+any close that overtakes a crash the router has not yet learned about. The
+prototype pays it down: `finish` selects on the worker's `DOWN` alongside
+its reply, so a dead worker ends the wait at once, and
+`a_dead_worker_does_not_stall_the_runtime_test` pins that.
+
+What remains is an `on_terminate` that *blocks* rather than dies, which
+still stalls every socket for up to `terminate_timeout_ms`. The shared
+runtime has the same exposure to a blocking callback, so it is not new; what
+a socket session (#334) adds is confinement of the stall to one connection.
+A worker that blocks in `on_terminate` forever also leaks itself and its
+watcher, since the router has already moved on — bounded in practice by the
+same thing that bounds an infinite callback today, which is nothing.
+
+## What was not done
+
+- **No benchmarks.** The issue asks for thresholds to be set before final
+  numbers, and none are set. What can be said without measuring: two
+  processes per joined channel (worker plus watcher) against zero today,
+  plus one extra message hop for every reply, against the ability to run
+  callbacks on more than one scheduler. Whether that trade pays depends
+  entirely on callback cost, which is the thing to measure first.
+- **No cross-node, presence, or broadcast workloads**, and no binary frame
+  path — the binary path is `Deliver`'s shape exactly.
+- **The Phoenix contract matrix was not run against the spike.** It is wired
+  to `beryl.child_spec` and `channel.child_spec`; the two breaks above say
+  what it would report.
+
+## Recommendation
+
+Do not pursue process-per-channel before #334. Reassess afterwards, when a
+socket session actually exists to own monitoring, backpressure, worker
+lifetime, and the drain that the third contract break needs, and when the
+watcher process — currently half the per-channel cost — disappears.
+
+Things to carry forward into a real implementation, none of which the spike
+resolves:
+
+- The close/batch drain (third contract break). Needs the per-socket process.
+- Join serialisation through the factory supervisor. Needs joins started off
+  the calling process, or a supervisor per socket.
+- A `Died` that arrives after a close, and a close that arrives after a
+  `Died`, are both handled here by deleting the topic first and letting the
+  other path miss. That works because a topic has exactly one ending; it
+  will not survive a design where a worker can be replaced in place.

--- a/docs/spikes/0337-process-per-channel.md
+++ b/docs/spikes/0337-process-per-channel.md
@@ -1,5 +1,12 @@
 # Spike: process-per-channel isolation (#337)
 
+> **Superseded in part by
+> [round 2](./0337-process-per-channel-round-2.md)**, which re-ran this
+> prototype on the per-socket runtime (#334). Three claims below did not
+> survive: the third contract break is core's close ordering rather than a
+> missing drain, the per-channel watcher was never a #334 cost, and a
+> per-socket in-flight budget always had somewhere to live.
+
 Prototype: `packages/beryl/test/spike_channel_worker.gleam`.
 Pinned behaviour: `packages/beryl/test/spike_channel_worker_test.gleam`.
 

--- a/packages/beryl/src/beryl/runtime.gleam
+++ b/packages/beryl/src/beryl/runtime.gleam
@@ -130,6 +130,32 @@ pub type Msg(msg) {
   /// socket is still waiting on exactly that operation.
   PresenceOpTimedOut(socket_id: String, op_id: Int)
   Stop(reply: Subject(Nil))
+  /// Prototype (#334): a socket actor joined a topic. The router owns the
+  /// global index and the pg subscription.
+  IndexJoin(socket_id: String, topic: String)
+  /// Prototype (#334): a socket actor left a topic.
+  IndexLeave(socket_id: String, topic: String)
+  /// Prototype (#334): a socket actor finished its teardown and is about to
+  /// stop; the router drops it from the index and the actor table.
+  SocketClosed(socket_id: String)
+  /// Prototype (#334): the router died. Decision 5 wants router death to
+  /// take every socket actor with it; the prototype monitors rather than
+  /// supervises.
+  RouterDown
+  /// Prototype (#334): shut one socket actor down. Unlike `Stop` there is
+  /// no reply — the router waits for `SocketClosed`, so a socket actor's
+  /// teardown broadcasts still reach the router on their way out.
+  StopSocketActor
+  /// Prototype (#334): a socket actor never reported back during shutdown
+  /// (it crashed, or its teardown hung). The router stops anyway.
+  StopTimedOut
+  /// Prototype (#334): shutdown phase one. Finalize in-flight presence work
+  /// while every other socket actor is still alive to receive the leaves it
+  /// publishes; the shared runtime got this for free by doing it before its
+  /// teardown loop.
+  FinalizeForStop
+  /// Prototype (#334): a socket actor finished shutdown phase one.
+  StopPhaseDone(socket_id: String)
 }
 
 pub type StatsSnapshot {
@@ -189,6 +215,20 @@ type State(model, msg) {
     /// are then fire-and-forget: there is no longer a runtime to deliver
     /// the acknowledgement to.
     stopping: Bool,
+    /// Prototype (#334): `None` in the router, `Some(router)` in a
+    /// per-socket actor. Every socket-scoped function below is lifted
+    /// unchanged by handing the socket actor this same `State` with exactly
+    /// one entry in `sockets`; this field is what the handful of
+    /// router-owned operations (fan-out, topic index, PubSub) branch on.
+    router: Option(Subject(Msg(msg))),
+    /// Prototype (#334): router-only. socket_id -> its socket actor.
+    socket_actors: Dict(String, Subject(Msg(msg))),
+    /// Prototype (#334): router-only. Set while the router is draining its
+    /// socket actors; answered once the last `SocketClosed` arrives.
+    stop_reply: Option(Subject(Nil)),
+    /// Prototype (#334): router-only. How many socket actors have finished
+    /// shutdown phase one. Teardown starts when every one of them has.
+    stop_finalized: Int,
   )
 }
 
@@ -470,8 +510,13 @@ pub fn start_named(
         queued: dict.new(),
         unacked_tracks: dict.new(),
         stopping: False,
+        router: None,
+        socket_actors: dict.new(),
+        stop_reply: None,
+        stop_finalized: 0,
       )
-    schedule_heartbeat_check(subject, config)
+    // Prototype (#334): heartbeats are per-socket timers now (phasing step
+    // 3), so the router runs no sweep and schedules nothing.
     let selector =
       process.new_selector()
       |> process.select(subject)
@@ -498,6 +543,49 @@ pub fn start_named(
   })
   |> actor.on_message(handle_message)
   |> actor.named(name)
+  |> actor.start
+}
+
+/// Prototype (#334): start one actor to own one socket.
+///
+/// It runs the same `handle_message` on the same `State` as the router —
+/// the socket actor is the router with `sockets` capped at one entry, no
+/// topic index beyond its own memberships, no PubSub subscriber, and
+/// `router` set. That is the whole lift of `dispatch_socket_msg`.
+fn start_socket_actor(
+  router_state: State(model, msg),
+  router_pid: process.Pid,
+) -> Result(actor.Started(Subject(Msg(msg))), actor.StartError) {
+  let router = router_state.self_subject
+  let config = router_state.config
+  actor.new_with_initialiser(5000, fn(subject) {
+    let ack_subject = process.new_subject()
+    // The router's own per-socket dicts are always empty, so copying its
+    // state is the same as building a fresh one.
+    let state =
+      State(
+        ..router_state,
+        pubsub: None,
+        subscriber: None,
+        self_subject: subject,
+        presence_ack: ack_subject,
+        router: Some(router),
+        socket_actors: dict.new(),
+        stop_reply: None,
+        stop_finalized: 0,
+      )
+    // Decision 5: router death must take its socket actors with it. A
+    // monitor is the prototype's stand-in for `one_for_all`.
+    let monitor = process.monitor(router_pid)
+    schedule_heartbeat_check(subject, config)
+    process.new_selector()
+    |> process.select(subject)
+    |> process.select_map(ack_subject, PresenceAcknowledged)
+    |> process.select_specific_monitor(monitor, fn(_) { RouterDown })
+    |> actor.selecting(actor.returning(actor.initialised(state), subject), _)
+    |> Ok
+  })
+  |> actor.on_message(handle_message)
   |> actor.start
 }
 
@@ -550,12 +638,41 @@ fn handle_message(
     | RouteDecodedBinary(socket_id, _)
     | HandleBinary(socket_id, _)
     | AppInfo(socket_id, _) ->
-      case dict.has_key(state.suspended, socket_id) {
-        True -> actor.continue(enqueue_socket_msg(state, socket_id, message))
-        False -> actor.continue(dispatch_socket_msg(state, message))
+      case state.router {
+        // ponytail: the router forwards every inbound message to the
+        // socket's actor, so it stays on the inbound path for one send per
+        // message. Ceiling: router throughput is still O(messages), though
+        // its turn is now a match-and-send instead of an app callback.
+        // Upgrade: hand the socket actor's subject back to the transport at
+        // admission (or keep a registry) so transports send direct.
+        None -> {
+          case dict.get(state.socket_actors, socket_id) {
+            Ok(socket_actor) -> process.send(socket_actor, message)
+            Error(Nil) -> Nil
+          }
+          actor.continue(state)
+        }
+        Some(_) ->
+          case dict.has_key(state.suspended, socket_id) {
+            True ->
+              actor.continue(enqueue_socket_msg(state, socket_id, message))
+            False ->
+              after_socket_turn(state, dispatch_socket_msg(state, message))
+          }
       }
     Broadcast(topic_name, event_name, payload, except) -> {
-      broadcast_with_pubsub(state, topic_name, event_name, payload, except)
+      case state.router {
+        // In a socket actor this is a delivery, not an origination: the
+        // router already resolved the recipients (decision 1's hop) and
+        // this actor encodes and sends for its own socket.
+        Some(_) -> {
+          let _counts =
+            local_broadcast(state, topic_name, event_name, payload, except)
+          Nil
+        }
+        None ->
+          broadcast_with_pubsub(state, topic_name, event_name, payload, except)
+      }
       actor.continue(state)
     }
     RemoteBroadcast(pubsub_msg) ->
@@ -574,26 +691,123 @@ fn handle_message(
         }
       }
     CheckHeartbeats -> actor.continue(handle_check_heartbeats(state))
-    PresenceAcknowledged(ack) -> actor.continue(handle_presence_ack(state, ack))
+    PresenceAcknowledged(ack) ->
+      after_socket_turn(state, handle_presence_ack(state, ack))
     PresenceOpTimedOut(socket_id, op_id) ->
-      actor.continue(handle_presence_timeout(state, socket_id, op_id))
+      after_socket_turn(state, handle_presence_timeout(state, socket_id, op_id))
     GetStats(reply) -> {
+      // Prototype (#334): answered entirely from the router's index; no
+      // socket actor is polled. `runtime_mailbox_length` is now only the
+      // router's — the pre-1.0 leak phasing step 2 exists to fix.
       process.send(
         reply,
         StatsSnapshot(
-          connected_sockets: dict.size(state.sockets),
-          joined_socket_topic_pairs: state.sockets
+          connected_sockets: dict.size(state.socket_actors),
+          joined_socket_topic_pairs: state.topics
             |> dict.values
-            |> list.fold(0, fn(total, socket) {
-              total + set.size(socket.subscribed_topics)
-            }),
+            |> list.fold(0, fn(total, ids) { total + set.size(ids) }),
           active_topics: dict.size(state.topics),
           runtime_mailbox_length: telemetry.mailbox_length(),
         ),
       )
       actor.continue(state)
     }
-    Stop(reply) -> handle_stop(state, reply)
+    Stop(reply) ->
+      case state.router {
+        Some(_) -> handle_stop(state, Some(reply))
+        None -> begin_router_stop(state, reply)
+      }
+    FinalizeForStop -> {
+      let state = finalize_for_stop(state)
+      case state.router, dict.keys(state.sockets) {
+        Some(router), [socket_id] ->
+          process.send(router, StopPhaseDone(socket_id))
+        // No socket ever registered here; report under a name the router
+        // does not need, since it only counts.
+        Some(router), _ -> process.send(router, StopPhaseDone(""))
+        None, _ -> Nil
+      }
+      actor.continue(state)
+    }
+    StopPhaseDone(_) -> {
+      let state = State(..state, stop_finalized: state.stop_finalized + 1)
+      case state.stop_finalized >= dict.size(state.socket_actors) {
+        True ->
+          dict.values(state.socket_actors)
+          |> list.each(process.send(_, StopSocketActor))
+        False -> Nil
+      }
+      actor.continue(state)
+    }
+    StopSocketActor -> {
+      // The router is waiting on `SocketClosed`, not on a reply, so the
+      // teardown's own broadcasts reach it before the actor goes away.
+      let socket_ids = dict.keys(state.sockets)
+      let next = handle_stop(state, None)
+      case state.router, socket_ids {
+        Some(router), [socket_id] ->
+          process.send(router, SocketClosed(socket_id))
+        _, _ -> Nil
+      }
+      next
+    }
+    StopTimedOut ->
+      case state.stop_reply {
+        None -> actor.continue(state)
+        Some(reply) -> {
+          state.logger
+          |> log.warn("Runtime stop: socket actors did not all report back", [
+            #("socket_count", int.to_string(dict.size(state.socket_actors))),
+          ])
+          process.send(reply, Nil)
+          actor.stop()
+        }
+      }
+    IndexJoin(socket_id, topic_name) ->
+      actor.continue(add_topic_subscriber(state, socket_id, topic_name))
+    IndexLeave(socket_id, topic_name) ->
+      actor.continue(remove_topic_subscriber(state, socket_id, topic_name))
+    SocketClosed(socket_id) -> {
+      // A teardown emits `IndexLeave` per joined topic, but sweeping is
+      // cheap and makes a dropped one impossible to leak.
+      let state =
+        dict.keys(state.topics)
+        |> list.fold(state, fn(st, topic_name) {
+          remove_topic_subscriber(st, socket_id, topic_name)
+        })
+      let state =
+        State(
+          ..state,
+          socket_actors: dict.delete(state.socket_actors, socket_id),
+        )
+      case state.stop_reply, dict.is_empty(state.socket_actors) {
+        Some(reply), True -> {
+          process.send(reply, Nil)
+          actor.stop()
+        }
+        _, _ -> actor.continue(state)
+      }
+    }
+    RouterDown -> actor.stop()
+  }
+}
+
+/// Prototype (#334): a socket actor's turn is over. If the socket is gone
+/// the actor has nothing left to own, so it tells the router and stops.
+fn after_socket_turn(
+  before: State(model, msg),
+  after: State(model, msg),
+) -> actor.Next(State(model, msg), Msg(msg)) {
+  case dict.keys(before.sockets), after.router {
+    [socket_id], Some(router) ->
+      case dict.has_key(after.sockets, socket_id) {
+        True -> actor.continue(after)
+        False -> {
+          process.send(router, SocketClosed(socket_id))
+          actor.stop()
+        }
+      }
+    _, _ -> actor.continue(after)
   }
 }
 
@@ -624,7 +838,15 @@ fn dispatch_socket_msg(
     | GetStats(..)
     | PresenceAcknowledged(..)
     | PresenceOpTimedOut(..)
-    | Stop(..) -> state
+    | Stop(..)
+    | StopSocketActor
+    | StopTimedOut
+    | FinalizeForStop
+    | StopPhaseDone(..)
+    | IndexJoin(..)
+    | IndexLeave(..)
+    | SocketClosed(..)
+    | RouterDown -> state
   }
 }
 
@@ -707,12 +929,11 @@ fn handle_admit_socket(
   admission: AdmissionToken,
   reply: Subject(Bool),
 ) -> State(model, msg) {
-  case process.self() == owner && admission_pending(admission) {
-    False -> {
-      process.send(reply, False)
-      state
-    }
-    True -> {
+  case state.router {
+    // Prototype (#334): in a socket actor, the router has already made the
+    // owner and admission-pending checks atomically in its own turn; this
+    // actor only registers.
+    Some(_) -> {
       let #(state, admitted) =
         register_socket(
           state,
@@ -727,6 +948,66 @@ fn handle_admit_socket(
       process.send(reply, admitted)
       state
     }
+    None ->
+      case process.self() == owner && admission_pending(admission) {
+        False -> {
+          process.send(reply, False)
+          state
+        }
+        // ponytail: the router starts the socket actor and waits for it to
+        // register, inside the admission turn — decision 4's cheap option.
+        // Ceiling: connection setup serialises through the router, exactly
+        // the bottleneck #337 hit on joins. Upgrade: have the transport's
+        // connection process start the actor and hand it over for an O(1)
+        // atomic admit.
+        True ->
+          case start_socket_actor(state, process.self()) {
+            Error(start_error) -> {
+              state.logger
+              |> log.error("Socket actor failed to start", [
+                #("socket_id", socket_id),
+                #("error", string.inspect(start_error)),
+              ])
+              process.send(reply, False)
+              state
+            }
+            Ok(started) -> {
+              // Unlinked: a socket actor crash must not take the router,
+              // and the actor monitors the router for the other direction.
+              process.unlink(started.pid)
+              let admitted =
+                process.call(started.data, 5000, fn(register_reply) {
+                  AdmitSocket(
+                    owner,
+                    socket_id,
+                    send,
+                    send_binary,
+                    socket_codec,
+                    seed,
+                    close,
+                    admission,
+                    register_reply,
+                  )
+                })
+              process.send(reply, admitted)
+              case admitted {
+                True ->
+                  State(
+                    ..state,
+                    socket_actors: dict.insert(
+                      state.socket_actors,
+                      socket_id,
+                      started.data,
+                    ),
+                  )
+                False -> {
+                  process.send(started.data, Stop(process.new_subject()))
+                  state
+                }
+              }
+            }
+          }
+      }
   }
 }
 
@@ -822,14 +1103,62 @@ fn handle_socket_disconnected(
   run(state, socket_id, [StepTeardown(sock.Normal)])
 }
 
-fn handle_stop(
+/// Prototype (#334): drain the socket actors, then stop.
+///
+/// The router casts `StopSocketActor` rather than calling, so a socket
+/// actor's teardown broadcasts and index updates still route through this
+/// mailbox. The router answers `reply` once the last `SocketClosed` lands.
+///
+/// ponytail: the fallback timeout is a hardcoded 2s, chosen only to sit
+/// inside `beryl.stop`'s own 5s budget. Ceiling: a socket actor whose
+/// teardown legitimately takes longer is abandoned. Upgrade: make it a
+/// config knob, or monitor the socket actors instead of timing out.
+fn begin_router_stop(
   state: State(model, msg),
   reply: Subject(Nil),
 ) -> actor.Next(State(model, msg), Msg(msg)) {
   state.logger
   |> log.info("Runtime stopping", [
+    #("socket_count", int.to_string(dict.size(state.socket_actors))),
+  ])
+  use <- bool.lazy_guard(when: dict.is_empty(state.socket_actors), return: fn() {
+    process.send(reply, Nil)
+    actor.stop()
+  })
+  dict.values(state.socket_actors)
+  |> list.each(process.send(_, FinalizeForStop))
+  let _timer = process.send_after(state.self_subject, 2000, StopTimedOut)
+  actor.continue(State(..state, stopping: True, stop_reply: Some(reply)))
+}
+
+fn handle_stop(
+  state: State(model, msg),
+  reply: Option(Subject(Nil)),
+) -> actor.Next(State(model, msg), Msg(msg)) {
+  state.logger
+  |> log.info("Runtime stopping", [
     #("socket_count", int.to_string(dict.size(state.sockets))),
   ])
+  let state = finalize_for_stop(state)
+  dict.keys(state.sockets)
+  |> list.fold(state, fn(st, socket_id) {
+    run(st, socket_id, [StepTeardown(sock.Shutdown)])
+  })
+  case reply {
+    Some(reply) -> process.send(reply, Nil)
+    None -> Nil
+  }
+  actor.stop()
+}
+
+/// The pre-teardown half of a shutdown: mark the actor stopping and settle
+/// every in-flight presence mutation it still owns.
+///
+/// Prototype (#334): the shared runtime ran this for all sockets before it
+/// tore any of them down. Per-socket actors have to be told to do it as a
+/// separate phase, or a socket's shutdown leaves can be fanned out to
+/// sockets that are already gone.
+fn finalize_for_stop(state: State(model, msg)) -> State(model, msg) {
   // From here on there is no runtime left to receive an acknowledgement,
   // so presence mutations are sent fire-and-forget and never suspend.
   let state = State(..state, stopping: True)
@@ -842,15 +1171,8 @@ fn handle_stop(
   // swept now, while there is still something to sweep them with. The sweep is
   // ordered behind the in-flight tracks themselves (same sender, same
   // mailbox), so it removes them rather than racing them.
-  let state =
-    dict.keys(state.unacked_tracks)
-    |> list.fold(state, sweep_unacked_track)
-  dict.keys(state.sockets)
-  |> list.fold(state, fn(st, socket_id) {
-    run(st, socket_id, [StepTeardown(sock.Shutdown)])
-  })
-  process.send(reply, Nil)
-  actor.stop()
+  dict.keys(state.unacked_tracks)
+  |> list.fold(state, sweep_unacked_track)
 }
 
 /// Finalize a socket's in-flight presence mutation during shutdown.
@@ -2424,6 +2746,10 @@ fn remove_topic_subscriber(
     dict.get(state.topics, topic_name)
     |> result.unwrap(set.new())
     |> set.delete(socket_id)
+  case state.router {
+    Some(router) -> process.send(router, IndexLeave(socket_id, topic_name))
+    None -> Nil
+  }
   case set.is_empty(subscribers) {
     True -> {
       case state.subscriber {
@@ -2435,6 +2761,44 @@ fn remove_topic_subscriber(
     False ->
       State(..state, topics: dict.insert(state.topics, topic_name, subscribers))
   }
+}
+
+/// Add a socket to a topic's subscriber set, joining the pg group when the
+/// topic becomes locally active.
+///
+/// Prototype (#334): in a socket actor the set only ever holds that one
+/// socket, and the router is told so it can keep the global index and the
+/// pg subscription. That notification is a cast, not a call — the router
+/// calls into socket actors during admission and shutdown, so a call back
+/// would deadlock. It is sent from `subscribe_socket`, before the join
+/// reply frame leaves this turn, so a client that acts on its own reply
+/// cannot beat its index entry to the router. A broadcast from a third
+/// process that races the cast still misses the socket: that is decision
+/// 2's cast option and its documented window.
+fn add_topic_subscriber(
+  state: State(model, msg),
+  socket_id: String,
+  topic_name: String,
+) -> State(model, msg) {
+  let existing =
+    dict.get(state.topics, topic_name)
+    |> result.unwrap(set.new())
+  case state.router {
+    Some(router) -> process.send(router, IndexJoin(socket_id, topic_name))
+    None ->
+      case state.subscriber, set.is_empty(existing) {
+        Some(subscriber), True -> pubsub.join(subscriber, topic_name)
+        _, _ -> Nil
+      }
+  }
+  State(
+    ..state,
+    topics: dict.insert(
+      state.topics,
+      topic_name,
+      set.insert(existing, socket_id),
+    ),
+  )
 }
 
 /// Notify the client that its topic ended. Phoenix clients rely on
@@ -2822,22 +3186,8 @@ fn subscribe_socket(
             pending_join.join_ref,
           ),
         )
-      let state = store_socket(state, socket)
-      let existing =
-        dict.get(state.topics, pending_join.topic)
-        |> result.unwrap(set.new())
-      case state.subscriber, set.is_empty(existing) {
-        Some(subscriber), True -> pubsub.join(subscriber, pending_join.topic)
-        _, _ -> Nil
-      }
-      State(
-        ..state,
-        topics: dict.insert(
-          state.topics,
-          pending_join.topic,
-          set.insert(existing, socket_id),
-        ),
-      )
+      store_socket(state, socket)
+      |> add_topic_subscriber(socket_id, pending_join.topic)
     }
   }
 }
@@ -3749,24 +4099,51 @@ fn local_broadcast(
     #("recipient_count", int.to_string(list.length(recipients))),
     #("except", optional_string(except)),
   ])
-  list.fold(recipients, #(0, 0), fn(counts, socket_id) {
-    case dict.get(state.sockets, socket_id) {
-      Ok(socket) -> {
-        let frame =
-          codec.encode_push(socket.codec)(topic_name, event_name, payload)
-        let send_result = send_frame_logged(state, socket, topic_name, frame)
-        #(
-          counts.0 + 1,
-          counts.1
-            + case send_result {
-            Ok(Nil) -> 0
-            Error(Nil) -> 1
-          },
-        )
-      }
-      Error(Nil) -> counts
+  case state.router {
+    // Socket actor: it is the only possible recipient, so encode and send
+    // inline exactly as the shared runtime did.
+    Some(_) ->
+      list.fold(recipients, #(0, 0), fn(counts, socket_id) {
+        case dict.get(state.sockets, socket_id) {
+          Ok(socket) -> {
+            let frame =
+              codec.encode_push(socket.codec)(topic_name, event_name, payload)
+            let send_result =
+              send_frame_logged(state, socket, topic_name, frame)
+            #(
+              counts.0 + 1,
+              counts.1
+                + case send_result {
+                Ok(Nil) -> 0
+                Error(Nil) -> 1
+              },
+            )
+          }
+          Error(Nil) -> counts
+        }
+      })
+    // Decision 1: the router resolves recipients and hands each one to its
+    // own actor, so encoding happens on N schedulers instead of in this
+    // turn, and only one process ever writes to a given transport.
+    //
+    // ponytail: send failures are no longer visible here, so the broadcast
+    // telemetry reports zero of them. Ceiling: `send_failures` is dead in
+    // this topology. Upgrade: have socket actors report failures back, or
+    // move the counter into per-socket telemetry.
+    None -> {
+      list.each(recipients, fn(socket_id) {
+        case dict.get(state.socket_actors, socket_id) {
+          Ok(socket_actor) ->
+            process.send(
+              socket_actor,
+              Broadcast(topic_name, event_name, payload, except),
+            )
+          Error(Nil) -> Nil
+        }
+      })
+      #(list.length(recipients), 0)
     }
-  })
+  }
 }
 
 fn emit_broadcast(
@@ -3803,6 +4180,29 @@ fn broadcast_with_pubsub(
   payload: Json,
   except: Option(String),
 ) -> Nil {
+  // Prototype (#334): a socket actor owns neither the topic index nor the
+  // PubSub handle, so everything it originates goes to the router, which
+  // fans out locally (decision 1's hop) and forwards to other nodes.
+  //
+  // This socket's own copy is sent inline first, so a broadcast to a topic
+  // it is joined to still lands in effect-list order instead of arriving a
+  // round trip later, behind the frames that followed it. The only
+  // `except` a socket actor ever originates is its own id (`BroadcastFrom`),
+  // so the exclusion handed to the router is always this socket.
+  use <- with_router(state, fn(router) {
+    case except, dict.keys(state.sockets) {
+      None, [socket_id] -> {
+        let _counts =
+          local_broadcast(state, topic_name, event_name, payload, None)
+        process.send(
+          router,
+          Broadcast(topic_name, event_name, payload, Some(socket_id)),
+        )
+      }
+      _, _ ->
+        process.send(router, Broadcast(topic_name, event_name, payload, except))
+    }
+  })
   emit_broadcast(
     state,
     topic_name,
@@ -3833,6 +4233,20 @@ fn broadcast_with_pubsub(
           )
       }
     None -> Nil
+  }
+}
+
+/// Prototype (#334): branch on topology. In a socket actor, run
+/// `in_socket_actor` with the router's subject and stop; in the router,
+/// fall through to the calling function's body.
+fn with_router(
+  state: State(model, msg),
+  in_socket_actor: fn(Subject(Msg(msg))) -> Nil,
+  in_router: fn() -> Nil,
+) -> Nil {
+  case state.router {
+    Some(router) -> in_socket_actor(router)
+    None -> in_router()
   }
 }
 

--- a/packages/beryl/test/spike_channel_worker.gleam
+++ b/packages/beryl/test/spike_channel_worker.gleam
@@ -24,9 +24,12 @@
 ////
 //// ## Shape
 ////
-//// - A `factory_supervisor` starts one `Temporary` worker per accepted
-////   join. Temporary is the point: a worker whose join and authorization
-////   state died must not be restarted behind the client's back.
+//// - Each socket starts **its own** `factory_supervisor` in `init`, linked
+////   to its own socket actor, and one `Temporary` worker per accepted join
+////   runs under it. Temporary is the point: a worker whose join and
+////   authorization state died must not be restarted behind the client's
+////   back. Per-socket is round 2's change (see below) — round 1 used one
+////   globally named factory for the whole server.
 //// - `join` runs **inside the worker's initialiser**, and the router waits
 ////   for it, because the core rejects a `Join` that is unanswered when the
 ////   update turn ends. There is no way to represent an asynchronous join
@@ -38,17 +41,31 @@
 //// - `on_terminate` is synchronous again, for the same reason `join` is:
 ////   its actions have to be lowered inside the `Closed` turn.
 ////
+//// ## Round 2, on the per-socket runtime (#334)
+////
+//// Round 1 ran on the shared runtime actor and concluded that #337 was
+//// downstream of #334. Round 2 re-ran it on the per-socket runtime and
+//// claimed what that made available:
+////
+//// - **A supervisor per socket**, started by and linked to the socket's own
+////   actor. Joins no longer serialise across sockets through one
+////   `supervisor:start_child`, and no worker outlives its connection. The
+////   global name and the `OneForAll` runtime coupling are both gone.
+//// - **One watcher per socket** instead of one per worker (see
+////   `start_watcher`). This was never a #334 cost; round 1 over-booked it.
+////
 //// ## Known ceilings
 ////
-//// `ponytail:` spike-scope cuts — no backpressure, no binary frames, no
-//// pattern validation, workers not linked to their socket (nothing
-//// per-socket exists to link them to), and a *blocking* `on_terminate`
-//// stalling every socket for `terminate_timeout_ms` (see `finish`).
+//// `ponytail:` spike-scope cuts — no backpressure, no binary frames, and no
+//// pattern validation. A *blocking* `on_terminate` still holds `finish` for
+//// `terminate_timeout_ms`, but #334 confines that to its own socket for
+//// free.
 ////
-//// One thing is not a cut but a finding: a close races the worker's own
-//// in-flight batch, and the batch loses (see `apply`). It is not fixable
-//// from here. Each ceiling's upgrade path, and what the prototype found,
-//// is in `docs/spikes/0337-process-per-channel.md`.
+//// One thing is not a cut and is not a topology problem either: a close
+//// races the worker's own in-flight batch, and the batch loses (see
+//// `apply`). Round 1 expected #334 to fix it. It does not, and no drain
+//// can — see `a_reply_ref_is_dead_by_the_closed_turn_test`. Findings are in
+//// `docs/spikes/0337-process-per-channel-round-2.md`.
 
 import beryl
 import beryl/channel
@@ -244,29 +261,60 @@ fn report(active: Channel, outcome: Outcome) -> Nil {
   )
 }
 
-/// Notify the socket when a worker exits, from a process that is allowed
-/// to receive `DOWN`.
+/// What the per-socket watcher is told to monitor.
+type Watch {
+  Watch(pid: process.Pid, topic: String, generation: Int)
+}
+
+/// Notify the socket when any of its workers exits.
 ///
-/// The router runs inside beryl's shared runtime actor and does not own
-/// that actor's selector, so it cannot monitor anything itself. One
-/// short-lived watcher per worker is the price of that, and it doubles the
-/// per-channel process count — the first thing #334 would pay back.
-fn watch(
-  pid: process.Pid,
-  home: socket.Sender(Envelope),
-  name: String,
-  generation: Int,
-) -> Nil {
-  let _watcher =
-    process.spawn_unlinked(fn() {
-      let monitor = process.monitor(pid)
-      let selector =
-        process.new_selector()
-        |> process.select_specific_monitor(monitor, fn(down) { down })
-      let _down = process.selector_receive_forever(selector)
-      socket.notify(home, Died(topic: name, generation: generation))
+/// **One process per socket, not per channel.** Round 1 spawned a watcher
+/// per worker and booked that as a cost #334 would repay. It was never a
+/// #334 cost: `init` has always run once per socket and `info.self` has
+/// always been that socket's own `Sender`, so a single watcher holding a
+/// monitor per worker was available on the shared runtime too. What #334
+/// does add is that the watcher can be started *by* the socket's own
+/// process, so it dies with the socket instead of outliving it.
+fn start_watcher(home: socket.Sender(Envelope)) -> process.Subject(Watch) {
+  let ready = process.new_subject()
+  let _pid =
+    process.spawn(fn() {
+      let inbox = process.new_subject()
+      process.send(ready, inbox)
+      watch_loop(inbox, home, dict.new())
     })
-  Nil
+  let assert Ok(inbox) = process.receive(ready, 1000)
+    as "the socket's watcher started"
+  inbox
+}
+
+fn watch_loop(
+  inbox: process.Subject(Watch),
+  home: socket.Sender(Envelope),
+  watched: dict.Dict(process.Pid, #(String, Int)),
+) -> Nil {
+  let selector =
+    process.new_selector()
+    |> process.select_map(inbox, Ok)
+    |> process.select_monitors(Error)
+  case process.selector_receive_forever(selector) {
+    Ok(Watch(pid: pid, topic: name, generation: generation)) -> {
+      let _monitor = process.monitor(pid)
+      watch_loop(inbox, home, dict.insert(watched, pid, #(name, generation)))
+    }
+    Error(down) ->
+      case down {
+        process.ProcessDown(pid: pid, ..) -> {
+          case dict.get(watched, pid) {
+            Ok(#(name, generation)) ->
+              socket.notify(home, Died(topic: name, generation: generation))
+            Error(Nil) -> Nil
+          }
+          watch_loop(inbox, home, dict.delete(watched, pid))
+        }
+        _ -> watch_loop(inbox, home, watched)
+      }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -309,7 +357,11 @@ type Worker {
 type Router {
   Router(
     handlers: List(Registered),
-    factory: process.Name(factory_supervisor.Message(Spawn, Report)),
+    /// This socket's own worker supervisor, started in `init` and linked
+    /// to the socket's process.
+    factory: factory_supervisor.Supervisor(Spawn, Report),
+    /// This socket's single watcher (see `start_watcher`).
+    watcher: process.Subject(Watch),
     socket_id: String,
     seed: socket.ConnectSeed,
     self: socket.Sender(Envelope),
@@ -318,11 +370,14 @@ type Router {
   )
 }
 
-/// Build a spike channel system: a factory supervisor for channel workers,
-/// then beryl's runtime.
+/// Build a spike channel system.
 ///
-/// Start order matters — the runtime's first join looks the factory up by
-/// name.
+/// Round 1 needed a supervision tree here: one globally named factory
+/// supervisor for every worker on every socket, wrapped with the runtime in
+/// `OneForAll` so a restarted runtime could not orphan them. Post-#334 the
+/// socket actor owns its own workers, so this is `beryl.child_spec` and
+/// nothing else — the whole tree, the global name, and the `OneForAll`
+/// coupling are gone.
 pub fn child_spec(
   config: beryl.Config,
   handlers handlers: List(channel.Handler),
@@ -330,33 +385,8 @@ pub fn child_spec(
   #(beryl.Sockets, supervision.ChildSpecification(static_supervisor.Supervisor)),
   beryl.ConfigError,
 ) {
-  let factory = process.new_name("spike_channel_factory")
   let table = table(handlers)
-
-  use #(sockets, runtime) <- result.map(beryl.child_spec(
-    config,
-    init: fn(info) { init(table, factory, info) },
-    update: update,
-  ))
-
-  let workers =
-    factory_supervisor.worker_child(start_worker)
-    |> factory_supervisor.restart_strategy(supervision.Temporary)
-    |> factory_supervisor.named(factory)
-    |> factory_supervisor.supervised()
-
-  // `OneForAll`, not `OneForOne`: a worker's `home` `Sender` closes over the
-  // runtime actor's subject, so a runtime that restarts alone would leave
-  // every worker on every socket talking to a dead process, with no `Finish`
-  // ever arriving to end them. Restarting the factory with it bounds that.
-  let tree = fn() {
-    static_supervisor.new(static_supervisor.OneForAll)
-    |> static_supervisor.add(workers)
-    |> static_supervisor.add(runtime)
-    |> static_supervisor.start()
-  }
-
-  #(sockets, supervision.supervisor(tree))
+  beryl.child_spec(config, init: fn(info) { init(table, info) }, update: update)
 }
 
 fn table(handlers: List(channel.Handler)) -> List(Registered) {
@@ -368,15 +398,26 @@ fn table(handlers: List(channel.Handler)) -> List(Registered) {
   })
 }
 
+/// Start this socket's worker supervisor and watcher.
+///
+/// Both are linked to the socket's own process, which is what #334 bought:
+/// worker lifetime is now bounded by the connection rather than by a global
+/// tree, and no worker can outlive the socket that joined it.
 fn init(
   handlers: List(Registered),
-  factory: process.Name(factory_supervisor.Message(Spawn, Report)),
   info: socket.ConnectInfo(Envelope),
 ) -> #(Router, List(socket.Effect)) {
+  let assert Ok(actor.Started(data: factory, pid: _)) =
+    factory_supervisor.worker_child(start_worker)
+    |> factory_supervisor.restart_strategy(supervision.Temporary)
+    |> factory_supervisor.start()
+    as "the socket's worker supervisor started"
+
   #(
     Router(
       handlers: handlers,
       factory: factory,
+      watcher: start_watcher(info.self),
       socket_id: info.socket_id,
       seed: info.seed,
       self: info.self,
@@ -452,12 +493,7 @@ fn join(
           generation: generation,
         )
 
-      case
-        factory_supervisor.start_child(
-          factory_supervisor.get_by_name(router.factory),
-          spawn,
-        )
-      {
+      case factory_supervisor.start_child(router.factory, spawn) {
         // A `join` that ran past `join_timeout_ms`. Core has no equivalent
         // — it cannot time a callback out — so this reason is the
         // prototype's own.
@@ -477,7 +513,10 @@ fn join(
           pid: pid,
           data: Opened(work: work, reply: reply, effects: accepted),
         )) -> {
-          watch(pid, router.self, name, generation)
+          process.send(
+            router.watcher,
+            Watch(pid: pid, topic: name, generation: generation),
+          )
           let live =
             dict.insert(
               router.live,
@@ -536,10 +575,15 @@ fn cast(router: Router, name: String, work: Work) -> Nil {
 /// slow path (worker → socket `Sender` → this turn) while `finish` answers
 /// on a direct subject, so a client that pushes and then leaves can have
 /// its reply produced, reported, and then dropped here — the topic is gone
-/// from `live` by the time the batch is read. Draining first is not
-/// available to the router: it is not a process, so it cannot selectively
-/// receive its own socket's envelopes. See the spike doc's third contract
-/// break.
+/// from `live` by the time the batch is read.
+///
+/// Round 1 read this as a missing drain that #334 would supply. It is not.
+/// Core deletes a topic's `pending_reply_refs` *before* it delivers
+/// `Closed`, so the raced reply is unanswerable from the closing turn no
+/// matter which process drains what — with no workers in the picture at
+/// all, `a_reply_ref_is_dead_by_the_closed_turn_test` loses the same reply.
+/// Preserving it needs core to hold the close until the worker is
+/// quiescent, which means core has to own the worker.
 fn apply(
   router: Router,
   name: String,
@@ -600,10 +644,11 @@ fn died(router: Router, name: String, generation: Int) -> socket.Next(Router) {
 /// wait at once instead of holding the shared runtime actor, and every
 /// socket on it, for the full timeout.
 ///
-/// `ponytail:` an `on_terminate` that *blocks* rather than dies still stalls
-/// every socket, up to `terminate_timeout_ms`. The shared runtime has the
-/// same exposure to a blocking callback, so this is not new; what a socket
-/// session (#334) would add is confinement of the stall to one connection.
+/// `ponytail:` an `on_terminate` that *blocks* rather than dies still holds
+/// this wait for up to `terminate_timeout_ms`. On the per-socket runtime
+/// that stalls only its own connection — pinned by
+/// `a_blocking_terminate_stalls_only_its_own_socket_test`, which needed no
+/// change here to pass.
 fn finish(
   router: Router,
   name: String,

--- a/packages/beryl/test/spike_channel_worker.gleam
+++ b/packages/beryl/test/spike_channel_worker.gleam
@@ -1,0 +1,602 @@
+//// Prototype for [#337](https://github.com/tylerbutler/beryl/issues/337):
+//// one temporary actor per accepted channel.
+////
+//// **This is a spike, not a second runtime.** It lives in `test/` because
+//// it exists to be measured and argued about, not shipped. Nothing in
+//// `src/` imports it.
+////
+//// ## What it reuses
+////
+//// Everything except the topology. Handlers, `join`, state sealing,
+//// callbacks, actions, and action lowering are `beryl/channel`'s own —
+//// `channel.open` produces the same non-generic `LiveChannel` the shipped
+//// router holds, and `channel.effects` lowers the same actions. The only
+//// difference is *which process* holds that `LiveChannel` and runs its
+//// callbacks:
+////
+//// ```text
+//// shipped:   runtime actor ── LiveChannel per topic (in its model)
+//// spike:     runtime actor ── Worker(topic) ── LiveChannel
+////                          └─ Worker(topic) ── LiveChannel
+//// ```
+////
+//// So a benchmark against `channel.child_spec` compares topology alone.
+////
+//// ## Shape
+////
+//// - A `factory_supervisor` starts one `Temporary` worker per accepted
+////   join. Temporary is the point: a worker whose join and authorization
+////   state died must not be restarted behind the client's back.
+//// - `join` runs **inside the worker's initialiser**, and the router waits
+////   for it, because the core rejects a `Join` that is unanswered when the
+////   update turn ends. There is no way to represent an asynchronous join
+////   handshake against today's core.
+//// - Everything after the join is asynchronous: the router casts work to
+////   the worker, and the worker reports an action batch back through the
+////   socket's own `Sender`, stamped with topic, generation, and sequence.
+////   The router validates the stamp before applying anything.
+//// - `on_terminate` is synchronous again, for the same reason `join` is:
+////   its actions have to be lowered inside the `Closed` turn.
+////
+//// ## Known ceilings
+////
+//// `ponytail:` spike-scope cuts — no backpressure, no binary frames, no
+//// pattern validation, workers not linked to their socket (nothing
+//// per-socket exists to link them to), and a panicking `on_terminate`
+//// stalling every socket for `terminate_timeout_ms` (see `finish`). Each
+//// one's upgrade path, and what the prototype found, is in
+//// `docs/spikes/0337-process-per-channel.md`.
+
+import beryl
+import beryl/channel
+import beryl/socket
+import beryl/topic
+import gleam/dict
+import gleam/dynamic
+import gleam/erlang/process
+import gleam/json
+import gleam/list
+import gleam/option.{type Option}
+import gleam/otp/actor
+import gleam/otp/factory_supervisor
+import gleam/otp/static_supervisor
+import gleam/otp/supervision
+import gleam/result
+
+/// How long a `join` callback has to finish before the worker's start is
+/// abandoned and the join rejected. The runtime actor is blocked for this
+/// long in the worst case — a real design would want it much lower than
+/// the supervisor's own call timeout, which is what actually bounds it.
+const join_timeout_ms = 1000
+
+/// How long the `Closed` turn waits for a worker's termination actions.
+const terminate_timeout_ms = 1000
+
+// ---------------------------------------------------------------------------
+// Worker
+// ---------------------------------------------------------------------------
+
+/// Work cast to one channel worker.
+type Work {
+  /// A client message for this channel's `on_message`.
+  Deliver(message: channel.Message)
+  /// One sealed server-side message for this channel's `on_info`.
+  ///
+  /// It arrives directly from the `Sender` that produced it, not by way of
+  /// the router: the join that sealed the mail *is* this process, so
+  /// process identity already carries the stamp the shipped router has to
+  /// check by hand. Mail for an ended join reaches a dead pid and is
+  /// dropped by the VM.
+  DeliverMail(mail: channel.Mail)
+  /// Run `on_terminate` and answer with its lowered actions, then stop.
+  Finish(reply: process.Subject(List(socket.Effect)), reason: socket.StopReason)
+  /// Stop without running any callback (a refused join has no channel).
+  Halt
+}
+
+/// What the factory supervisor hands back to the router when a worker
+/// starts.
+type Report {
+  /// The join was accepted. `effects` are its accept-time actions, already
+  /// lowered and in order; the router must apply them after the accept.
+  Opened(
+    work: process.Subject(Work),
+    reply: Option(json.Json),
+    effects: List(socket.Effect),
+  )
+  /// The join was refused. The worker stops itself.
+  Refused(reason: json.Json)
+}
+
+/// The factory supervisor's child argument: one join attempt.
+type Spawn {
+  Spawn(
+    handler: channel.Handler,
+    home: socket.Sender(Envelope),
+    socket_id: String,
+    seed: socket.ConnectSeed,
+    topic: String,
+    params: List(String),
+    payload: dynamic.Dynamic,
+    generation: Int,
+  )
+}
+
+/// An accepted channel, owned by exactly one worker process.
+type Channel {
+  Channel(
+    live: channel.LiveChannel,
+    topic: String,
+    generation: Int,
+    /// Batches this worker has reported, monotonic from 1.
+    sequence: Int,
+    home: socket.Sender(Envelope),
+  )
+}
+
+type State {
+  Running(Channel)
+  Refusing
+}
+
+/// Start one channel worker, running its `join` callback in the new
+/// process.
+///
+/// A panic in `join` fails the start, which the router turns into a
+/// rejection — the same observable outcome the shipped layer gets from
+/// core's rescue boundary, by a different mechanism.
+fn start_worker(spawn: Spawn) -> actor.StartResult(Report) {
+  actor.new_with_initialiser(join_timeout_ms, fn(work) {
+    let context =
+      channel.RoutedJoinContext(
+        socket_id: spawn.socket_id,
+        seed: spawn.seed,
+        topic: spawn.topic,
+        params: spawn.params,
+        payload: spawn.payload,
+        deliver: fn(mail) { process.send(work, DeliverMail(mail)) },
+      )
+
+    case channel.open(spawn.handler, context) {
+      channel.Rejected(reason) -> {
+        process.send(work, Halt)
+        Ok(actor.initialised(Refusing) |> actor.returning(Refused(reason)))
+      }
+      channel.Accepted(reply: reply, actions: actions, channel: live) ->
+        Ok(
+          actor.initialised(
+            Running(Channel(
+              live: live,
+              topic: spawn.topic,
+              generation: spawn.generation,
+              sequence: 0,
+              home: spawn.home,
+            )),
+          )
+          |> actor.returning(Opened(
+            work: work,
+            reply: reply,
+            effects: channel.effects(spawn.topic, actions),
+          )),
+        )
+    }
+  })
+  |> actor.on_message(handle)
+  |> actor.start
+}
+
+fn handle(state: State, work: Work) -> actor.Next(State, Work) {
+  case state {
+    Refusing -> actor.stop()
+    Running(active) ->
+      case work {
+        Deliver(message: message) ->
+          advance(active, active.live.on_message(message))
+        DeliverMail(mail: mail) -> advance(active, active.live.on_mail(mail))
+        Finish(reply: reply, reason: reason) -> {
+          process.send(
+            reply,
+            channel.effects(active.topic, active.live.on_terminate(reason)),
+          )
+          actor.stop()
+        }
+        Halt -> actor.stop()
+      }
+  }
+}
+
+/// Report one callback result to the router and keep the next channel.
+///
+/// A worker never closes its own topic: `Closing` and `StopSocket` are
+/// requests, and the worker stays alive until the router's `Closed` turn
+/// asks it for its termination actions.
+fn advance(current: Channel, step: channel.Step) -> actor.Next(State, Work) {
+  let next = Channel(..current, sequence: current.sequence + 1)
+  case step {
+    channel.StepContinue(next: live, actions: actions) -> {
+      report(next, Continue(channel.effects(next.topic, actions)))
+      actor.continue(Running(Channel(..next, live: live)))
+    }
+    channel.StepClose(actions: actions) -> {
+      report(next, Closing(channel.effects(next.topic, actions)))
+      actor.continue(Running(next))
+    }
+    channel.StepStop(reason: reason) -> {
+      report(next, StopSocket(reason))
+      actor.continue(Running(next))
+    }
+  }
+}
+
+fn report(active: Channel, outcome: Outcome) -> Nil {
+  socket.notify(
+    active.home,
+    Batch(
+      topic: active.topic,
+      generation: active.generation,
+      sequence: active.sequence,
+      outcome: outcome,
+    ),
+  )
+}
+
+/// Notify the socket when a worker exits, from a process that is allowed
+/// to receive `DOWN`.
+///
+/// The router runs inside beryl's shared runtime actor and does not own
+/// that actor's selector, so it cannot monitor anything itself. One
+/// short-lived watcher per worker is the price of that, and it doubles the
+/// per-channel process count — the first thing #334 would pay back.
+fn watch(
+  pid: process.Pid,
+  home: socket.Sender(Envelope),
+  name: String,
+  generation: Int,
+) -> Nil {
+  let _watcher =
+    process.spawn_unlinked(fn() {
+      let monitor = process.monitor(pid)
+      let selector =
+        process.new_selector()
+        |> process.select_specific_monitor(monitor, fn(down) { down })
+      let _down = process.selector_receive_forever(selector)
+      socket.notify(home, Died(topic: name, generation: generation))
+    })
+  Nil
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/// The socket-level message type: worker results coming home.
+///
+/// The stamp the issue proposed carries a socket id too. It is redundant
+/// here — an envelope travels through one socket's own `Sender`, so it can
+/// only arrive at the socket it belongs to.
+type Envelope {
+  Batch(topic: String, generation: Int, sequence: Int, outcome: Outcome)
+  Died(topic: String, generation: Int)
+}
+
+/// One worker's answer to one unit of work.
+type Outcome {
+  Continue(effects: List(socket.Effect))
+  Closing(effects: List(socket.Effect))
+  StopSocket(reason: socket.StopReason)
+}
+
+type Registered {
+  Registered(pattern: topic.TopicPattern, handler: channel.Handler)
+}
+
+type Worker {
+  Worker(
+    generation: Int,
+    work: process.Subject(Work),
+    /// The highest batch sequence applied for this join.
+    sequence: Int,
+  )
+}
+
+type Router {
+  Router(
+    handlers: List(Registered),
+    factory: process.Name(factory_supervisor.Message(Spawn, Report)),
+    socket_id: String,
+    seed: socket.ConnectSeed,
+    self: socket.Sender(Envelope),
+    generation: Int,
+    live: dict.Dict(String, Worker),
+  )
+}
+
+/// Build a spike channel system: a factory supervisor for channel workers,
+/// then beryl's runtime.
+///
+/// Start order matters — the runtime's first join looks the factory up by
+/// name.
+pub fn child_spec(
+  config: beryl.Config,
+  handlers handlers: List(channel.Handler),
+) -> Result(
+  #(beryl.Sockets, supervision.ChildSpecification(static_supervisor.Supervisor)),
+  beryl.ConfigError,
+) {
+  let factory = process.new_name("spike_channel_factory")
+  let table = table(handlers)
+
+  use #(sockets, runtime) <- result.map(beryl.child_spec(
+    config,
+    init: fn(info) { init(table, factory, info) },
+    update: update,
+  ))
+
+  let workers =
+    factory_supervisor.worker_child(start_worker)
+    |> factory_supervisor.restart_strategy(supervision.Temporary)
+    |> factory_supervisor.named(factory)
+    |> factory_supervisor.supervised()
+
+  let tree = fn() {
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(workers)
+    |> static_supervisor.add(runtime)
+    |> static_supervisor.start()
+  }
+
+  #(sockets, supervision.supervisor(tree))
+}
+
+fn table(handlers: List(channel.Handler)) -> List(Registered) {
+  list.map(handlers, fn(handler) {
+    Registered(
+      pattern: topic.parse_pattern(channel.pattern(handler)),
+      handler: handler,
+    )
+  })
+}
+
+fn init(
+  handlers: List(Registered),
+  factory: process.Name(factory_supervisor.Message(Spawn, Report)),
+  info: socket.ConnectInfo(Envelope),
+) -> #(Router, List(socket.Effect)) {
+  #(
+    Router(
+      handlers: handlers,
+      factory: factory,
+      socket_id: info.socket_id,
+      seed: info.seed,
+      self: info.self,
+      generation: 0,
+      live: dict.new(),
+    ),
+    [],
+  )
+}
+
+fn update(
+  router: Router,
+  input: socket.Input(Envelope),
+) -> socket.Next(Router) {
+  case input {
+    socket.Join(topic: name, payload: payload, ref: ref) ->
+      join(router, name, payload, ref)
+
+    socket.Message(topic: name, event: event, payload: payload, ref: ref) -> {
+      cast(
+        router,
+        name,
+        Deliver(channel.Message(
+          topic: name,
+          event: event,
+          payload: payload,
+          reply: ref,
+        )),
+      )
+      socket.Next(router, [])
+    }
+
+    // Out of spike scope: identical in shape to `Deliver`.
+    socket.Binary(topic: _, data: _) -> socket.Next(router, [])
+
+    socket.Closed(topic: name, reason: reason) -> finish(router, name, reason)
+
+    socket.Info(Batch(
+      topic: name,
+      generation: generation,
+      sequence: sequence,
+      outcome: outcome,
+    )) -> apply(router, name, generation, sequence, outcome)
+
+    socket.Info(Died(topic: name, generation: generation)) ->
+      died(router, name, generation)
+  }
+}
+
+/// Start a worker for an accepted topic, blocking the runtime until the
+/// join answers.
+fn join(
+  router: Router,
+  name: String,
+  payload: dynamic.Dynamic,
+  ref: socket.JoinRef,
+) -> socket.Next(Router) {
+  case select(router.handlers, name) {
+    Error(Nil) ->
+      socket.Next(router, [socket.RejectJoin(ref, refusal("unmatched topic"))])
+    Ok(#(handler, params)) -> {
+      let generation = router.generation + 1
+      let router = Router(..router, generation: generation)
+      let spawn =
+        Spawn(
+          handler: handler,
+          home: router.self,
+          socket_id: router.socket_id,
+          seed: router.seed,
+          topic: name,
+          params: params,
+          payload: payload,
+          generation: generation,
+        )
+
+      case
+        factory_supervisor.start_child(
+          factory_supervisor.get_by_name(router.factory),
+          spawn,
+        )
+      {
+        // A `join` that ran past `join_timeout_ms`. Core has no equivalent
+        // — it cannot time a callback out — so this reason is the
+        // prototype's own.
+        Error(actor.InitTimeout) ->
+          socket.Next(router, [socket.RejectJoin(ref, refusal("join timeout"))])
+
+        // A panicking join, which is what core reports as `join crashed`
+        // from its rescue boundary. `InitFailed` cannot happen here: the
+        // initialiser reports a refusal as data, never as an error.
+        Error(actor.InitExited(_)) | Error(actor.InitFailed(_)) ->
+          socket.Next(router, [socket.RejectJoin(ref, refusal("join crashed"))])
+
+        Ok(actor.Started(data: Refused(reason: reason), pid: _)) ->
+          socket.Next(router, [socket.RejectJoin(ref, reason)])
+
+        Ok(actor.Started(
+          pid: pid,
+          data: Opened(work: work, reply: reply, effects: accepted),
+        )) -> {
+          watch(pid, router.self, name, generation)
+          let live =
+            dict.insert(
+              router.live,
+              name,
+              Worker(generation: generation, work: work, sequence: 0),
+            )
+          socket.Next(Router(..router, live: live), [
+            socket.AcceptJoin(ref, reply),
+            ..accepted
+          ])
+        }
+      }
+    }
+  }
+}
+
+fn select(
+  handlers: List(Registered),
+  name: String,
+) -> Result(#(channel.Handler, List(String)), Nil) {
+  case handlers {
+    [] -> Error(Nil)
+    [registered, ..rest] ->
+      case topic.matches(registered.pattern, name) {
+        False -> select(rest, name)
+        True -> {
+          let params =
+            topic.extract_wildcards(registered.pattern, name)
+            |> result.unwrap([])
+          Ok(#(registered.handler, params))
+        }
+      }
+  }
+}
+
+fn refusal(reason: String) -> json.Json {
+  json.object([#("reason", json.string(reason))])
+}
+
+fn cast(router: Router, name: String, work: Work) -> Nil {
+  case dict.get(router.live, name) {
+    Error(Nil) -> Nil
+    Ok(worker) -> process.send(worker.work, work)
+  }
+}
+
+/// Apply one worker's action batch, after checking its stamp.
+///
+/// Generation rejects a batch from a superseded join; sequence rejects a
+/// replayed or reordered one. Locally the sequence check can never fire —
+/// the VM already orders messages between one pair of processes — so it is
+/// here for the distributed case and as a live assertion that the
+/// invariant holds.
+fn apply(
+  router: Router,
+  name: String,
+  generation: Int,
+  sequence: Int,
+  outcome: Outcome,
+) -> socket.Next(Router) {
+  case dict.get(router.live, name) {
+    Error(Nil) -> socket.Next(router, [])
+    Ok(worker) ->
+      case worker.generation == generation && sequence > worker.sequence {
+        False -> socket.Next(router, [])
+        True -> {
+          let live =
+            dict.insert(router.live, name, Worker(..worker, sequence: sequence))
+          let router = Router(..router, live: live)
+          case outcome {
+            Continue(effects: effects) -> socket.Next(router, effects)
+            // The worker stays live until the kick's `Closed` comes back,
+            // so termination runs on the one path every ending topic takes.
+            Closing(effects: effects) ->
+              socket.Next(
+                router,
+                list.append(effects, [socket.KickTopic(name)]),
+              )
+            StopSocket(reason: reason) -> socket.Stop(reason)
+          }
+        }
+      }
+  }
+}
+
+/// A worker exited.
+///
+/// Its state died with it, so there is no `on_terminate` to run and no way
+/// to rebuild the channel: the topic closes and the client must rejoin.
+/// Dropping the worker here also keeps the `Closed` this kick produces
+/// from waiting on a process that is already gone.
+fn died(router: Router, name: String, generation: Int) -> socket.Next(Router) {
+  case dict.get(router.live, name) {
+    Error(Nil) -> socket.Next(router, [])
+    Ok(worker) ->
+      case worker.generation == generation {
+        False -> socket.Next(router, [])
+        True ->
+          socket.Next(Router(..router, live: dict.delete(router.live, name)), [
+            socket.KickTopic(name),
+          ])
+      }
+  }
+}
+
+/// A topic ended: collect the worker's termination actions synchronously,
+/// because they have to be lowered inside this turn.
+///
+/// `ponytail:` a worker that panics in `on_terminate` never replies, so
+/// this blocks the shared runtime actor — and therefore every socket on it
+/// — for the full `terminate_timeout_ms`. The timeout is the only thing
+/// that ends the wait. Upgrade: monitor the worker and select on its
+/// `DOWN` alongside the reply, so a dead worker ends the wait immediately.
+fn finish(
+  router: Router,
+  name: String,
+  reason: socket.StopReason,
+) -> socket.Next(Router) {
+  case dict.get(router.live, name) {
+    Error(Nil) -> socket.Next(router, [])
+    Ok(worker) -> {
+      let router = Router(..router, live: dict.delete(router.live, name))
+      let reply = process.new_subject()
+      process.send(worker.work, Finish(reply: reply, reason: reason))
+      case process.receive(reply, terminate_timeout_ms) {
+        Ok(effects) -> socket.Next(router, effects)
+        // The worker died between the cast and the reply. Its termination
+        // actions are lost; the topic still closes.
+        Error(Nil) -> socket.Next(router, [])
+      }
+    }
+  }
+}

--- a/packages/beryl/test/spike_channel_worker.gleam
+++ b/packages/beryl/test/spike_channel_worker.gleam
@@ -42,10 +42,13 @@
 ////
 //// `ponytail:` spike-scope cuts — no backpressure, no binary frames, no
 //// pattern validation, workers not linked to their socket (nothing
-//// per-socket exists to link them to), and a panicking `on_terminate`
-//// stalling every socket for `terminate_timeout_ms` (see `finish`). Each
-//// one's upgrade path, and what the prototype found, is in
-//// `docs/spikes/0337-process-per-channel.md`.
+//// per-socket exists to link them to), and a *blocking* `on_terminate`
+//// stalling every socket for `terminate_timeout_ms` (see `finish`).
+////
+//// One thing is not a cut but a finding: a close races the worker's own
+//// in-flight batch, and the batch loses (see `apply`). It is not fixable
+//// from here. Each ceiling's upgrade path, and what the prototype found,
+//// is in `docs/spikes/0337-process-per-channel.md`.
 
 import beryl
 import beryl/channel
@@ -64,9 +67,10 @@ import gleam/otp/supervision
 import gleam/result
 
 /// How long a `join` callback has to finish before the worker's start is
-/// abandoned and the join rejected. The runtime actor is blocked for this
-/// long in the worst case — a real design would want it much lower than
-/// the supervisor's own call timeout, which is what actually bounds it.
+/// abandoned and the join rejected. This is the *only* bound on the wait:
+/// `supervisor:start_child` calls with `infinity`, so the runtime actor is
+/// blocked for this long in the worst case. A real design would want it
+/// much lower.
 const join_timeout_ms = 1000
 
 /// How long the `Closed` turn waits for a worker's termination actions.
@@ -294,6 +298,9 @@ type Worker {
   Worker(
     generation: Int,
     work: process.Subject(Work),
+    /// Kept so `finish` can monitor the worker rather than trust that it is
+    /// still alive.
+    pid: process.Pid,
     /// The highest batch sequence applied for this join.
     sequence: Int,
   )
@@ -338,8 +345,12 @@ pub fn child_spec(
     |> factory_supervisor.named(factory)
     |> factory_supervisor.supervised()
 
+  // `OneForAll`, not `OneForOne`: a worker's `home` `Sender` closes over the
+  // runtime actor's subject, so a runtime that restarts alone would leave
+  // every worker on every socket talking to a dead process, with no `Finish`
+  // ever arriving to end them. Restarting the factory with it bounds that.
   let tree = fn() {
-    static_supervisor.new(static_supervisor.OneForOne)
+    static_supervisor.new(static_supervisor.OneForAll)
     |> static_supervisor.add(workers)
     |> static_supervisor.add(runtime)
     |> static_supervisor.start()
@@ -471,7 +482,7 @@ fn join(
             dict.insert(
               router.live,
               name,
-              Worker(generation: generation, work: work, sequence: 0),
+              Worker(generation: generation, work: work, pid: pid, sequence: 0),
             )
           socket.Next(Router(..router, live: live), [
             socket.AcceptJoin(ref, reply),
@@ -520,6 +531,15 @@ fn cast(router: Router, name: String, work: Work) -> Nil {
 /// the VM already orders messages between one pair of processes — so it is
 /// here for the distributed case and as a live assertion that the
 /// invariant holds.
+///
+/// **A close beats a batch it should have followed.** A batch travels the
+/// slow path (worker → socket `Sender` → this turn) while `finish` answers
+/// on a direct subject, so a client that pushes and then leaves can have
+/// its reply produced, reported, and then dropped here — the topic is gone
+/// from `live` by the time the batch is read. Draining first is not
+/// available to the router: it is not a process, so it cannot selectively
+/// receive its own socket's envelopes. See the spike doc's third contract
+/// break.
 fn apply(
   router: Router,
   name: String,
@@ -575,11 +595,15 @@ fn died(router: Router, name: String, generation: Int) -> socket.Next(Router) {
 /// A topic ended: collect the worker's termination actions synchronously,
 /// because they have to be lowered inside this turn.
 ///
-/// `ponytail:` a worker that panics in `on_terminate` never replies, so
-/// this blocks the shared runtime actor — and therefore every socket on it
-/// — for the full `terminate_timeout_ms`. The timeout is the only thing
-/// that ends the wait. Upgrade: monitor the worker and select on its
-/// `DOWN` alongside the reply, so a dead worker ends the wait immediately.
+/// The wait selects on the worker's `DOWN` alongside its reply, so a worker
+/// that is already dead — or that panics inside `on_terminate` — ends the
+/// wait at once instead of holding the shared runtime actor, and every
+/// socket on it, for the full timeout.
+///
+/// `ponytail:` an `on_terminate` that *blocks* rather than dies still stalls
+/// every socket, up to `terminate_timeout_ms`. The shared runtime has the
+/// same exposure to a blocking callback, so this is not new; what a socket
+/// session (#334) would add is confinement of the stall to one connection.
 fn finish(
   router: Router,
   name: String,
@@ -590,12 +614,21 @@ fn finish(
     Ok(worker) -> {
       let router = Router(..router, live: dict.delete(router.live, name))
       let reply = process.new_subject()
+      let monitor = process.monitor(worker.pid)
       process.send(worker.work, Finish(reply: reply, reason: reason))
-      case process.receive(reply, terminate_timeout_ms) {
-        Ok(effects) -> socket.Next(router, effects)
-        // The worker died between the cast and the reply. Its termination
-        // actions are lost; the topic still closes.
-        Error(Nil) -> socket.Next(router, [])
+      let answer =
+        process.new_selector()
+        |> process.select_map(reply, Ok)
+        |> process.select_specific_monitor(monitor, fn(_down) { Error(Nil) })
+        |> process.selector_receive(terminate_timeout_ms)
+      // Flushes a `DOWN` that raced the reply, so none is left for the
+      // runtime actor's own selector to trip over.
+      process.demonitor_process(monitor)
+      case answer {
+        Ok(Ok(effects)) -> socket.Next(router, effects)
+        // The worker died before replying, or never replied at all. Its
+        // termination actions are lost; the topic still closes.
+        Ok(Error(Nil)) | Error(Nil) -> socket.Next(router, [])
       }
     }
   }

--- a/packages/beryl/test/spike_channel_worker_test.gleam
+++ b/packages/beryl/test/spike_channel_worker_test.gleam
@@ -100,6 +100,19 @@ fn message_panics(trace: process.Subject(String)) -> channel.Handler {
   })
 }
 
+/// A channel whose `on_terminate` panics, taking the worker down before it
+/// can answer the router's synchronous `Finish`.
+fn terminate_panics() -> channel.Handler {
+  channel.handler("crash_term:*", fn(_context) {
+    let callbacks =
+      channel.callbacks()
+      |> channel.on_terminate(fn(_state, _reason) {
+        panic as "terminate exploded"
+      })
+    channel.accept(Nil, callbacks)
+  })
+}
+
 // --- helpers ---------------------------------------------------------------
 
 fn next_pid(pids: process.Subject(process.Pid)) -> process.Pid {
@@ -306,4 +319,57 @@ pub fn a_disconnect_terminates_every_worker_test() -> Nil {
   |> should.be_true
   { await_exit(channel_a, 50) } |> should.be_true
   { await_exit(channel_b, 50) } |> should.be_true
+}
+
+/// A worker that dies instead of answering `Finish` must not hold the
+/// shared runtime actor: the `Closed` turn selects on the worker's `DOWN`
+/// alongside its reply, so the wait ends with the process rather than with
+/// `terminate_timeout_ms`.
+///
+/// The disconnect is a cast, so a runtime that blocked for the full second
+/// would still be inside that turn when the second socket joins, and its
+/// join frame would miss `recv`'s 500ms window.
+pub fn a_dead_worker_does_not_stall_the_runtime_test() -> Nil {
+  let channels = start([terminate_panics()])
+  let first = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "crash_term:a", "jr-1", "r-1")
+  let _join = helper.recv(first)
+
+  helper.disconnect(channels, "s1")
+
+  let second = helper.connect(channels, "s2")
+  helper.join(channels, "s2", "crash_term:b", "jr-2", "r-2")
+  helper.recv(second) |> string.contains("phx_reply") |> should.be_true
+}
+
+/// **Third contract break.** A close overtakes the worker's own in-flight
+/// batch, and the batch loses.
+///
+/// The push is cast to the worker and the leave is handled in the very next
+/// turn, so the router drops the topic before the worker's reply gets home
+/// — and then discards it. The client's `r-2` is never answered. The
+/// shipped shared runtime cannot lose this: it runs `on_message` in the
+/// same process that handles the leave, so the reply is already lowered.
+///
+/// It is not fixable from the router, which is not a process and so cannot
+/// drain its own socket's envelopes before finishing. It needs a per-socket
+/// owner (#334).
+pub fn a_leave_discards_the_reply_it_raced_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([room(pids, trace)])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _join = helper.recv(frames)
+
+  helper.push(channels, "s1", "room:a", "ping", "r-2")
+  helper.leave(channels, "s1", "room:a", "jr-1", "r-3")
+
+  // The leave is answered and the topic closes, but nothing the push
+  // produced — neither its reply nor its `pong` — ever reaches the client.
+  helper.recv(frames) |> string.contains("\"r-3\"") |> should.be_true
+  helper.recv(frames) |> string.contains("phx_close") |> should.be_true
+  helper.recv_none(frames)
 }

--- a/packages/beryl/test/spike_channel_worker_test.gleam
+++ b/packages/beryl/test/spike_channel_worker_test.gleam
@@ -7,11 +7,13 @@
 
 import beryl
 import beryl/channel
+import beryl/socket
 import beryl/transport
 import beryl/wire
 import channel_dispatch_helper as helper
 import gleam/erlang/process
 import gleam/json
+import gleam/option
 import gleam/otp/static_supervisor
 import gleam/string
 import gleeunit/should
@@ -352,9 +354,11 @@ pub fn a_dead_worker_does_not_stall_the_runtime_test() -> Nil {
 /// shipped shared runtime cannot lose this: it runs `on_message` in the
 /// same process that handles the leave, so the reply is already lowered.
 ///
-/// It is not fixable from the router, which is not a process and so cannot
-/// drain its own socket's envelopes before finishing. It needs a per-socket
-/// owner (#334).
+/// Round 1 read this as a missing drain and expected #334 to supply it. It
+/// does not: the reply is unanswerable from the closing turn regardless of
+/// topology, because core invalidates the topic's reply refs before it
+/// delivers `Closed`. See `a_reply_ref_is_dead_by_the_closed_turn_test`,
+/// which loses the same reply with no workers at all.
 pub fn a_leave_discards_the_reply_it_raced_test() -> Nil {
   let pids = process.new_subject()
   let trace = process.new_subject()
@@ -369,6 +373,159 @@ pub fn a_leave_discards_the_reply_it_raced_test() -> Nil {
 
   // The leave is answered and the topic closes, but nothing the push
   // produced — neither its reply nor its `pong` — ever reaches the client.
+  helper.recv(frames) |> string.contains("\"r-3\"") |> should.be_true
+  helper.recv(frames) |> string.contains("phx_close") |> should.be_true
+  helper.recv_none(frames)
+}
+
+// --- round 2: what the per-socket actor (#334) actually changed ------------
+
+/// A channel whose `join` sleeps for longer than a frame wait.
+fn slow_join(delay: Int) -> channel.Handler {
+  channel.handler("slow:*", fn(_context) {
+    process.sleep(delay)
+    channel.accept(Nil, channel.callbacks())
+  })
+}
+
+/// A channel whose `on_terminate` blocks — the ceiling round 1 could not
+/// pay down, because a blocked `Finish` held the one shared runtime actor.
+fn terminate_blocks(delay: Int) -> channel.Handler {
+  channel.handler("slow_term:*", fn(_context) {
+    channel.callbacks()
+    |> channel.on_terminate(fn(_state, _reason) {
+      process.sleep(delay)
+      []
+    })
+    |> channel.accept(Nil, _)
+  })
+}
+
+/// Joins no longer serialise across sockets.
+///
+/// Round 1 started every worker through one globally named factory
+/// supervisor, so `supervisor:start_child` — a `gen_server:call` — put every
+/// join on every socket behind one process. Each socket now has its own
+/// supervisor, started by and linked to its own socket actor, so a join
+/// that blocks for 700ms delays only the socket that asked for it.
+///
+/// The delay is longer than `recv`'s 500ms window on purpose: under round
+/// 1's shared factory, `s2`'s join frame could not arrive in time.
+pub fn a_slow_join_does_not_block_another_socket_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([slow_join(700), room(pids, trace)])
+  let first = helper.connect(channels, "s1")
+  let second = helper.connect(channels, "s2")
+
+  helper.join(channels, "s1", "slow:a", "jr-1", "r-1")
+  helper.join(channels, "s2", "room:b", "jr-2", "r-2")
+
+  // `recv`'s window is 500ms, so `s2` cannot have queued behind the 700ms
+  // join `s1` is still inside.
+  helper.recv(second)
+  |> string.contains("\"handler\":\"room\"")
+  |> should.be_true
+
+  // `s1`'s own join still takes the full 700ms, which is the point: the
+  // wait is confined to the socket that asked for it.
+  let assert Ok(frame) = process.receive(first, 2000) as "s1 joined eventually"
+  frame |> string.contains("phx_reply") |> should.be_true
+}
+
+/// A blocking `on_terminate` stalls one connection, not the server.
+///
+/// This is the ceiling round 1 named and could not lift: `finish` is a
+/// synchronous call, and on the shared runtime the socket it blocked was
+/// every socket. The `Finish` wait is unchanged here — only the process it
+/// blocks is different.
+pub fn a_blocking_terminate_stalls_only_its_own_socket_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([terminate_blocks(700), room(pids, trace)])
+  let first = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "slow_term:a", "jr-1", "r-1")
+  let _join = helper.recv(first)
+
+  helper.disconnect(channels, "s1")
+
+  let second = helper.connect(channels, "s2")
+  helper.join(channels, "s2", "room:b", "jr-2", "r-2")
+  helper.recv(second)
+  |> string.contains("\"handler\":\"room\"")
+  |> should.be_true
+}
+
+// --- round 2: why the raced reply is not a topology problem ---------------
+
+/// The app-dispatch model for `a_reply_ref_is_dead_by_the_closed_turn_test`:
+/// the pending reply ref for the one topic, if any.
+type Stashed =
+  option.Option(socket.ReplyRef)
+
+/// A minimal app that answers a client's `ref` one turn too late — from the
+/// topic's own `Closed` input, which is exactly where a drained worker
+/// batch would land.
+fn late_reply_app() -> beryl.Sockets {
+  let assert Ok(#(sockets, spec)) =
+    beryl.child_spec(
+      beryl.config(wire.phoenix_codec()),
+      init: fn(_info) { #(option.None, []) },
+      update: fn(stashed: Stashed, input) {
+        case input {
+          socket.Join(ref: ref, ..) ->
+            socket.Next(stashed, [socket.AcceptJoin(ref, option.None)])
+          socket.Message(ref: option.Some(ref), ..) ->
+            socket.Next(option.Some(ref), [])
+          socket.Closed(..) ->
+            case stashed {
+              option.Some(ref) ->
+                socket.Next(option.None, [
+                  socket.ReplyOk(ref, json.object([#("late", json.bool(True))])),
+                ])
+              option.None -> socket.Next(stashed, [])
+            }
+          _ -> socket.Next(stashed, [])
+        }
+      },
+    )
+    as "the late-reply app config is valid"
+  let assert Ok(_) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(spec)
+    |> static_supervisor.start()
+    as "the late-reply app starts"
+  sockets
+}
+
+/// **The third contract break is core's rule, not the topology's.**
+///
+/// Round 1 recorded that a close discards the worker's in-flight batch, and
+/// blamed the router for not being a process: it could not drain its own
+/// socket's envelopes before finishing, so #334 would fix it.
+///
+/// It does not, and no drain can. This test uses no workers at all — one
+/// plain `beryl.child_spec` app, one socket, one process — and it still
+/// loses the reply. `exec_close_topic` deletes the topic's
+/// `pending_reply_refs` *before* it delivers `Closed`, so by the time any
+/// layer sees the close its refs are already invalid. A drained batch lands
+/// in that same turn and is dropped for that same reason.
+///
+/// Fixing it means core must hold the close until the worker is quiescent,
+/// which means core must know the worker exists — so process-per-channel
+/// belongs in `beryl/runtime`, not in a layer above it.
+pub fn a_reply_ref_is_dead_by_the_closed_turn_test() -> Nil {
+  let channels = late_reply_app()
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  helper.recv(frames) |> string.contains("\"r-1\"") |> should.be_true
+
+  helper.push(channels, "s1", "room:a", "ping", "r-2")
+  helper.leave(channels, "s1", "room:a", "jr-1", "r-3")
+
+  // The leave is acknowledged and the topic closes; `r-2` never is.
   helper.recv(frames) |> string.contains("\"r-3\"") |> should.be_true
   helper.recv(frames) |> string.contains("phx_close") |> should.be_true
   helper.recv_none(frames)

--- a/packages/beryl/test/spike_channel_worker_test.gleam
+++ b/packages/beryl/test/spike_channel_worker_test.gleam
@@ -1,0 +1,309 @@
+//// What the process-per-channel prototype (#337) actually does, pinned
+//// against the shipped shared-runtime layer.
+////
+//// The interesting assertions are the ones that *differ* from
+//// `channel_crash_test`: those are the parity costs of moving a channel
+//// into its own process, and they are the reason this spike exists.
+
+import beryl
+import beryl/channel
+import beryl/transport
+import beryl/wire
+import channel_dispatch_helper as helper
+import gleam/erlang/process
+import gleam/json
+import gleam/otp/static_supervisor
+import gleam/string
+import gleeunit/should
+import spike_channel_worker as spike
+
+/// A channel's server-side message type.
+pub type Note {
+  Announce(String)
+}
+
+// --- systems ---------------------------------------------------------------
+
+fn start(handlers: List(channel.Handler)) -> beryl.Sockets {
+  let assert Ok(#(sockets, spec)) =
+    spike.child_spec(beryl.config(wire.phoenix_codec()), handlers: handlers)
+    as "the spike config is valid"
+  let assert Ok(_) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(spec)
+    |> static_supervisor.start()
+    as "the spike supervision tree starts"
+  sockets
+}
+
+// --- test channels ---------------------------------------------------------
+
+/// A counting channel that reports the pid it runs in, replies to
+/// `"ping"`, and traces its termination.
+fn room(
+  pids: process.Subject(process.Pid),
+  trace: process.Subject(String),
+) -> channel.Handler {
+  channel.handler("room:*", fn(context) {
+    process.send(pids, process.self())
+    let callbacks =
+      channel.callbacks()
+      |> channel.on_message(fn(count, message) {
+        channel.next(count + 1, [
+          channel.reply_ok(message.reply, json.int(count + 1)),
+          channel.push("pong", json.int(count + 1)),
+        ])
+      })
+      |> channel.on_terminate(fn(_count, reason) {
+        process.send(
+          trace,
+          "terminate:" <> context.topic <> ":" <> helper.reason_name(reason),
+        )
+        []
+      })
+    channel.accept(0, callbacks)
+    |> channel.with_reply(json.object([#("handler", json.string("room"))]))
+  })
+}
+
+/// A channel that hands its typed sender out and pushes what it receives.
+fn mailbox(senders: process.Subject(channel.Sender(Note))) -> channel.Handler {
+  channel.handler("mail:*", fn(context) {
+    process.send(senders, context.self)
+    let callbacks =
+      channel.callbacks()
+      |> channel.on_info(fn(state, note) {
+        let Announce(text) = note
+        channel.next(state, [channel.push("announce", json.string(text))])
+      })
+    channel.accept(Nil, callbacks)
+  })
+}
+
+/// A channel whose `join` panics.
+fn join_panics() -> channel.Handler {
+  channel.handler("crash_join:*", fn(_context) { panic as "join exploded" })
+}
+
+/// A channel whose `on_message` panics, and which traces its termination
+/// so the test can prove it never runs.
+fn message_panics(trace: process.Subject(String)) -> channel.Handler {
+  channel.handler("crash_msg:*", fn(context) {
+    let callbacks =
+      channel.callbacks()
+      |> channel.on_message(fn(_state, _message) { panic as "message exploded" })
+      |> channel.on_terminate(fn(_state, _reason) {
+        process.send(trace, "terminate:" <> context.topic)
+        []
+      })
+    channel.accept(Nil, callbacks)
+  })
+}
+
+// --- helpers ---------------------------------------------------------------
+
+fn next_pid(pids: process.Subject(process.Pid)) -> process.Pid {
+  let assert Ok(pid) = process.receive(pids, 500) as "a channel opened"
+  pid
+}
+
+/// Wait for `pid` to exit, up to roughly a second.
+fn await_exit(pid: process.Pid, attempts: Int) -> Bool {
+  case process.is_alive(pid), attempts {
+    False, _ -> True
+    True, 0 -> False
+    True, _ -> {
+      process.sleep(20)
+      await_exit(pid, attempts - 1)
+    }
+  }
+}
+
+// --- topology --------------------------------------------------------------
+
+pub fn each_channel_runs_in_its_own_process_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([room(pids, trace)])
+  let frames = helper.connect(channels, "s1")
+  let assert Ok(runtime) = transport.runtime_pid(channels)
+    as "the runtime is running"
+
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  helper.recv(frames)
+  |> string.contains("\"handler\":\"room\"")
+  |> should.be_true
+  let channel_a = next_pid(pids)
+
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  let _join_b = helper.recv(frames)
+  let channel_b = next_pid(pids)
+
+  // Two joins on one socket: three distinct processes.
+  { channel_a == runtime } |> should.be_false
+  { channel_b == runtime } |> should.be_false
+  { channel_a == channel_b } |> should.be_false
+
+  // ...and the callbacks still work, through the same wire contract.
+  helper.push(channels, "s1", "room:a", "ping", "r-3")
+  helper.recv(frames) |> string.contains("\"status\":\"ok\"") |> should.be_true
+  helper.recv(frames) |> string.contains("\"pong\",1") |> should.be_true
+}
+
+pub fn a_typed_sender_reaches_its_own_worker_test() -> Nil {
+  let senders = process.new_subject()
+  let channels = start([mailbox(senders)])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "mail:a", "jr-1", "r-1")
+  let _join = helper.recv(frames)
+  let assert Ok(sender) = process.receive(senders, 500)
+    as "the channel handed out its sender"
+
+  channel.notify(sender, Announce("hello"))
+
+  // Mail goes straight to the worker that sealed it; the batch it
+  // produces comes back through the socket.
+  let push = helper.recv(frames)
+  push |> string.contains("\"announce\"") |> should.be_true
+  push |> string.contains("hello") |> should.be_true
+}
+
+pub fn a_rejoin_gets_a_fresh_worker_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([room(pids, trace)])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _join = helper.recv(frames)
+  let first = next_pid(pids)
+
+  helper.push(channels, "s1", "room:a", "ping", "r-2")
+  let _reply = helper.recv(frames)
+  helper.recv(frames) |> string.contains("\"pong\",1") |> should.be_true
+
+  helper.leave(channels, "s1", "room:a", "jr-1", "r-3")
+  helper.next_trace(trace) |> should.equal("terminate:room:a:normal")
+  { await_exit(first, 50) } |> should.be_true
+  let _leave_reply = helper.recv(frames)
+  let _close = helper.recv(frames)
+
+  helper.join(channels, "s1", "room:a", "jr-2", "r-4")
+  let _rejoin = helper.recv(frames)
+  let second = next_pid(pids)
+  { first == second } |> should.be_false
+
+  // A new worker means new state: the count starts over, and nothing the
+  // old worker held leaked into it.
+  helper.push(channels, "s1", "room:a", "ping", "r-5")
+  let _reply = helper.recv(frames)
+  helper.recv(frames) |> string.contains("\"pong\",1") |> should.be_true
+}
+
+// --- crash containment -----------------------------------------------------
+
+pub fn a_panic_in_join_rejects_that_join_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([join_panics(), room(pids, trace)])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "crash_join:a", "jr-1", "r-1")
+  let reply = helper.recv(frames)
+  reply |> string.contains("\"status\":\"error\"") |> should.be_true
+  reply |> string.contains("{\"reason\":\"join crashed\"}") |> should.be_true
+
+  // The socket is untouched: a worker that never started took nothing
+  // with it.
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  helper.recv(frames)
+  |> string.contains("\"handler\":\"room\"")
+  |> should.be_true
+}
+
+pub fn a_panic_handling_a_message_closes_only_that_topic_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([message_panics(trace), room(pids, trace)])
+  let frames = helper.connect(channels, "s1")
+  let assert Ok(runtime) = transport.runtime_pid(channels)
+    as "the runtime is running"
+
+  helper.join(channels, "s1", "crash_msg:a", "jr-1", "r-1")
+  let _join_a = helper.recv(frames)
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  let _join_b = helper.recv(frames)
+  let survivor = next_pid(pids)
+
+  helper.push(channels, "s1", "crash_msg:a", "boom", "r-3")
+
+  // The crash is contained by a process boundary, not a rescue: the
+  // runtime and the sibling channel are both untouched.
+  let close = helper.recv(frames)
+  close |> string.contains("crash_msg:a") |> should.be_true
+  { process.is_alive(runtime) } |> should.be_true
+  { process.is_alive(survivor) } |> should.be_true
+
+  helper.push(channels, "s1", "room:b", "ping", "r-4")
+  helper.recv(frames) |> string.contains("\"status\":\"ok\"") |> should.be_true
+  helper.recv(frames) |> string.contains("\"pong\",1") |> should.be_true
+}
+
+/// Both parity costs of the process boundary, pinned on one crash.
+///
+/// `on_terminate` is unreachable: the shipped layer runs it, because core
+/// rescues the callback and keeps the model, so the channel's state is
+/// still there to terminate. Here the state died with the process. This
+/// matches Phoenix, where a channel process crash skips `terminate/2`, but
+/// it is a change from what beryl does today.
+///
+/// And the close is announced as `phx_close`, not `phx_error`: core picks
+/// that from the stop reason, and the only way this layer can close a
+/// topic it no longer owns is `KickTopic`, which is `Shutdown`. Preserving
+/// the Phoenix contract needs a core effect that carries a reason.
+pub fn a_crashed_worker_loses_terminate_and_closes_as_shutdown_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([message_panics(trace), room(pids, trace)])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "crash_msg:a", "jr-1", "r-1")
+  let _join = helper.recv(frames)
+
+  helper.push(channels, "s1", "crash_msg:a", "boom", "r-2")
+
+  let close = helper.recv(frames)
+  close |> string.contains("phx_close") |> should.be_true
+  close |> string.contains("phx_error") |> should.be_false
+  helper.no_trace(trace)
+}
+
+// --- teardown --------------------------------------------------------------
+
+pub fn a_disconnect_terminates_every_worker_test() -> Nil {
+  let pids = process.new_subject()
+  let trace = process.new_subject()
+  let channels = start([room(pids, trace)])
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _join_a = helper.recv(frames)
+  let channel_a = next_pid(pids)
+  helper.join(channels, "s1", "room:b", "jr-2", "r-2")
+  let _join_b = helper.recv(frames)
+  let channel_b = next_pid(pids)
+
+  helper.disconnect(channels, "s1")
+
+  // Both channels ran `on_terminate` and then stopped: no worker outlives
+  // the socket it belongs to.
+  helper.next_trace(trace)
+  |> string.starts_with("terminate:room:")
+  |> should.be_true
+  helper.next_trace(trace)
+  |> string.starts_with("terminate:room:")
+  |> should.be_true
+  { await_exit(channel_a, 50) } |> should.be_true
+  { await_exit(channel_b, 50) } |> should.be_true
+}


### PR DESCRIPTION
Two spikes on the runtime topology question, plus the prototypes behind them.
Neither is proposed for merge — the findings docs are the deliverable, the
code is here so they can be checked.

## #334, one actor per socket

[`0334-per-socket-actor.md`](docs/spikes/0334-per-socket-actor.md) (plan) +
[`-findings.md`](docs/spikes/0334-per-socket-actor-findings.md) (result), prototype
in `src/beryl/runtime.gleam` (+540/−63). The socket actor runs the same
`handle_message` on the same `State` as the router, with `sockets` capped at
one entry and one new field:

```gleam
router: Option(Subject(Msg(msg)))   // None in the router, Some(router) in a socket actor
```

Six functions branch on that field; nothing below `dispatch_socket_msg` was
touched. `beryl_mist`/`beryl_ewe` pass unchanged.

**496 pass, 3 fail, no test edited** — all three are contract breaks the issue
asks for (callbacks now run in the socket's own pid, not the router's; stats
go eventually-consistent). Two orderings the plan didn't name, both fixed:
effect-list order stops being wire order at the first broadcast (fixed with
inline self-delivery), and shutdown needs to be two-phase because the router
can never block on a socket actor without deadlocking.

## #337, process-per-channel — round 1 blocked, round 2 discharged it

[`0337-process-per-channel.md`](docs/spikes/0337-process-per-channel.md), prototype in
`test/spike_channel_worker{,_test}.gleam`.

**Round 1** (on the shared runtime): *do not pursue before #334* — a socket
isn't a process, so per-socket monitoring, join serialisation, and the
close/batch drain have no owner.

**Round 2** re-ran the same prototype on #334's landed runtime and mostly
inverted that. [`0337-process-per-channel-round-2.md`](docs/spikes/0337-process-per-channel-round-2.md):

- **Claimed for real:** a `factory_supervisor` per socket, linked to its
  socket actor. Joins stop serialising across sockets, and the global name +
  `OneForAll` coupling round 1 needed are deleted.
- **Free:** a blocking `on_terminate` now stalls only its own socket —
  passes against round 1's prototype unmodified.
- **Never blocked on #334 at all:** the per-channel watcher (`init` was
  always per-socket) and a per-socket in-flight budget (`Router` was always
  per-socket).
- **The one that reframes round 1:** the raced reply isn't a topology
  problem. `exec_close_topic` deletes a topic's `pending_reply_refs` *before*
  delivering `Closed` — so even a single socket, single process, zero workers
  loses the reply. A drain is buildable (selective receive on a
  socket-owned subject) but useless, because it recovers effects for a ref
  core already invalidated. Fixing it means routing the leave to the worker
  before closing, which only `runtime.gleam` can do.

**503 pass, 3 fail** — same three #334 contract breaks, unrelated.

**Recommendation:** process-per-channel can't be built as an external layer
on `beryl.child_spec`; it needs to be a change inside `runtime.gleam` where
the socket actor owns `Dict(topic, worker)` directly and routes leaves to the
worker before closing.

## Benchmarks: step 0 is discharged

[`0334-per-socket-actor-benchmarks.md`](docs/spikes/0334-per-socket-actor-benchmarks.md).
Added a `BENCH_CALLBACK_COST_US` knob to `examples/load_test` (a CPU-burning
busy-wait standing in for real app callback cost) and swept it 0–10ms against
both topologies with the existing k6 harness.

- **Point-to-point (`push-round-trip`): no measurable difference, at any
  cost.** The extra message hop is free here — 10 independent sockets never
  give the router's mailbox enough concurrent volume to queue behind itself.
- **Broadcast/fan-out (`broadcast-fanout`): a sharp crossover at ~1–10ms.**
  At 10ms/callback the shared router serializes every recipient's cost
  through one mailbox (`local_broadcast` sends from the router, inside its
  own turn) and saturates: p50/p95 delivery latency 83ms/144ms, 85% of
  checks passing, 1,591 broadcast operations completed in the 20s window.
  Per-socket-actor stays near the injected cost (p50/p95 12ms/21ms, 92.5%
  checks passing) and completes **80% more operations** in the same window,
  because each socket's cost lands on its own process instead of a shared
  one.

1–10ms is an ordinary callback-cost range (a DB round trip, a non-trivial
JSON payload, a presence merge), not a corner case, so the crossover is a
real one: #334 is worth its complexity for any deployment with concurrent
broadcast traffic, and costs nothing measurable for point-to-point traffic
even at high per-callback cost.

## Not done

Net lines are still up (+2523/−63 across both spikes, before the benchmark
harness). Of the plan's six decisions, 1 (broadcast routing, the biggest
lever, and what the benchmark measured) and 2 (topic index) are wired for
real or cheaply-but-viably; 3 (presence suspension deletion) is untried; 4
(admission) and 5 (router failure) are still the cheap stand-ins the plan
warned about — a serialised admission turn and a monitor instead of real
supervision. Also not built: pg-per-socket, transport-side socket start,
backpressure. Also not measured: per-socket process/memory overhead
(`/stats` was sampled after clients had already disconnected). Deliberate
shortcuts carry `ponytail:` comments naming their ceiling and upgrade path.


