### PR TITLE
docs: simplify website language

### DIFF
--- a/packages/beryl/src/beryl/channel.gleam
+++ b/packages/beryl/src/beryl/channel.gleam
@@ -606,7 +606,7 @@ pub fn with_reply(
 /// while this socket waits; a check followed by [`presence_track`](#presence_track)
 /// is therefore not an atomic cross-socket capacity reservation.
 ///
-/// This is what to reach for instead of notifying yourself from `join`:
+/// Use this function instead of notifying the channel from `join`:
 /// [`notify`](#notify) schedules a *later* input, while actions preserve
 /// their declared position immediately after the join acknowledgment.
 ///

--- a/website/scripts/generate-reference.mjs
+++ b/website/scripts/generate-reference.mjs
@@ -344,15 +344,15 @@ ${moduleRows}`;
 
 	return `---
 title: API Reference
-description: Generated API reference from Gleam docs metadata.
+description: API reference generated from Gleam docs metadata.
 ---
 
 ${GENERATED_MARKER}
 
-This reference is generated from Gleam's docs metadata for ${packageList}.
+This reference uses Gleam docs metadata for ${packageList}.
 
 :::note[Generated content]
-Pages under \`${referenceBasePath}/\` are generated from Gleam's docs metadata and reflect every public type, function, and constant. This is beryl's canonical API reference. Beryl packages are currently distributed from GitHub, not Hex.
+The generator creates pages under \`${referenceBasePath}/\` from Gleam docs metadata. The pages include each public type, function, and constant. This is beryl's canonical API reference. Install beryl packages from GitHub. They are not on Hex.
 :::
 
 ${packageSections}

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -29,8 +29,8 @@ const isHome = Boolean(gem);
 const snippet = `import beryl
 import beryl/presence
 
-// Track who's online and broadcast every change to the room —
-// Phoenix-compatible presence diffs, backed by a CRDT.
+// Track connected users and send each change to the room.
+// The CRDT produces Phoenix-compatible presence diffs.
 let config =
   presence.Config(
     pubsub: Some(ps),
@@ -41,11 +41,11 @@ let config =
     }),
   )
 
-// …then, inside your channel's join callback:
+// In the channel join callback:
 let _ref =
   presence.track(p, "room:lobby", "user:alice", socket.id(socket), meta)
 
-// ps, channels, p and meta come from your app — see the Presence guide.
+// Your app provides ps, channels, p, and meta. See the Presence guide.
 `;
 ---
 

--- a/website/src/content/docs/404.md
+++ b/website/src/content/docs/404.md
@@ -5,7 +5,7 @@ editUrl: false
 pagefind: false
 lastUpdated: false
 hero:
-  tagline: That page slipped through a facet. Check the URL, or jump back to something solid below.
+  tagline: We could not find this page. Check the URL or use one of these links.
   actions:
     - text: Back to home
       link: /

--- a/website/src/content/docs/architecture/message-lifecycle.md
+++ b/website/src/content/docs/architecture/message-lifecycle.md
@@ -2,11 +2,16 @@
 title: Message Lifecycle
 ---
 
-This page traces every significant step a message takes from the moment a WebSocket connection opens until it is pushed back to one or more clients. Each diagram corresponds to a distinct phase; together they give you a complete mental model of how beryl processes real-time traffic.
+This page follows a message from the WebSocket connection to the client. Each
+diagram shows one phase of beryl's message processing.
 
 ## Connect and init
 
-When a client initiates a WebSocket upgrade, the Mist transport layer generates a unique socket id, assembles a `ConnectSeed` from the upgrade request (path, query, headers), and hands the socket, along with its send functions, to the runtime. The runtime calls your app's `init` with a `ConnectInfo` carrying the socket id, the seed, and a typed `Sender` for server-side messages, and stores the returned model.
+When a client requests a WebSocket upgrade, Mist creates a unique socket ID. It
+builds a `ConnectSeed` from the path, query, and headers. Mist then sends the
+socket and its send functions to the runtime. The runtime calls your app's
+`init` with `ConnectInfo`. This value contains the socket ID, seed, and typed
+`Sender`. The runtime stores the model that `init` returns.
 
 ```mermaid
 sequenceDiagram
@@ -23,7 +28,9 @@ sequenceDiagram
 
 ## Join a topic
 
-A client joins a topic by sending a `phx_join` frame. The transport decodes the raw frame in the connection process, and the runtime delivers a `Join` event to your `update` function, which answers with an `AcceptJoin` or `RejectJoin` effect.
+A client sends a `phx_join` frame to join a topic. The connection process
+decodes the frame. The runtime sends a `Join` event to your `update` function.
+The function returns an `AcceptJoin` or `RejectJoin` effect.
 
 ```mermaid
 sequenceDiagram
@@ -42,11 +49,13 @@ sequenceDiagram
   RT-->>Client: phx_reply (ok/error)
 ```
 
-A `Join` left unanswered by the update's effects is rejected automatically; beryl fails closed.
+The runtime rejects a `Join` that has no answer. Thus, beryl fails closed.
 
 ## Handle an inbound event
 
-After a successful join, every subsequent inbound frame for that topic arrives at `update` as a `Message` event. The effects list decides what goes back on the wire: a reply correlated to the client's ref, pushes, broadcasts, presence writes, or nothing at all.
+After a successful join, `update` receives each later topic frame as a
+`Message` event. The effects list can send a reply, push, broadcast, or presence
+write. An empty list sends nothing.
 
 ```mermaid
 sequenceDiagram
@@ -61,7 +70,11 @@ sequenceDiagram
 
 ## Broadcast fan-out
 
-Broadcasting delivers a message to every socket subscribed to a topic. The `Broadcast` effect (or `beryl.broadcast` from outside `update`) reaches all subscribers; `BroadcastFrom` / `beryl.broadcast_from` excludes the originating socket. When PubSub is configured, the pg-based layer forwards the broadcast to every other node's runtime, which fans out to its local subscribers.
+A broadcast sends a message to each socket on a topic. `Broadcast` and
+`beryl.broadcast` include the source socket. `BroadcastFrom` and
+`beryl.broadcast_from` exclude it. When you configure PubSub, Erlang `pg` sends
+the broadcast to other runtime nodes. Each runtime then sends it to local
+subscribers.
 
 ```mermaid
 sequenceDiagram
@@ -77,7 +90,9 @@ sequenceDiagram
 
 ## Heartbeat and eviction
 
-Clients periodically send a `heartbeat` frame on the `"phoenix"` topic to signal liveness. The runtime replies immediately and tracks the last-seen timestamp; a periodic timer evicts sockets that have not sent a heartbeat within the configured deadline. The app never sees heartbeat frames.
+Clients send a `heartbeat` frame on the `"phoenix"` topic at set intervals. The
+runtime replies and records the time. A timer removes sockets that miss the
+configured deadline. The app does not receive heartbeat frames.
 
 ```mermaid
 sequenceDiagram
@@ -91,7 +106,9 @@ sequenceDiagram
 
 ## Disconnect and close
 
-When a client closes the WebSocket connection, Mist notifies the runtime, which delivers a `Closed(topic, reason)` event to `update` for every joined topic and then cleans up all subscriptions and socket state.
+When a client closes the WebSocket, Mist notifies the runtime. The runtime sends
+`Closed(topic, reason)` to `update` for each joined topic. It then removes the
+subscriptions and socket state.
 
 ```mermaid
 sequenceDiagram
@@ -110,8 +127,8 @@ The same `Closed` path is used for client leaves, heartbeat timeouts,
 
 ## Where the channel layer fits
 
-`beryl/channel` supplies the `init`/`update` pair in every diagram above.
-Its `init` builds one router per socket; its `update` maps each input to the
+`beryl/channel` supplies the `init` and `update` pair in these diagrams. Its
+`init` builds one router for each socket. Its `update` maps each input to the
 live channel instance for that topic.
 
 | Runtime input | Router behavior |
@@ -121,21 +138,22 @@ live channel instance for that topic.
 | `Info(envelope)` | Topic and join generation are checked before the sealed typed value is opened; stale mail is dropped |
 | `Closed(topic, reason)` | Calls `on_terminate` and lowers its actions after the topic is already unsubscribed |
 
-Termination has one deliberate edge case. The router removes the instance in
-the model returned by the `Closed` turn. If `on_terminate` panics, core
-discards that returned model and keeps the pre-`Closed` one, so the retained
-instance can still receive its own generation-scoped `channel.notify` mail.
-Client messages cannot reach it because the topic is closed; a rejoin replaces
-it, and ending the socket removes it. See
+Termination has one edge case. The router removes the instance in the model
+returned by the `Closed` turn. If `on_terminate` panics, the core discards that
+model and keeps the old model. The retained instance can receive its own
+generation-scoped `channel.notify` mail. Client messages cannot reach the
+closed topic. A rejoin replaces the instance, and socket shutdown removes it.
+See
 [Crash behavior](/guides/channels/#crash-behavior).
 
-Channel actions lower one-to-one onto core effects. Their order is preserved,
-but asynchronous presence effects may park only that socket while other
-sockets continue.
+Each channel action maps to one core effect. The runtime preserves their order.
+An asynchronous presence effect can pause one socket while other sockets
+continue.
 
 ## Concurrency note
 
-The runtime is a single OTP actor processing its mailbox sequentially; broadcasts arrive as messages, so tests must select the exact message shape and drain queued messages (BEAM mailbox gotcha).
+One OTP actor processes the runtime mailbox in sequence. Broadcasts arrive as
+messages. Tests must select the exact message shape and drain queued messages.
 
 ## Where this lives
 

--- a/website/src/content/docs/architecture/overview.md
+++ b/website/src/content/docs/architecture/overview.md
@@ -3,16 +3,16 @@ title: Architecture Overview
 description: How beryl is organized, the major modules, and where to make changes.
 ---
 
-beryl layers a Phoenix-compatible socket runtime on top of OTP actors and Erlang `pg`, with a pluggable wire codec and WebSocket transport.
-An app can supply an `init`/`update` pair directly to `beryl.child_spec`, or
-use `channel.child_spec`, which builds that pair from a typed handler
-table. The runtime dispatches decoded wire messages and applies the effects
-either layer returns.
-Presence and groups are independent domain actors; PubSub is the only cross-node primitive; everything else is local to a node.
+beryl provides a Phoenix-compatible socket runtime on OTP actors and Erlang
+`pg`. It supports pluggable wire codecs and WebSocket transports. An app can
+pass an `init` and `update` pair to `beryl.child_spec`. It can also pass a typed
+handler table to `channel.child_spec`. The runtime dispatches decoded messages
+and applies the returned effects. Separate actors manage presence and groups.
+Only PubSub sends data across nodes.
 
 ## How to read these docs
 
-Each subsystem page covers one slice of the stack end-to-end and ends with a **"Where this lives"** pointer back to the relevant source files.
+Each page describes one subsystem and lists its source files.
 
 - [Message Lifecycle](/architecture/message-lifecycle): how a frame travels from WebSocket to your `update` function and back
 - [Runtime & Supervision](/architecture/runtime): the runtime actor, typed dispatch, and the built-in supervision
@@ -78,11 +78,14 @@ flowchart TB
   RT -. "group broadcasts" .-> GR
 ```
 
-The runtime supervises itself inside `child_spec`; presence and groups are plain actors the application starts and owns. See the [Supervision guide](/guides/supervision/).
+`child_spec` supervises the runtime. The application starts and owns the
+presence and group actors. See the [Supervision guide](/guides/supervision/).
 
 ## Where things live
 
-Core source files live under `packages/beryl/src/beryl/`; transports under `packages/beryl_mist/` and `packages/beryl_ewe/`.
-The runtime is the entry point for understanding behaviour. Start with [Runtime & Supervision](/architecture/runtime).
-For how a message actually moves through the system, see [Message Lifecycle](/architecture/message-lifecycle).
-For cross-node concerns, see [PubSub & Distribution](/architecture/pubsub-and-distribution).
+Core source files are under `packages/beryl/src/beryl/`. Transport source files
+are under `packages/beryl_mist/` and `packages/beryl_ewe/`. Start with
+[Runtime & Supervision](/architecture/runtime) to learn the runtime. See
+[Message Lifecycle](/architecture/message-lifecycle) for the message path. See
+[PubSub & Distribution](/architecture/pubsub-and-distribution) for cross-node
+behavior.

--- a/website/src/content/docs/architecture/presence.md
+++ b/website/src/content/docs/architecture/presence.md
@@ -4,22 +4,27 @@ title: Presence
 
 ## Model
 
-Beryl presence is an OTP actor that wraps [`lattice_presence/presence_state`](https://hex.pm/packages/lattice_presence) — an **add-wins, observed-remove CRDT**. Each node in a cluster holds its own replica of the CRDT state. Because the data structure is conflict-free, replicas merge in any order without coordination: concurrent joins and leaves from different nodes always converge to the same result.
+Beryl presence is an OTP actor that wraps
+[`lattice_presence/presence_state`](https://hex.pm/packages/lattice_presence).
+It uses an **add-wins, observed-remove CRDT**. Each cluster node keeps one CRDT
+replica. Replicas can merge in any order without coordination. Concurrent joins
+and leaves converge to the same result.
 
-Every tracked entry is stamped with a **replica name** (the `replica` argument to `default_config/1`). The replica name must be unique across the cluster; it is used as the CRDT replica identifier when merging remote state.
+Each tracked entry has a **replica name**, set by the `replica` argument to
+`default_config/1`. Use a unique name for each cluster node. The CRDT uses this
+name to identify remote state.
 
 ## How Beryl apps use it
 
-The presence actor is a standalone supervised child that the application
-builds with `presence.child_spec`, adds to its supervision tree, and supplies
-to `beryl.Config` with `with_presence_handle`.
+The application builds the presence actor with `presence.child_spec`. Add the
+child to the supervision tree. Then pass its handle to `beryl.Config` with
+`with_presence_handle`.
 
 App-side dispatch uses `PresenceTrack`, `PresenceUntrack`, `PushPresence`, and
-`BroadcastPresence` effects. Mutations are sent asynchronously to the presence
-actor and acknowledged only after both the CRDT and its ETS read model are
-updated. The runtime suspends the issuing socket's remaining effects and later
-inputs until that acknowledgement arrives; other sockets, broadcasts,
-heartbeats, and shutdown handling continue normally.
+`BroadcastPresence` effects. The runtime sends mutations to the presence actor. The actor acknowledges a
+mutation after it updates the CRDT and ETS read model. Until then, the runtime
+pauses later effects and inputs for that socket. Other sockets, broadcasts,
+heartbeats, and shutdown work continue.
 
 Snapshot effects read the actor-owned ETS model directly, so they do not wait
 on the actor mailbox. Re-tracking a runtime-owned key is one atomic
@@ -41,11 +46,10 @@ read-after-write behavior.
 |---|---|
 | `child_spec(config)` | Return a stable presence handle and its supervised child specification |
 
-On the node where the child specification runs, the handle keeps working across
-actor restarts because both the process and its ETS read model use the same
-stable name. The replacement actor starts with fresh in-memory CRDT state and
-tracking refs. The handle itself is node-affine; PubSub replicates presence
-state between nodes.
+The handle keeps working after an actor restart on the same node. The process
+and ETS read model use stable names. The replacement actor starts with empty
+in-memory CRDT state and tracking refs. The handle works only on its node.
+PubSub copies presence state between nodes.
 
 ### Configuration builders
 
@@ -84,13 +88,20 @@ state between nodes.
 
 ## Replication
 
-When `with_pubsub` and `with_broadcast_interval` are both configured, the presence actor runs a periodic broadcast loop:
+When you configure `with_pubsub` and `with_broadcast_interval`, the presence
+actor runs a broadcast loop:
 
-1. On each tick, if the local CRDT has changed since the last broadcast (`dirty = true`), the actor publishes a typed `SyncPayload(v, sender, state)` term to the well-known topic `"beryl:presence:sync"` using `broadcast_from` — which excludes self-delivery at the PubSub layer.
-2. Remote replicas on other nodes receive that typed payload through PubSub, merge the incoming state with `state.merge_with_diff`, and update their CRDT replica.
-3. If the merge changes membership (new joins or leaves relative to local state), `on_diff` fires immediately with the resulting `Diff`. This ensures no diff is silently dropped when multiple merges arrive in rapid succession.
+1. On each tick, the actor checks the `dirty` value. If local state changed,
+   it sends `SyncPayload(v, sender, state)` to `"beryl:presence:sync"`.
+   `broadcast_from` prevents self-delivery.
+2. Remote replicas receive the typed payload through PubSub. They merge it with
+   `state.merge_with_diff` and update their CRDT state.
+3. If the merge changes membership, the actor calls `on_diff` with the
+   resulting `Diff`. It calls the function for each merge, so rapid merges do
+   not lose diffs.
 
-Setting `broadcast_interval_ms` to `0` (the default in `default_config`) disables periodic broadcasts entirely, which is appropriate for single-node deployments.
+Set `broadcast_interval_ms` to `0` to disable periodic broadcasts. This is the
+default and is suitable for one-node deployments.
 
 ## Diagram
 

--- a/website/src/content/docs/architecture/pubsub-and-distribution.md
+++ b/website/src/content/docs/architecture/pubsub-and-distribution.md
@@ -4,9 +4,13 @@ title: PubSub & Distribution
 
 ## Foundation
 
-Beryl's PubSub layer is built on Erlang's built-in [`pg`](https://www.erlang.org/doc/man/pg.html) module (process groups). When a process subscribes to a topic, it joins a named `pg` group scoped to the PubSub instance. When a broadcast is sent, beryl looks up all members of that group and delivers the message to each one.
+Beryl's PubSub layer uses Erlang's
+[`pg`](https://www.erlang.org/doc/man/pg.html) process groups. A subscriber
+joins a named `pg` group in the PubSub scope. For each broadcast, beryl finds
+the group members and sends the message to them.
 
-Because `pg` is cluster-aware, this works transparently across nodes in an Erlang cluster: a process on Node A subscribing to `"room:lobby"` will receive broadcasts from Node B without any additional configuration.
+Erlang `pg` works across connected cluster nodes. A process on Node A can
+subscribe to `"room:lobby"` and receive broadcasts from Node B.
 
 Each PubSub instance is identified and isolated by a **scope** (an Erlang
 atom). The default scope is `beryl_pubsub`; use `config_with_scope/1` to create
@@ -16,7 +20,9 @@ type.
 
 ## The FFI Boundary
 
-The Gleam module `beryl/pubsub` delegates all low-level pg operations to `src/beryl_pubsub_ffi.erl` via `@external` declarations. The FFI file is intentionally minimal: a thin wrapper that maps Gleam calls directly to `pg` BIFs.
+The Gleam module `beryl/pubsub` sends low-level `pg` operations to
+`src/beryl_pubsub_ffi.erl` through `@external` declarations. The FFI file maps
+Gleam calls to `pg` BIFs.
 
 **Public surface of `beryl/pubsub`:**
 
@@ -34,11 +40,11 @@ The Gleam module `beryl/pubsub` delegates all low-level pg operations to `src/be
 | `subscribers(ps, topic)` | Return all subscriber pids (all nodes) |
 | `subscriber_count(ps, topic)` | Return subscriber count (all nodes) |
 
-Broadcasts are sent raw through `pg` as the scope atom followed by the four
+`pg` sends each broadcast as the scope atom followed by the four
 `Message(payload)` fields (`topic`, `event`, `payload`, `from`). This
 five-element tuple is a frozen wire contract. The scoped and previously
-unscoped shapes do not interoperate during a rolling upgrade; applications
-must also version payload-shape changes that cross nodes.
+unscoped shapes cannot communicate during a rolling upgrade. Applications must
+also version payload changes that cross nodes.
 
 The `PubSubFrom` type tags each message with its origin so downstream receivers can inspect whether a message came from the system, a specific process, or a process with an associated socket:
 
@@ -52,13 +58,17 @@ pub type PubSubFrom {
 
 ## Exclusion Semantics
 
-`broadcast_from` and `broadcast_from_socket` implement **sender exclusion**: the originating process does not receive its own broadcast. This prevents a runtime from echoing a message back to the socket that sent it.
+`broadcast_from` and `broadcast_from_socket` exclude the sender. The source
+process does not receive its broadcast. This prevents an echo to the source
+socket.
 
 - `broadcast_from(ps, from, ...)` skips delivery to the process whose `Pid` matches `from`.
 - `broadcast_from_socket(ps, from, except_socket_id, ...)` also skips delivery to `from`, and carries `FromSocket(from, except_socket_id)` in the message so that any remote runtime receiving it can optionally suppress re-delivery to a matching socket ID on their node.
 
 :::caution[Regression-prone contract]
-The exclusion behaviour is load-bearing for channel correctness. If the comparison `pid == from` is ever changed or skipped, senders will receive their own messages. Tests that cover `broadcast_from` exclusion must be preserved when refactoring the PubSub layer.
+Channel behavior depends on sender exclusion. If code changes or skips the
+`pid == from` comparison, senders receive their own messages. Keep the
+`broadcast_from` exclusion tests when you change PubSub code.
 :::
 
 ## Distribution Diagram
@@ -76,16 +86,17 @@ flowchart LR
   PG -- deliver --> C2
 ```
 
-When socket A sends a message on Node 1, its runtime calls `broadcast_from`, which iterates the `pg` group members. Members on Node 2 receive the message via Erlang distribution; no extra message-bus infrastructure is required.
+When socket A sends a message on Node 1, its runtime calls `broadcast_from`.
+The function iterates through the `pg` group members. Erlang distribution sends
+the message to members on Node 2. You do not need another message bus.
 
 ## Trust Model
 
-All traffic arriving over Erlang distribution is treated as **fully trusted
-cluster input**. A peer can execute arbitrary code on connected nodes; the
-beryl-specific capabilities below are only a subset of that access. Network
-isolation and mutually verified TLS distribution enforce the security
-boundary. Erlang cookies prevent accidental cross-cluster connections but are
-not cryptographically secure peer authentication.
+Treat all Erlang distribution traffic as **trusted cluster input**. A peer can
+run arbitrary code on connected nodes. The beryl capabilities below are only
+part of that access. Use network isolation and mutual TLS verification for the
+security boundary. Erlang cookies prevent accidental cluster connections, but
+they do not provide secure peer authentication.
 
 A process on any peer node can:
 

--- a/website/src/content/docs/architecture/runtime.md
+++ b/website/src/content/docs/architecture/runtime.md
@@ -2,11 +2,19 @@
 title: Runtime & Supervision
 ---
 
-The runtime is the central OTP actor for app-side socket dispatch. Transports send admitted, decoded frames to it, and your application's `init`/`update` functions run inside it during event dispatch. Presence and groups are independent application-owned supervised children; PubSub is an Erlang `pg` wrapper rather than a child of the runtime.
+The runtime is the main OTP actor for socket dispatch. Transports send admitted
+and decoded frames to it. The runtime calls your application's `init` and
+`update` functions for each event. The application owns separate supervised
+children for presence and groups. PubSub wraps Erlang `pg` and is not a runtime
+child.
 
 ## Role
 
-The runtime is the single source of truth for connected socket IDs, app models, topic subscriptions, and heartbeat timestamps. It processes its mailbox sequentially, which gives it a consistent view of app dispatch without locks. Transport connection processes still own edge concerns such as WebSocket state, frame limits, decoding, and the local message-rate bucket; the model returned by `update` is the app state the next event sees.
+The runtime stores connected socket IDs, app models, topic subscriptions, and
+heartbeat times. It processes mailbox messages in sequence. This gives it a
+consistent view without locks. Transport connection processes manage WebSocket
+state, frame limits, decoding, and the local message-rate bucket. The next event
+uses the model returned by `update`.
 
 ## What it tracks
 
@@ -19,7 +27,12 @@ The runtime maintains four categories of state:
 
 ## Typed dispatch without erasure
 
-The runtime actor is generic over the app's `model` and `msg` types. `beryl.child_spec` captures those types in a record of monomorphic closures at construction time, so the public `Sockets` handle — and the frame-level transport SPI behind it — stays unparameterized while the runtime holds fully typed state. This is plain closure capture by a generic function: there are no unchecked casts, `Dynamic` round-trips, or identity FFI in the socket-dispatch path. PubSub separately validates the frozen raw mailbox record before its package-internal payload coercion.
+The runtime actor is generic over the app's `model` and `msg` types.
+`beryl.child_spec` captures those types in monomorphic closures. The public
+`Sockets` handle and transport SPI do not need type parameters. The runtime
+still keeps typed state. This path uses no unchecked casts, `Dynamic`
+round-trips, or identity FFI. PubSub validates its raw mailbox record before
+its internal payload coercion.
 
 Server-side messages work the same way: `init` receives a typed `Sender(msg)` whose closure captures the message type, and `socket.notify` delivers messages that arrive in `update` as `Info(msg)` — an ordinary typed send.
 
@@ -43,13 +56,25 @@ Inbound WebSocket frames follow a two-step path:
 
 ## Effect ordering
 
-Effects are applied strictly in list order. Because the same runtime actor interprets the list and writes frames for that socket, list order is wire order; an `AcceptJoin` is guaranteed to reach the wire before a `Push` later in the same list.
+The runtime applies effects in list order. The same actor interprets the list
+and writes the frames. Thus, list order is wire order. An `AcceptJoin` reaches
+the wire before a later `Push`.
 
-Most lists are applied in a single actor turn. `PresenceTrack` and `PresenceUntrack` are applied by the presence actor instead, so the runtime holds the rest of that socket's list — and queues that socket's later inbound messages — until the mutation is acknowledged, then resumes exactly where it left off. Ordering for the socket is unchanged; what changes is that only that socket waits. Every other socket, broadcast, heartbeat check, and shutdown keeps being processed, which also means an unrelated broadcast can land between two of the waiting socket's effects.
+The runtime applies most lists in one actor turn. The presence actor applies
+`PresenceTrack` and `PresenceUntrack`. The runtime pauses the rest of that
+socket's list until the presence actor responds. It also queues later input for
+that socket. Then it resumes at the next effect. The socket keeps its effect
+order. Other sockets, broadcasts, heartbeat checks, and shutdown work continue.
+An unrelated broadcast can occur between two effects from the paused socket.
 
 ## Crash containment
 
-Crashes in app callbacks are rescued rather than allowed to take down the shared runtime. The blast radius is scoped to what crashed: a crashing `Join` is rejected; a crashing topic-scoped `Message` or `Binary` closes only that topic; a crashing `Info` tears down the whole socket because it has no topic to attribute; a crashing `Closed` is logged while teardown continues; and a crashing `init` leaves the socket unregistered. Crash descriptions are depth-limited and truncated before logging. Other sockets remain isolated.
+The runtime catches crashes in app callbacks. A `Join` crash rejects that join.
+A topic `Message` or `Binary` crash closes only that topic. An `Info` crash
+closes the socket because the message has no topic. A `Closed` crash is logged,
+and teardown continues. An `init` crash prevents socket registration. The
+runtime limits and truncates crash descriptions before logging. Other sockets
+continue.
 
 This is a deliberate trade-off with OTP's usual "let it crash" model. Every
 socket's model lives in the same runtime actor, so allowing one app callback
@@ -68,7 +93,12 @@ finishes closing the topic and continues closing sibling channels.
 
 ## Heartbeat enforcement
 
-The runtime schedules a recurring self-check at `heartbeat_timeout_ms / 2`. On each check it compares the current monotonic time to each socket's `last_heartbeat` and evicts any socket past the timeout. Eviction delivers `Closed(topic, HeartbeatTimeout)` for each joined topic, invokes the transport's registered closer so the underlying connection is actually shut, and removes the socket from all state. `child_spec` rejects timeouts below 2 loudly, because integer division would otherwise round the check interval to zero and silently disable eviction.
+The runtime checks heartbeats every `heartbeat_timeout_ms / 2`. It compares the
+current monotonic time with each socket's `last_heartbeat`. It removes each
+socket that exceeds the timeout. Removal sends
+`Closed(topic, HeartbeatTimeout)` for each joined topic. It also calls the
+transport closer and removes all socket state. `child_spec` rejects timeouts
+below 2 because integer division would set the check interval to zero.
 
 ## Supervision
 
@@ -82,12 +112,16 @@ flowchart TB
   SUP -. optional .-> LIMITER["connection limiter"]
 ```
 
-- The `init`/`update` closures live in the child specification, so a restart resumes dispatch immediately — there is no registration step to replay.
-- The runtime is registered under a stable name; the `Sockets` handle keeps working across restarts, and sends during a restart window degrade to quiet no-ops.
+- The child specification contains the `init` and `update` closures. A restart
+  resumes dispatch without a registration step.
+- The runtime uses a stable registered name. The `Sockets` handle works after a
+  restart. Sends during the restart window do nothing.
 - A restart drops per-socket state (models, joined topics); clients rejoin exactly as they would after any server restart.
 - The child is `Transient`, so a graceful `beryl.stop` is final.
 
-PubSub is **not** part of this tree; it is backed by Erlang's `pg` module, which manages its own lifecycle. Presence and groups expose their own child specifications for the application's supervision tree (see the [Supervision guide](/guides/supervision/)).
+PubSub is **not** part of this tree. Erlang `pg` manages its lifecycle.
+Presence and groups provide child specifications for the application
+supervision tree. See the [Supervision guide](/guides/supervision/).
 
 ## Where this lives
 

--- a/website/src/content/docs/architecture/wire-and-transport.md
+++ b/website/src/content/docs/architecture/wire-and-transport.md
@@ -2,11 +2,15 @@
 title: Wire & Transport
 ---
 
-The wire and transport layer sits between raw WebSocket frames and the runtime. It is split into two concerns: a pluggable **codec** that translates bytes into structured messages, and the **Mist transport** that owns the socket lifecycle.
+The wire and transport layer connects raw WebSocket frames to the runtime. A
+pluggable **codec** converts bytes to structured messages. The **Mist
+transport** manages the socket lifecycle.
 
 ## Codec abstraction
 
-A `Codec` is opaque. Use the public factory and builder functions in `beryl/wire/codec`, or use the ready-made `wire.phoenix_codec()`. The runtime is framing-agnostic: it only ever sees `Inbound` values and emits `Frame` values; the codec performs every translation.
+A `Codec` is opaque. Use the public factory and builder functions in
+`beryl/wire/codec`, or use `wire.phoenix_codec()`. The runtime receives
+`Inbound` values and emits `Frame` values. The codec converts all frames.
 
 ```
 src/beryl/wire/codec.gleam
@@ -26,13 +30,14 @@ The public codec builders configure these behaviors:
 
 Build a custom text codec with `codec.new(...)`, then add optional behavior with builders such as `codec.with_binary_decoder`, `codec.with_close_encoder`, `codec.with_error_encoder`, and `codec.with_topicless_events`. The built-in `wire.phoenix_codec()` configures Phoenix text and V2 binary framing.
 
-Every Beryl `Config` requires a codec explicitly; there is no implicit default:
+Each Beryl `Config` requires a codec. There is no default:
 
 ```gleam
 beryl.config(wire.phoenix_codec())
 ```
 
-Pass a custom opaque `Codec` to `beryl.config(codec)` to use an alternative protocol without changing the runtime or app logic.
+Pass a custom `Codec` to `beryl.config(codec)` to use another protocol. You do
+not need to change the runtime or app logic.
 
 ## Frame shapes
 
@@ -42,32 +47,55 @@ Phoenix uses a JSON array for every message on the wire:
 [join_ref, ref, topic, event, payload]
 ```
 
-The `join_ref` and `ref` fields are nullable strings used for reply correlation. `topic` is the subscription key (e.g. `"room:lobby"`). `event` names the protocol action or user event.
+The `join_ref` and `ref` fields are nullable strings that link requests and
+replies. `topic` is the subscription key, such as `"room:lobby"`. `event` names
+the protocol action or user event.
 
 ### Key functions in `beryl/wire`
 
-**`decode_message(json_string)`**: parses a raw JSON string into an `Inbound`. Returns `InvalidJson` or `InvalidFormat` errors for malformed input.
+**`decode_message(json_string)`** parses a raw JSON string into an `Inbound`.
+It returns `InvalidJson` or `InvalidFormat` for malformed input.
 
-**`encode(msg)`**: round-trips an `Inbound` back to a Phoenix wire JSON string.
+**`encode(msg)`** converts an `Inbound` to a Phoenix wire JSON string.
 
-**`reply_json(join_ref, ref, topic, status, response)`**: produces a `phx_reply` frame. The `payload` field is `{"status": "ok"|"error", "response": <payload>}`.
+**`reply_json(join_ref, ref, topic, status, response)`** creates a `phx_reply`
+frame. The `payload` field is
+`{"status": "ok"|"error", "response": <payload>}`.
 
-**`push(topic, event, payload)`**: produces a server-initiated push. Server pushes carry `null` for both `join_ref` and `ref` because there is no client message to correlate against.
+**`push(topic, event, payload)`** creates a server push. Server pushes use
+`null` for `join_ref` and `ref` because they do not answer a client message.
 
-**`heartbeat_reply(ref)`**: produces the heartbeat acknowledgement. The topic is always `"phoenix"`, the event is `"phx_reply"`, and the status is `"ok"` with an empty response object. The client sends heartbeats with topic `"phoenix"` / event `"heartbeat"`.
+**`heartbeat_reply(ref)`** creates the heartbeat acknowledgment. It uses topic
+`"phoenix"`, event `"phx_reply"`, status `"ok"`, and an empty response object.
+The client sends heartbeats with topic `"phoenix"` and event `"heartbeat"`.
 
 ## Shared transport core
 
-`beryl/transport/server` owns the server-agnostic admission, connection, and
-frame pipeline. `beryl_mist` and `beryl_ewe` provide only their server-specific
-upgrade, frame-send, and peer-IP glue:
+`beryl/transport/server` manages admission, connections, and frames.
+`beryl_mist` and `beryl_ewe` provide the server-specific upgrade, frame-send,
+and peer-IP functions:
 
-1. **Generating a unique socket id**: the shared server uses `crypto.strong_random_bytes` to produce a 16-byte random id encoded as base16.
-2. **Admitting the socket atomically**: the shared server captures `transport.runtime_pid`, installs a monitor for that exact pid, then calls `transport.admit_socket` with the send functions, closer, codec, and `ConnectSeed`. A restart or registration failure closes the connection instead of registering it with a successor runtime.
-3. **Routing text frames**: `mist.Text` frames are decoded in the connection process with the codec from `transport.active_codec` and routed with `transport.route_decoded`.
-4. **Routing binary frames**: when the active codec supplies `decode_binary`, `mist.Binary` frames are decoded in the connection process and routed with `transport.route_decoded_binary`, producing normal `Join`/`Message` semantics while preserving binary telemetry classification; without a binary decoder, the transport uses `transport.route_binary` to deliver the raw `BitArray` to the app as a `Binary` event. Ewe follows the same routing contract.
-5. **Notifying on close**: each server adapter calls the shared close path, which releases the connection permit and invokes `transport.socket_disconnected`.
-6. **Rejecting disallowed origins**: when configured, `with_allowed_origins` checks the full `Origin` header before the WebSocket handshake and returns HTTP 403 for missing or non-matching origins.
+1. **Generate a unique socket ID:** The shared server uses
+   `crypto.strong_random_bytes` to create a 16-byte random ID in base16.
+2. **Admit the socket as one operation:** The server captures
+   `transport.runtime_pid` and monitors that PID. It then calls
+   `transport.admit_socket` with the send functions, closer, codec, and
+   `ConnectSeed`. A restart or registration failure closes the connection.
+3. **Route text frames:** The connection process decodes `mist.Text` frames
+   with `transport.active_codec`. It routes them with
+   `transport.route_decoded`.
+4. **Route binary frames:** If the codec provides `decode_binary`, the
+   connection process decodes `mist.Binary` frames. It routes them with
+   `transport.route_decoded_binary`. This keeps normal `Join` and `Message`
+   behavior and binary telemetry classification. Without a binary decoder,
+   `transport.route_binary` sends the raw `BitArray` to the app as `Binary`.
+   Ewe uses the same contract.
+5. **Notify on close:** Each server adapter calls the shared close path. This
+   path releases the connection permit and calls
+   `transport.socket_disconnected`.
+6. **Reject disallowed origins:** When configured, `with_allowed_origins`
+   checks the full `Origin` header before the handshake. It returns HTTP 403
+   for a missing or non-matching origin.
 
 ### Key functions
 

--- a/website/src/content/docs/choosing-an-api.md
+++ b/website/src/content/docs/choosing-an-api.md
@@ -1,21 +1,19 @@
 ---
 title: Choose an API
-description: Channel layer or raw app-side dispatch — a short decision guide for beryl's two programming models.
+description: Compare beryl's channel layer and raw app-side dispatch APIs.
 ---
 
 beryl has one runtime and two ways to program it.
 
-- **The channel layer** (`beryl/channel`) — register a list of channel
-  handlers, one per topic pattern. Each channel keeps private state and a
-  private server-side message type, and the layer routes every event to
-  the channel that owns the topic. **This is the recommended default.**
-- **Raw app-side dispatch** (`beryl`) — one `init`/`update` pair per
-  socket. You match on `socket.Input` values and return ordered effects.
-  This is the core; the channel layer is built on top of it, using nothing
-  but its public API.
+- **The channel layer** (`beryl/channel`): Register one handler for each topic
+  pattern. Each channel keeps private state and a server-side message type. The
+  layer routes each event to the correct channel. **Use this API by default.**
+- **Raw app-side dispatch** (`beryl`): Define one `init` and `update` pair for
+  each socket. Match `socket.Input` values and return ordered effects. The
+  channel layer uses this public core API.
 
-Both lower to the same runtime, wire codec, presence, PubSub, and abuse
-controls. Neither is faster or more capable at the wire level — the
+Both APIs use the same runtime, wire codec, presence, PubSub, and abuse
+controls. They have the same wire-level features and performance. The main
 difference is who writes the router.
 
 ## Pick in one line
@@ -42,42 +40,36 @@ difference is who writes the router.
 | Side effects | Ordered `Action(Active)` lists scoped to the channel's topic | `socket.Effect` values naming any topic |
 | Cleanup | `on_terminate` per channel | `socket.Closed(topic, reason)` in your `update` |
 | Cross-topic effects | External `Sockets` APIs only | Direct, in any effect list |
-| Boilerplate as channels grow | Constant | Grows with the number of topic families |
+| Routing code as channels grow | Handler list stays the same shape | More topic families require more branches |
 
 ## What the layer buys you
 
-Adding a fourth topic family to a raw-dispatch app means widening the
-socket model, widening the message union, and adding branches to the
-router — work that grows linearly with the number of channel types. With
-the channel layer, it means adding one value to a list.
+To add a topic family to raw dispatch, extend the socket model and message
+union. Then add router branches. With the channel layer, add one handler to the
+list.
 
-The layer also gives each channel a *private* state type and a *private*
-server-side message type, so unrelated channels never have to agree on a
-shared `Model` or `Msg`. And because a channel is just a value, a channel
-can be published by a library and used without app-side wiring.
+The layer gives each channel a private state type and server-side message type.
+Unrelated channels do not need a shared `Model` or `Msg`. A library can publish
+a channel value for direct use.
 
 ## What raw dispatch buys you
 
-One `update` sees everything for a socket, so cross-topic behavior is
-ordinary code: an event on one topic can broadcast on another in the same
-effect list, in a guaranteed order. The channel layer gives that up on
-purpose — its actions are always scoped to the channel's own topic, and
-cross-topic publishing has to go through the `Sockets` handle.
+One `update` sees all events for a socket. An event on one topic can broadcast
+on another topic in the same ordered effect list. Channel actions apply only to
+their own topic. Use the `Sockets` handle for cross-topic publishing.
 
 Raw dispatch is the smaller API surface: no handler table and no routing
 rules other than the ones you write.
 
 ## Mixing them
 
-Pick one per socket endpoint. The channel layer owns the socket-level
-model and message type — that is what lets channels keep private state —
-so a channel system is not something you embed inside a hand-written
-`update`. Two different endpoints in one application can use different
-layers, and both can share the same presence, PubSub, and group actors.
+Select one API for each socket endpoint. The channel layer owns the
+socket-level model and message type. This design lets each channel keep private
+state. Do not embed a channel system in a hand-written `update`. Different
+endpoints can use different APIs and share presence, PubSub, and group actors.
 
-Migrating later is a rewrite of your routing code, not of your protocol:
-the wire format, join semantics, presence payloads, and client code are
-identical either way.
+A later migration changes routing code only. Both APIs use the same wire
+format, join rules, presence payloads, and client code.
 
 ## Next steps
 

--- a/website/src/content/docs/examples.mdx
+++ b/website/src/content/docs/examples.mdx
@@ -1,17 +1,16 @@
 ---
 title: Examples
-description: Four runnable beryl demos, including the composed channel showcase.
+description: Four runnable beryl examples, including the channel showcase.
 ---
 
 import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
 
-beryl ships four fully runnable example applications in the
+beryl includes four runnable example applications in the
 [`examples/`](https://github.com/tylerbutler/beryl/tree/main/examples)
-directory. They use a Gleam/BEAM backend with browser frontends that exercise
-different realtime collaboration patterns.
+directory. Each example uses a Gleam/BEAM backend and a browser frontend. The
+examples show different real-time collaboration patterns.
 
-The examples live in the repository, not in the package you install as a
-dependency, so clone it first:
+The installed package does not include the examples. Clone the repository:
 
 ```bash
 git clone https://github.com/tylerbutler/beryl.git
@@ -19,17 +18,17 @@ cd beryl
 ```
 
 <Aside type="note" title="Pre-1.0">
-beryl is pre-1.0: the API can change between minor releases and it isn't production-hardened yet. Build with it and tell us what breaks; that feedback is shaping 1.0.
+beryl is not yet version 1.0. Minor releases can change the API. The library is not ready for production. Try it and report problems. Your feedback will help define version 1.0.
 </Aside>
 
 ## Showcase
 
 **Source**: [`examples/showcase`](https://github.com/tylerbutler/beryl/tree/main/examples/showcase)
 
-One socket runtime and three topic families, composed with `beryl/channel`.
-The cursors, chatrooms, and collab-docs behaviors are each a channel handler
-registered on one supervised socket system — no socket-wide model and no
-hand-written router.
+This example uses one socket runtime and three topic families. The
+`beryl/channel` API combines cursor, chat room, and shared document handlers in
+one supervised socket system. It does not need a socket-wide model or a custom
+router.
 
 ```bash
 cd examples/showcase
@@ -67,8 +66,8 @@ Server (Gleam)
 
 **Source**: [`examples/cursors`](https://github.com/tylerbutler/beryl/tree/main/examples/cursors)
 
-Move your mouse and see everyone else's cursor in real time. Open the app in
-multiple browser tabs to try it.
+Move your mouse to send its position in real time. Open the app in multiple
+browser tabs to see other cursors.
 
 ```bash
 cd examples/cursors
@@ -117,8 +116,7 @@ gleam run
 
 ### What it demonstrates
 
-This demo is designed to complement the cursors example by covering a different
-slice of the beryl API:
+This example uses parts of the beryl API that the cursor example does not use:
 
 | beryl feature | How it's used |
 |---|---|
@@ -163,8 +161,8 @@ Server (Gleam)
 
 **Source**: [`examples/collab_docs`](https://github.com/tylerbutler/beryl/tree/main/examples/collab_docs)
 
-A collaborative document editor where clients merge block state locally with a
-CRDT and use beryl as an unordered realtime transport.
+This shared document editor merges block state in each client with a CRDT. It
+uses beryl as an unordered real-time transport.
 
 ```bash
 just deps

--- a/website/src/content/docs/guides/authentication.md
+++ b/website/src/content/docs/guides/authentication.md
@@ -3,10 +3,10 @@ title: Authentication
 description: Verify real tokens in on_connect, decode claims into your model in init, and authorize joins.
 ---
 
-beryl authenticates a connection **once**, at the transport's `on_connect` hook,
-before any topic join. This guide shows a realistic token flow: read a token
-from the handshake, verify it into typed **claims**, carry those claims in the
-socket's model, and then authorize individual topic joins in `update`.
+beryl authenticates a connection once in the transport `on_connect` hook. This
+happens before any topic join. This guide reads a token from the handshake and
+verifies it into typed **claims**. It stores the claims in the socket model.
+Then `update` uses them to authorize topic joins.
 
 For the mechanics of `with_on_connect` and rejection behavior, see the
 [WebSocket Transport guide](/guides/websocket#authentication). This page focuses
@@ -14,8 +14,8 @@ on wiring *real* auth end to end.
 
 ## 1. Model your claims
 
-Decode the token into a typed record so your app logic never touches raw token
-strings:
+Decode the token into a typed record. Do not use raw token strings in app
+logic:
 
 ```gleam
 pub type Claims {
@@ -23,16 +23,16 @@ pub type Claims {
 }
 ```
 
-The claims live in your per-socket model, so every `Join` and `Message` arm of
-`update` can read them without re-authenticating.
+Store the claims in the per-socket model. Each `Join` and `Message` branch can
+then read them without another authentication check.
 
 ## 2. Read the token from the handshake
 
-Browsers cannot set custom headers on a WebSocket handshake, so the two common
-transports for a token are a **query parameter** (browser clients) or the
-**`Authorization` header** (server-to-server clients). Support whichever you
-need. The same helpers work on the transport request in `on_connect` and on
-the `ConnectSeed` in `init`:
+Browsers cannot set custom headers on a WebSocket handshake. Browser clients
+usually send a token in a **query parameter**. Server clients can use the
+**`Authorization` header**. Support the methods that your clients need. The
+same helpers work with the transport request in `on_connect` and the
+`ConnectSeed` in `init`:
 
 ```gleam
 import beryl/socket
@@ -85,13 +85,13 @@ fn seed_bearer(seed: socket.ConnectSeed) -> Result(String, Nil) {
 
 ## 3. Verify the token in `on_connect`
 
-`verify_token` is where you plug in your token library — for example a call to
-[`gleam_crypto`](https://hexdocs.pm/gleam_crypto/) to check an HMAC signature, or
-a JWT library to validate a signed token issued by your identity provider. It
-must validate the signature and expiry and return typed `Claims`. (The upstream
-sign-in flow that mints these tokens is a separate concern — an OAuth2 library
-such as [`vestibule`](https://vestibule.tylerbutler.com) handles social login
-and hands you an authenticated identity to build the token from.)
+Implement `verify_token` with your token library. For example, use
+[`gleam_crypto`](https://hexdocs.pm/gleam_crypto/) to check an HMAC signature.
+You can also use a JWT library for signed identity-provider tokens. The
+function must validate the signature and expiry and return typed `Claims`.
+Token creation is a separate process. An OAuth2 library such as
+[`vestibule`](https://vestibule.tylerbutler.com) can provide an authenticated
+identity for token creation.
 
 ```gleam
 import beryl_mist as mist_transport
@@ -115,14 +115,14 @@ let ws_config =
   })
 ```
 
-Returning `Error(server.ConnectRejected)` sends HTTP 403 before the
-upgrade, so an unauthenticated client never reaches your app.
+Return `Error(server.ConnectRejected)` to send HTTP 403 before the upgrade.
+The app does not receive an unauthenticated connection.
 
 ## 4. Decode claims into the model in `init`
 
-`on_connect` gates the connection; `init` builds the socket's state. The same
-request data arrives in `init` as `ConnectInfo.seed`, so decode the (already
-gate-checked) token into claims there and carry them in the model:
+`on_connect` accepts or rejects the connection. `init` builds the socket state.
+The same request data reaches `init` as `ConnectInfo.seed`. Decode the verified
+token into claims and store them in the model:
 
 ```gleam
 pub type Model {
@@ -147,15 +147,14 @@ beryl.child_spec(
 )
 ```
 
-`verify_token` is a pure check, so running it in both places is cheap; the
-`Anonymous` arm exists only for defense in depth (it is unreachable when
-`on_connect` gates correctly, and every join under it rejects).
+`verify_token` is a pure check, so this example calls it in both places. The
+`Anonymous` branch provides a second check. Correct `on_connect` logic makes
+that branch unreachable, and it rejects all joins.
 
 ## 5. Authorize the topic at join
 
-Because the claims are already in the model, `update` authenticates for free
-and only needs to decide **authorization** — is this user allowed on *this*
-topic?
+The model already contains the claims. `update` only decides whether the user
+can join the topic:
 
 ```gleam
 fn update(model: Model, ev: socket.Input(Msg)) -> socket.Next(Model) {
@@ -192,15 +191,15 @@ fn forbidden() -> json.Json {
 
 ## With the channel layer
 
-Transport authentication is unchanged: `with_on_connect` still validates the
-handshake once before upgrade. A channel system has no app-level `init`, so
-each handler receives the same request-derived `ConnectSeed` as
-`channel.JoinContext.seed` inside its `join` callback. Decode the already-verified
-identity from `seed.query` or `seed.headers`, apply topic authorization, and
-store the typed claims as that channel's private state with `channel.accept`.
+Transport authentication is the same for the channel layer.
+`with_on_connect` validates the handshake before the upgrade. A channel system
+has no app-level `init`. Each handler receives the request `ConnectSeed` as
+`channel.JoinContext.seed`. Decode the verified identity from `seed.query` or
+`seed.headers`. Apply topic authorization and store the typed claims with
+`channel.accept`.
 
-Keep expensive signature and expiry checks in `with_on_connect`; the per-join
-callback should only decode request data and apply cheap authorization rules.
+Put signature and expiry checks in `with_on_connect`. In each join callback,
+only decode request data and apply authorization rules.
 See [JoinContext and the typed sender](/guides/channels/#joincontext-and-the-typed-sender).
 
 ## Notes

--- a/website/src/content/docs/guides/backend-integration.md
+++ b/website/src/content/docs/guides/backend-integration.md
@@ -3,14 +3,16 @@ title: Backend Integration
 description: Use Beryl alongside an existing backend that owns auth and persistence and publishes over an internal endpoint.
 ---
 
-Beryl does not have to own your whole application. A common setup keeps an existing backend — Phoenix, Rails, or another Gleam service — as the source of truth for **authentication and persistence**, and uses Beryl purely as the realtime fan-out layer.
+Beryl does not need to manage your full application. An existing Phoenix,
+Rails, or Gleam backend can manage **authentication and persistence**. Beryl can
+provide only real-time fan-out.
 
-This guide wires up that split:
+This guide uses this design:
 
-1. the existing backend authenticates users and issues a token,
-2. Beryl verifies that token at connect time,
-3. when domain data changes, the backend calls an internal publish endpoint,
-4. that endpoint forwards the change with `beryl.broadcast`.
+1. The backend authenticates users and issues a token.
+2. Beryl verifies the token when the socket connects.
+3. The backend calls an internal publish endpoint when domain data changes.
+4. The endpoint sends the change with `beryl.broadcast`.
 
 ```text
 Browser ──WebSocket──► beryl ◄──HTTP POST /internal/publish── Backend
@@ -18,13 +20,14 @@ Browser ──WebSocket──► beryl ◄──HTTP POST /internal/publish─�
                          └── broadcasts to topic subscribers     └── owns auth + DB
 ```
 
-The `beryl.Sockets` handle in this guide can come from either layer —
-`beryl.child_spec` and `channel.child_spec` return the same handle
-type, and `beryl.broadcast` behaves identically for both.
+Either API can provide the `beryl.Sockets` handle.
+`beryl.child_spec` and `channel.child_spec` return the same handle type.
+`beryl.broadcast` works the same with both APIs.
 
 ## The internal publish endpoint
 
-Run the endpoint on the same Mist listener as the WebSocket transport. Guard it with a shared secret so only your backend can publish.
+Run the endpoint on the Mist listener that serves the WebSocket transport.
+Protect it with a shared secret. Only the backend must be able to publish.
 
 ```gleam
 import beryl
@@ -121,7 +124,8 @@ fn authorized_internal(req: Request(mist.Connection)) -> Bool {
 }
 ```
 
-Keep this endpoint on a private network or behind trusted ingress. Browsers should never be able to hit it directly.
+Keep this endpoint on a private network or behind trusted ingress. Do not let
+browsers access it.
 
 ## Response helpers
 
@@ -148,14 +152,19 @@ fn not_found() -> Response(mist.ResponseData) {
 
 ## Socket-local integrations
 
-`beryl.broadcast` is the right tool when the backend wants to fan out JSON payloads by topic.
+Use `beryl.broadcast` when the backend sends JSON payloads by topic.
 
-If you instead need a long-lived domain actor to stream typed updates into one socket, pair the socket's `socket.Sender(msg)` with `beryl/bridge` and forward that actor's subject into `socket.Info(msg)`.
+For typed updates from a long-lived domain actor, use the socket's
+`socket.Sender(msg)` with `beryl/bridge`. The bridge forwards the actor's
+subject to `socket.Info(msg)`.
 
 ## Why this split works
 
-- **One source of truth.** Your backend keeps owning auth and the database; Beryl relays updates to connected clients.
-- **Push from anywhere.** Any trusted backend process can publish — an HTTP handler, a worker, or a webhook consumer.
-- **Distributed fan-out.** When Beryl is configured with PubSub, one `beryl.broadcast` reaches subscribers across the cluster.
+- **One source of truth:** Your backend manages authentication and the
+  database. Beryl sends updates to connected clients.
+- **Publish from trusted processes:** An HTTP handler, worker, or webhook
+  consumer can publish.
+- **Distributed fan-out:** With PubSub, one `beryl.broadcast` reaches
+  subscribers across the cluster.
 
 For connect-time verification of the tokens your backend issues, see [Authentication](/guides/authentication/).

--- a/website/src/content/docs/guides/channels.md
+++ b/website/src/content/docs/guides/channels.md
@@ -1,30 +1,29 @@
 ---
 title: Channels
-description: The beryl/channel layer — handler tables, per-channel private state, typed senders, ordered actions, and lifecycle from join to termination.
+description: Use beryl/channel handlers, private state, typed senders, ordered actions, and lifecycle callbacks.
 ---
 
 `beryl/channel` is the **recommended default** for applications that serve
-more than one topic namespace on a socket, and for anyone porting a
-Phoenix-shaped design. You register a list of channel handlers, and the
-layer routes every join, message, binary frame, typed server-side message,
-and close to the channel that owns the topic.
+more than one topic namespace on a socket. It is also the default for a Phoenix
+style design. Register a list of channel handlers. The layer routes each join,
+message, binary frame, server message, and close to the correct channel.
 
 If you are not sure which layer you want, read
 [Choose an API](/choosing-an-api/) first. If you want one topic family and
 complete control over routing, use [App-Side Dispatch](/guides/dispatch/)
-instead — it is the core the channel layer is built on.
+instead. It is the core API under the channel layer.
 
 :::note[One package]
-The channel layer is the `beryl/channel` module in the `beryl` package.
-Applications add only `beryl` plus a transport. See
+The `beryl` package includes the `beryl/channel` module. Applications need
+`beryl` and one transport. See
 [Installation](/installation/) for the dependency block.
 :::
 
 ## The shape
 
 A channel is a **topic pattern** plus a typed `join` callback. The `join`
-callback receives one context value and answers with a rejection or an
-accepted private state and callback set.
+callback receives one context value. It rejects the join or accepts it with
+private state and callbacks.
 
 ```gleam
 // src/my_app/room_channel.gleam
@@ -80,16 +79,17 @@ fn callbacks() -> channel.Callbacks(State, Note) {
 }
 ```
 
-Nothing about `State` or `Note` escapes: `channel.handler` returns a
-plain `channel.Handler`, not a generic one, so channels that agree on
-nothing compose in a single list.
+`State` and `Note` stay private. `channel.handler` returns a plain
+`channel.Handler`, not a generic value. Thus, unrelated channels can use one
+handler list.
 
 ## Starting a channel system
 
-`channel.child_spec` takes the same `beryl.Config` as
-`beryl.child_spec` — codec, rate limits, presence handle, PubSub, logging —
-plus the handler table. It returns the ordinary `beryl.Sockets` handle and a
-child specification for your application's supervision tree.
+`channel.child_spec` takes the same `beryl.Config` as `beryl.child_spec`. The
+config contains the codec, rate limits, presence handle, PubSub, and logging.
+`channel.child_spec` also takes the handler table. It returns a
+`beryl.Sockets` handle and a child specification for the application
+supervision tree.
 
 ```gleam
 // src/my_app.gleam
@@ -146,14 +146,14 @@ fn handle_http(
 }
 ```
 
-`handle_http` is the plain HTTP fallback: `mist_transport.handler` routes
-WebSocket upgrades on the configured path into beryl and hands every other
-request to it. The [Quick Start](/quick-start/#2-start-the-channel-system-and-wire-the-transport)
-serves real pages from the same function.
+`handle_http` is the HTTP fallback. `mist_transport.handler` routes WebSocket
+upgrades on the configured path to beryl. It sends all other requests to
+`handle_http`. The
+[Quick Start](/quick-start/#2-start-the-channel-system-and-wire-the-transport)
+shows how to serve pages from this function.
 
-Everything downstream of `child_spec` is unchanged from raw dispatch: the same
-runtime, the same wire codec, the same presence and abuse controls, the
-same transports. The layer only supplies the `init`/`update` pair.
+Both APIs use the same runtime, wire codec, presence, abuse controls, and
+transports. The channel layer supplies only the `init` and `update` pair.
 
 `child_spec` reports eager validation failures as
 `channel.ChildSpecError`:
@@ -166,9 +166,9 @@ same transports. The layer only supplies the `init`/`update` pair.
 
 ## Handler patterns and precedence
 
-Patterns use beryl's topic pattern syntax — `"room:lobby"`, `"room:*"`,
-`"document:*:ops"`, `"*"` — and are matched in **registration order**.
-The first pattern that matches a topic owns it.
+Patterns use beryl topic syntax, such as `"room:lobby"`, `"room:*"`,
+`"document:*:ops"`, and `"*"`. The layer checks patterns in
+**registration order**. The first match owns the topic.
 
 A bigger `handlers()` returns one entry per channel module:
 
@@ -182,14 +182,12 @@ A bigger `handlers()` returns one entry per channel module:
 ]
 ```
 
-Overlapping patterns are allowed and useful — `"room:lobby"` ahead of
-`"room:*"` is the normal way to give one topic its own channel — but more
-specific patterns must come first: a `"room:*"` registered ahead of
-`"room:lobby"` would make the lobby channel unreachable, a routing mistake
-the layer cannot detect for you. Two handlers with the same pattern string
-are rejected, since the second could never receive a join, and a join for a
-topic no handler matches is refused explicitly with
-`{"reason": "unmatched topic"}` rather than left unanswered.
+Patterns can overlap. Put `"room:lobby"` before `"room:*"` to give the lobby a
+separate channel. Put specific patterns first. If `"room:*"` comes first, the
+lobby handler cannot receive a join. The layer cannot detect this routing
+error. It rejects duplicate pattern strings because the second handler cannot
+receive a join. It also rejects unmatched topics with
+`{"reason": "unmatched topic"}`.
 
 `InvalidPattern` carries the core
 [`topic.TopicError`](/reference/api/beryl-topic/) itself rather than a
@@ -206,10 +204,9 @@ The same rule applies to
 `beryl.InvalidTopicPattern(pattern, reason)`, which nests the identical
 `topic.TopicError`.
 
-Validation is deterministic and two-phase: every pattern's syntax is
-checked in registration order first, then duplicate pattern strings are
-looked for in registration order. `child_spec` performs this check before
-building the supervised subtree.
+Validation has two phases. First, `child_spec` checks pattern syntax in
+registration order. Then it checks for duplicate strings in the same order. It
+does this before it builds the supervised subtree.
 
 ## Typed state instead of assigns
 
@@ -229,11 +226,10 @@ channel.accept(
 )
 ```
 
-`channel.accept` binds the state to the callbacks by capturing it in
-closures. Each `channel.next` result rebuilds the same closures over the
-next state. No value is ever erased to `Dynamic`, and no
-unchecked coercion is involved — which is why a `List(Handler)` can hold
-channels whose states have nothing in common.
+`channel.accept` captures the state in the callback closures. Each
+`channel.next` result rebuilds the closures with the next state. The layer does
+not erase the state to `Dynamic` or use unchecked coercion. Therefore, one
+`List(Handler)` can contain channels with unrelated state types.
 
 The layer keeps **one instance per joined topic**. A socket joined to
 `room:general` and `room:random` has two independent `State` values, and
@@ -253,12 +249,10 @@ The `join` callback receives a `channel.JoinContext(info)`:
 | `params` | `List(String)` | Wildcard captures in pattern order; exact patterns receive `[]` |
 | `payload` | `Dynamic` | Raw client join payload |
 
-`JoinContext` is a per-join view built by the layer, not beryl's core
-`socket.ConnectInfo`. The layer owns the socket-level model and the
-socket-level message type — that is what lets channels keep private state
-and private message types — so it hands each join the connection facts it
-needs plus a sender scoped to *this* join, rather
-than the core connect record.
+The layer builds one `JoinContext` for each join. It is not the core
+`socket.ConnectInfo`. The layer owns the socket model and message type. This
+lets channels keep private state and private message types. Each join receives
+the required connection data and a sender for that join.
 
 `channel.notify(sender, message)` delivers `message` to that channel's
 `on_info` callback with its type intact:
@@ -272,50 +266,44 @@ pub type Note {
 channel.notify(sender, Tick(1))
 ```
 
-The mechanism is cast-free. `notify` seals the typed value inside a
-closure and hands the layer an **envelope** stamped with this join's topic
-and generation — a counter the layer advances on every join attempt and
-never reuses. The envelope carries no readable payload; the router
-compares its stamp against the live instance and only then lets the
-owning join open it, in the same turn it is delivered. Nothing typed is
-ever parked in a shared mailbox between turns, and nothing is coerced on
-the way through.
+This mechanism does not use casts. `notify` seals the typed value in a closure.
+It creates an **envelope** with the join topic and generation. The layer
+increments the generation for each join attempt and does not reuse it. The
+envelope has no readable payload. The router compares the envelope with the
+live instance. Only the owning join can open it, during the delivery turn. The
+shared mailbox does not store the typed value between turns.
 
-Cast-free is not cost-free. Opening the envelope is a selective receive
-on the socket's runtime actor mailbox, performed in the same turn, so one
-delivery costs O(mailbox depth). At ordinary depths that is noise; on a
-socket running a deep backlog it is the thing to know before making
-`notify` a high-rate data path. See
+Opening the envelope uses a selective receive on the runtime actor mailbox.
+This occurs in the same turn, so one delivery costs O(mailbox depth). The cost
+is small for a short mailbox. A deep backlog makes `notify` unsuitable for a
+high-rate data path. See
 [Limitations](#limitations).
 
 ### Stale senders
 
-A sender is scoped to the join that produced it. Sending is asynchronous
-and never fails, so it cannot report that the channel is gone — liveness
-is decided where the message is delivered:
+A sender applies only to the join that produced it. Sending is asynchronous
+and does not report failure. The receiver determines whether the channel is
+live:
 
-- If the channel has **closed** normally — a client leave, a `close([])`
-  result, a socket teardown — the envelope is dropped, still sealed.
+- If the channel has **closed** after a client leave, `close([])`, or socket
+  teardown, the layer drops the sealed envelope.
 - If the same topic has since been **joined again**, the envelope's
   generation no longer matches the live instance, so it is dropped rather
   than handed to the new join.
 - A live match delivers exactly one `on_info` call. Sends are never
   coalesced, and they arrive in the order the owning socket receives them.
 
-So a sender kept by a long-lived process is always safe to use: it never
-reaches a *different* join, and the ordinary worst case is that the
-message goes nowhere.
+A long-lived process can keep a sender. It cannot send a message to a different
+join. If the target join is gone, the message is dropped.
 
-There is one exception, and it is the only one: a **panic inside
-`on_terminate`**. Core's policy for a crash while closing a topic is to
-log it and keep the model from before the close — which is the model that
-still lists that instance. The instance therefore outlives its own
-termination, and its own sender keeps delivering `on_info` to it until
-the topic is joined again or the socket ends. See
+A **panic inside `on_terminate`** is an exception. For a crash during topic
+close, the core logs the crash and keeps the model from before the close. That
+model still contains the channel instance. Its sender can deliver `on_info`
+until the topic joins again or the socket ends. See
 [Crash behavior](#crash-behavior).
 
-Use `notify` to schedule a **later** turn — including from another
-process. Work that has to be part of the join itself belongs in
+Use `notify` to schedule a **later** turn, including from another process. Put
+work that must occur during the join in
 [join actions](#join-actions).
 
 ## Action builders
@@ -344,10 +332,10 @@ warning, exactly as the equivalent core effects are.
 
 ### Order is wire order
 
-Channel actions are applied strictly in the order they were added. They lower
-one-to-one onto core `socket.Effect` values, which the runtime applies in
-list order. An asynchronous presence effect can park this socket while other
-sockets continue; the remaining actions resume only after it completes.
+The runtime applies channel actions in list order. Each action maps to one core
+`socket.Effect`. An asynchronous presence effect can pause this socket while
+other sockets continue. The remaining actions resume after the effect
+completes.
 
 The `encode` callbacks of `push_presence` and `broadcast_presence` run
 **when the action is applied**, so a snapshot already reflects any
@@ -388,9 +376,9 @@ Two consequences worth designing around:
 `with_actions` appends, so it composes with itself, and it returns
 `channel.reject` results unchanged: a refused join has no topic to act on.
 
-This is what to reach for instead of notifying yourself from `join`.
-`notify` schedules a later input; actions preserve their declared position
-immediately after the join acknowledgment.
+Use join actions instead of sending `notify` to the same channel from `join`.
+`notify` schedules a later input. Join actions stay directly after the join
+acknowledgment.
 
 ## Handling input
 
@@ -443,10 +431,10 @@ but each channel still runs its `on_terminate`.
 
 ## Termination
 
-`on_terminate` runs **exactly once per accepted join**, on every exit
-path: a client `phx_leave`, a `close([])` result, `stop_socket`, a socket
-disconnect, a heartbeat timeout, and `beryl.stop`. A join that was
-*rejected* never started an instance, so it never terminates.
+`on_terminate` runs once for each accepted join. It runs after `phx_leave`,
+`close([])`, `stop_socket`, socket disconnect, heartbeat timeout, and
+`beryl.stop`. A rejected join does not create an instance, so it does not run
+`on_terminate`.
 
 The actions it returns are lowered inside the turn that closes the topic,
 right after the instance has been removed. Closing-phase lists can contain
@@ -467,11 +455,10 @@ channel.on_terminate(fn(state: State, _reason) {
 })
 ```
 
-Ordering the explicit `presence_untrack` *before* the
-`broadcast_presence` is what makes the roster correct: the snapshot is
-encoded when the action is applied, after the untrack, so it cannot be
-stale. Presence entries are auto-untracked when the topic closes anyway, but the
-automatic untrack runs after `Closed`, not before your actions.
+Put `presence_untrack` before `broadcast_presence`. The runtime encodes the
+snapshot after it applies the untrack, so the roster is current. The runtime
+also removes presence entries when the topic closes. That removal occurs after
+`Closed`, not before your actions.
 
 ## Lifecycle at a glance
 
@@ -497,9 +484,8 @@ sequenceDiagram
 
 ## Crash behavior
 
-App code that panics never takes the runtime down. The core's crash
-policy is attributed by *where* the panic happened, and the layer does not
-blunt it:
+An app panic does not stop the runtime. The core limits the effect based on
+where the panic occurred:
 
 | Panic in | Effect |
 |---|---|
@@ -508,23 +494,19 @@ blunt it:
 | `on_info` | The whole socket is torn down |
 | `on_terminate` | Teardown still completes, and sibling channels still run their own termination actions |
 
-A panic inside `on_terminate` discards that channel's own `Closed` turn,
-so its termination actions are lost — and so is the model update that
-removed its instance from the layer's map. The instance is retained at
-its original generation. Core cannot reach it: the topic is closed, so no
-client message, binary frame, or second `Closed` can name it. But
-`on_info` is socket-scoped rather than topic-scoped, so a `Sender` created
-by that join still resolves to the retained instance and still delivers to
-it — until the topic is joined again (a rejoin overwrites the entry) or
-the socket ends.
+A panic inside `on_terminate` discards the channel's `Closed` turn. The
+termination actions and model update are lost. The instance stays at its
+original generation. The core cannot reach it through the closed topic.
+Client messages, binary frames, and another `Closed` cannot name it. However,
+`on_info` applies to the socket, not the topic. A `Sender` from that join can
+still deliver to the retained instance. A rejoin replaces the entry, and
+socket shutdown removes it.
 
-That is a deliberate trade, not an oversight. Undoing it is exactly the
-model update the panic threw away, and the alternatives — rescuing the
-callback inside the layer, or moving termination onto a second turn — hide
-a crash core is responsible for logging, or make a terminate panic
-socket-fatal. `crash_test` pins the behavior so it cannot drift quietly.
-Keep `on_terminate` free of code that can panic and the ordinary rule
-holds: a closed channel is gone, and its senders reach nothing.
+The panic discards the model update that would remove the instance. Catching
+the callback in the layer would hide a crash that the core must log. Moving
+termination to another turn would make a termination panic close the socket.
+`crash_test` fixes this behavior. Keep code that can panic out of
+`on_terminate`. Then a closed channel is removed and its senders reach nothing.
 
 Crash isolation stops at the socket, as it does with raw dispatch: a
 panic in `on_info` ends one socket, not the runtime. A crash of the
@@ -564,10 +546,10 @@ It reports the same eager validation failures as
 `channel.ChildSpecError` — see the table in
 [Starting a channel system](#starting-a-channel-system).
 
-The subtree, restart policy, and `beryl.stop` semantics are the core's,
-unchanged — see the [Supervision guide](/guides/supervision/). PubSub,
-presence, and group actors are still yours to start and supervise; pass
-their handles into `beryl.Config` as usual.
+The channel layer uses the core subtree, restart policy, and `beryl.stop`
+behavior. See the [Supervision guide](/guides/supervision/). The application
+must start and supervise PubSub, presence, and group actors. Pass their handles
+to `beryl.Config`.
 
 After a runtime crash the handle keeps working for new connections, but
 every live channel instance is gone: clients reconnect and rejoin, and
@@ -590,8 +572,7 @@ remaining old import or qualified error name.
 
 ## Limitations
 
-The layer is deliberately scoped to *one topic at a time*. These are the
-edges to know before you design around it:
+The layer handles one topic at a time. Note these limits:
 
 - **Each action is topic-scoped.** A `room:general` channel cannot broadcast
   on `lobby`. Cross-topic publishing goes through the external `Sockets`

--- a/website/src/content/docs/guides/coming-from-phoenix.md
+++ b/website/src/content/docs/guides/coming-from-phoenix.md
@@ -1,48 +1,45 @@
 ---
 title: Coming from Phoenix
-description: Map Phoenix Channels concepts — channel modules, join/handle_in/handle_info, assigns, Presence — onto beryl's channel layer and its dispatch core.
+description: Compare Phoenix Channels modules, callbacks, assigns, and Presence with both beryl APIs.
 ---
 
 beryl speaks the same wire protocol as Phoenix Channels (`phx_join`, refs,
 heartbeats, `presence_state`/`presence_diff`), so Phoenix client libraries
-work unchanged. The server-side programming model is different, and this page
-maps one onto the other.
+work without changes. The server programming model is different. This page
+compares the two systems.
 
 beryl gives you two layers, and Phoenix maps onto both:
 
-- **`beryl/channel`, the channel layer** — the close analogue, and the
-  recommended default for a Phoenix-shaped app. You register a handler per
-  topic pattern, and each channel gets colocated callbacks plus its own
-  private state.
-- **`beryl`, raw app-side dispatch** — the core underneath. One `init`/`update`
-  pair per socket; you own the router.
+- **`beryl/channel`, the channel layer:** This is the closest match and the
+  recommended default for a Phoenix style app. Register one handler for each
+  topic pattern. Each channel has callbacks and private state.
+- **`beryl`, raw app-side dispatch:** This is the core API. Define one `init`
+  and `update` pair for each socket. Your code owns the router.
 
-[Choose an API](/choosing-an-api/) has the decision in one table. Everything
-below the programming model works the way you expect from Phoenix:
-colon-delimited topics with wildcard patterns, CRDT-backed presence, pg-backed
-PubSub, heartbeats, and the JSON array wire format.
+[Choose an API](/choosing-an-api/) compares both APIs. Both support
+colon-delimited topics, wildcard patterns, CRDT presence, `pg` PubSub,
+heartbeats, and the Phoenix JSON array format.
 
 ## The core difference: processes and state
 
-In Phoenix, the framework owns the router *and* the process tree. You declare a
-routing table in your socket module (`channel "room:*", RoomChannel`), Phoenix
-spawns **one channel process per joined topic**, and it calls your callbacks
-(`join`, `handle_in`, `handle_info`, `terminate`) with per-channel state in
-`socket.assigns` — a map of atoms to untyped terms.
+In Phoenix, the framework owns the router and process tree. You define a
+routing table in the socket module, such as
+`channel "room:*", RoomChannel`. Phoenix starts **one channel process for each
+joined topic**. It calls `join`, `handle_in`, `handle_info`, and `terminate`.
+Each callback receives channel state in `socket.assigns`, which is a map of
+atoms to untyped terms.
 
-beryl keeps the routing table idea and drops the process-per-topic idea. With
-the channel layer you declare handlers and get colocated callbacks with
-per-topic state, but every channel on a socket runs sequentially inside that
-socket's runtime actor, and its state is a **value of your own type**, not an
-assigns map. With raw dispatch there is no routing table at all: every event
-for a socket arrives at one `update` as a `socket.Input(msg)` value, and
-per-socket state lives in one `model`.
+beryl keeps the routing table but does not start one process for each topic.
+With the channel layer, define handlers, callbacks, and per-topic state. All
+channels on one socket run in sequence in the runtime actor. Each channel state
+is a **value of your type**, not an assigns map. Raw dispatch has no routing
+table. One `update` receives each socket event as `socket.Input(msg)`. One
+`model` stores the per-socket state.
 
-Two practical consequences either way:
+Both APIs have these effects:
 
-- **Long or blocking work belongs in your own process.** A slow callback holds
-  up the socket. Hand results back with `channel.notify` (layer) or
-  `socket.notify` (core).
+- **Run long or blocking work in another process.** A slow callback delays the
+  socket. Return results with `channel.notify` or `socket.notify`.
 - **Crash scope depends on the callback.** A join panic rejects that join;
   message/binary panics close that topic; an `on_info` panic ends the socket;
   and a terminate panic loses that callback's actions while core teardown
@@ -215,17 +212,17 @@ fn update(model: Model, ev: socket.Input(Msg)) -> socket.Next(Model) {
 }
 ```
 
-Three shifts to notice, common to both layers:
+Both beryl APIs differ from Phoenix in these ways:
 
 - **Side effects are values.** Phoenix callbacks call `push` and
-  `broadcast_from!` imperatively; a beryl callback returns a list, and the
-  runtime applies it strictly in order after the turn ends. List order is wire
-  order, so an acknowledgment followed by a push guarantees the client sees
-  them in that order.
-- **Join acks are explicit and fail closed.** Phoenix infers the ack from
-  `join/3`'s return value. In beryl you answer with `accept`/`reject` (layer)
-  or `AcceptJoin`/`RejectJoin` (core); a join left unanswered is rejected
-  automatically, and with the layer a topic no handler claims is refused with
+  `broadcast_from!`. A beryl callback returns a list. The runtime applies the
+  list in order after the turn. List order is wire order, so an acknowledgment
+  before a push reaches the client first.
+- **Join acknowledgments are explicit and fail closed.** Phoenix infers the
+  acknowledgment from the `join/3` return value. In beryl, return
+  `accept` or `reject` from the channel layer. In raw dispatch, return
+  `AcceptJoin` or `RejectJoin`. The runtime rejects an unanswered join. The
+  channel layer rejects an unmatched topic with
   `{"reason": "unmatched topic"}`.
 - **Server-side messages are typed.** Phoenix's `handle_info` receives any
   term. The channel layer's `on_info` receives *this channel's* own `info`
@@ -266,8 +263,8 @@ end
 ```
 
 You do not need the self-send. `channel.with_actions` attaches actions to the
-accepted join; they are applied strictly after the acknowledgment, so the
-socket is already subscribed:
+accepted join. The runtime applies them after the acknowledgment, when the
+socket has joined the topic:
 
 ```gleam
 channel.accept(state, callbacks())
@@ -309,9 +306,10 @@ replication.
 
 ## Broadcasting from outside a socket
 
-Where you would call `MyAppWeb.Endpoint.broadcast("room:lobby", "notice", %{})`
-from a controller or background job, call `beryl.broadcast` with the `Sockets`
-handle returned by `channel.child_spec` or `beryl.child_spec`:
+From a controller or background job, Phoenix uses
+`MyAppWeb.Endpoint.broadcast("room:lobby", "notice", %{})`. In beryl, call
+`beryl.broadcast` with the `Sockets` handle from `channel.child_spec` or
+`beryl.child_spec`:
 
 ```gleam
 beryl.broadcast(sockets, "room:lobby", "notice", json.object([]))

--- a/website/src/content/docs/guides/dispatch.md
+++ b/website/src/content/docs/guides/dispatch.md
@@ -3,13 +3,15 @@ title: App-Side Dispatch
 description: Route joins, messages, binary frames, close events, and typed server messages in one update function.
 ---
 
-Raw **app-side dispatch** is beryl's core programming model: build one
-supervised runtime with `beryl.child_spec`, build a per-socket model in
-`init`, and route every socket event in one `update` function. For
-multi-channel or Phoenix-shaped apps, the recommended
-[`beryl/channel` layer](/guides/channels/) supplies this router for you.
+Raw **app-side dispatch** is beryl's core programming model. Build one
+supervised runtime with `beryl.child_spec`. Build a per-socket model in `init`.
+Route each socket event in one `update` function. For multi-channel or
+Phoenix-style apps, use the recommended
+[`beryl/channel` layer](/guides/channels/).
 
-There is no registry to populate and no per-topic module lifecycle to wire up. Your application owns routing by matching on `socket.Input` values and returning `socket.Next(model, effects)`.
+Your application routes `socket.Input` values and returns
+`socket.Next(model, effects)`. You do not need a registry or a per-topic module
+lifecycle.
 
 ## The app entry point
 
@@ -46,7 +48,8 @@ let assert Ok(_root) =
 
 ## Topics and patterns
 
-Topics are still colon-delimited strings, and `beryl/topic` is still the routing helper to reach for inside `update`.
+Topics are colon-delimited strings. Use `beryl/topic` to route them in
+`update`.
 
 ```gleam
 import beryl/topic
@@ -70,13 +73,15 @@ topic.extract_wildcards(
 // -> Ok(["tenant-a", "doc-42"])
 ```
 
-For one namespace, match directly inside `update`. When several namespaces
-share a socket, use [`beryl/channel`](/guides/channels/) instead — see
+For one namespace, match in `update`. When several namespaces share a socket,
+use [`beryl/channel`](/guides/channels/). See
 [Routing many topics from one app](#routing-many-topics-from-one-app).
 
 ## Single-topic example
 
-This example accepts `room:*` joins, replies to `ping`, broadcasts `typing` to everyone except the sender, tracks joined topics in the model, and reacts to typed server-side `Info` messages.
+This example accepts `room:*` joins and replies to `ping`. It broadcasts
+`typing` to all clients except the sender. The model tracks joined topics. The
+app also handles typed server-side `Info` messages.
 
 ```gleam
 import beryl/socket as socket
@@ -224,7 +229,9 @@ remaining `Match` and `Namespace` types that need direct topic values or
 
 ## Typed server-side messages
 
-`socket.ConnectInfo.self` gives each socket a typed `socket.Sender(msg)`. Any process can keep that sender and deliver `socket.Info(msg)` later with `socket.notify`.
+`socket.ConnectInfo.self` gives each socket a typed `socket.Sender(msg)`. A
+process can keep the sender. It can later call `socket.notify` to deliver
+`socket.Info(msg)`.
 
 ```gleam
 import beryl/socket
@@ -244,7 +251,7 @@ For long-lived external actors that should stream updates into a socket, see `be
 
 ## Effect order is observable order
 
-The runtime applies effects strictly in list order inside one actor turn. That means this is guaranteed:
+The runtime applies effects in list order during one actor turn. Therefore:
 
 ```gleam
 socket.Next(model, [

--- a/website/src/content/docs/guides/error-handling.md
+++ b/website/src/content/docs/guides/error-handling.md
@@ -2,7 +2,8 @@
 title: Error Handling
 ---
 
-This guide covers how beryl surfaces errors to your app and to connected clients, and how to handle them defensively.
+This guide explains how beryl reports errors to your app and clients. It also
+shows how to handle them.
 
 ## Rejected joins
 
@@ -35,14 +36,18 @@ The client sees:
 ["1", "1", "room:lobby", "phx_reply", {"status": "error", "response": {"reason": "unauthorized"}}]
 ```
 
-On rejection the client remains connected but is not subscribed to the topic. If the reject payload carries a `reason` field, Phoenix-style clients surface it directly on the `.join().receive("error", ...)` callback.
+After rejection, the client stays connected but does not join the topic. If the
+payload has a `reason` field, Phoenix clients pass it to the
+`.join().receive("error", ...)` callback.
 
 With `beryl/channel`, return `channel.reject(reason)` from the handler's
 `join` callback. A topic no handler matches is rejected automatically with
 `{"reason": "unmatched topic"}`.
 
 :::note[Unanswered joins fail closed]
-Every `Join` must be answered with `AcceptJoin` or `RejectJoin` in the same update's effects. A join left unanswered is rejected automatically and logged — a forgotten match arm cannot silently admit a client.
+Answer each `Join` with `AcceptJoin` or `RejectJoin` in the same update. The
+runtime rejects and logs an unanswered join. A missing match branch cannot
+admit a client.
 :::
 
 ## Connection-level authentication rejection
@@ -66,7 +71,9 @@ The client never receives a WebSocket handshake and cannot send any messages.
 
 ## Malformed wire messages
 
-beryl parses incoming frames as Phoenix protocol arrays `[join_ref, ref, topic, event, payload]`. Frames that cannot be decoded are dropped silently — no error is sent to the client. This is intentional: malformed frames are treated as protocol violations and do not warrant a reply.
+beryl parses incoming Phoenix protocol arrays:
+`[join_ref, ref, topic, event, payload]`. It drops frames that it cannot decode
+and does not send an error. Malformed frames are protocol violations.
 
 If you need to surface decode errors in your own payload handling, decode the `Dynamic` payload with `gleam/dynamic/decode` and return an explicit `ReplyOk` or `ReplyError`:
 
@@ -89,12 +96,16 @@ socket.Message(_topic, "create_item", payload, option.Some(ref)) ->
 ```
 
 :::note[Refless messages cannot be answered]
-`ReplyOk`/`ReplyError` need the message's `ReplyRef`, which is `Some` only when the client expects a reply. A `Message` whose ref is `None` has nothing to correlate an answer with — the type system makes an unanswerable reply unrepresentable. Use `Push` for server-initiated messages with your own event name.
+`ReplyOk` and `ReplyError` need the message `ReplyRef`. It is `Some` only when
+the client expects a reply. A `Message` with `None` has no request reference.
+Use `Push` for a server message with its own event name.
 :::
 
 ## Unmatched topics
 
-If a client sends `phx_join` for a topic your `update` does not accept, reject it explicitly — typically with a catch-all `Join` arm returning `RejectJoin`. If your `update` simply ignores the join, beryl's fail-closed default rejects it for you.
+If `update` does not accept a `phx_join` topic, reject it with a catch-all
+`Join` branch that returns `RejectJoin`. If `update` ignores the join, beryl's
+fail-closed default rejects it.
 
 Messages pushed to a topic the socket never joined get an automatic error reply with `response: {"reason": "unmatched topic"}` when they carry a ref, matching Phoenix; refless pushes to unjoined topics are dropped.
 
@@ -156,7 +167,9 @@ non-panicking; see [Crash behavior](/guides/channels/#crash-behavior).
 
 ## Rate limiting
 
-When a client exceeds a configured rate limit, the offending frame or message is **dropped**. No error is sent to the client (joins are the exception: an over-rate join gets an error reply with `reason: "rate_limited"`).
+When a client exceeds a rate limit, beryl **drops** the frame or message. It
+does not send an error. An over-rate join is the exception. It receives an
+error reply with `reason: "rate_limited"`.
 
 | Limit | Scope | Enforced | Config function |
 |-------|-------|----------|-----------------|
@@ -180,9 +193,9 @@ let config =
   |> beryl.with_topic_rate(pattern: "cursor:*", per_second: 30, burst: 60)
 ```
 
-`with_topic_rate` overrides the global `channel_rate` for topics matching its
-pattern — use it to give a fast-streaming namespace (like live cursors) more
-headroom than chat. A non-positive `per_second` makes matching topics unlimited,
+`with_topic_rate` overrides the global `channel_rate` for matching topics. Use
+it to give a high-rate namespace, such as live cursors, more capacity than
+chat. A non-positive `per_second` makes matching topics unlimited,
 even when a global channel limit is configured, and allocates no per-topic
 bucket. If you need to inform the client that it has been rate-limited,
 implement application-level tracking in `update` and return an explicit
@@ -234,7 +247,8 @@ a specific variant differently.
 
 ## Sender delivery is best-effort
 
-`socket.notify` delivers a typed message to a socket's `update` as an `Info` event. If the socket has disconnected, the message is **silently dropped** — no error is returned:
+`socket.notify` sends a typed message to socket `update` as an `Info` event. If
+the socket disconnected, beryl drops the message and returns no error:
 
 ```gleam
 // This is always Nil — no error even if the socket is gone
@@ -262,7 +276,8 @@ beryl uses the Phoenix wire protocol. Error responses take these shapes:
 [null, null, "room:lobby", "phx_close", {}]
 ```
 
-Phoenix client libraries handle `phx_error` and `phx_close` automatically — the channel is marked as errored or closed, and the client may attempt to rejoin.
+Phoenix client libraries handle `phx_error` and `phx_close`. The client marks
+the channel as errored or closed and can try to rejoin.
 
 ## See also
 

--- a/website/src/content/docs/guides/groups.md
+++ b/website/src/content/docs/guides/groups.md
@@ -2,10 +2,13 @@
 title: Groups
 ---
 
-Groups are **server-side named collections of topics**. They let you broadcast a single event to many topics at once without tracking subscriptions yourself — similar to Socket.IO rooms or SignalR groups, but adapted to beryl's topic/channel model.
+Groups are **named topic collections on the server**. Use one group broadcast
+to send an event to many topics. You do not need to track subscriptions. Groups
+are similar to Socket.IO rooms and SignalR groups.
 
 :::note[Server-side only]
-Groups are a server concern. Clients join individual topics via `phx_join`; they have no concept of groups. Groups exist purely to make multi-topic server broadcasts convenient.
+Only the server uses groups. Clients join individual topics with `phx_join`.
+Clients do not receive group information.
 :::
 
 ## Starting the groups actor
@@ -21,8 +24,8 @@ let assert Ok(_root) =
   |> static_supervisor.start()
 ```
 
-`group.child_spec()` returns the stable `Groups` handle immediately. Add its
-child specification to your application supervisor before using the handle.
+`group.child_spec()` returns a stable `Groups` handle. Add its child
+specification to the application supervisor before you use the handle.
 
 Synchronous group operations wait up to 5 seconds for the actor by default.
 Configure a different timeout when starting the actor:
@@ -68,7 +71,8 @@ case group.delete(groups, "team:gone") {
 
 ## Adding and removing topics
 
-Topics are plain strings that match existing channel topics. Groups do not validate that a topic has any subscribers — they are just sets of strings.
+Topics are strings that match channel topics. Groups do not check whether a
+topic has subscribers. They store sets of strings.
 
 ```gleam
 let assert Ok(Nil) = group.add(groups, "team:engineering", "room:frontend")
@@ -81,7 +85,7 @@ let assert Ok(Nil) = group.remove(groups, "team:engineering", "room:infra")
 // Both add and remove return Error(GroupNotFound) if the group doesn't exist
 ```
 
-Adding the same topic twice is a no-op (topics are stored in a set).
+Adding the same topic twice does nothing because the group stores a set.
 
 ## Inspecting groups
 
@@ -99,7 +103,10 @@ let names = group.list_groups(groups)  // ["team:engineering", "team:design"]
 
 ## Broadcasting to a group
 
-`group.broadcast` looks up the group's topics through the groups actor, then sends an event to every topic using `beryl.broadcast` in the caller's process. The lookup provides backpressure without making the actor perform fan-out. The return type is `Nil`, not `Result`. If the named group does not exist, the call silently does nothing.
+`group.broadcast` asks the groups actor for the topic set. The calling process
+then sends the event to each topic with `beryl.broadcast`. The lookup provides
+backpressure, but the actor does not perform fan-out. The function returns
+`Nil`, not `Result`. If the group does not exist, the function does nothing.
 
 ```gleam
 group.broadcast(
@@ -111,10 +118,13 @@ group.broadcast(
 )
 ```
 
-This is equivalent to calling `beryl.broadcast` on each topic in the group in sequence.
+This has the same effect as one `beryl.broadcast` call for each group topic.
 
 :::note[Missing group is a no-op]
-`group.broadcast` never returns an error. Broadcasting to a group that does not exist (or has no topics) silently does nothing. Like other group operations, it panics if the groups actor is unavailable or does not reply within 5 seconds. If you need to confirm a group exists before broadcasting, call `group.topics` first and handle `GroupNotFound`.
+`group.broadcast` does not return an error. It does nothing if the group is
+missing or empty. It panics if the groups actor is unavailable or does not
+reply within 5 seconds. To check a group first, call `group.topics` and handle
+`GroupNotFound`.
 :::
 
 ## Error reference
@@ -160,10 +170,10 @@ let assert Ok(Nil) = group.delete(groups, "team:eng")
 
 ## Lifecycle
 
-The groups actor only starts through `group.child_spec`. Its handle is backed by
-a stable registered name and reaches the replacement actor after a supervised
-restart. Group definitions and topic memberships are in-memory state and reset
-when the actor restarts.
+Start the groups actor with `group.child_spec`. Its handle uses a stable
+registered name and reaches the replacement actor after a supervised restart.
+The actor keeps group definitions and topic memberships in memory. A restart
+clears them.
 
 The registered name is node-local. Keep a `Groups` handle on the node where its
 child specification runs. From another BEAM node, synchronous operations cannot

--- a/website/src/content/docs/guides/observability.md
+++ b/website/src/content/docs/guides/observability.md
@@ -3,13 +3,13 @@ title: Observability
 description: Telemetry events, runtime snapshots, and application-owned metrics export.
 ---
 
-Beryl provides two complementary signals:
+Beryl provides two types of data:
 
-- opt-in `:telemetry` events for rates, outcomes, and operation durations;
-- `beryl/stats.snapshot` for point-in-time local runtime state.
+- Optional `:telemetry` events report rates, outcomes, and operation durations.
+- `beryl/stats.snapshot` reports local runtime state at one time.
 
-Beryl deliberately does not depend on a Prometheus or OpenTelemetry exporter.
-Your application owns aggregation, labels, and export.
+Beryl does not include a Prometheus or OpenTelemetry exporter. Your application
+must aggregate, label, and export the data.
 
 ## Enable telemetry
 
@@ -21,12 +21,11 @@ let config =
   |> beryl.with_telemetry
 ```
 
-Attach handlers before traffic begins. Erlang `:telemetry` invokes handlers
-**synchronously in the process emitting the event**. A slow handler therefore
-adds latency to a WebSocket connection process or the shared runtime.
-Perform bounded counter/histogram updates or enqueue a small message and
-return immediately; never make network calls, format logs, or run expensive
-label conversion in the handler.
+Attach handlers before traffic starts. Erlang `:telemetry` calls a handler in
+the process that emits the event. A slow handler adds latency to a WebSocket
+connection process or the shared runtime. Update bounded counters or
+histograms, or enqueue a small message. Do not make network calls, format logs,
+or convert expensive labels in the handler.
 
 Event names and their measurement/metadata keys form Beryl's stable,
 low-cardinality telemetry taxonomy:
@@ -69,8 +68,7 @@ remain bounded:
 | disconnect `reason` | `normal`, `heartbeat_timeout`, `shutdown`, `callback_error` |
 | broadcast `origin` | `local`, `remote` |
 
-Treat unknown future values as an `"unknown"` label rather than crashing a
-handler.
+Map future unknown values to an `"unknown"` label. Do not crash the handler.
 
 ## Export to Prometheus or Grafana
 
@@ -118,11 +116,11 @@ detach(Id) ->
     telemetry:detach(Id).
 ```
 
-The supervised aggregator can translate messages into your existing metrics
-library's API. Monitor its mailbox and use bounded aggregation/backpressure;
-moving work to another process prevents direct request latency but an
-unbounded mailbox merely relocates overload. Detach the handler during
-shutdown. No exporter dependency is required in Beryl itself.
+The supervised aggregator can convert messages for your metrics library.
+Monitor its mailbox and use bounded aggregation or backpressure. Another
+process prevents direct request latency, but an unbounded mailbox can still
+overload the system. Detach the handler during shutdown. Beryl does not need an
+exporter dependency.
 
 Useful derived signals include upgrade rejection rate by outcome, frame decode
 and rate-limit rates, join/message callback failures, connection lifetime,
@@ -153,19 +151,17 @@ case stats.snapshot(channels) {
 }
 ```
 
-The snapshot is local to one socket runtime on one BEAM node; it is not a
-transactional cluster view or an event stream. Aggregate gauges across nodes
-in the monitoring system. `joined_socket_topic_pairs` counts memberships, so
-one socket joined to two topics contributes two. Counts are captured as
-observed by the runtime process servicing the request and may lag in-flight
-connect/disconnect notifications.
+The snapshot describes one socket runtime on one BEAM node. It is not a cluster
+transaction or an event stream. Aggregate gauges across nodes in the monitoring
+system. `joined_socket_topic_pairs` counts memberships. One socket on two
+topics adds two. The runtime records counts when it handles the request, so
+in-flight connection changes can appear later.
 
-Poll no more frequently than roughly once per second. Polling itself sends a
-request through the runtime, and synchronized polling across many
-scrapers can add load. Prefer one application poller per node, cache the latest
-successful snapshot for the scrape endpoint, add jitter, and expose snapshot
-age. Do not turn a timeout into a zero-valued snapshot: it indicates restart
-or overload and should remain distinguishable from an idle system.
+Poll no more than once per second. Each poll sends a request through the
+runtime. Many synchronized scrapers can add load. Use one application poller
+per node. Cache the latest successful snapshot, add jitter, and expose the
+snapshot age. Do not convert a timeout to a zero-valued snapshot. A timeout can
+mean restart or overload, not an idle system.
 
 For a runnable JSON endpoint combining Beryl and BEAM runtime gauges, see the
 benchmark server's [`/stats` reference](https://github.com/tylerbutler/beryl/blob/main/examples/load_test/README.md#health-and-stats)

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -2,11 +2,15 @@
 title: Presence
 ---
 
-beryl includes a presence system for tracking connected users and their metadata. It's backed by the `lattice_presence` CRDT (conflict-free replicated data type), which automatically resolves conflicts across distributed Erlang nodes.
+beryl can track connected users and their metadata. It uses the
+`lattice_presence` conflict-free replicated data type (CRDT). The CRDT resolves
+conflicts across Erlang nodes.
 
 ## How it works
 
-Presence tracking uses an **add-wins observed-remove set** (AWORSet) with causal context. When a user joins or leaves, the state is merged across all nodes without coordination — no leader election or consensus required.
+Presence uses an **add-wins observed-remove set** (AWORSet) with causal context.
+When a user joins or leaves, nodes merge their state without coordination. The
+system does not need a leader or consensus.
 
 The presence system has two layers:
 
@@ -76,13 +80,12 @@ let ref = presence.track(
 )
 ```
 
-The **key** groups multiple connections from the same user. The **session ID**
-uniquely identifies each connection (typically the socket ID).
+The **key** groups connections from one user. The **session ID** identifies one
+connection and is usually the socket ID.
 
 ## Updating metadata
 
-Replace one tracked presence's metadata without briefly removing its key from
-the roster:
+Replace one presence entry's metadata without removing its key from the roster:
 
 ```gleam
 let assert Ok(new_ref) =
@@ -108,11 +111,10 @@ presence.untrack(p, new_ref)
 presence.untrack_all(p, socket_id)
 ```
 
-`track` returns a server-generated ref that identifies exactly the presence it
-created. Hold onto that ref if you need to remove one specific presence later
-with `untrack`. To clear every presence for a disconnecting socket, use
-`untrack_all` with the session ID instead. The string `session_id` identifies
-the logical session; it is not a BEAM process identifier.
+`track` returns a ref for the new presence entry. Keep the ref if you must
+remove that entry with `untrack`. To clear all entries for a disconnected
+socket, call `untrack_all` with the session ID. The `session_id` string
+identifies the logical session, not a BEAM process.
 
 ## Listing presences
 
@@ -154,9 +156,15 @@ must re-track their presence.
 
 ## Diff callbacks
 
-Get notified immediately when presence state changes:
+Use `on_diff` to receive presence changes:
 
-The callback runs synchronously on the presence actor — for both local mutations and remote merges, identically — before the affected topics' read-model snapshots are (re)published and before the triggering call replies. So if the callback reads presence state through the same handle (`list`, `get_by_key`, `count`) for a topic the diff touches, it sees the *previous* snapshot, not the one this diff is about to produce; read what you need from the `Diff` argument itself (`diff_joins`/`diff_leaves`) rather than re-reading through the handle inside the callback. Keep the callback fast: it runs on the actor process, so a slow callback delays that topic's publish, the reply to the mutating call, and anything else queued behind it in the actor's mailbox.
+The presence actor calls the callback for local changes and remote merges. It
+calls the function before it publishes new read-model snapshots and before it
+replies to the source call. If the callback calls `list`, `get_by_key`, or
+`count` for an affected topic, it reads the previous snapshot. Read the change
+from the `Diff` argument with `diff_joins` and `diff_leaves`. Keep the callback
+short. A slow callback delays snapshot publication, the source call reply, and
+later actor messages.
 
 ```gleam
 let config =
@@ -174,11 +182,14 @@ let config =
   })
 ```
 
-The `on_diff` callback fires whenever local tracking changes or remote merges produce non-empty changes, ensuring no diffs are lost during rapid state changes.
+The actor calls `on_diff` after a local change or a remote merge produces a
+non-empty diff. It calls the function for each change, so rapid changes do not
+lose diffs.
 
 ## Broadcasting Phoenix-compatible diffs
 
-Use `beryl.broadcast_presence_diff` to send a `presence_diff` event to sockets subscribed to the changed topic:
+Use `beryl.broadcast_presence_diff` to send a `presence_diff` event to sockets
+on the changed topic:
 
 ```gleam
 import beryl
@@ -219,12 +230,12 @@ For lower-level integrations, `beryl/presence/wire.encode_diff(diff, topic)` ret
 
 ## Cross-node replication
 
-When PubSub is configured, the presence actor:
+When you configure PubSub, the presence actor:
 
-1. Periodically broadcasts its full CRDT state to the `beryl:presence:sync` topic
-2. Receives remote state from other nodes via PubSub
-3. Merges remote state using the AWORSet merge algorithm
-4. Fires `on_diff` for any changes from the merge
+1. Sends its full CRDT state to `beryl:presence:sync` at set intervals.
+2. Receives remote state from other nodes through PubSub.
+3. Merges remote state with the AWORSet merge algorithm.
+4. Calls `on_diff` for changes from the merge.
 
 Self-delivery is prevented by `pubsub.broadcast_from`, so nodes don't process their own sync messages.
 

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -2,11 +2,11 @@
 title: Production Hardening
 ---
 
-Beryl ships with all rate and connection limits **disabled**, because no
-default is right for every deployment. That is fine for development, but a
-production server with no abuse controls can be degraded by a single hostile
-(or buggy) client. Beryl logs a warning at startup when every control is
-off; this guide explains what to turn on and why.
+Beryl disables all rate and connection limits by default. Each deployment
+needs different limits. The defaults are suitable for development. In
+production, one hostile or faulty client can degrade a server with no abuse
+controls. Beryl logs a startup warning when all controls are off. This guide
+explains which controls to configure.
 
 ## What is always on
 
@@ -25,11 +25,11 @@ Even with no configuration, beryl enforces:
 - **Heartbeat eviction**: sockets that stop sending heartbeats are evicted
   and their connections closed (60 s window by default, `with_heartbeat`).
 
-The frame-size check limits downstream decoding and routing work, but it does
-**not** bound transport-layer memory: buffering and reassembly happen before
-Beryl receives the frame. In production, configure a WebSocket frame/message
-size limit at or below Beryl's limit at your reverse proxy or load balancer,
-plus a matching request/body limit for the HTTP upgrade.
+The frame-size check limits decoding and routing work. It does **not** limit
+transport memory because buffering and reassembly occur before Beryl receives
+the frame. In production, set a WebSocket frame or message limit in the reverse
+proxy or load balancer. Set it at or below Beryl's limit. Also set a matching
+HTTP request or body limit for the upgrade.
 
 ## What you should configure for production
 
@@ -55,13 +55,12 @@ let config =
   |> beryl.with_max_connections(max_connections: 10_000)
 ```
 
-`with_frame_rate` and `with_message_rate` are independent. Joins consume frame
-and join quota, but not message quota; leaves and heartbeats consume both frame
-and message quota. Configure both, with frame capacity slightly higher for
-protocol traffic and malformed frames that never reach the runtime. If either
-limiter sheds a heartbeat, the socket's heartbeat deadline is not refreshed.
-Sustained over-rate traffic is therefore terminated by heartbeat eviction
-rather than merely being shed forever.
+`with_frame_rate` and `with_message_rate` are independent. Joins use frame and
+join quota, but not message quota. Leaves and heartbeats use frame and message
+quota. Configure both limits. Give the frame limit more capacity for protocol
+traffic and malformed frames. If a limiter drops a heartbeat, the runtime does
+not refresh the heartbeat deadline. Continued excess traffic then causes
+heartbeat eviction.
 
 Size both rate and burst allowances with enough headroom for legitimate client
 traffic **plus heartbeats**. A limit that admits an application's normal events
@@ -87,11 +86,10 @@ limit; otherwise the transport rejects it with `429` **before** allocating any
 long-lived socket or runtime state. Freed concurrency capacity is reclaimed on
 normal close, transport failure, heartbeat eviction, crash, and setup failure.
 
-The node-wide ceiling exists because a per-IP limit alone cannot stop many
-**distinct** source addresses — a botnet, or a single host rotating through an
-IPv6 range — from each opening a few connections and collectively exhausting
-the node's process, socket, and runtime budget. The global ceiling bounds
-that total regardless of how the connections are spread across IPs.
+A per-IP limit cannot stop many source addresses. A botnet or a host that
+rotates IPv6 addresses can open a few connections from each address. Together,
+these connections can exhaust the node. The node-wide ceiling limits the total
+number of connections across all IP addresses.
 
 Because it is enforced per BEAM node, a load-balanced cluster of N nodes has an
 effective ceiling of roughly `max_connections × N`. Size the per-node value
@@ -100,9 +98,9 @@ connection/rate controls when you need a cluster-wide cap.
 
 ### The per-IP caveat
 
-The connection limit uses the **real TCP peer address** and deliberately
-ignores forwarded headers like `X-Forwarded-For`, which clients can forge.
-Two consequences:
+The connection limit uses the **TCP peer address**. It ignores forwarded
+headers such as `X-Forwarded-For` because clients can forge them. This has two
+effects:
 
 - Behind a reverse proxy or load balancer, every connection appears to come
   from the proxy's IP, so a per-IP cap would throttle all clients together.
@@ -131,15 +129,12 @@ addresses.
 
 ## Erlang cluster security boundary
 
-Beryl's distributed PubSub and presence replication run over Erlang
-distribution. Every connected peer is **fully trusted**: distributed Erlang
-allows peers to execute arbitrary code on connected nodes, so a hostile peer
-means full node compromise that can extend across the cluster. Subscribing to
-beryl topics, receiving broadcasts, injecting trusted internal traffic, and
-reading or corrupting presence state are only a subset of that access. Channel
-authorization callbacks and WebSocket-layer controls do **not** apply to
-messages delivered over distribution — they protect only inbound WebSocket
-clients.
+Beryl PubSub and presence replication use Erlang distribution. Trust every
+connected peer. Erlang peers can run arbitrary code on connected nodes. A
+hostile peer can compromise the full cluster. Topic access, broadcasts,
+internal traffic, and presence state are only part of that access. Channel
+authorization and WebSocket controls do not apply to distribution messages.
+They protect only WebSocket clients.
 
 ### Internal vs. client messages
 
@@ -148,9 +143,8 @@ clients.
 | WebSocket clients | Untrusted | `with_on_connect` authentication, `Join` authorization, and `Message` handling in `update` |
 | Erlang distribution peers | Fully trusted | Network isolation + mutually verified TLS distribution (cookies prevent accidental cross-cluster connections only) |
 
-This is not a beryl-specific deployment prerequisite. Network isolation and
-secure distribution are the baseline for every distributed BEAM application;
-beryl assumes that boundary is already enforced.
+All distributed BEAM applications need network isolation and secure
+distribution. Beryl assumes that you enforce this boundary.
 
 ### Erlang cookie
 
@@ -194,10 +188,9 @@ and your chosen distribution port at the network layer.
 
 ### Do not share clusters with untrusted tenants
 
-Adding a node to an existing cluster grants it arbitrary code execution on
-connected nodes; visibility into all `pg` groups (PubSub topics) and presence
-state is only part of that access. Never connect beryl to a cluster that
-contains nodes owned or operated by parties outside your trust boundary.
+Adding a node to a cluster lets it run arbitrary code on connected nodes. It
+can also access all `pg` groups and presence state. Do not connect beryl to
+nodes outside your trust boundary.
 
 See [SECURITY.md](https://github.com/tylerbutler/beryl/blob/main/SECURITY.md)
 for the full trust-boundary and distribution-hardening reference.

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -2,7 +2,8 @@
 title: PubSub
 ---
 
-beryl's PubSub layer provides distributed publish/subscribe messaging built on Erlang's `pg` (process groups) module.
+beryl's PubSub layer uses Erlang `pg` process groups for distributed publish
+and subscribe messaging.
 
 ## Starting PubSub
 
@@ -16,10 +17,9 @@ let ps = pubsub.start(pubsub.default_config())
 let ps = pubsub.start(pubsub.config_with_scope("my_app_pubsub"))
 ```
 
-The scope maps to a `pg` scope atom and identifies the PubSub instance at
-runtime. Different scopes are completely isolated and can safely use different
-payload types in the same process mailbox. Every handle using the same scope
-must use the same payload type.
+The scope maps to a `pg` scope atom and identifies the PubSub instance.
+Different scopes are isolated and can use different payload types in one
+process mailbox. All handles in one scope must use the same payload type.
 
 :::danger[The scope must be a static, bounded deployment value]
 The scope name is converted to an Erlang atom. Atoms are never
@@ -32,8 +32,8 @@ acceptable only when validated or selected from a fixed bounded set.
 
 ## Subscribing
 
-Create one typed subscriber in the process that owns the mailbox, join any
-topics it needs, and fold PubSub delivery into that process's selector:
+Create one typed subscriber in the process that owns the mailbox. Join the
+required topics. Add PubSub delivery to the process selector:
 
 ```gleam
 let sub = pubsub.subscriber(ps)
@@ -48,10 +48,9 @@ let selector =
 pubsub.leave(sub, "room:lobby")
 ```
 
-PubSub records arrive as raw BEAM messages, so `selecting` is the typed
-validation boundary. It matches the subscriber's scope, allowing one process
-to select subscribers with different payload types as long as their scopes
-differ.
+PubSub records arrive as raw BEAM messages. `selecting` validates their types
+and matches the subscriber scope. One process can select subscribers with
+different payload types if their scopes differ.
 
 ## Messages
 
@@ -81,7 +80,9 @@ interoperate, so upgrade the cluster together when adopting this version.
 Version changes to your own payload type explicitly when rolling upgrades must
 accept old and new nodes concurrently.
 
-`FromSocket` carries both the sending process PID and a socket ID to exclude. Receiving runtimes use this to suppress delivery to the named socket, so that `beryl.broadcast_from` correctly excludes the sender across cluster nodes.
+`FromSocket` contains the sender PID and a socket ID to exclude. Receiving
+runtimes do not send the message to that socket. Thus,
+`beryl.broadcast_from` excludes the sender across cluster nodes.
 
 ## Broadcasting
 
@@ -114,7 +115,9 @@ pubsub.broadcast_from_socket(
 pubsub.local_broadcast(ps, "room:lobby", "new_message", json.string("hello"))
 ```
 
-Use `broadcast_from_socket` when you need to broadcast to all subscribers across a cluster while excluding one specific socket — even if that socket's runtime is on a different node. `beryl.broadcast_from` calls this internally.
+Use `broadcast_from_socket` to send to all cluster subscribers except one
+socket. The socket can be on another node. `beryl.broadcast_from` calls this
+function.
 
 ## Querying subscribers
 
@@ -128,7 +131,9 @@ let count = pubsub.subscriber_count(ps, "room:lobby")
 
 ## Distributed operation
 
-Because PubSub is built on `pg`, it automatically works across connected Erlang nodes. When nodes join a cluster, their process groups are merged and messages are delivered to subscribers on all nodes — no configuration required.
+Erlang `pg` works across connected nodes. When nodes join a cluster, `pg`
+merges their process groups. It then sends messages to subscribers on all
+nodes. PubSub needs no extra cluster configuration.
 
 ## Integration with beryl channels
 

--- a/website/src/content/docs/guides/supervision.md
+++ b/website/src/content/docs/guides/supervision.md
@@ -3,10 +3,10 @@ title: Supervision
 ---
 
 Beryl has no unsupervised mode. `beryl.child_spec` returns a stable `Sockets`
-handle and a child specification that you add to your application's OTP
-supervisor. Your `init`/`update` functions are captured in that specification.
-`channel.child_spec` returns the same handle/spec shape after compiling
-its handler table into the core `init`/`update` pair.
+handle and a child specification. Add the specification to your application's
+OTP supervisor. The specification contains your `init` and `update` functions.
+`channel.child_spec` returns the same handle and specification shape. It first
+converts the handler table to a core `init` and `update` pair.
 
 ## What child_spec supervises
 
@@ -15,14 +15,13 @@ beryl internal supervisor (one-for-one, 3 restarts / 5 seconds)
 `- runtime actor (Transient)
 ```
 
-- The **runtime actor** holds every socket's model and dispatches events to
-  your `update` function. If it crashes, the supervisor restarts it with
-  dispatch intact — the `init`/`update` closures live in the child
-  specification, so no re-registration step exists or is needed.
-- The runtime is registered under a stable name, so the `Sockets` handle
-  (and every transport connection holding it) keeps working across
-  restarts. Sends that race a restart window degrade to quiet no-ops
-  instead of crashes.
+- The **runtime actor** holds each socket model and sends events to your
+  `update` function. If the actor crashes, the supervisor restarts it. The
+  child specification still contains the `init` and `update` closures. You do
+  not need to register them again.
+- The runtime uses a stable registered name. The `Sockets` handle and transport
+  connections keep working after a restart. Sends during the restart window do
+  nothing.
 - The child is `Transient`: a graceful `beryl.stop` is final and is not
   resurrected.
 
@@ -35,9 +34,8 @@ A runtime restart drops **per-socket state**: models, joined topics, and
 pending joins. Transports monitor the runtime that accepted each connection,
 so those WebSockets close and clients reconnect and rejoin normally.
 
-Crashes inside `update` itself do **not** restart the runtime. Beryl
-rescues callback crashes and contains the blast radius to the socket that
-triggered them:
+Crashes inside `update` do **not** restart the runtime. Beryl catches callback
+crashes and limits their effect:
 
 | Crash site | Effect |
 |------------|--------|
@@ -47,13 +45,12 @@ triggered them:
 | `update` on `Info` | The socket is torn down |
 | `update` on `Closed` | Logged; the close completes anyway |
 
-This boundary is intentional: all app callbacks run inside the one runtime
-actor, so a supervisor restart for one callback would discard every socket's
-model and close every connection on that `Sockets` handle. The boundary is
-used only when Beryl can discard the failed callback result and reject or tear
-down the narrowest safe scope. Other runtime faults still escape to the
-supervisor. See [Runtime crash containment](/architecture/runtime/#crash-containment)
-for the design trade-off.
+All app callbacks run in one runtime actor. A supervisor restart for one
+callback would discard all socket models and close all connections on the
+`Sockets` handle. Beryl catches a callback crash only when it can discard the
+result and close the smallest safe scope. Other runtime faults reach the
+supervisor. See
+[Runtime crash containment](/architecture/runtime/#crash-containment).
 
 See the [Error Handling guide](/guides/error-handling/) for details.
 
@@ -97,11 +94,11 @@ pub fn main() {
 }
 ```
 
-Presence is a separate application-owned actor. Drive it from socket code with
-`socket.PresenceTrack` / `PresenceUntrack` effects or the equivalent channel
-actions. The runtime applies those mutations asynchronously and parks only the
-affected socket until completion. Do not call the synchronous public presence
-API directly from `init`, `update`, or a channel callback.
+Presence is a separate actor that the application owns. From socket code, use
+`socket.PresenceTrack` and `PresenceUntrack` effects or the channel actions.
+The runtime pauses only the affected socket until the mutation completes. Do
+not call the synchronous public presence API from `init`, `update`, or a
+channel callback.
 
 Both handles are name-backed and reach the replacement actor after a supervised
 restart. Presence entries and tracking refs, and group definitions and
@@ -129,11 +126,9 @@ case beryl.child_spec(config, init: init, update: update) {
 
 ## Stopping
 
-`beryl.stop(channels)` drains sockets gracefully: every joined topic
-receives a `Closed` event, transport connections are closed, and the
-runtime exits without being restarted. Calling `stop` again returns
-`Error(NotRunning)`. Other operations using the handle after `stop` are
-quiet no-ops.
+`beryl.stop(channels)` sends a `Closed` event to each joined topic. It closes
+transport connections and stops the runtime without a restart. A second call
+returns `Error(NotRunning)`. Other operations after `stop` do nothing.
 
 ## Production checklist
 

--- a/website/src/content/docs/guides/websocket.md
+++ b/website/src/content/docs/guides/websocket.md
@@ -2,11 +2,12 @@
 title: WebSocket Transport
 ---
 
-beryl provides a WebSocket transport layer that integrates directly with [Mist](https://hexdocs.pm/mist/) for handling browser client connections.
+beryl provides a WebSocket transport for
+[Mist](https://hexdocs.pm/mist/) browser connections.
 
 ## Basic setup
 
-The simplest way to add WebSocket support is with `mist_transport.upgrade`:
+Use `mist_transport.upgrade` to add WebSocket support:
 
 ```gleam
 import beryl
@@ -37,14 +38,16 @@ fn handle_request(
 }
 ```
 
-The `upgrade` function checks if the request path matches, performs the WebSocket upgrade, and wires the connection to the beryl runtime.
+The `upgrade` function checks the request path. It upgrades a matching request
+and connects it to the beryl runtime.
 
 The transport is layer-agnostic. A handle from
 `channel.child_spec` is the same `beryl.Sockets` type as one from
 `beryl.child_spec`, so this wiring is identical for both.
 
 :::tip[Phoenix JS clients]
-The Phoenix JS client (`new Socket("/socket", ...)`) connects to `/socket/websocket` by default — it appends `/websocket` to the path you pass. Configure the transport path to match:
+The Phoenix JS client (`new Socket("/socket", ...)`) adds `/websocket` to the
+path. Configure the transport to use `/socket/websocket`:
 
 ```gleam
 // Matches Phoenix JS: new Socket("/socket", ...)
@@ -56,9 +59,9 @@ Raw WebSocket clients connect directly to the configured path with no suffix app
 
 ## Authentication
 
-Use `with_on_connect` to authenticate connections before upgrading. The hook is
-beryl's analogue of Phoenix's `UserSocket.connect/3`: it runs **once per socket**,
-before any channel join, and can reject the whole connection.
+Use `with_on_connect` to authenticate a connection before the upgrade. It is
+similar to Phoenix `UserSocket.connect/3`. The hook runs once for each socket
+before any channel join. It can reject the connection.
 
 ```gleam
 let config =
@@ -74,7 +77,12 @@ let config =
 use <- mist_transport.upgrade(req, channels, config)
 ```
 
-Returning `Error(server.ConnectRejected)` sends an HTTP 403 before the WebSocket upgrade. See [Connection-level authentication rejection](/guides/error-handling#connection-level-authentication-rejection) for the client-visible error shape and [Authentication failures](/troubleshooting#authentication-failures) for diagnosis steps.
+Return `Error(server.ConnectRejected)` to send HTTP 403 before the WebSocket
+upgrade. See
+[Connection-level authentication rejection](/guides/error-handling#connection-level-authentication-rejection)
+for the client error. See
+[Authentication failures](/troubleshooting#authentication-failures) for
+diagnostic steps.
 
 ### Origin validation and CSWSH
 
@@ -106,12 +114,10 @@ tokens before upgrading.
 
 ### Connect-time data and the ConnectSeed
 
-`on_connect` is a pure gate — it allows or rejects the upgrade. The request
-data itself (path, query parameters, headers) reaches your app separately:
-the transport assembles a `ConnectSeed` from the upgrade request and delivers
-it to your `init` as `ConnectInfo.seed`. Authenticate once in `on_connect`,
-then derive per-socket state from the seed in `init` — no re-auth in any
-join:
+`on_connect` accepts or rejects the upgrade. The transport puts the request
+path, query parameters, and headers in a `ConnectSeed`. Your `init` function
+receives it as `ConnectInfo.seed`. Authenticate in `on_connect`. Then use the
+seed to build per-socket state in `init`. Do not authenticate each join again:
 
 ```gleam
 let config =
@@ -156,7 +162,9 @@ Pass `wire.phoenix_codec()` to `beryl.config` to use the Phoenix JSON array form
 [join_ref, ref, topic, event, payload]
 ```
 
-Applications can pass a custom codec to `beryl.config(codec)` to use another text framing or a binary framing. Codec-produced outbound frames are sent as text or binary WebSocket frames according to the codec result.
+Applications can pass a custom codec to `beryl.config(codec)`. The codec can
+use another text framing or binary framing. The transport sends each outbound
+frame as the type that the codec returns.
 
 `wire.phoenix_codec()` uses Beryl's native Phoenix wire implementation, which has no extra dependencies. The public `beryl/wire/codec.Codec` API and wire format are stable, so applications can supply their own codec to `beryl.config` for alternative framings.
 
@@ -254,18 +262,16 @@ let config =
   |> beryl.with_max_connections_per_ip(max_connections: 5)
 ```
 
-When a peer exhausts either limit, the Mist transport rejects the new upgrade
-with `429 Too Many Requests` before the WebSocket handshake completes.
-Concurrent capacity is released automatically when a connection closes. Rate
-allowance is not: its per-IP bucket survives reconnects and app runtime restarts,
-preventing a client from reconnecting for a fresh frame/message burst.
+When a peer reaches either limit, Mist rejects the upgrade with
+`429 Too Many Requests` before the handshake. A closed connection releases its
+concurrent capacity. The per-IP rate bucket remains after reconnects and app
+runtime restarts. Thus, a reconnect does not provide a new rate allowance.
 
 ### Reverse proxies and `X-Forwarded-For`
 
-Both controls use the **real socket peer IP** — the address of the TCP connection
-Mist accepts. beryl deliberately does **not** trust or parse
-forwarded headers such as `X-Forwarded-For`, because any client can set them and
-would otherwise be able to spoof its address and bypass the limit.
+Both controls use the **socket peer IP**, which is the TCP address that Mist
+accepts. beryl does not trust forwarded headers such as `X-Forwarded-For`.
+Clients can forge these headers and bypass the limit.
 
 This has an important consequence when beryl runs **behind a reverse proxy or
 load balancer** (nginx, HAProxy, a cloud LB, etc.): every connection arrives

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -92,18 +92,18 @@ import { Aside } from '@astrojs/starlight/components';
 	<ol>
 		<li>
 			<h3>Install beryl</h3>
-			<p>Beryl packages are currently distributed from GitHub, not Hex. Add beryl and a WebSocket transport as Git dependencies; the channel layer is included in beryl.</p>
+			<p>Install beryl packages from GitHub. Add beryl and one WebSocket transport as Git dependencies. The beryl package includes the channel layer.</p>
 			<p class="beryl-path__cmd"><code>gleam deps download</code></p>
 			<a class="beryl-path__go" href="/installation/">Installation guide →</a>
 		</li>
 		<li>
 			<h3>Build your first socket app</h3>
-			<p>Write one channel handler, wire the WebSocket transport, and connect a Phoenix JS client, end to end, in one sitting. Prefer to own the router? <a href="/choosing-an-api/">Choose an API</a> lays out both layers.</p>
+			<p>Write a channel handler. Connect the WebSocket transport and a Phoenix JS client. If you want to control routing, <a href="/choosing-an-api/">compare the two APIs</a>.</p>
 			<a class="beryl-path__go" href="/quick-start/">Open the Quick Start →</a>
 		</li>
 		<li>
-			<h3>See it running</h3>
-			<p>Browse complete, runnable examples, then go deeper in the <a href="/guides/channels/">channel guide</a> or the <a href="/reference/api/beryl-channel/">API reference</a>.</p>
+			<h3>Run an example</h3>
+			<p>Use a complete example. Then read the <a href="/guides/channels/">channel guide</a> or the <a href="/reference/api/beryl-channel/">API reference</a>.</p>
 			<a class="beryl-path__go" href="/examples/">View examples →</a>
 		</li>
 	</ol>
@@ -226,26 +226,26 @@ import { Aside } from '@astrojs/starlight/components';
 <div class="beryl-features">
 	<article class="beryl-feature beryl-feature--lead">
 		<h3>Channels, or your own router</h3>
-		<p>Register one handler per topic pattern and let <code>beryl/channel</code> route joins, messages, and closes to the channel that owns the topic — each with private, typed state. Or drop to the core and route every event yourself in one typed <code>update</code> function. No registry, no assigns, no type erasure either way.</p>
+		<p>Register one handler for each topic pattern. <code>beryl/channel</code> routes each event to the correct channel. Each channel keeps private, typed state. You can also route all events in one typed <code>update</code> function.</p>
 		<a class="beryl-feature__link" href="/choosing-an-api/">Choose an API →</a>
 	</article>
 	<article class="beryl-feature">
 		<h3>Presence tracking</h3>
-		<p>Know who's online with a CRDT-backed presence system. An add-wins observed-remove set resolves joins and leaves automatically across distributed nodes.</p>
+		<p>Track connected users with a CRDT. The add-wins observed-remove set resolves concurrent joins and leaves across nodes.</p>
 		<a class="beryl-feature__link" href="/guides/presence/">Presence guide →</a>
 	</article>
 	<article class="beryl-feature">
 		<h3>PubSub on OTP</h3>
-		<p>Distributed publish/subscribe powered by Erlang's <code>pg</code> process groups. Works across cluster nodes with zero configuration.</p>
+		<p>Erlang <code>pg</code> process groups provide distributed publish and subscribe. Connected cluster nodes need no extra message broker.</p>
 		<a class="beryl-feature__link" href="/guides/pubsub/">PubSub guide →</a>
 	</article>
 	<article class="beryl-feature">
 		<h3>Phoenix-compatible wire</h3>
-		<p>A JSON array wire format compatible with Phoenix client libraries, with first-class WebSocket support via Mist integration. Coming from Phoenix? <a href="/guides/coming-from-phoenix/">See how the concepts map</a>.</p>
+		<p>Use Phoenix client libraries with beryl's JSON array format. Mist provides WebSocket support. Phoenix users can <a href="/guides/coming-from-phoenix/">compare the concepts</a>.</p>
 		<a class="beryl-feature__link" href="/guides/websocket/">WebSocket guide →</a>
 	</article>
 </div>
 
 <Aside type="note" title="Pre-1.0">
-beryl is pre-1.0: the API can change between minor releases and it isn't production-hardened yet. Build with it and tell us what breaks; that feedback is shaping 1.0.
+beryl is not yet version 1.0. Minor releases can change the API. The library is not ready for production. Try it and report problems. Your feedback will help define version 1.0.
 </Aside>

--- a/website/src/content/docs/installation.md
+++ b/website/src/content/docs/installation.md
@@ -3,12 +3,14 @@ title: Installation
 ---
 
 :::note[Pre-1.0]
-beryl is pre-1.0: the API can change between minor releases and it isn't production-hardened yet. Build with it and tell us what breaks; that feedback is shaping 1.0.
+beryl is not yet version 1.0. Minor releases can change the API. The library is
+not ready for production. Try it and report problems. Your feedback will help
+define version 1.0.
 :::
 
-Beryl packages are currently distributed from
-[GitHub](https://github.com/tylerbutler/beryl), not Hex. Add them to your
-Gleam project as git dependencies by editing `gleam.toml`:
+Install beryl packages from
+[GitHub](https://github.com/tylerbutler/beryl). They are not on Hex. Add them
+as Git dependencies in `gleam.toml`:
 
 ```toml
 [dependencies]
@@ -16,26 +18,26 @@ beryl = { git = "https://github.com/tylerbutler/beryl.git", ref = "main", path =
 beryl_mist = { git = "https://github.com/tylerbutler/beryl.git", ref = "main", path = "packages/beryl_mist" }
 ```
 
-Then download the dependencies:
+Download the dependencies:
 
 ```bash
 gleam deps download
 ```
 
-`gleam add` only installs Hex packages, so these dependency entries must be
-written by hand.
+`gleam add` installs only Hex packages. Add these entries by hand.
 
-`beryl` includes the core runtime and the recommended `beryl/channel`
-programming layer. `beryl_mist` is the
-[Mist](https://hex.pm/packages/mist) WebSocket transport. If you prefer
-[Ewe](https://hex.pm/packages/ewe), use `path = "packages/beryl_ewe"` instead.
-All packages share the same `git` and `ref` values.
+`beryl` includes the core runtime and the recommended `beryl/channel` API.
+`beryl_mist` provides the [Mist](https://hex.pm/packages/mist) WebSocket
+transport. For [Ewe](https://hex.pm/packages/ewe), use
+`path = "packages/beryl_ewe"`. Use the same `git` and `ref` values for all
+packages.
 
-beryl targets the **Erlang (BEAM)** runtime — it does not support the JavaScript target.
+beryl supports only the **Erlang (BEAM)** target. It does not support the
+JavaScript target.
 
 ## Packages
 
-A typical application adds two packages: beryl and a WebSocket transport.
+A typical application needs beryl and one WebSocket transport.
 
 | Package | Add it when |
 |---------|-------------|
@@ -54,17 +56,15 @@ for raw dispatch. See [Choose an API](/choosing-an-api/) for the tradeoff.
 
 ### Why Gleam 1.18?
 
-beryl is a monorepo: the packages live in subdirectories (`packages/beryl`,
-`packages/beryl_mist`, `packages/beryl_ewe`) rather
-than at the repository root.
-Pointing a git dependency at a subdirectory needs the `path` field, which Gleam
-added in 1.18. Gleam 1.17 and earlier have no way to point a git dependency at
-anything but the repository root, so beryl cannot be used as a dependency from
-those versions.
+beryl is a monorepo. Its packages are in the `packages/beryl`,
+`packages/beryl_mist`, and `packages/beryl_ewe` subdirectories. Git
+dependencies use the `path` field to select a subdirectory. Gleam added this
+field in version 1.18. Older versions can select only the repository root and
+cannot install beryl.
 
-This is a requirement on *your* Gleam, not on beryl's code: the packages
-themselves declare `gleam = ">= 1.13.0"` and compile fine on older toolchains.
-1.18 is only what it takes to write the dependency line above.
+This requirement applies to the Gleam version that installs beryl. The packages
+declare `gleam = ">= 1.13.0"` and can compile with older toolchains. You need
+Gleam 1.18 only to use the dependency entries above.
 
 On an older Gleam, `gleam deps download` fails while parsing your `gleam.toml`
 rather than reporting a version problem:
@@ -87,13 +87,12 @@ upgrade Gleam.
 
 ## Choosing a ref
 
-The example uses `main`, which matches these docs but can change without
-warning. Check [GitHub Releases](https://github.com/tylerbutler/beryl/releases);
-once a tag contains every package you use, replace `main` with that tag.
+The example uses `main`, which matches these docs. The branch can change without
+warning. Check [GitHub Releases](https://github.com/tylerbutler/beryl/releases).
+When one tag contains all required packages, replace `main` with that tag.
 
-Git dependencies are resolved at the exact ref you name. Always use the same
-ref for `beryl` and the transport package; mixing versions
-across them is unsupported.
+Gleam resolves Git dependencies at the specified ref. Use the same ref for
+`beryl` and its transport package. Do not mix versions.
 
 ## Dependencies
 

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -3,34 +3,37 @@ title: What is beryl?
 ---
 
 :::note[Pre-1.0]
-beryl is pre-1.0: the API can change between minor releases and it isn't production-hardened yet. Build with it and tell us what breaks; that feedback is shaping 1.0.
+beryl is not yet version 1.0. Minor releases can change the API. The library is
+not ready for production. Try it and report problems. Your feedback will help
+define version 1.0.
 :::
 
 beryl is a **type-safe real-time channels and presence library** for Gleam,
-targeting the Erlang (BEAM) runtime. It provides the building blocks for adding
-real-time features to your Gleam web applications.
+for the Erlang (BEAM) runtime. It helps you add real-time features to Gleam web
+applications.
 
 ## Why beryl?
 
-Building real-time features — like chat rooms, live cursors, collaborative
-editing, or presence indicators — requires coordinating state across many
-connected clients. beryl gives you:
+Real-time features must coordinate state across many connected clients. These
+features include chat rooms, live cursors, shared editing, and presence
+indicators. beryl provides:
 
-- **Channels** — Register one handler per topic pattern; each channel keeps private, typed state and its own server-side message type (`beryl/channel`)
-- **App-side dispatch** — Or route every socket event yourself in one typed `update` function, with pattern matching such as `"room:*"`
-- **Presence** — Distributed tracking of connected users backed by a conflict-free CRDT
-- **PubSub** — Distributed publish/subscribe built on Erlang's `pg` process groups
-- **Groups** — Named collections of topics for multi-topic broadcasting
-- **WebSocket transport** — Mist integration with JSON wire protocol (Phoenix-compatible)
+- **Channels:** Register one handler for each topic pattern. Each channel keeps
+  private, typed state and a server-side message type (`beryl/channel`).
+- **App-side dispatch:** Route all socket events in one typed `update` function.
+  Match topic patterns such as `"room:*"`.
+- **Presence:** Track connected users across nodes with a conflict-free CRDT.
+- **PubSub:** Publish and subscribe across nodes with Erlang `pg` process groups.
+- **Groups:** Put topics in named groups for multi-topic broadcasts.
+- **WebSocket transport:** Use Mist with the Phoenix-compatible JSON protocol.
 
 ## Two layers, one runtime
 
 beryl ships one runtime and two ways to program it.
 
-The **channel layer** (`beryl/channel`) is the recommended default. You
-register a list of channel handlers — a topic pattern plus a typed `join`
-callback — and the layer routes every join, message, binary frame, typed
-server-side message, and close to the channel that owns the topic:
+The **channel layer** (`beryl/channel`) is the recommended default. Register a
+list of channel handlers. Each handler has a topic pattern and a typed `join`
+callback. The layer routes each event to the channel that owns the topic:
 
 ```gleam
 let assert Ok(#(sockets, spec)) =
@@ -40,10 +43,9 @@ let assert Ok(#(sockets, spec)) =
   )
 ```
 
-**Raw app-side dispatch** (`beryl`) is the core underneath. You pass one
-`init`/`update` pair to `beryl.child_spec` and own the router yourself. It is
-the right choice for a single-topic system, or when you want complete control
-over routing and effect ordering:
+**Raw app-side dispatch** (`beryl`) is the core API. Pass one `init` and
+`update` pair to `beryl.child_spec`. Use this API for one topic family or for
+full control of routing and effect order:
 
 ```gleam
 let assert Ok(#(sockets, spec)) =
@@ -54,21 +56,21 @@ let assert Ok(#(sockets, spec)) =
   )
 ```
 
-Both lower to the same runtime, wire codec, presence, PubSub, and abuse
-controls — and both child specifications belong in your application's
-supervision tree. The channel layer is built entirely on beryl's public API. See
-[Choose an API](/choosing-an-api/) for the decision in one table.
+Both APIs use the same runtime, wire codec, presence, PubSub, and abuse
+controls. Add either child specification to your application's supervision
+tree. The channel layer uses only beryl's public API. See
+[Choose an API](/choosing-an-api/) for a comparison.
 
 ## Design principles
 
 ### Type safety first
 
-Nothing in beryl is erased to `Dynamic` and nothing is coerced. With the
-channel layer, each channel picks its own private state type and its own
-server-side message type, and both stay sealed inside that channel's closures —
-which is how channels that agree on nothing compose in one list. With raw
-dispatch, your socket app owns one `Model` type and one `update` function, and
-the Gleam compiler keeps every branch honest:
+beryl does not erase typed socket state to `Dynamic`. It does not use unchecked
+coercion. With the channel layer, each channel defines private state and
+server-side message types. The channel keeps these types inside its closures,
+so unrelated channels can use one handler list. With raw dispatch, your socket
+app defines one `Model` type and one `update` function. The Gleam compiler
+checks each branch:
 
 ```gleam
 import beryl/socket
@@ -100,32 +102,28 @@ fn update(model: Model, ev: socket.Input(Nil)) -> socket.Next(Model) {
 
 ### Built on OTP
 
-The runtime behind each `beryl.Sockets` handle is an OTP actor. Presence
-tracking is a separate OTP actor wrapping a CRDT, and PubSub uses Erlang's `pg`
-directly.
+An OTP actor runs each `beryl.Sockets` handle. A separate OTP actor manages the
+presence CRDT. PubSub uses Erlang `pg`.
 
 ### CRDT-backed presence
 
-Presence state uses an **add-wins observed-remove set** (AWORSet) with causal
-context — a conflict-free replicated data type that resolves concurrent joins
-and leaves automatically, even across distributed Erlang nodes.
+Presence uses an **add-wins observed-remove set** (AWORSet) with causal context.
+This CRDT resolves concurrent joins and leaves across Erlang nodes.
 
 ### Focused dependencies
 
 The core library depends on `gleam_stdlib`, `gleam_erlang`, `gleam_otp`,
-`gleam_json`, `gleam_crypto`, `lattice_presence`, and `palabres` — all standard
-BEAM ecosystem packages. A WebSocket transport such as `beryl_mist` adds `mist`
-and `gleam_http`. `beryl/channel` is part of the core package, so choosing the
-channel model adds no dependency. No external message broker or database is
-required.
+`gleam_json`, `gleam_crypto`, `lattice_presence`, and `palabres`. A WebSocket
+transport such as `beryl_mist` adds `mist` and `gleam_http`. The core package
+includes `beryl/channel`. beryl does not require an external message broker or
+database.
 
 ### Phoenix wire protocol compatibility
 
-beryl uses the same JSON array wire format as Phoenix channels
-(`[join_ref, ref, topic, event, payload]`), making it compatible with existing
-Phoenix client libraries. If you know Phoenix Channels, the
-[Coming from Phoenix](/guides/coming-from-phoenix/) guide maps channel
-modules, callbacks, and assigns onto both of beryl's layers.
+beryl uses the Phoenix Channels JSON array format:
+`[join_ref, ref, topic, event, payload]`. Existing Phoenix client libraries can
+use this format. The [Coming from Phoenix](/guides/coming-from-phoenix/) guide
+compares Phoenix modules, callbacks, and assigns with both beryl APIs.
 
 ## Next steps
 

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -1,27 +1,24 @@
 ---
 title: Quick Start
-description: Build your first beryl socket app end-to-end — a channel handler, the WebSocket transport, and a Phoenix JS client.
+description: Build a beryl socket app with a channel handler, WebSocket transport, and Phoenix JS client.
 ---
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
 <Aside type="note" title="Pre-1.0">
-beryl is pre-1.0: the API can change between minor releases and it isn't production-hardened yet. Build with it and tell us what breaks; that feedback is shaping 1.0.
+beryl is not yet version 1.0. Minor releases can change the API. The library is not ready for production. Try it and report problems. Your feedback will help define version 1.0.
 </Aside>
 
-This guide walks you through building a working real-time app from scratch:
-a Gleam server built on the **channel layer**, wired to a Phoenix JS client
-running in the browser.
+This guide shows how to build a real-time app. You will create a Gleam server
+with the **channel layer** and connect a Phoenix JS browser client.
 
-The channel layer is beryl's recommended default. If you want one topic family
-and full control over routing, the same app in raw app-side dispatch is
-[a few lines further down](#alternative-raw-app-side-dispatch) and in the
-[Dispatch guide](/guides/dispatch/). See [Choose an API](/choosing-an-api/) for
-the decision.
+Use the channel layer by default. For one topic family and full routing control,
+use [raw app-side dispatch](#alternative-raw-app-side-dispatch). The
+[Dispatch guide](/guides/dispatch/) has more information. See
+[Choose an API](/choosing-an-api/) for a comparison.
 
-The snippets here are abbreviated to keep things readable. For a fully
-runnable application with HTML, static assets, and end-to-end tests, see the
-[examples](/examples/).
+The snippets omit some application code. See the [examples](/examples/) for
+runnable applications with HTML, static assets, and end-to-end tests.
 
 ## Prerequisites
 
@@ -31,9 +28,8 @@ runnable application with HTML, static assets, and end-to-end tests, see the
 
 ## 1. Write a channel
 
-A channel is a topic pattern plus a typed `join` callback. The callback answers
-with a rejection, or with a joined channel: callbacks bound to that channel's
-own private state.
+A channel has a topic pattern and a typed `join` callback. The callback rejects
+the join or accepts it with private state and callback functions.
 
 ```gleam
 // src/my_app/room_channel.gleam
@@ -109,18 +105,18 @@ fn callbacks() -> channel.Callbacks(State, Note) {
 ```
 
 <Aside type="note" title="Reply vs Push vs Broadcast">
-Every action is scoped to the channel's own topic, and they are applied in the order you add them.
-- **`channel.reply_ok` / `channel.reply_error`** — send `phx_reply` back to the calling client on the ref from `message.reply`.
-- **`channel.push`** — send a named event to this socket only.
-- **`channel.broadcast`** — send a named event to every socket on this topic, including the sender; **`channel.broadcast_from`** excludes the sender.
-- **`channel.next(state, [])`** — continue with no outgoing frames.
+Each action applies to the channel's topic. The runtime applies actions in list order.
+- **`channel.reply_ok` / `channel.reply_error`:** Send `phx_reply` to the calling client. The reply uses the ref from `message.reply`.
+- **`channel.push`:** Send a named event only to this socket.
+- **`channel.broadcast`:** Send a named event to all sockets on this topic, including the sender.
+- **`channel.broadcast_from`:** Send a named event to all other sockets on this topic.
+- **`channel.next(state, [])`:** Continue with no outgoing frames.
 </Aside>
 
 ## 2. Start the channel system and wire the transport
 
-Register the handler table and pass the returned `beryl.Sockets` handle to the
-Mist transport. That handle is an ordinary core handle — the same one
-`beryl.child_spec` returns.
+Register the handler table. Pass the returned `beryl.Sockets` handle to the
+Mist transport. `beryl.child_spec` returns the same core handle type.
 
 ```gleam
 // src/my_app.gleam
@@ -184,21 +180,20 @@ fn handle_http(
 }
 ```
 
-Handlers are matched in registration order and the first pattern that matches a
-topic owns it, so put more specific patterns first. A join for a topic no
-handler matches is refused with `{"reason": "unmatched topic"}`.
+The layer checks handlers in registration order. The first matching pattern
+owns the topic. Put specific patterns before general patterns. The layer
+rejects an unmatched topic with `{"reason": "unmatched topic"}`.
 
 <Aside type="tip" title="Transport path">
 `server.default_config("/socket/websocket")` tells beryl to intercept
 requests on `/socket/websocket`. When you create a Phoenix JS socket with
-`new Socket("/socket")`, the client appends `/websocket` automatically — so
-the paths line up.
+`new Socket("/socket")`, the client adds `/websocket`. The paths then match.
 </Aside>
 
 ## 3. Connect from the browser
 
-beryl uses the same wire format as Phoenix channels, so you can use the official
-`phoenix` npm package (or CDN build) in your frontend.
+beryl uses the Phoenix Channels wire format. You can use the official
+`phoenix` npm package or CDN build.
 
 <Tabs>
   <TabItem label="Install (npm)">
@@ -249,8 +244,8 @@ channel
 
 ## 4. Rejecting a join
 
-Return `channel.reject` when a topic should not be admitted. Join-level auth,
-capacity checks, and payload validation all live in the `join` callback:
+Return `channel.reject` when a client cannot join a topic. Put join
+authentication, capacity checks, and payload validation in the `join` callback:
 
 ```gleam
 channel.handler("room:*", fn(context) {
@@ -264,14 +259,14 @@ channel.handler("room:*", fn(context) {
 })
 ```
 
-A rejected join never becomes a channel instance, so it never runs
-`on_terminate`. A topic no handler claims is rejected by the layer itself, so
-joins fail closed by default.
+A rejected join does not create a channel instance and does not run
+`on_terminate`. The layer also rejects topics that have no handler. Thus, joins
+fail closed by default.
 
 ## Alternative: raw app-side dispatch
 
-The same server without the channel layer: one `init`/`update` pair passed to
-`beryl.child_spec`, and you own the routing.
+The raw dispatch version passes one `init` and `update` pair to
+`beryl.child_spec`. Your code routes each event.
 
 ```gleam
 // src/my_app/room_app.gleam
@@ -336,10 +331,10 @@ pub fn update(model: Model, ev: socket.Input(Msg)) -> socket.Next(Model) {
 
 Build it with
 `beryl.child_spec(config, init: room_app.init, update: room_app.update)`
-instead of `channel.child_spec`; add the returned child specification
-to the same supervisor. Everything else — transport wiring, client code, and
-wire format — is identical. A `Join` that reaches the end of the `update` turn
-unanswered is rejected automatically, so joins fail closed here too.
+instead of `channel.child_spec`. Add the returned child specification to the
+same supervisor. Both versions use the same transport wiring, client code, and
+wire format. The runtime rejects each unanswered `Join`, so raw dispatch also
+fails closed.
 
 The [Dispatch guide](/guides/dispatch/) covers this model in full, including
 routing several topic families from one `update`.
@@ -354,5 +349,5 @@ routing several topic families from one `update`.
 - Set up [PubSub](/guides/pubsub/) for distributed messaging
 - Configure [WebSocket transport](/guides/websocket/) options including `on_connect` auth
 
-Channel not connecting? The [Troubleshooting guide](/troubleshooting/) is
-organized by symptom — start there.
+If a channel does not connect, start with the
+[Troubleshooting guide](/troubleshooting/).

--- a/website/src/content/docs/reference/api/beryl-channel.md
+++ b/website/src/content/docs/reference/api/beryl-channel.md
@@ -594,7 +594,7 @@ Add ordered actions to run as part of accepting this join.
  while this socket waits; a check followed by [`presence_track`](#presence_track)
  is therefore not an atomic cross-socket capacity reservation.
 
- This is what to reach for instead of notifying yourself from `join`:
+ Use this function instead of notifying the channel from `join`:
  [`notify`](#notify) schedules a *later* input, while actions preserve
  their declared position immediately after the join acknowledgment.
 

--- a/website/src/content/docs/reference/api/index.md
+++ b/website/src/content/docs/reference/api/index.md
@@ -1,6 +1,6 @@
 ---
 title: API Reference
-description: Generated API reference from Gleam docs metadata.
+description: API reference generated from Gleam docs metadata.
 ---
 
 <!--
@@ -9,10 +9,10 @@ description: Generated API reference from Gleam docs metadata.
   `just docs` (gleam docs build + pnpm -C website generate:reference).
 -->
 
-This reference is generated from Gleam's docs metadata for `beryl`, `beryl_ewe`, and `beryl_mist`.
+This reference uses Gleam docs metadata for `beryl`, `beryl_ewe`, and `beryl_mist`.
 
 :::note[Generated content]
-Pages under `/reference/api/` are generated from Gleam's docs metadata and reflect every public type, function, and constant. This is beryl's canonical API reference. Beryl packages are currently distributed from GitHub, not Hex.
+The generator creates pages under `/reference/api/` from Gleam docs metadata. The pages include each public type, function, and constant. This is beryl's canonical API reference. Install beryl packages from GitHub. They are not on Hex.
 :::
 
 ## `beryl` `0.3.0`

--- a/website/src/content/docs/reference/index.md
+++ b/website/src/content/docs/reference/index.md
@@ -4,17 +4,19 @@ description: Module map, wire protocol, broadcast cheatsheet, and client compati
 ---
 
 :::note[Pre-1.0]
-beryl is pre-1.0: the API can change between minor releases and it isn't production-hardened yet. See the [stability policy](#pre-10-stability-policy) below.
+beryl is not yet version 1.0. Minor releases can change the API. The library is
+not ready for production. See the
+[stability policy](#pre-10-stability-policy).
 :::
 
-The canonical function-level API reference is generated from Gleam's docs
-metadata and hosted on this site. Beryl packages are currently distributed
-from GitHub, not Hex:
+The site generates the function-level API reference from Gleam docs metadata.
+Install beryl packages from GitHub. They are not on Hex:
 
 **[beryl](/reference/api/beryl/)** ·
 **[beryl/channel](/reference/api/beryl-channel/)**
 
-This page provides a module map, broadcast cheatsheet, Phoenix wire protocol reference, and client compatibility notes.
+This page contains a module map, broadcast table, Phoenix wire protocol
+reference, and client compatibility notes.
 
 ---
 
@@ -52,16 +54,17 @@ This page provides a module map, broadcast cheatsheet, Phoenix wire protocol ref
 | Send a typed server-side message to one socket | `socket.notify(sender, message)` | Store `ConnectInfo.self` from `init`; delivered later as `socket.Info(message)` |
 | Broadcast presence diff | `beryl.broadcast_presence_diff(sockets, topic, diff)` | Manual Phoenix-shaped `presence_diff`; ordinary socket/channel presence effects are applied asynchronously by the runtime |
 
-The channel layer exposes topic-scoped equivalents through
-ordered `channel.Action(Active)` lists: `push`, `broadcast`,
-`broadcast_from`, `reply_ok`, `reply_error`, and the presence actions. They
-lower onto the same core effects.
+The channel layer provides topic-scoped versions through ordered
+`channel.Action(Active)` lists. These actions include `push`, `broadcast`,
+`broadcast_from`, `reply_ok`, `reply_error`, and the presence actions. They use
+the same core effects.
 
 ---
 
 ## Phoenix wire protocol reference
 
-beryl speaks the same JSON array wire format as Phoenix channels. All frames are JSON arrays with five elements:
+beryl uses the Phoenix Channels JSON array format. Each frame has five
+elements:
 
 ```
 [join_ref, ref, topic, event, payload]
@@ -88,7 +91,8 @@ beryl speaks the same JSON array wire format as Phoenix channels. All frames are
 
 ### Reply shape (`phx_reply`)
 
-Sent in response to any client message. `socket.ReplyOk` and `socket.ReplyError` always serialize as `phx_reply` keyed by the original ref.
+The server sends this frame in response to a client message. `socket.ReplyOk`
+and `socket.ReplyError` use `phx_reply` with the original ref.
 
 ```json
 [join_ref, original_ref, "topic:name", "phx_reply", {"status": "ok", "response": <your_payload>}]
@@ -114,7 +118,9 @@ The client sends heartbeats on the `"phoenix"` topic; beryl replies immediately:
 
 ### Presence diff shape
 
-Follows the Phoenix presence diff format. Both `joins` and `leaves` are objects keyed by presence key (typically the user ID). Each value has a `metas` array:
+The payload uses the Phoenix presence diff format. The `joins` and `leaves`
+objects use the presence key, usually the user ID. Each value has a `metas`
+array:
 
 ```json
 {
@@ -133,7 +139,8 @@ Follows the Phoenix presence diff format. Both `joins` and `leaves` are objects 
 
 ## Client compatibility
 
-When started with `wire.phoenix_codec()`, beryl uses the standard Phoenix wire format, so any Phoenix-compatible WebSocket client works out of the box:
+With `wire.phoenix_codec()`, beryl uses the standard Phoenix wire format. You
+can use any compatible WebSocket client:
 
 | Client | Notes |
 |---|---|
@@ -142,7 +149,11 @@ When started with `wire.phoenix_codec()`, beryl uses the standard Phoenix wire f
 | Phoenix Swift / Kotlin clients | Community Phoenix clients; wire-compatible |
 | Plain WebSocket | Use the JSON array format directly; no reconnect logic |
 
-The WebSocket upgrade path is caller-provided — there is no default. Pass the path when constructing your transport config with `beryl/transport/server.default_config(path)`. The Phoenix JS client appends `/websocket` to the socket endpoint, so if you configure the client with `"/socket"`, mount your handler at `"/socket/websocket"`. See the [WebSocket Transport guide](/guides/websocket) for details.
+You must set the WebSocket upgrade path. Pass the path to
+`beryl/transport/server.default_config(path)`. The Phoenix JS client adds
+`/websocket` to the socket endpoint. If the client uses `"/socket"`, mount the
+handler at `"/socket/websocket"`. See the
+[WebSocket Transport guide](/guides/websocket).
 
 ---
 

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -2,15 +2,19 @@
 title: Troubleshooting
 ---
 
-This page lists common symptoms with targeted diagnosis steps. Start from your symptom and follow the checks in order.
+Find the symptom that matches your problem. Perform its checks in order.
 
 ## Clients cannot connect at all
 
-**Symptoms:** Browser WebSocket error, `net::ERR_CONNECTION_REFUSED`, or immediate close before any Phoenix messages.
+**Symptoms:** The browser reports a WebSocket error or
+`net::ERR_CONNECTION_REFUSED`. The connection can also close before a Phoenix
+message arrives.
 
 **Checks:**
 
-1. **Is Mist listening?** Confirm your HTTP server started without error. `mist.serve` or `mist.serve_ssl` returns a `Result` — make sure you handle `Error`.
+1. **Check that Mist is listening.** Confirm that the HTTP server started
+   without an error. `mist.serve` and `mist.serve_ssl` return a `Result`.
+   Handle the `Error` case.
 
 2. **Path mismatch.** The Phoenix JS client appends `/websocket` to the socket path you pass:
    ```js
@@ -22,19 +26,26 @@ This page lists common symptoms with targeted diagnosis steps. Start from your s
    ```
    Raw WebSocket clients (non-Phoenix) connect directly to the path with no suffix.
 
-3. **on_connect rejection.** If you configured `with_on_connect`, returning `Error(server.ConnectRejected)` sends an HTTP 403 before the upgrade. Check your auth logic and incoming headers.
+3. **Check `on_connect`.** If `with_on_connect` returns
+   `Error(server.ConnectRejected)`, the server sends HTTP 403 before the
+   upgrade. Check the authentication logic and request headers.
 
-4. **Reverse proxy not forwarding upgrade headers.** See [Reverse proxy / nginx](#reverse-proxy--nginx) below.
+4. **Check the reverse proxy headers.** See
+   [Reverse proxy / nginx](#reverse-proxy--nginx).
 
 ---
 
 ## Client connects but joins are never acknowledged
 
-**Symptoms:** Phoenix JS client hangs in "connecting" or "joining" state; no `phx_reply` received.
+**Symptoms:** The Phoenix JS client stays in the `connecting` or `joining`
+state. It does not receive `phx_reply`.
 
 **Checks:**
 
-1. **Does your `update` answer the join?** Every `Join` event must be answered with an `AcceptJoin` or `RejectJoin` effect. An unanswered join is rejected automatically (fail closed) — check the server logs for `Join not acknowledged by update; rejecting`, and confirm your topic match arms cover the topic the client is joining:
+1. **Check that `update` answers the join.** Return `AcceptJoin` or
+   `RejectJoin` for each `Join` event. The runtime rejects an unanswered join.
+   Check the logs for `Join not acknowledged by update; rejecting`. Confirm
+   that a match branch covers the client topic:
    ```gleam
    // "room:" <> _ matches "room:lobby", "room:42", etc.
    socket.Join("room:" <> _, payload, ref) ->
@@ -48,23 +59,33 @@ This page lists common symptoms with targeted diagnosis steps. Start from your s
    use <- mist_transport.upgrade(req, channels, config)
    ```
 
-3. **Update crashes on `Join`.** A crash while handling a `Join` rejects that join (the socket survives). Check the logs for the crash description and fix the panic.
+3. **Check for a `Join` crash.** A crash during `Join` rejects the join but
+   keeps the socket open. Check the crash description in the logs and fix the
+   panic.
 
-4. **Topic string mismatch.** Your `update` routes topics with ordinary pattern matching — verify the prefix or shape you match covers the exact topic the client sends (`"room:" <> _` does not match `"rooms:lobby"`). For multi-segment shapes, `topic.extract_wildcards` with `topic.parse_pattern("document:*:*")` verifies the shape explicitly.
+4. **Check the topic string.** `update` routes topics with pattern matching.
+   Confirm that the prefix or shape matches the exact client topic.
+   `"room:" <> _` does not match `"rooms:lobby"`. For multiple segments, use
+   `topic.extract_wildcards` with
+   `topic.parse_pattern("document:*:*")`.
 
 ---
 
 ## Messages sent from the client are not received
 
-**Symptoms:** `update` never receives a `Message` event; no reply or push received.
+**Symptoms:** `update` does not receive a `Message` event. The client does not
+receive a reply or push.
 
 **Checks:**
 
 1. **Did the client successfully join?** `Message` events are only delivered after a successful `phx_join`. If join was rejected, messages to the topic get an `unmatched topic` error reply (when they carry a ref) or are dropped.
 
-2. **Rate limits dropping traffic.** `with_frame_rate` sheds complete frames at the transport edge before decode. `with_message_rate`, `with_channel_rate`, and `with_topic_rate` apply after decode in the runtime.
+2. **Check rate limits.** `with_frame_rate` drops complete frames before
+   decoding. `with_message_rate`, `with_channel_rate`, and `with_topic_rate`
+   apply after decoding in the runtime.
 
-3. **Event name mismatch.** The `Message` event carries the raw event string. Verify the client sends the exact event name your `update` matches on.
+3. **Check the event name.** `Message` contains the event string from the
+   client. Confirm that it matches the string in `update`.
 
 ---
 
@@ -104,7 +125,8 @@ socket. See [Crash behavior](/guides/channels/#crash-behavior).
 
 ## Enable Beryl debug diagnostics
 
-Beryl uses [palabres](https://hexdocs.pm/palabres/) loggers under the `beryl.*` namespaces. Normal configurations keep production output quiet, but you can opt into detailed runtime lifecycle diagnostics while debugging integration issues:
+Beryl uses [palabres](https://hexdocs.pm/palabres/) loggers under the `beryl.*`
+namespaces. Enable debug logs when you diagnose integration problems:
 
 ```gleam
 let config =
@@ -127,11 +149,15 @@ let logging =
 
 ## Broadcasts are not received by clients
 
-**Symptoms:** `beryl.broadcast` is called server-side but connected clients do not receive the event.
+**Symptoms:** Server code calls `beryl.broadcast`, but connected clients do not
+receive the event.
 
 **Checks:**
 
-1. **Topic string must match exactly.** `beryl.broadcast("room:lobby", ...)` delivers only to sockets subscribed to the *exact* topic `"room:lobby"`. Wildcard patterns are for *routing incoming messages*, not for targeting broadcasts.
+1. **Check the exact topic string.**
+   `beryl.broadcast("room:lobby", ...)` sends only to sockets on
+   `"room:lobby"`. Wildcard patterns route incoming messages. They do not
+   select broadcast targets.
 
 2. **Client has not joined the topic.** A socket must have successfully completed `phx_join` for the topic before it receives broadcasts on that topic.
 
@@ -147,7 +173,8 @@ let logging =
 
 ## Presence is stale or incorrect
 
-**Symptoms:** `presence.list` returns entries for users who have disconnected; joins/leaves are not reflected.
+**Symptoms:** `presence.list` includes disconnected users. It does not show
+recent joins or leaves.
 
 **Checks:**
 
@@ -172,7 +199,7 @@ let logging =
 
 ## Authentication failures
 
-**Symptoms:** All clients get 403 on connect, or all joins are rejected.
+**Symptoms:** All connections receive HTTP 403, or all joins are rejected.
 
 **Checks:**
 
@@ -180,13 +207,16 @@ let logging =
 
 2. **Token validation error.** Check that your token validation logic handles expired or malformed tokens gracefully and returns `Error(Nil)` rather than panicking.
 
-3. **`update` rejecting every join.** Log the `payload` argument of the `Join` event to confirm the client is sending the expected shape. `payload` arrives as `Dynamic` (already decoded from the raw frame) — run your decoder against it explicitly.
+3. **Check whether `update` rejects each join.** Log the `Join` payload and
+   confirm its shape. The transport has decoded the raw frame, but `payload`
+   is still `Dynamic`. Run your decoder on it.
 
 ---
 
 ## Heartbeat disconnects
 
-**Symptoms:** Clients are disconnected after a period of inactivity; `update` receives `Closed(topic, HeartbeatTimeout)`.
+**Symptoms:** Clients disconnect after inactivity. `update` receives
+`Closed(topic, HeartbeatTimeout)`.
 
 **Checks:**
 
@@ -200,7 +230,8 @@ let logging =
 
 ## PubSub cluster issues
 
-**Symptoms:** Broadcasts do not propagate across Erlang nodes; presence state diverges.
+**Symptoms:** Broadcasts do not reach other Erlang nodes. Presence state differs
+between nodes.
 
 **Checks:**
 
@@ -212,9 +243,10 @@ let logging =
 
 ---
 
-## Rate limiting is unexpectedly aggressive
+## Rate limits drop valid traffic
 
-**Symptoms:** Clients receive partial message delivery; high-frequency operations are silently dropped.
+**Symptoms:** Clients receive only some messages. High-rate operations are
+dropped.
 
 **Checks:**
 
@@ -230,7 +262,8 @@ let logging =
 
 ## Reverse proxy / nginx
 
-WebSocket upgrades require forwarding the `Upgrade` and `Connection` headers. A minimal nginx configuration:
+WebSocket upgrades require the `Upgrade` and `Connection` headers. Use this
+minimal nginx configuration:
 
 ```nginx
 location /socket/websocket {
@@ -243,18 +276,27 @@ location /socket/websocket {
 }
 ```
 
-Without `proxy_http_version 1.1` and the upgrade headers, nginx downgrades to HTTP/1.0 and the WebSocket handshake fails. `proxy_read_timeout` should exceed your client heartbeat interval to avoid proxy-side idle disconnects.
+Without HTTP/1.1 and the upgrade headers, nginx uses HTTP/1.0 and the WebSocket
+handshake fails. Set `proxy_read_timeout` above the client heartbeat interval.
+This prevents proxy idle disconnects.
 
 ---
 
 ## Runtime crash / no messages processed
 
-**Symptoms:** All WebSocket operations stop working; the runtime is unresponsive.
+**Symptoms:** All WebSocket operations stop. The runtime does not respond.
 
 **Checks:**
 
-1. **Crash loop exhausted the restart budget.** The runtime always starts supervised and restarts automatically, but after 3 restarts in 5 seconds the supervisor gives up and the crash propagates to the process that called `child_spec`. Check the logs for the underlying crash.
+1. **Check the restart budget.** The supervised runtime restarts after a crash.
+   After 3 restarts in 5 seconds, the supervisor stops and sends the failure to
+   the process that called `child_spec`. Check the logs for the first crash.
 
-2. **Panic in your app code.** Crashes inside `init`/`update` are rescued and scoped to one socket or topic — they do not stop the runtime. A runtime-wide stop points at a crash outside the rescued paths; audit `let assert` expressions in code the runtime calls indirectly (e.g. presence `on_diff` callbacks).
+2. **Check for an app panic.** The runtime catches crashes in `init` and
+   `update` and limits them to one socket or topic. They do not stop the
+   runtime. A runtime stop indicates a crash outside those paths. Check
+   indirect callbacks, such as presence `on_diff`, for `let assert`.
 
-3. **After a restart, clients must rejoin.** A restarted runtime has no socket state. Connected clients will see their topics close (or stop receiving replies) and the Phoenix JS client will reconnect and rejoin automatically.
+3. **Rejoin after a restart.** A restarted runtime has no socket state.
+   Connected clients see their topics close or stop receiving replies. The
+   Phoenix JS client reconnects and rejoins.


### PR DESCRIPTION
## Summary

- rewrite website prose with shorter, direct sentences and active voice
- simplify homepage, guide, architecture, reference, and troubleshooting copy
- update generated reference sources so regeneration preserves the wording
