### PR TITLE
docs: simplify README and API wording

### DIFF
--- a/.changes/unreleased/beryl-simplified-the-readme-and.toml
+++ b/.changes/unreleased/beryl-simplified-the-readme-and.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Simplified the README and public API documentation."

--- a/.changes/unreleased/beryl-simplified-the-readme-and.toml
+++ b/.changes/unreleased/beryl-simplified-the-readme-and.toml
@@ -1,3 +1,0 @@
-package = "beryl"
-kind = "Fixed"
-body = "Simplified the README and public API documentation."

--- a/.changes/unreleased/beryl_ewe-simplified-the-public-api.toml
+++ b/.changes/unreleased/beryl_ewe-simplified-the-public-api.toml
@@ -1,0 +1,3 @@
+package = "beryl_ewe"
+kind = "Fixed"
+body = "Simplified the public API documentation."

--- a/.changes/unreleased/beryl_ewe-simplified-the-public-api.toml
+++ b/.changes/unreleased/beryl_ewe-simplified-the-public-api.toml
@@ -1,3 +1,0 @@
-package = "beryl_ewe"
-kind = "Fixed"
-body = "Simplified the public API documentation."

--- a/.changes/unreleased/beryl_mist-simplified-the-public-api.toml
+++ b/.changes/unreleased/beryl_mist-simplified-the-public-api.toml
@@ -1,0 +1,3 @@
+package = "beryl_mist"
+kind = "Fixed"
+body = "Simplified the public API documentation."

--- a/.changes/unreleased/beryl_mist-simplified-the-public-api.toml
+++ b/.changes/unreleased/beryl_mist-simplified-the-public-api.toml
@@ -1,3 +1,0 @@
-package = "beryl_mist"
-kind = "Fixed"
-body = "Simplified the public API documentation."

--- a/README.md
+++ b/README.md
@@ -4,14 +4,13 @@
 </tr></table>
 
 > [!IMPORTANT]
-> beryl is not yet 1.0. The API is unstable, features may be removed in minor
-> releases, and quality should not be considered production-ready. We welcome
-> usage and feedback in the meantime!
+> Beryl is not yet 1.0. Minor releases can change the API or remove features.
+> Treat Beryl as experimental. Try it and send feedback.
 
 ## Install
 
-Beryl packages are currently distributed from GitHub, not Hex. Add them to
-`gleam.toml`:
+GitHub hosts the current Beryl packages. Hex does not. Add these dependencies
+to `gleam.toml`:
 
 ```toml
 [dependencies]
@@ -23,13 +22,13 @@ beryl_mist = { git = "https://github.com/tylerbutler/beryl.git", ref = "main", p
 gleam deps download
 ```
 
-`beryl` includes both raw dispatch and the recommended `beryl/channel`
-composition layer. `beryl_mist` is the
-[Mist](https://hex.pm/packages/mist) WebSocket transport. An
-[Ewe](https://hex.pm/packages/ewe) transport is also available as
-`beryl_ewe` and mirrors the `beryl_mist` API.
+`beryl` includes raw dispatch and the recommended `beryl/channel` composition
+layer. `beryl_mist` provides the [Mist](https://hex.pm/packages/mist)
+WebSocket transport. `beryl_ewe` provides an
+[Ewe](https://hex.pm/packages/ewe) transport with the same API.
 
-beryl targets the **Erlang/BEAM** runtime only. It does not support the JavaScript target.
+Beryl supports only the **Erlang/BEAM** runtime. It does not support
+JavaScript.
 
 ## Quick start
 
@@ -79,7 +78,7 @@ pub fn main() {
 
   let assert Ok(_) =
     mist_transport.handler(channels, server.default_config("/socket/websocket"), fn(_req) {
-      // your regular HTTP handler here
+      // your HTTP handler here
       panic as "not implemented"
     })
     |> mist.new
@@ -90,27 +89,27 @@ pub fn main() {
 }
 ```
 
-`mist_transport.handler` composes the WebSocket upgrade and your HTTP handler
-into a single Mist request handler: WebSocket upgrades on the configured path go
-to beryl, everything else falls through to the HTTP fallback. If you need to drive
-the upgrade decision yourself, `mist_transport.upgrade` (and the
-`beryl/transport/server.is_websocket_request` guard) remain available.
+`mist_transport.handler` combines the WebSocket upgrade and your HTTP handler
+in one Mist request handler. It sends WebSocket upgrades on the configured
+path to Beryl. It sends all other requests to the HTTP fallback. To control
+the upgrade decision, use `mist_transport.upgrade` and
+`beryl/transport/server.is_websocket_request`.
 
-For a complete end-to-end walkthrough including Phoenix JS client code, see the
-**[Quick Start guide](https://beryl.tylerbutler.com/quick-start/)** on the docs website.
+For a full example with Phoenix JS client code, see the
+**[Quick Start guide](https://beryl.tylerbutler.com/quick-start/)**.
 
 ## Documentation
 
-- **Website & guides**: <https://beryl.tylerbutler.com>
+- **Website and guides**: <https://beryl.tylerbutler.com>
 - **Generated API reference**: <https://beryl.tylerbutler.com/reference/api/>
 - **Repository and git releases**: <https://github.com/tylerbutler/beryl>
 
 ## Ecosystem
 
-Beryl is the server-side real-time runtime. It owns socket registration,
-broadcasts, presence, groups, PubSub, and transport integration.
-Beryl has its own pluggable wire codec, and its Phoenix codec is kept compatible
-with Roost and Aquamarine by shared conformance fixtures.
+Beryl is a server runtime for real-time applications. It manages socket
+registration, broadcasts, presence, groups, PubSub, and transport integration.
+Beryl has a pluggable wire codec. Shared conformance fixtures keep its Phoenix
+codec compatible with Roost and Aquamarine.
 
 ```mermaid
 flowchart TD
@@ -135,25 +134,32 @@ flowchart TD
 | Package | Responsibility |
 |---------|----------------|
 | `phoenix_channel_fixtures` | Shared test fixtures for Phoenix channel wire compatibility. |
-| `roost` | Pure Phoenix channel frame constants, encode/decode helpers, and reply helpers. |
+| `roost` | Phoenix channel frame constants, encode/decode helpers, and reply helpers. |
 | `beryl` | Server-side runtime with its own pluggable codec; its Phoenix codec is fixture-tested. |
 | `beryl/channel` | Typed channel composition module in the `beryl` package. |
 | `aquamarine` | Client-side channel runtime that uses Roost for Phoenix compatibility. |
 
 ## Features
 
-- **Channels** — register typed handlers by topic pattern; each joined topic keeps private state and a typed server-message API
-- **App-side dispatch** — use the core `init`/`update` API directly when you want to own the router
-- **Presence** — Distributed presence tracking using a CRDT (add-wins observed-remove set)
-- **Groups** — Named channel groups for multi-topic broadcasting
-- **PubSub** — pg-based distributed publish/subscribe
-- **Typed server messages** — any process reaches a socket through a typed `Sender(msg)`; messages arrive in `update` as `Info(msg)` with no casts
-- **WebSocket transport** — Mist integration with Phoenix-compatible wire protocol
-- **Connect hook** — Socket-level `on_connect` authentication (Phoenix `UserSocket.connect/3` analogue): runs once per socket and can reject the whole connection before any join; request data reaches `init` via the `ConnectSeed`
+- **Channels:** Register typed handlers by topic pattern. Each joined topic has
+  private state and a typed server-message API.
+- **App dispatch:** Use the core `init` and `update` API when you need direct
+  control of the router.
+- **Presence:** Track distributed presence with an add-wins observed-remove set
+  CRDT.
+- **Groups:** Broadcast to named groups of channels.
+- **PubSub:** Publish and subscribe across Erlang nodes with `pg`.
+- **Typed server messages:** Send a message to a socket through
+  `Sender(msg)`. `update` receives it as `Info(msg)` without a cast.
+- **WebSocket transport:** Use Mist with the Phoenix wire protocol.
+- **Connect hook:** Use socket-level `on_connect` authentication, similar to
+  Phoenix `UserSocket.connect/3`. The hook runs once for each socket and can
+  reject the connection before a join. `ConnectSeed` passes request data to
+  `init`.
 
 ## Examples
 
-Four runnable demos are included in the `examples/` directory:
+The `examples/` directory contains four runnable demos:
 
 | Example | What it demonstrates |
 |---------|----------------------|
@@ -162,14 +168,15 @@ Four runnable demos are included in the `examples/` directory:
 | [`examples/collab_docs`](examples/collab_docs/) | Channel handlers, client-side CRDT document blocks, segment wildcards, conflict resolution |
 | [`examples/showcase`](examples/showcase/) | End-to-end `beryl/channel` composition across every subsystem |
 
-See the [Examples page](https://beryl.tylerbutler.com/examples/) in the docs for a full comparison.
+See the [Examples page](https://beryl.tylerbutler.com/examples/) for a full
+comparison.
 
 ## Recipe: bridge an external actor to a socket
 
-A long-lived domain actor (for example a per-document session) often emits
-updates that need to be pushed to each joined socket. `beryl/bridge` owns the
-small forwarder process, translates the actor's messages, and delivers typed
-`Info` events through the socket's `Sender`.
+A long-lived actor, such as a document session, can send updates to each joined
+socket. `beryl/bridge` starts a small forwarding process. The process converts
+the actor messages and sends typed `Info` events through the socket
+`Sender`.
 
 ```gleam
 import beryl/bridge.{type Bridge}
@@ -213,70 +220,73 @@ fn update(model: Model, ev: socket.Input(Msg)) -> socket.Next(Model) {
 }
 ```
 
-Call `bridge.stop` when the owning socket/topic closes. The bridge also
-monitors the process that created it as a leak-prevention backstop.
+Call `bridge.stop` when the owner socket or topic closes. The bridge monitors
+its creator and stops if that process exits.
 
-## Releases & changelog
+## Releases and changelog
 
-See the [GitHub Releases](https://github.com/tylerbutler/beryl/releases) page for
-release notes. Releases follow [Conventional Commits](https://www.conventionalcommits.org/)
-and changelogs are managed with [trellis](https://trellis.tylerbutler.com) changelog fragments.
+See [GitHub Releases](https://github.com/tylerbutler/beryl/releases) for release
+notes. Releases use
+[Conventional Commits](https://www.conventionalcommits.org/). The project uses
+[trellis](https://trellis.tylerbutler.com) changelog fragments.
 
 ## Security
 
-Beryl uses **Erlang distribution** for its distributed PubSub and presence
-replication, which means **every node in your cluster is fully trusted**.
-Application- and channel-level authorization protects you against untrusted
-WebSocket clients; it does **not** protect you against a hostile Erlang
-distribution peer, which can inject internal beryl traffic and presence state.
+Beryl uses **Erlang distribution** for PubSub and presence replication. You
+must trust **every node in the cluster**. Application and channel authorization
+protect against untrusted WebSocket clients. They do **not** protect against a
+hostile Erlang distribution peer. Such a peer can inject internal Beryl
+traffic and presence state.
 
-Before running beryl in production, read **[SECURITY.md](SECURITY.md)**, which
-covers:
+Read **[SECURITY.md](SECURITY.md)** before you run Beryl in production. It
+explains:
 
-- The Erlang distribution **trust boundary** and what a compromised peer can do.
-- Distribution hardening: a strong protected cookie, TLS distribution, EPMD/port
-  firewalling, and keeping cluster membership closed.
-- Why internal PubSub/presence messages are trusted while client WebSocket
-  messages are validated and rate-limited.
-- The `pubsub.config_with_scope` atom-table constraint (never pass it
-  user-derived values).
+- The Erlang distribution **trust boundary** and the effect of a compromised
+  peer.
+- Distribution security: a strong protected cookie, TLS distribution,
+  EPMD and port firewall rules, and closed cluster membership.
+- Why Beryl trusts internal PubSub and presence messages but validates and
+  rate-limits client WebSocket messages.
+- The atom-table limit for `pubsub.config_with_scope`. Do not pass values from
+  users to this function.
 
-For client-facing abuse controls (rate limits, connection caps, origin checks),
-see the [Production Hardening guide](https://beryl.tylerbutler.com/guides/production-hardening/).
+For controls against client abuse, such as rate limits, connection limits, and
+origin checks, see the
+[Production Hardening guide](https://beryl.tylerbutler.com/guides/production-hardening/).
 
 ### Required: an edge proxy frame-size limit
 
-Beryl's `with_max_inbound_frame_bytes` limit is enforced **post-assembly** —
-the WebSocket transport (Mist/gramps) buffers and reassembles a complete frame
-*before* Beryl measures it and rejects oversized frames. This bounds
-per-message processing cost, but it does **not** bound transport memory.
+Beryl applies the `with_max_inbound_frame_bytes` limit **after frame
+assembly**. The WebSocket transport (Mist/gramps) buffers and assembles a full
+frame before Beryl measures it. Beryl then rejects an oversized frame. This
+limit controls the processing cost of one message. It does **not** limit
+transport memory.
 
-A hostile client can therefore exhaust node memory with a single connection by
-either:
+A hostile client can exhaust node memory through one connection in two ways:
 
-- declaring a huge payload length in a frame header and streaming the body
-  slowly, or
-- sending a long run of fragmented continuation frames that the transport
-  aggregates into one buffer.
+- It can declare a large payload length in a frame header and send the body
+  at a low rate.
+- It can send many fragmented continuation frames that the transport puts in
+  one buffer.
 
-In both cases the transport's receive buffer grows unbounded *before* Beryl's
-frame-size check ever runs. **Beryl's per-IP connection limit
+In both cases, the transport receive buffer has no size limit before Beryl
+checks the frame size. **Beryl's per-IP connection limit
 (`with_max_connections_per_ip`), per-connection frame-rate limit
 (`with_frame_rate`), and per-socket message-rate limit (`with_message_rate`)
-do not mitigate this vector** — all run post-assembly, so the buffer grows
-within one admitted connection before dispatch.
+do not prevent this attack**. These limits run after frame assembly. The
+buffer can grow in one accepted connection before dispatch.
 
-To bound transport memory in production you **must** place an edge proxy or
-load balancer (e.g. nginx, HAProxy, Envoy, or your cloud LB) in front of Beryl
-and configure:
+To limit transport memory in production, you **must** put an edge proxy or load
+balancer in front of Beryl. You can use nginx, HAProxy, Envoy, or a cloud load
+balancer. Configure:
 
-- a **maximum WebSocket frame/message size** at or below your chosen
-  `with_max_inbound_frame_bytes` value, and
-- a matching **request/body size limit** for the initial HTTP upgrade.
+- A **maximum WebSocket frame or message size** that is not greater than the
+  `with_max_inbound_frame_bytes` value.
+- A matching **request or body size limit** for the first HTTP upgrade request.
 
-Set the proxy limit to reject oversized frames at the edge, before they are
-buffered by the BEAM node. Beryl's in-process limit should be treated as
-defense-in-depth for per-message cost, not as a memory bound.
+Set the proxy to reject oversized frames before the BEAM node buffers them.
+Use Beryl's in-process limit as a second control for message processing cost.
+Do not use it as a memory limit.
 
 ## Development
 
@@ -308,12 +318,16 @@ just ci        # Run all CI checks
 
 ### CI/CD
 
-This project uses GitHub Actions for CI and automated releases:
+This project uses GitHub Actions for CI and releases:
 
-- **CI**: Runs on every push/PR to main
-- **PR Validation**: Checks PR title (commitlint), workspace invariants (`trellis doctor`), and changelog fragments (`trellis changelog check`)
-- **Release**: [trellis](https://trellis.tylerbutler.com) maintains a release PR from unreleased changelog fragments
-- **Publish**: Merging the release PR creates per-package tags and GitHub releases (Hex.pm publishing is temporarily disabled)
+- **CI:** Runs for each push and pull request to `main`.
+- **PR validation:** Checks the PR title with commitlint, checks workspace
+  rules with `trellis doctor`, and checks changelog fragments with
+  `trellis changelog check`.
+- **Release:** [trellis](https://trellis.tylerbutler.com) maintains a release
+  PR from unreleased changelog fragments.
+- **Publish:** Merging the release PR creates package tags and GitHub releases.
+  Hex.pm publishing is disabled.
 
 ### GitHub Secrets Required
 
@@ -325,12 +339,12 @@ This project uses GitHub Actions for CI and automated releases:
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/):
 
-- `feat:` - New features (minor version bump)
-- `fix:` - Bug fixes (patch version bump)
-- `docs:` - Documentation changes
-- `chore:` - Maintenance tasks
-- `BREAKING CHANGE:` in commit body - Major version bump
+- `feat:` - Adds a feature and causes a minor version increase.
+- `fix:` - Fixes a defect and causes a patch version increase.
+- `docs:` - Changes documentation.
+- `chore:` - Performs maintenance.
+- `BREAKING CHANGE:` in the commit body - Causes a major version increase.
 
 ## License
 
-MIT — see [LICENSE](LICENSE) for details.
+MIT. See [LICENSE](LICENSE).

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -6,13 +6,13 @@
 ////
 //// ## Features
 ////
-//// - **Sockets** — App-side dispatch: topic-based WebSocket messaging
+//// - **Sockets**: App-side dispatch with topic-based WebSocket messaging
 ////   routed by your `update` function (`beryl`, `beryl/socket`)
-//// - **PubSub** — Distributed publish/subscribe via Erlang `pg`
+//// - **PubSub**: Distributed publish/subscribe via Erlang `pg`
 ////   (`beryl/pubsub`)
-//// - **Presence** — Distributed presence tracking backed by a causal-context
+//// - **Presence**: Distributed presence tracking backed by a causal-context
 ////   CRDT (add-wins observed-remove set) (`beryl/presence`)
-//// - **Groups** — Named collections of topics for multi-topic broadcasting
+//// - **Groups**: Named collections of topics for multi-topic broadcasting
 ////   (`beryl/group`)
 ////
 //// ## Quick Start
@@ -92,8 +92,8 @@ pub type LogLevel {
 
 /// Logging configuration for Beryl diagnostics.
 ///
-/// This type is opaque: construct it with `logging_config` and adjust it with
-/// the `with_*` builder functions so Beryl can add logging options without a
+/// This type is opaque. Construct it with `logging_config` and adjust it with
+/// the `with_*` functions. Beryl can then add logging options without a
 /// breaking change.
 pub opaque type LoggingConfig {
   LoggingConfig(
@@ -108,9 +108,9 @@ pub opaque type LoggingConfig {
 
 /// Configuration for an app-side socket runtime.
 ///
-/// This type is opaque: construct it with `config` and adjust it with the
-/// `with_*` builder functions. Keeping it opaque lets Beryl add configuration
-/// options in the future without a breaking change.
+/// This type is opaque. Construct it with `config` and adjust it with the
+/// `with_*` functions. Beryl can then add configuration options without a
+/// breaking change.
 pub opaque type Config {
   Config(
     /// Wire codec used to decode inbound text and encode replies/pushes.
@@ -200,7 +200,7 @@ pub fn logging_config(
 
 /// Build a configuration with sensible defaults.
 ///
-/// A `codec` is required — beryl no longer ships an implicit Phoenix
+/// A `codec` is required. Beryl no longer provides an implicit Phoenix
 /// default. Pass `wire.phoenix_codec()` to keep Phoenix wire compatibility,
 /// or your own `Codec` for a custom framing.
 pub fn config(codec: codec.Codec) -> Config {
@@ -237,9 +237,9 @@ pub fn config(codec: codec.Codec) -> Config {
 /// runtime built with `child_spec`.
 ///
 /// Patterns use the same syntax as topic routing (`"room:*"`,
-/// `"document:*:ops"`, `"*"`). Limits are consulted in the order they were
-/// added and the first matching pattern wins; topics matching no pattern
-/// fall back to the global `with_channel_rate` limit. The limiter applies
+/// `"document:*:ops"`, `"*"`). The runtime checks limits in the order they
+/// were added. The first matching pattern wins. Topics that match no pattern
+/// use the global `with_channel_rate` limit. The limiter applies
 /// only after a socket has joined the topic. A non-positive `per_second`
 /// explicitly disables limiting for matching topics, including any global
 /// channel limit, and allocates no bucket.
@@ -257,7 +257,7 @@ pub fn with_topic_rate(
   )
 }
 
-/// Add PubSub to a configuration for distributed broadcasts
+/// Add PubSub to a configuration for distributed broadcasts.
 pub fn with_pubsub(config: Config, ps: PubSub(json.Json)) -> Config {
   Config(..config, pubsub: Some(ps))
 }
@@ -289,8 +289,8 @@ pub fn with_telemetry(config: Config) -> Config {
 
 /// Configure the server-side heartbeat staleness window.
 ///
-/// A socket that sends no heartbeat within `timeout_ms` is evicted. The
-/// runtime checks at half this window, so values below 2 are rejected by
+/// The runtime evicts a socket that sends no heartbeat within `timeout_ms`.
+/// It checks at half this window, so values below 2 are rejected by
 /// `validate_config` with `HeartbeatTimeoutTooLow`. The default is 60000 ms.
 pub fn with_heartbeat(config: Config, timeout_ms timeout_ms: Int) -> Config {
   Config(..config, heartbeat_timeout_ms: timeout_ms)
@@ -299,17 +299,18 @@ pub fn with_heartbeat(config: Config, timeout_ms timeout_ms: Int) -> Config {
 /// Configure the maximum number of concurrent connections allowed per client
 /// IP address.
 ///
-/// A value of 0 (the default) means unlimited. When a limit is set, a transport
-/// admits a new connection only while the peer is below the limit and rejects
-/// it otherwise; the slot is freed when the connection closes.
+/// A value of 0, the default, means unlimited. When a limit is set, a
+/// transport admits a new connection only while the peer is below the limit.
+/// It rejects other connections. The transport frees the slot when the
+/// connection closes.
 ///
 /// ## Which IP is used
 ///
 /// The limit is enforced on the **real socket peer IP** as reported by the
 /// transport (for the Mist transport, the address of the TCP connection).
-/// Beryl deliberately does **not** trust or parse forwarded headers such as
-/// `X-Forwarded-For`, because a client can set them freely and would otherwise
-/// be able to spoof its address and bypass this limit.
+/// Beryl does **not** trust or parse forwarded headers such as
+/// `X-Forwarded-For`. A client can set these headers and spoof its address to
+/// bypass this limit.
 ///
 /// If Beryl runs behind a trusted reverse proxy or load balancer, every
 /// connection shares the proxy's address, so a per-IP limit throttles all
@@ -349,22 +350,23 @@ pub fn with_connection_rate_per_ip(
 /// Configure the maximum number of concurrent connections allowed across the
 /// whole node, regardless of source IP.
 ///
-/// A value of 0 (the default) means unlimited. When a limit is set, a transport
-/// admits a new connection only while the node is below the limit and rejects
-/// it (before allocating any long-lived per-socket runtime state) otherwise;
-/// the slot is freed when the connection closes, its process dies, or its
-/// handshake/setup fails. The check-and-increment is atomic inside the limiter
-/// actor, so a burst of concurrent opens cannot materially exceed the ceiling.
+/// A value of 0, the default, means unlimited. When a limit is set, a
+/// transport admits a connection only while the node is below the limit. It
+/// rejects other connections before it allocates long-lived per-socket state.
+/// The transport frees the slot when the connection closes, its process dies,
+/// or its handshake or setup fails. The limiter actor performs the check and
+/// increment atomically. Concurrent opens cannot materially exceed the
+/// ceiling.
 ///
 /// ## Composition with per-IP limits
 ///
-/// This node-wide ceiling composes with `with_max_connections_per_ip`: when
-/// both are set a connection must be under *both* limits to be admitted. The
-/// per-IP limit throttles any single abusive peer, while this global ceiling
+/// This node-wide ceiling works with `with_max_connections_per_ip`. When both
+/// are set, a connection must be under *both* limits. The per-IP limit
+/// throttles any single abusive peer, while this global ceiling
 /// bounds the node's total resource use so that many distinct source addresses
-/// (for example a botnet or IPv6 address rotation) still cannot exhaust the
-/// node's process, socket, and runtime budget — a case a per-IP limit alone
-/// cannot stop.
+/// (for example, a botnet or IPv6 address rotation) cannot exhaust the node's
+/// process, socket, and runtime budget. A per-IP limit alone cannot stop this
+/// case.
 ///
 /// ## Composition with external load balancers
 ///
@@ -372,7 +374,7 @@ pub fn with_connection_rate_per_ip(
 /// load balancer, each node enforces its own limit independently, so the
 /// cluster's effective ceiling is roughly `max_connections × node_count`
 /// (subject to how the balancer distributes connections). Size the per-node
-/// value against a single node's capacity, and use the load balancer's own
+/// value against a single node's capacity. Use the load balancer's
 /// global connection/rate controls when you need a cluster-wide cap.
 pub fn with_max_connections(
   config: Config,
@@ -425,7 +427,7 @@ pub fn with_message_rate(
   Config(..config, message_rate: rate, message_burst: burst)
 }
 
-/// Configure per-socket join rate limiting
+/// Configure per-socket join rate limiting.
 pub fn with_join_rate(
   config: Config,
   per_second rate: Int,
@@ -485,15 +487,15 @@ pub fn with_max_event_length(
 // nolint: unused_exports -- enforced in sibling transport handler tests
 /// Configure the maximum allowed inbound WebSocket frame size in bytes.
 ///
-/// The limit is enforced **post-assembly**: the transport (Mist/gramps)
-/// buffers and assembles a complete frame first, and only then does Beryl
-/// measure it and close the connection if it exceeds `max_bytes`. This bounds
+/// Beryl enforces the limit **post-assembly**. The transport (Mist/gramps)
+/// buffers and assembles a complete frame first. Beryl then measures it and
+/// closes the connection if it exceeds `max_bytes`. This bounds
 /// per-message processing cost (decode, routing, rate-limit accounting), but
 /// it does **not** by itself bound transport memory. A hostile client can
 /// declare a huge payload and stream it slowly, or send many fragmented
 /// continuation frames, and the transport's receive buffer grows before this
-/// check ever runs — so this setting alone does not stop a single connection
-/// from exhausting node memory.
+/// check runs. This setting alone does not stop one connection from exhausting
+/// node memory.
 ///
 /// For a true transport memory bound you **must** place an edge proxy or load
 /// balancer in front of Beryl and configure a WebSocket frame-size limit
@@ -563,16 +565,15 @@ pub fn frame_limits(channels: Sockets) -> Option(rate_limit.RateLimitConfig) {
   optional_limits(channels.config.frame_rate, channels.config.frame_burst)
 }
 
-/// Runtime system handle.
+/// A runtime system handle.
 ///
-/// This opaque handle is returned with the supervised subtree from
-/// `child_spec` and passed to broadcast, group, and transport functions. Its
-/// internals are intentionally hidden so Beryl can evolve them without
-/// breaking application code.
+/// `child_spec` returns this opaque handle with the supervised subtree. Pass
+/// it to broadcast, group, and transport functions. Beryl hides its internals
+/// so they can change without breaking application code.
 ///
-/// The handle is deliberately non-generic: an app-side dispatch system is
+/// The handle is non-generic. An app-side dispatch system is
 /// generic over the application's `model`/`msg`, but those types are sealed
-/// inside the monomorphic closures captured at construction time, so they
+/// inside monomorphic closures at construction time. They
 /// never appear in this handle or in any transport signature.
 pub opaque type Sockets {
   Sockets(
@@ -643,14 +644,14 @@ pub fn configured_max_inbound_frame_bytes(channels: Sockets) -> Int {
 
 /// Why an eagerly validated `Config` was rejected before any process started.
 ///
-/// `child_spec` validates the configuration before allocating names or
-/// starting the runtime, so an invalid configuration fails fast instead of
-/// crashing a supervised child at init time.
+/// `child_spec` validates the configuration before it allocates names or
+/// starts the runtime. It returns an invalid configuration instead of
+/// crashing a supervised child during initialization.
 pub type ConfigError {
   /// `heartbeat_timeout_ms` was below the minimum. The server derives its
   /// staleness check interval as `heartbeat_timeout_ms / 2` (integer
-  /// division), so a timeout of 1 would round down to a check interval of 0 —
-  /// which disables heartbeat eviction entirely. The wrapped `Int` is the
+  /// division). A timeout of 1 would round down to a check interval of 0 and
+  /// disable heartbeat eviction. The wrapped `Int` is the
   /// smallest accepted timeout.
   HeartbeatTimeoutTooLow(minimum: Int)
   /// A per-topic-pattern rate limit used a pattern string that is not a valid
@@ -678,7 +679,7 @@ pub type StopError {
   StopTimeout
 }
 
-/// Eagerly validate a [`Config`](#config) without starting anything.
+/// Validate a [`Config`](#config) without starting any process.
 ///
 /// This checks that `heartbeat_timeout_ms` is at least 2 and that every
 /// per-topic rate-limit pattern is valid.
@@ -696,14 +697,15 @@ pub fn validate_config(config: Config) -> Result(Nil, ConfigError) {
 
 /// Stop a Beryl system.
 ///
-/// This drains the supervised runtime and stops it, delivering `Closed` to
-/// every joined topic before closing each transport connection. Presence is
-/// application-owned and is not stopped by this function. The runtime is a
-/// `Transient` child, so it is not restarted after a graceful stop.
+/// This function drains and stops the supervised runtime. It delivers
+/// `Closed` to every joined topic before it closes each transport connection.
+/// Presence is application-owned and is not stopped by this function. The
+/// runtime is a `Transient` child, so it is not restarted after a graceful
+/// stop.
 ///
-/// `stop` is safe to call more than once and on a handle whose system was
-/// never started: in those cases it returns `Error(NotRunning)` rather than
-/// crashing. It returns `Error(StopTimeout)` if the app runtime does not
+/// You can call `stop` more than once or use a handle whose system never
+/// started. In these cases, it returns `Error(NotRunning)` and does not crash.
+/// It returns `Error(StopTimeout)` if the app runtime does not
 /// acknowledge the stop within the shutdown window. After a successful stop
 /// the handle should no longer be used.
 pub fn stop(sockets: Sockets) -> Result(Nil, StopError) {
@@ -803,9 +805,10 @@ fn await_down(monitor: process.Monitor) -> Result(Nil, Nil) {
 
 /// Build the app-side dispatch supervision child specification.
 ///
-/// Add the returned specification to the application's own supervision tree.
-/// The configuration is validated eagerly, before the application's supervisor
-/// starts, rather than crashing a supervised child at init time.
+/// Add the returned specification to the application's supervision tree.
+/// This function validates the configuration before the application's
+/// supervisor starts. It returns an error instead of crashing a supervised
+/// child during initialization.
 ///
 /// The returned `Sockets` handle is name-backed and usable immediately, even
 /// before the supervision tree that owns the returned child specification is
@@ -1172,10 +1175,10 @@ pub fn app_dispatch(sockets: Sockets) -> AppHandle {
   sockets.app
 }
 
-/// Broadcast a message to all subscribers of a topic
+/// Broadcast a message to all subscribers of a topic.
 ///
-/// This sends the message to all sockets subscribed to the topic. When the
-/// system was started with PubSub, the broadcast is also distributed to
+/// This function sends the message to all sockets subscribed to the topic.
+/// When the system was started with PubSub, it also sends the broadcast to
 /// subscribers on other nodes.
 ///
 /// ## Example
@@ -1223,7 +1226,7 @@ pub fn broadcast_presence_diff(
   )
 }
 
-/// Broadcast a message to all subscribers except one socket
+/// Broadcast a message to all subscribers except one socket.
 ///
 /// Useful for broadcasting a message to everyone except the sender.
 /// When PubSub is configured, the excluded socket ID is preserved across

--- a/packages/beryl/src/beryl/bridge.gleam
+++ b/packages/beryl/src/beryl/bridge.gleam
@@ -58,19 +58,19 @@ import gleam/erlang/process.{type Pid, type Subject}
 /// timeout only guards against a forwarder that failed to spawn.
 const handshake_timeout_ms = 5000
 
-/// A handle to a running bridge forwarder process.
+/// A handle to a running bridge forwarder.
 ///
-/// `message` is the type emitted by the external actor and received on the
-/// bridge's `Subject`. Obtain that subject with `subject` to wire it up to a
-/// domain actor, and call `stop` to tear the forwarder down.
+/// `message` is the type that the external actor sends to the bridge's
+/// `Subject`. Get the subject with `subject`. Call `stop` to stop the
+/// forwarder.
 pub opaque type Bridge(message) {
   Bridge(pid: Pid, subject: Subject(message), control: Subject(Control))
 }
 
 /// Why a bridge failed to start.
 pub type StartError {
-  /// The forwarder process did not report its subjects within
-  /// `handshake_timeout_ms` — it failed to spawn or start.
+  /// The forwarder did not report its subjects within
+  /// `handshake_timeout_ms`. It failed to spawn or start.
   ForwarderUnavailable
 }
 
@@ -86,22 +86,21 @@ type Event(message) {
   OwnerDown
 }
 
-/// Start a bridge that forwards values from an external `Subject` to a
-/// socket's `update` function as `Info` events.
+/// Start a bridge from an external `Subject` to a socket's `update` function.
 ///
-/// The returned `Bridge` owns a freshly spawned forwarder process. Pass
-/// `subject(bridge)` to the external/domain actor so it delivers its stream
-/// to the forwarder; each received value is mapped with `transform` and
-/// delivered via `socket.notify(sender, transform(value))`.
+/// The returned `Bridge` owns a new forwarder process. Pass `subject(bridge)`
+/// to the external or domain actor. The forwarder maps each received value
+/// with `transform` and sends it as an `Info` event through
+/// `socket.notify(sender, transform(value))`.
 ///
 /// Use `transform` to translate the domain message into your app's
 /// server-side `msg` type (the `Info` payload). If no translation is needed,
 /// pass the identity function `fn(value) { value }`.
 ///
-/// Always call `stop` when the owning socket or topic ends — that is the
-/// per-owner cleanup. The forwarder also monitors the calling process, but
-/// that monitor is only a backstop: it fires if the owner dies without a
-/// `stop`, not as a per-topic lifecycle.
+/// Always call `stop` when the owning socket or topic ends. The forwarder
+/// also monitors the calling process. This monitor stops the forwarder if
+/// the owner dies without calling `stop`, but it does not track topic
+/// lifecycles.
 pub fn start(
   to sender: Sender(info),
   with transform: fn(message) -> info,
@@ -151,23 +150,23 @@ fn forward_loop(
   }
 }
 
-/// The `Subject` the external actor should send its stream to.
+/// Return the `Subject` that receives the external actor's stream.
 ///
-/// Hand this to your domain actor (e.g. as its subscriber) so each emitted
-/// value is forwarded to the bridged socket.
+/// Give this subject to the domain actor, for example as its subscriber.
+/// Each value is then sent to the bridged socket.
 pub fn subject(bridge: Bridge(message)) -> Subject(message) {
   bridge.subject
 }
 
-/// The forwarder process id.
+/// Return the forwarder process ID.
 ///
-/// Exposed for diagnostics and supervision; you normally only need `subject`
-/// and `stop`.
+/// Use this value for diagnostics and supervision. Most callers need only
+/// `subject` and `stop`.
 pub fn pid(bridge: Bridge(message)) -> Pid {
   bridge.pid
 }
 
-/// Stop the bridge's forwarder process.
+/// Stop the bridge's forwarder.
 ///
 /// Call this when the owning socket or topic ends. It is safe to call more
 /// than once and after the forwarder has already exited.

--- a/packages/beryl/src/beryl/channel.gleam
+++ b/packages/beryl/src/beryl/channel.gleam
@@ -49,17 +49,17 @@
 //// unrelated `state` and `info` types compose in one list. No value is
 //// ever erased to `Dynamic` and no unchecked coercion is involved:
 //// typed `info` values travel inside a closure that only the join which
-//// created it can open, and the socket that owns the join opens it — or
-//// drops it unopened, if the join has since ended.
+//// created it can open. The socket that owns the join opens it. If the join
+//// has ended, the socket drops it unopened.
 ////
 //// ## Ordering
 ////
 //// Action lists are applied strictly from left to right, and they always
 //// target the channel's own topic. They lower onto
-//// beryl's core `Effect` values, which the runtime applies in list order —
-//// so action order is wire order. An asynchronous presence effect can park
-//// this socket while other sockets continue; the remaining actions resume
-//// only after that effect completes.
+//// beryl's core `Effect` values, which the runtime applies in list order.
+//// Action order is therefore wire order. An asynchronous presence effect can
+//// park this socket while other sockets continue. The remaining actions
+//// resume only after that effect completes.
 ////
 //// A join's actions (see [`with_actions`](#with_actions)) are emitted with
 //// the join acknowledgment, immediately after it: the socket is already
@@ -94,10 +94,10 @@ import gleam/set
 
 /// Why building a channel-system child specification failed.
 ///
-/// Handler patterns are validated before the core configuration. Validation
-/// checks every pattern's syntax in registration order, then checks exact
-/// duplicates in registration order. Overlapping non-identical patterns are
-/// allowed because routing takes the first match.
+/// The function validates handler patterns before the core configuration. It
+/// checks each pattern's syntax in registration order. It then checks for
+/// exact duplicates in the same order. Overlapping patterns are allowed when
+/// they are not identical because routing uses the first match.
 pub type ChildSpecError {
   /// A handler used an invalid topic pattern.
   InvalidPattern(pattern: String, reason: topic.TopicError)
@@ -110,10 +110,10 @@ pub type ChildSpecError {
 /// Build a channel system's supervision child specification for embedding
 /// in an application's supervision tree.
 ///
-/// Like `beryl.child_spec`, this reports only what can be detected before
-/// the tree is started: the handler table is validated first, then the
-/// `beryl.Config`. The returned `beryl.Sockets` is usable as soon as the
-/// owning tree is running.
+/// Like `beryl.child_spec`, this function reports only errors that it can
+/// detect before the tree starts. It validates the handler table first and
+/// then validates `beryl.Config`. You can use the returned `beryl.Sockets`
+/// after the owning tree starts.
 ///
 /// ## Example
 ///
@@ -184,24 +184,24 @@ fn check_duplicates(
 
 /// A typed handle for sending server-side messages to one joined channel.
 ///
-/// Obtained from [`JoinContext`](#joincontext) in the `join` callback and safe to
-/// share with any process. Messages sent through it are delivered to the
-/// channel's `on_info` callback with their type intact.
+/// Get this handle from [`JoinContext`](#joincontext) in the `join` callback.
+/// You can share it with any process. The channel's `on_info` callback
+/// receives each message with its type intact.
 ///
-/// A sender is scoped to the join that produced it. Sending is
-/// asynchronous and never fails, so it cannot report that the channel is
-/// gone: liveness is decided where the message is delivered. After a
-/// normal close — a client leave, a [`close`](#close) result, a socket
-/// teardown — or after the same topic has been joined again, the message
-/// is dropped there and is never handed to a different join.
+/// A sender is scoped to the join that produced it. Sending is asynchronous
+/// and never fails. It cannot report that the channel is gone. The delivery
+/// point checks liveness. It drops the message after a normal close, such as
+/// a client leave, a [`close`](#close) result, or a socket teardown. It also
+/// drops the message after the same topic is joined again. A different join
+/// never receives the message.
 ///
 /// The one exception is a panic inside [`on_terminate`](#on_terminate).
 /// Core's policy for a crash while closing a topic is to log it and keep
 /// the model from before the close, so the channel system keeps that
 /// instance: a sender created by it can still reach its `on_info` until
 /// the topic is joined again or the socket ends. Nothing is handed to
-/// another join in that window either — it is the *same* instance,
-/// outliving its own termination.
+/// another join in that window. It is the *same* instance, outliving its own
+/// termination.
 ///
 /// ## Cost
 ///
@@ -218,20 +218,19 @@ pub opaque type Sender(info) {
 
 /// Send a typed server-side message to the channel that owns `sender`.
 ///
-/// Each call enqueues exactly one message, and each enqueued message
-/// produces exactly one `on_info` call — sends are never coalesced, and
-/// they are delivered in the order the owning socket receives them.
+/// Each call enqueues one message. Each enqueued message produces one
+/// `on_info` call. The runtime does not combine sends. It delivers them in
+/// the order that the owning socket receives them.
 ///
-/// This is a fire-and-forget send: it returns as soon as the message is
-/// enqueued, whether or not the channel is still joined. A message
-/// enqueued for a channel that has already ended is discarded on arrival
-/// (see [`Sender`](#sender), which also covers the cost of a delivery and
-/// the one case where an ended channel still receives one).
+/// This is a fire-and-forget send. It returns when the message is enqueued,
+/// whether or not the channel is still joined. The runtime discards a message
+/// for a channel that has ended. See [`Sender`](#sender) for delivery cost and
+/// the one case in which an ended channel can still receive a message.
 pub fn notify(sender: Sender(info), message: info) -> Nil {
   sender.send(message)
 }
 
-/// Everything a `join` callback learns about one join attempt.
+/// Information about one join attempt.
 ///
 /// `params` contains wildcard captures in pattern order and is empty for
 /// exact patterns. `self` is this channel's generation-scoped
@@ -290,8 +289,8 @@ pub opaque type Closing {
 
 /// One operation on the channel's own topic.
 ///
-/// The phase parameter prevents active-only operations from being returned
-/// by [`on_terminate`](#on_terminate). Put actions in a list in wire order.
+/// The phase parameter prevents [`on_terminate`](#on_terminate) from returning
+/// active-only operations. Put actions in a list in wire order.
 pub opaque type Action(phase) {
   PushAction(phase: phase, event: String, payload: json.Json)
   BroadcastAction(event: String, payload: json.Json)
@@ -339,7 +338,7 @@ pub fn broadcast_from(event: String, payload: json.Json) -> Action(phase) {
 /// Reply successfully when a client message supplied a reply handle.
 ///
 /// [`option.None`](https://hexdocs.pm/gleam_stdlib/gleam/option.html#Option)
-/// lowers to no effect.
+/// produces no effect.
 pub fn reply_ok(
   reply: option.Option(socket.ReplyRef),
   payload: json.Json,
@@ -350,7 +349,7 @@ pub fn reply_ok(
 /// Reply with an error when a client message supplied a reply handle.
 ///
 /// [`option.None`](https://hexdocs.pm/gleam_stdlib/gleam/option.html#Option)
-/// lowers to no effect.
+/// produces no effect.
 pub fn reply_error(
   reply: option.Option(socket.ReplyRef),
   payload: json.Json,
@@ -416,7 +415,7 @@ pub fn next(state: state, actions: List(Action(Active))) -> Next(state) {
 
 /// Leave this channel after applying `actions` in order.
 ///
-/// The socket stays connected and its other channels are untouched; this
+/// The socket stays connected. Its other channels do not change. This
 /// channel's [`on_terminate`](#on_terminate) callback still runs.
 pub fn close(actions: List(Action(Active))) -> Next(state) {
   NextClose(actions: actions)
@@ -424,8 +423,8 @@ pub fn close(actions: List(Action(Active))) -> Next(state) {
 
 /// Tear down the whole socket, not just this channel.
 ///
-/// This deliberately carries no actions: the socket and every channel on
-/// it are going away, so there is nothing left to apply them to.
+/// This result carries no actions. The socket and all its channels are
+/// stopping, so no target remains for the actions.
 pub fn stop_socket(reason: socket.StopReason) -> Next(state) {
   NextStop(reason: reason)
 }
@@ -437,9 +436,9 @@ pub fn stop_socket(reason: socket.StopReason) -> Next(state) {
 /// The typed callbacks of one channel, over its private `state` and its
 /// server-side message type `info`.
 ///
-/// Start from [`callbacks`](#callbacks) — which ignores every input and
-/// stays joined — and override only what the channel cares about. Pass the
-/// result to [`accept`](#accept) with the initial state.
+/// Start with [`callbacks`](#callbacks), which ignores every input and stays
+/// joined. Override only the callbacks that the channel needs. Pass the result
+/// to [`accept`](#accept) with the initial state.
 pub opaque type Callbacks(state, info) {
   Callbacks(
     message: fn(state, Message) -> Next(state),
@@ -489,18 +488,18 @@ pub fn on_info(
   Callbacks(..callbacks, info: handle)
 }
 
-/// Run cleanup when the channel ends, for any reason: client leave, a
+/// Run cleanup when the channel ends for any reason: client leave, a
 /// [`close`](#close) result, a socket teardown, or a disconnect.
 ///
-/// The returned closing-phase actions are applied in the turn that closes
-/// this topic, right after the channel instance is gone. The phase allows
-/// broadcasts, presence untracking, and presence broadcasts, while making
-/// pushes, replies, and presence tracking unavailable.
+/// The runtime applies the returned closing-phase actions in the turn that
+/// closes this topic, after it removes the channel instance. This phase
+/// allows broadcasts, presence untracking, and presence broadcasts. It does
+/// not allow pushes, replies, or presence tracking.
 ///
-/// A panic here is not fatal, but it is not free either: core keeps the
-/// model from before the close, so this instance stays in the channel
-/// system's map and its own [`Sender`](#sender) can still reach it until
-/// the topic is rejoined or the socket ends.
+/// A panic here is not fatal. Core keeps the model from before the close.
+/// This instance stays in the channel system's map, and its
+/// [`Sender`](#sender) can reach it until the topic is rejoined or the socket
+/// ends.
 pub fn on_terminate(
   callbacks: Callbacks(state, info),
   handle: fn(state, socket.StopReason) -> List(Action(Closing)),
@@ -597,22 +596,22 @@ pub fn with_reply(
   }
 }
 
-/// Add ordered actions to run as part of accepting this join.
+/// Add ordered actions to an accepted join.
 ///
-/// They are emitted with the acknowledgment and applied strictly after it,
-/// so the socket is already subscribed to the topic: a [`push`](#push)
-/// here cannot overtake its own join reply. If an action lowers to an
+/// The runtime emits the actions with the acknowledgment and applies them
+/// after it. The socket is therefore already subscribed to the topic. A
+/// [`push`](#push) cannot overtake its own join reply. If an action becomes an
 /// asynchronous presence effect, the runtime may process other sockets
-/// while this socket waits; a check followed by [`presence_track`](#presence_track)
-/// is therefore not an atomic cross-socket capacity reservation.
+/// while this socket waits. A check followed by
+/// [`presence_track`](#presence_track) is not an atomic cross-socket capacity
+/// reservation.
 ///
 /// Use this function instead of notifying the channel from `join`:
 /// [`notify`](#notify) schedules a *later* input, while actions preserve
 /// their declared position immediately after the join acknowledgment.
 ///
-/// Existing actions stay ahead of the ones added here. A refused
-/// join has no topic to act on, so this returns [`reject`](#reject)
-/// results unchanged.
+/// Existing actions stay before the actions added here. A refused join has no
+/// topic, so this function returns [`reject`](#reject) results unchanged.
 pub fn with_actions(
   result: JoinResult(info),
   actions: List(Action(Active)),
@@ -639,9 +638,9 @@ pub fn reject(reason: json.Json) -> JoinResult(info) {
 
 /// A registered channel: a topic pattern plus its sealed `join` callback.
 ///
-/// `Handler` is deliberately not generic. A channel's `state` and `info`
-/// types are sealed inside the closure captured here, so a single
-/// `List(Handler)` can hold channels that agree on nothing.
+/// `Handler` is not generic. The closure contains the channel's sealed `state`
+/// and `info` types. A single `List(Handler)` can therefore hold channels
+/// with unrelated types.
 pub opaque type Handler {
   Handler(pattern: String, open: fn(RoutedJoinContext) -> JoinOutcome)
 }

--- a/packages/beryl/src/beryl/error.gleam
+++ b/packages/beryl/src/beryl/error.gleam
@@ -17,7 +17,7 @@ type StartFailureReason {
   StartExited(String)
 }
 
-/// Convert a startup failure to a human-readable diagnostic string.
+/// Return a human-readable description of a startup failure.
 pub fn describe_start_failure(failure: StartFailure) -> String {
   case failure.reason {
     StartTimedOut -> "actor init timed out"
@@ -26,7 +26,7 @@ pub fn describe_start_failure(failure: StartFailure) -> String {
   }
 }
 
-/// Convert a `gleam/otp/actor.StartError` into beryl's `StartFailure`.
+/// Convert a `gleam/otp/actor.StartError` to Beryl's `StartFailure`.
 pub fn from_actor_start_error(error: actor.StartError) -> StartFailure {
   case error {
     actor.InitTimeout -> StartFailure(StartTimedOut)

--- a/packages/beryl/src/beryl/group.gleam
+++ b/packages/beryl/src/beryl/group.gleam
@@ -31,10 +31,10 @@ import gleam/otp/supervision
 import gleam/result
 import gleam/set.{type Set}
 
-/// A running Groups instance.
+/// A running groups instance.
 ///
-/// This handle is intentionally opaque so callers cannot forge the backing
-/// actor subject or depend on its runtime representation.
+/// This handle is opaque. Callers cannot forge the actor subject or depend
+/// on its runtime representation.
 ///
 /// ## Node affinity
 ///
@@ -53,15 +53,15 @@ pub opaque type Config {
   Config(call_timeout_ms: Int)
 }
 
-/// Errors from group operations
+/// Errors from group operations.
 pub type GroupError {
-  /// The group already exists
+  /// The group already exists.
   GroupAlreadyExists
-  /// The group was not found
+  /// The group was not found.
   GroupNotFound
 }
 
-/// Messages the groups actor handles
+/// Messages that the groups actor handles.
 pub opaque type Message {
   Create(name: String, reply: Subject(Result(Nil, GroupError)))
   Delete(name: String, reply: Subject(Result(Nil, GroupError)))
@@ -155,7 +155,7 @@ fn build_groups() -> actor.Builder(State, Message, Subject(Message)) {
   |> actor.on_message(handle_message)
 }
 
-/// Create a new named group
+/// Create a named group.
 ///
 /// Panics if the groups actor is unavailable or does not reply within the
 /// configured call timeout (5 seconds by default).
@@ -165,7 +165,7 @@ pub fn create(groups: Groups, name: String) -> Result(Nil, GroupError) {
   })
 }
 
-/// Delete a group
+/// Delete a group.
 ///
 /// Panics if the groups actor is unavailable or does not reply within the
 /// configured call timeout (5 seconds by default).
@@ -175,7 +175,7 @@ pub fn delete(groups: Groups, name: String) -> Result(Nil, GroupError) {
   })
 }
 
-/// Add a topic to a group
+/// Add a topic to a group.
 ///
 /// Panics if the groups actor is unavailable or does not reply within the
 /// configured call timeout (5 seconds by default).
@@ -189,7 +189,7 @@ pub fn add(
   })
 }
 
-/// Remove a topic from a group
+/// Remove a topic from a group.
 ///
 /// Panics if the groups actor is unavailable or does not reply within the
 /// configured call timeout (5 seconds by default).
@@ -203,7 +203,7 @@ pub fn remove(
   })
 }
 
-/// Get all topics in a group
+/// Return all topics in a group.
 ///
 /// Panics if the groups actor is unavailable or does not reply within the
 /// configured call timeout (5 seconds by default).
@@ -216,7 +216,7 @@ pub fn topics(
   })
 }
 
-/// List all group names
+/// Return all group names.
 ///
 /// Panics if the groups actor is unavailable or does not reply within the
 /// configured call timeout (5 seconds by default).
@@ -226,13 +226,14 @@ pub fn list_groups(groups: Groups) -> List(String) {
   })
 }
 
-/// Broadcast a message to all topics in a group
+/// Broadcast a message to all topics in a group.
 ///
-/// Sends the message to every topic in the named group via beryl.broadcast().
-/// The topic lookup runs through the groups actor, then fan-out runs in the
-/// caller. If the group doesn't exist, this is a silent no-op.
+/// This function sends the message to each topic through `beryl.broadcast`.
+/// The groups actor performs the topic lookup. The caller performs the
+/// fan-out. If the group does not exist, this function does nothing.
 ///
-/// Panics if the groups actor is unavailable or does not reply within 5 seconds.
+/// Panics if the groups actor is unavailable or does not reply within the
+/// configured call timeout.
 pub fn broadcast(
   groups: Groups,
   channels: beryl.Sockets,

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -55,9 +55,9 @@ const sync_event = "presence_sync"
 
 /// A running Presence instance.
 ///
-/// This handle is intentionally opaque so callers cannot forge actor subjects
-/// or depend on the runtime representation. It carries the actor's stable
-/// registered subject and the name of its actor-owned ETS read model.
+/// This handle is opaque. Callers cannot forge actor subjects or depend on
+/// the runtime representation. It contains the actor's stable registered
+/// subject and the name of its actor-owned ETS read model.
 ///
 /// ## Node affinity
 ///
@@ -82,8 +82,8 @@ type State =
 
 /// An opaque diff representing presence joins and leaves grouped by topic.
 ///
-/// This is passed to `Config.on_diff` and accepted by
-/// `beryl.broadcast_presence_diff`.
+/// Beryl passes this value to `Config.on_diff`.
+/// `beryl.broadcast_presence_diff` also accepts it.
 pub opaque type Diff {
   Diff(
     joins: Dict(String, List(PresenceEntry)),
@@ -93,16 +93,16 @@ pub opaque type Diff {
 
 /// A presence entry returned from queries and diff accessors.
 ///
-/// This type is intentionally transparent so callers can inspect query results
-/// and construct entries for `diff`.
+/// This type is transparent. Callers can inspect query results and construct
+/// entries for `diff`.
 pub type PresenceEntry {
   PresenceEntry(session_id: String, key: String, meta: json.Json)
 }
 
 /// Build a presence diff from topic-grouped joins and leaves.
 ///
-/// Most applications receive diffs from `Config.on_diff`; this helper is for
-/// callers that need to construct a diff to pass to `beryl.broadcast_presence_diff`.
+/// Most applications receive diffs from `Config.on_diff`. Use this function
+/// to construct a diff for `beryl.broadcast_presence_diff`.
 pub fn diff(
   joins joins: List(#(String, List(PresenceEntry))),
   leaves leaves: List(#(String, List(PresenceEntry))),
@@ -116,13 +116,13 @@ pub fn diff_topics(diff: Diff) -> List(String) {
   |> unique_strings(set.new(), [])
 }
 
-/// Get presence joins for a topic in this diff.
+/// Return presence joins for a topic in this diff.
 pub fn diff_joins(diff: Diff, topic: String) -> List(PresenceEntry) {
   dict.get(diff.joins, topic)
   |> result.unwrap([])
 }
 
-/// Get presence leaves for a topic in this diff.
+/// Return presence leaves for a topic in this diff.
 pub fn diff_leaves(diff: Diff, topic: String) -> List(PresenceEntry) {
   dict.get(diff.leaves, topic)
   |> result.unwrap([])
@@ -182,8 +182,8 @@ pub type SyncPayload {
 
 /// Configuration for starting presence.
 ///
-/// Build configs with `default_config` and the `with_*` functions so beryl can
-/// add future options without exposing record fields as public API.
+/// Build configurations with `default_config` and the `with_*` functions.
+/// Beryl can then add options without exposing record fields as public API.
 pub opaque type Config {
   Config(
     /// PubSub instance for cross-node replication
@@ -207,13 +207,13 @@ pub opaque type Config {
   )
 }
 
-/// Errors from updating a tracked presence.
+/// Errors from an update to a tracked presence.
 pub type PresenceUpdateError {
   /// The ref is unknown, already removed, or was not returned by `track`.
   UnknownRef
 }
 
-/// Messages the presence actor handles
+/// Messages that the presence actor handles.
 pub opaque type Message {
   Track(
     topic: String,
@@ -432,10 +432,10 @@ type ActorState {
 
 /// Default configuration (no PubSub).
 ///
-/// The broadcast interval defaults to 1500 ms so that adding `with_pubsub`
-/// yields working two-way replication out of the box; without PubSub the
-/// interval is unused. Use `with_broadcast_interval(0)` to disable periodic
-/// broadcasts and control replication manually.
+/// The broadcast interval defaults to 1500 ms. Adding `with_pubsub` therefore
+/// enables two-way replication without more configuration. Without PubSub,
+/// the interval is unused. Use `with_broadcast_interval(0)` to disable
+/// periodic broadcasts and control replication manually.
 pub fn default_config(replica: String) -> Config {
   Config(
     pubsub: None,
@@ -460,38 +460,37 @@ pub fn with_broadcast_interval(config: Config, interval_ms: Int) -> Config {
 
 /// Set the timeout for synchronous presence mutations, in milliseconds.
 ///
-/// This applies to `track`, `untrack`, and `untrack_all`. These functions panic
-/// if the actor does not reply within this timeout. The default is 5000 ms.
+/// This timeout applies to `track`, `untrack`, and `untrack_all`. These
+/// functions panic if the actor does not reply before the timeout. The default
+/// is 5000 ms.
 pub fn with_call_timeout(config: Config, timeout_ms: Int) -> Config {
   Config(..config, call_timeout_ms: timeout_ms)
 }
 
-/// Set the callback invoked when local changes or remote merges produce a diff.
+/// Set the callback for diffs from local changes or remote merges.
 ///
 /// The callback runs synchronously on the presence actor, for both local
 /// mutations (`track`/`untrack`/`untrack_all`, and the asynchronous
 /// mutations the runtime issues for presence effects) and remote merges,
 /// before the affected topics' read-model snapshots are (re)published and
 /// before the triggering call replies or the mutation is acknowledged.
-/// This ordering is identical for local and remote diffs -- there is no
-/// divergent local-vs-remote behavior.
+/// This ordering is the same for local and remote diffs.
 ///
-/// One consequence: if the callback reads presence state through the same
+/// If the callback reads presence state through the same
 /// `Presence` handle (`list`, `get_by_key`, `count`) for a topic this diff
-/// touches, it observes the *previous* snapshot -- the one from before this
-/// diff -- not the one the diff itself is about to produce. Read the
-/// entries and counts you need directly from the `Diff` argument (via
+/// changes, it observes the *previous* snapshot. It does not observe the
+/// snapshot that the diff will produce. Read the entries and counts you need
+/// directly from the `Diff` argument (via
 /// `diff_joins`/`diff_leaves`) instead of re-reading through `presence`
 /// inside the callback.
 ///
-/// Keep the callback fast and non-blocking: it runs on the actor process,
-/// so a slow or blocking callback delays that topic's read-model publish,
+/// Keep the callback fast and non-blocking. It runs on the actor process.
+/// A slow or blocking callback delays that topic's read-model publish,
 /// the reply to (or acknowledgement of) the mutating operation, and every
-/// other message queued behind it in the actor's mailbox (though concurrent
-/// `list`/`get_by_key`/`count` reads from other processes are unaffected,
-/// since those bypass the mailbox entirely). It no longer stalls a Beryl
-/// runtime wholesale: only the socket whose presence effect is in flight
-/// waits on it.
+/// other message behind it in the actor's mailbox. Concurrent
+/// `list`/`get_by_key`/`count` calls from other processes do not use the
+/// mailbox and are not delayed. Only the socket with an active presence
+/// effect waits for the callback.
 pub fn with_on_diff(config: Config, callback: fn(Diff) -> Nil) -> Config {
   Config(..config, on_diff: Some(callback))
 }
@@ -504,9 +503,8 @@ pub fn subject(presence: Presence) -> Subject(Message) {
 /// Build the supervised presence actor.
 ///
 /// Add the returned child specification to your application's supervisor.
-/// The returned handle is name-backed and resumes working after a supervised
-/// restart. Presence entries and tracking refs are in-memory state and are
-/// reset by a restart.
+/// The returned handle is name-backed and works again after a supervised
+/// restart. A restart resets the in-memory presence entries and tracking refs.
 pub fn child_spec(
   config: Config,
 ) -> #(Presence, supervision.ChildSpecification(Subject(Message))) {
@@ -748,14 +746,14 @@ fn meta_with_phx_ref(meta: json.Json, ref: String) -> json.Json {
 
 /// Track a presence in a topic.
 ///
-/// `session_id` identifies the session (e.g. socket) that owns this presence
-/// and is the value `untrack_all` matches on when the session disconnects.
+/// `session_id` identifies the session, such as a socket, that owns this
+/// presence. `untrack_all` matches this value when the session disconnects.
 ///
-/// Returns a server-generated tracking ref: an opaque, unique handle for this
-/// specific presence. Pass it to `untrack` to remove exactly this entry later.
-/// The ref is not the session id — it is minted by the presence actor and is
-/// only meaningful to that actor. The ref is also merged into object metas as
-/// `phx_ref` for Phoenix client compatibility.
+/// Returns a server-generated tracking ref. It is an opaque, unique handle for
+/// this presence. Pass it to `untrack` to remove this entry. The ref is not
+/// the session ID. The presence actor creates it, and it is meaningful only
+/// to that actor. The ref is also merged into object metas as `phx_ref` for
+/// Phoenix client compatibility.
 ///
 /// Panics if the presence actor is unavailable or does not reply within the
 /// configured call timeout (5 seconds by default).
@@ -773,9 +771,9 @@ pub fn track(
 
 /// Replace the meta of a presence created by `track`.
 ///
-/// The old ref's leave and the new ref's join are emitted together in one
-/// diff, so subscribers never observe an intermediate state without the
-/// presence key. Other tracked refs for the same key are left unchanged.
+/// One diff contains the old ref's leave and the new ref's join. Subscribers
+/// do not observe an intermediate state without the presence key. Other
+/// tracked refs for the same key do not change.
 ///
 /// Returns the replacement ref, which must be used for subsequent `update`
 /// or `untrack` calls. Returns `Error(UnknownRef)` when `ref` is
@@ -802,7 +800,7 @@ pub fn untrack(presence: Presence, ref: String) -> Nil {
   })
 }
 
-/// Untrack all presences for a session (e.g., when a socket disconnects)
+/// Untrack all presences for a session, such as when a socket disconnects.
 ///
 /// Panics if the presence actor is unavailable or does not reply within the
 /// configured call timeout (5 seconds by default).
@@ -898,12 +896,12 @@ pub fn is_running(presence: Presence) -> Bool {
 
 /// List all presences for a topic.
 ///
-/// Reads the actor-owned read model directly (an ETS snapshot materialized
-/// after each mutation, merge, or prune) rather than calling the actor, so
-/// this never waits on the actor mailbox.
+/// This function reads the actor-owned read model directly. The read model is
+/// an ETS snapshot created after each mutation, merge, or prune. This function
+/// does not wait on the actor mailbox.
 ///
-/// Returns `Error(Nil)` when the presence read model is unavailable --
-/// either the presence actor is not running, or this handle is being used
+/// Returns `Error(Nil)` when the presence read model is unavailable. This can
+/// occur when the presence actor is not running or when this handle is used
 /// from a process on another BEAM node than the one it was started on (see
 /// the node affinity note on `Presence`).
 pub fn list(
@@ -915,12 +913,12 @@ pub fn list(
 
 /// Get presences for a specific key within a topic.
 ///
-/// Reads the actor-owned read model directly (an ETS snapshot materialized
-/// after each mutation, merge, or prune) rather than calling the actor, so
-/// this never waits on the actor mailbox.
+/// This function reads the actor-owned read model directly. The read model is
+/// an ETS snapshot created after each mutation, merge, or prune. This function
+/// does not wait on the actor mailbox.
 ///
-/// Returns `Error(Nil)` when the presence read model is unavailable --
-/// either the presence actor is not running, or this handle is being used
+/// Returns `Error(Nil)` when the presence read model is unavailable. This can
+/// occur when the presence actor is not running or when this handle is used
 /// from a process on another BEAM node than the one it was started on (see
 /// the node affinity note on `Presence`).
 pub fn get_by_key(
@@ -938,17 +936,17 @@ pub fn get_by_key(
 
 /// Count presences in a topic.
 ///
-/// Equivalent to `list(presence, topic) |> list.length`, but O(1): it reads
-/// the materialized count directly from the read model via
+/// This is equivalent to `list(presence, topic) |> list.length`, but O(1). It
+/// reads the materialized count directly from the read model via
 /// `ets:lookup_element/4` instead of building (and copying) the entry list
 /// just to measure it.
 ///
-/// Reads the actor-owned read model directly (an ETS snapshot materialized
-/// after each mutation, merge, or prune) rather than calling the actor, so
-/// this never waits on the actor mailbox.
+/// This function reads the actor-owned read model directly. The read model is
+/// an ETS snapshot created after each mutation, merge, or prune. This function
+/// does not wait on the actor mailbox.
 ///
-/// Returns `Error(Nil)` when the presence read model is unavailable --
-/// either the presence actor is not running, or this handle is being used
+/// Returns `Error(Nil)` when the presence read model is unavailable. This can
+/// occur when the presence actor is not running or when this handle is used
 /// from a process on another BEAM node than the one it was started on (see
 /// the node affinity note on `Presence`).
 pub fn count(presence: Presence, topic: String) -> Result(Int, Nil) {

--- a/packages/beryl/src/beryl/presence/wire.gleam
+++ b/packages/beryl/src/beryl/presence/wire.gleam
@@ -8,8 +8,8 @@ import gleam/result
 
 /// Encode a presence diff for one topic as a Phoenix-compatible payload.
 ///
-/// The resulting JSON has `joins` and `leaves` maps keyed by presence key,
-/// where each value contains the tracked metadata under `metas`.
+/// The resulting JSON has `joins` and `leaves` maps. Presence keys index the
+/// maps. Each value contains the tracked metadata under `metas`.
 ///
 /// ```json
 /// {
@@ -27,17 +27,17 @@ pub fn encode_diff(diff: Diff, topic: String) -> json.Json {
 /// Encode a topic's full presence list as a Phoenix-compatible
 /// `presence_state` payload.
 ///
-/// The resulting JSON is a map keyed by presence key, where each value
-/// contains the tracked metadata under `metas` — the same shape as one side
-/// of a `presence_diff`:
+/// The resulting JSON is a map indexed by presence key. Each value contains
+/// the tracked metadata under `metas`. This is the same shape as one side of
+/// a `presence_diff`:
 ///
 /// ```json
 /// { "user:1": { "metas": [{ "status": "online", "phx_ref": "..." }] } }
 /// ```
 ///
-/// Phoenix clients expect a `presence_state` event carrying this payload
-/// after joining a presence-enabled topic (followed by incremental
-/// `presence_diff` events). Build the entry list with `presence.list`.
+/// Phoenix clients expect a `presence_state` event with this payload after
+/// they join a presence-enabled topic. Incremental `presence_diff` events
+/// follow it. Build the entry list with `presence.list`.
 pub fn encode_state(entries: List(PresenceEntry)) -> json.Json {
   encode_entries(entries)
 }

--- a/packages/beryl/src/beryl/pubsub.gleam
+++ b/packages/beryl/src/beryl/pubsub.gleam
@@ -6,9 +6,9 @@
 ////
 //// The payload is generic: `PubSub(payload)` and `Message(payload)` carry
 //// whatever Gleam type a given scope is started with. A broadcast sends that
-//// value as a scope-tagged native BEAM term — there is no encoding step, even
-//// across nodes, since Erlang's own distribution protocol marshals arbitrary
-//// terms for you. Use a `gleam/json` payload only when the data is also
+//// value as a scope-tagged native BEAM term. There is no encoding step, even
+//// across nodes, because Erlang's distribution protocol marshals arbitrary
+//// terms. Use a `gleam/json` payload only when the data is also
 //// destined for a JSON-speaking client (e.g. relayed on to a WebSocket
 //// browser); payloads that never leave the cluster are cheaper and safer as
 //// plain Gleam types.
@@ -39,22 +39,22 @@ import gleam/list
 
 /// A PubSub message delivered to subscribers.
 ///
-/// This type is intentionally transparent so subscribers can inspect the topic,
-/// event, payload, and sender metadata delivered to their process mailbox.
+/// This type is transparent. Subscribers can inspect the topic, event,
+/// payload, and sender metadata in their process mailbox.
 ///
 /// ## Frozen wire contract
 ///
-/// Beryl sends broadcasts **raw between nodes** via `pg` as a five-element tuple:
-/// the PubSub scope atom followed by this message's four fields in order. That
-/// scope-tagged runtime shape forms the frozen wire contract for each `payload`
-/// type. The contract also applies to `PubSubFrom`.
+/// Beryl sends broadcasts **raw between nodes** through `pg` as a five-element
+/// tuple. The PubSub scope atom comes first. The four message fields follow in
+/// order. This scope-tagged runtime shape is the frozen wire contract for each
+/// `payload` type. The contract also applies to `PubSubFrom`.
 ///
-/// Because payloads travel as native terms rather than a self-describing
-/// format like JSON, evolving the *shape* of your own `payload` type is also
-/// a wire change — version it yourself (e.g. an explicit `v` field) if it
-/// needs to change across a rolling upgrade. Receive broadcasts with
-/// `selecting`, which safely folds the subscriber's raw mailbox messages into
-/// a typed `Selector`; never match on the raw process message yourself.
+/// Payloads travel as native terms, not in a self-describing format such as
+/// JSON. A change to the *shape* of your `payload` type is therefore a wire
+/// change. Add your own version, for example an explicit `v` field, if the
+/// shape must change during a rolling upgrade. Receive broadcasts with
+/// `selecting`. It safely adds the subscriber's raw mailbox messages to a
+/// typed `Selector`. Do not match the raw process message yourself.
 pub type Message(payload) {
   Message(topic: String, event: String, payload: payload, from: PubSubFrom)
 }
@@ -63,11 +63,11 @@ pub type Message(payload) {
 ///
 /// Part of the frozen wire contract described on `Message`.
 pub type PubSubFrom {
-  /// Broadcast originated from the system (no sender pid)
+  /// The broadcast came from the system and has no sender PID.
   System
-  /// Broadcast originated from a specific process
+  /// The broadcast came from a specific process.
   FromPid(Pid)
-  /// Broadcast originated from a process and should exclude a socket ID
+  /// The broadcast came from a process and must exclude a socket ID.
   FromSocket(Pid, String)
 }
 
@@ -85,11 +85,10 @@ pub opaque type PubSubConfig {
 
 /// A running PubSub instance.
 ///
-/// This handle is intentionally opaque so callers cannot forge pg scopes or
-/// depend on the runtime representation. `payload` fixes the Gleam type
-/// every `Message` broadcast through this instance carries. The scope is the
-/// runtime instance identity, so all handles using one scope must use the same
-/// payload type.
+/// This handle is opaque. Callers cannot forge pg scopes or depend on the
+/// runtime representation. `payload` sets the Gleam type for every `Message`
+/// sent through this instance. The scope identifies the runtime instance.
+/// All handles for one scope must use the same payload type.
 pub opaque type PubSub(payload) {
   PubSub(scope: atom.Atom)
 }
@@ -123,16 +122,16 @@ fn unsafe_coerce_to_message(value: Dynamic) -> Message(payload)
 
 // ── Public API ──────────────────────────────────────────────────────────────
 
-/// Create a default PubSub configuration with scope `beryl_pubsub`
+/// Create a default PubSub configuration with scope `beryl_pubsub`.
 pub fn default_config() -> PubSubConfig {
   PubSubConfig(scope: atom.create("beryl_pubsub"))
 }
 
-/// Create a PubSub configuration with a custom scope name
+/// Create a PubSub configuration with a custom scope name.
 ///
 /// The scope name is converted to an Erlang atom via `binary_to_atom`.
 /// Atoms are never garbage-collected, so the scope name must be a
-/// **static, bounded deployment or configuration value** — never raw
+/// **static, bounded deployment or configuration value**. Never use raw
 /// user-derived, per-request, per-tenant, database-derived, or otherwise
 /// unbounded high-cardinality runtime input. A deployment-controlled value
 /// is acceptable only when validated or selected from a fixed bounded set.
@@ -140,13 +139,13 @@ pub fn default_config() -> PubSubConfig {
 /// and crash the VM.
 ///
 /// ```gleam
-/// // Correct — static deployment constant
+/// // Correct: static deployment constant
 /// pubsub.config_with_scope("my_app_pubsub")
 ///
-/// // Correct — deployment-controlled, selected from a fixed bounded set
+/// // Correct: deployment-controlled and selected from a fixed bounded set
 /// // pubsub.config_with_scope(config.pubsub_scope())
 ///
-/// // WRONG — never do this
+/// // WRONG: never do this
 /// // pubsub.config_with_scope(user_request.tenant_id)
 /// // pubsub.config_with_scope(database_row.name)
 /// ```
@@ -154,13 +153,13 @@ pub fn config_with_scope(name: String) -> PubSubConfig {
   PubSubConfig(scope: atom.create(name))
 }
 
-/// Start a PubSub instance
+/// Start a PubSub instance.
 ///
-/// This starts a pg scope. If the scope is already started (e.g., by another
-/// node or previous call), this is a no-op.
+/// This starts a pg scope. If another node or an earlier call started the
+/// scope, this function does nothing.
 ///
-/// `payload` is fixed by how the returned value is used (or annotated) at the
-/// call site — e.g. `pubsub.start(config) : PubSub(MySyncPayload)`.
+/// `payload` is fixed by how the returned value is used or annotated at the
+/// call site. For example: `pubsub.start(config) : PubSub(MySyncPayload)`.
 /// Starting the same scope again returns another handle to the same runtime
 /// instance, so every use of that scope must choose the same payload type.
 pub fn start(config: PubSubConfig) -> PubSub(payload) {
@@ -171,22 +170,22 @@ pub fn start(config: PubSubConfig) -> PubSub(payload) {
 
 /// A typed subscription handle owned by a single process.
 ///
-/// A `Subscriber` bundles the pg scope and owning process while carrying the
-/// payload type at compile time. Join it to any number of topics with `join`;
-/// a single `selecting` fold receives their frozen raw `Message(payload)`
+/// A `Subscriber` contains the pg scope and owning process. It also carries
+/// the payload type at compile time. Join it to any number of topics with
+/// `join`. One `selecting` call receives their frozen raw `Message(payload)`
 /// records as typed values.
 ///
-/// Create it in the process that will receive (e.g. an actor's initialiser),
-/// since a `Subject` only delivers to its owner.
+/// Create it in the receiving process, such as an actor's initializer.
+/// A `Subject` delivers messages only to its owner.
 pub opaque type Subscriber(payload) {
   Subscriber(scope: atom.Atom, owner: Pid)
 }
 
 /// Create a subscription handle owned by the current process.
 ///
-/// Call it from the process that will receive broadcasts (its own actor
-/// initialiser or test process), then `join` topics and fold `selecting` into
-/// that process's `Selector`.
+/// Call this function from the process that will receive broadcasts, such as
+/// an actor initializer or test process. Then join topics and add `selecting`
+/// to that process's `Selector`.
 ///
 /// A process may create subscribers for multiple scopes and payload types.
 /// `selecting` uses each subscriber's scope to keep their raw mailbox messages
@@ -197,8 +196,8 @@ pub fn subscriber(ps: PubSub(payload)) -> Subscriber(payload) {
 
 /// Join a topic so this subscriber receives broadcasts sent to it.
 ///
-/// A subscriber may join many topics; they all deliver through its one
-/// subject. Joining is idempotent per topic.
+/// A subscriber can join many topics. All topics deliver through its one
+/// subject. Joining a topic is idempotent.
 pub fn join(sub: Subscriber(payload), topic: String) -> Nil {
   ffi_join_group(sub.scope, topic, sub.owner)
 }
@@ -212,9 +211,9 @@ pub fn leave(sub: Subscriber(payload), topic: String) -> Nil {
 /// process's own subjects.
 ///
 /// `pg` tracks bare pids, so broadcasts arrive as raw process messages.
-/// `selecting` is the one place that validates the subscriber's scope tag and
-/// four-field arity before recovering its compile-time payload type. Fold it
-/// once; every joined topic is delivered through the same mailbox.
+/// `selecting` validates the subscriber's scope tag and four-field arity
+/// before it recovers the compile-time payload type. Add it once. Every
+/// joined topic uses the same mailbox.
 ///
 /// Subscribers for different scopes may safely use different payload types in
 /// one process. All subscribers for the same scope must use the same payload
@@ -238,7 +237,7 @@ pub fn selecting(
   })
 }
 
-/// Broadcast a message to all subscribers of a topic (all nodes)
+/// Broadcast a message to all topic subscribers on all nodes.
 pub fn broadcast(
   ps: PubSub(payload),
   topic: String,
@@ -250,7 +249,7 @@ pub fn broadcast(
   list.each(members, fn(pid) { ffi_send_to_pid(pid, ps.scope, msg) })
 }
 
-/// Broadcast a message to all subscribers except those from a specific pid
+/// Broadcast a message to all subscribers except a specific PID.
 pub fn broadcast_from(
   ps: PubSub(payload),
   from: Pid,
@@ -265,8 +264,9 @@ pub fn broadcast_from(
   |> list.each(ffi_send_to_pid(_, ps.scope, msg))
 }
 
-/// Broadcast a message to all subscribers except a process, preserving a socket
-/// ID that receiving runtimes should exclude locally.
+/// Broadcast a message to all subscribers except a process.
+///
+/// Preserve a socket ID that receiving runtimes must exclude locally.
 pub fn broadcast_from_socket(
   ps: PubSub(payload),
   from: Pid,
@@ -288,7 +288,7 @@ pub fn broadcast_from_socket(
 }
 
 // nolint: unused_exports -- public PubSub API intended for downstream consumers
-/// Broadcast a message to local subscribers only (current node)
+/// Broadcast a message only to subscribers on the current node.
 pub fn local_broadcast(
   ps: PubSub(payload),
   topic: String,
@@ -300,12 +300,12 @@ pub fn local_broadcast(
   list.each(members, fn(pid) { ffi_send_to_pid(pid, ps.scope, msg) })
 }
 
-/// Get all subscribers for a topic (all nodes)
+/// Return all topic subscribers on all nodes.
 pub fn subscribers(ps: PubSub(payload), topic: String) -> List(Pid) {
   ffi_get_members(ps.scope, topic)
 }
 
-/// Get the number of subscribers for a topic (all nodes)
+/// Return the number of topic subscribers on all nodes.
 pub fn subscriber_count(ps: PubSub(payload), topic: String) -> Int {
   list.length(ffi_get_members(ps.scope, topic))
 }

--- a/packages/beryl/src/beryl/socket.gleam
+++ b/packages/beryl/src/beryl/socket.gleam
@@ -3,27 +3,27 @@
 //// With app-side dispatch the application owns routing: beryl delivers
 //// every wire event for a socket to one `update` function, and the
 //// function returns the next model plus a list of `Effect`s for beryl to
-//// apply. There are no channel modules, no registry, and no type erasure —
-//// each socket has a single `model` and a single `msg` type.
+//// apply. There are no channel modules, no registry, and no type erasure.
+//// Each socket has a single `model` and a single `msg` type.
 ////
 //// ## Effect ordering guarantee
 ////
 //// Effects are applied strictly in list order, and every frame for a
-//// socket is written by the single runtime actor — so list order is wire
-//// order. An `AcceptJoin` followed by a `Push` in the same list is
+//// socket is written by the single runtime actor. List order is therefore
+//// wire order. An `AcceptJoin` followed by a `Push` in the same list is
 //// guaranteed to arrive as the join acknowledgment first and the push
 //// second.
 ////
 //// Most effects are applied in one actor turn. `PresenceTrack` and
 //// `PresenceUntrack` are the exception: they are applied by the presence
-//// actor, so beryl holds the rest of the list — and every later input for
-//// that socket — until the mutation has been applied, then continues
-//// exactly where it left off. The visible order is unchanged (a
+//// actor. Beryl holds the rest of the list and every later input for that
+//// socket until the mutation has been applied. It then continues exactly
+//// where it left off. The visible order is unchanged (a
 //// `PushPresence` after a `PresenceTrack` still sees the track), and the
 //// socket's own inputs still arrive in the order the client sent them.
-//// What it buys is that no other socket, broadcast, or heartbeat waits on
-//// that mutation — and, because those keep flowing, a broadcast from
-//// elsewhere may land between two of this socket's effects.
+//// No other socket, broadcast, or heartbeat waits on that mutation. Those
+//// continue, so a broadcast from elsewhere may arrive between two effects
+//// from this socket.
 
 import beryl/presence.{type PresenceEntry}
 import gleam/dynamic.{type Dynamic}
@@ -34,7 +34,7 @@ import gleam/option.{type Option, None, Some}
 /// A pending join correlation handle.
 ///
 /// Pass it back in `AcceptJoin` or `RejectJoin`. A join ref is valid only for
-/// its pending join and carries a unique runtime token, so a delayed completion
+/// its pending join. It carries a unique runtime token. A delayed completion
 /// for an older same-topic join cannot answer a replacement or retry.
 pub opaque type JoinRef {
   JoinRef(
@@ -47,10 +47,10 @@ pub opaque type JoinRef {
 
 /// A client message reply correlation handle.
 ///
-/// Pass it back in `ReplyOk` or `ReplyError`. Reply refs may be stored in the
-/// model and answered from a later `update` turn (for example, after an async
-/// lookup completes). They are single-use and remain valid only while the
-/// topic instance that received the message stays open.
+/// Pass it back in `ReplyOk` or `ReplyError`. You can store reply refs in the
+/// model and answer them in a later `update` turn, for example after an
+/// asynchronous lookup. They are single-use. They remain valid only while
+/// the topic instance that received the message stays open.
 pub opaque type ReplyRef {
   ReplyRef(topic: String, join_ref: Option(String), msg_ref: Option(String))
 }
@@ -105,8 +105,8 @@ pub fn reply_ref_msg_ref(ref: ReplyRef) -> Option(String) {
 
 /// Why a socket or topic is stopping.
 ///
-/// Delivered in `Closed` inputs and accepted by `Stop`. Match with a
-/// catch-all (`_`) arm: new stop reasons may be added in minor releases.
+/// The runtime delivers this reason in `Closed` inputs, and `Stop` accepts it.
+/// Match with a catch-all (`_`) arm. Minor releases can add stop reasons.
 pub type StopReason {
   /// Normal shutdown (client left or disconnected cleanly).
   Normal
@@ -114,17 +114,17 @@ pub type StopReason {
   Shutdown
   /// The client failed to send a heartbeat within the configured timeout.
   HeartbeatTimeout
-  /// Stopped because of an error (named `Errored` so importing it
-  /// unqualified does not shadow the prelude's `Result` `Error`
-  /// constructor).
+  /// An error stopped the socket or topic. The name `Errored` prevents an
+  /// unqualified import from shadowing the prelude's `Result` `Error`
+  /// constructor.
   Errored(String)
 }
 
 /// Everything the runtime delivers to the app's `update` function.
 pub type Input(msg) {
-  /// A client asked to join a topic. Answer with `AcceptJoin` or
-  /// `RejectJoin` in the returned effects; a `Join` left unanswered by the
-  /// end of the update turn is rejected automatically (fail closed).
+  /// A client asked to join a topic. Return an `AcceptJoin` or `RejectJoin`
+  /// effect. The runtime rejects a `Join` that is unanswered at the end of
+  /// the update turn.
   Join(topic: String, payload: Dynamic, ref: JoinRef)
   /// A client message on a joined topic. `ref` is present for messages
   /// that expect a reply.
@@ -132,9 +132,9 @@ pub type Input(msg) {
   /// A binary frame on a joined topic (codecs without a binary decoder
   /// deliver the raw frame once per joined topic).
   Binary(topic: String, data: BitArray)
-  /// A joined topic ended (client leave, kick, crash, or socket close).
-  /// Delivered on every exit path — use it to prune per-topic state from
-  /// the model. Frames pushed to the closing topic from this input are
+  /// A joined topic ended because of a client leave, kick, crash, or socket
+  /// close. The runtime sends this input on every exit path. Use it to remove
+  /// per-topic state from the model. Frames pushed to the closing topic are
   /// dropped; broadcasts still reach the topic's remaining subscribers.
   Closed(topic: String, reason: StopReason)
   /// A typed server-side message, sent via the socket's `Sender` (see
@@ -142,8 +142,10 @@ pub type Input(msg) {
   Info(msg)
 }
 
-/// The result of one `update` call: the next model plus effects to apply,
-/// or an instruction to stop the whole socket.
+/// The result of one `update` call.
+///
+/// It contains the next model and effects, or an instruction to stop the
+/// socket.
 pub type Next(model) {
   /// Continue with the given model, applying the effects in order.
   Next(model: model, effects: List(Effect))
@@ -155,9 +157,9 @@ pub type Next(model) {
 /// One update may return several effects, applied strictly in list order
 /// (see the module docs for the ordering guarantee).
 pub type Effect {
-  /// Accept a pending join. Subscribes the socket to the topic and sends
-  /// the join acknowledgment (with an optional reply payload). Only valid
-  /// while the `Join` input's ref is pending.
+  /// Accept a pending join. This subscribes the socket to the topic and sends
+  /// the join acknowledgment with an optional reply payload. The effect is
+  /// valid only while the `Join` input's ref is pending.
   AcceptJoin(ref: JoinRef, reply: Option(Json))
   /// Reject a pending join with an error payload.
   RejectJoin(ref: JoinRef, reason: Json)
@@ -166,8 +168,8 @@ pub type Effect {
   /// Reply with an error to a client message ref.
   ReplyError(ref: ReplyRef, payload: Json)
   /// Push a server-initiated message to this socket on a joined topic.
-  /// Pushes to topics this socket has not joined (yet) are dropped with a
-  /// warning — order a `Push` after its topic's `AcceptJoin`.
+  /// The runtime drops pushes to topics that this socket has not joined and
+  /// logs a warning. Put a `Push` after its topic's `AcceptJoin`.
   Push(topic: String, event: String, payload: Json)
   /// Broadcast to every subscriber of a topic (including this socket, when
   /// joined). Distributed via PubSub when configured.
@@ -175,32 +177,31 @@ pub type Effect {
   /// Broadcast to every subscriber of a topic except this socket.
   BroadcastFrom(topic: String, event: String, payload: Json)
   /// Track this socket's presence under a key in a topic and broadcast the
-  /// corresponding `presence_diff` join. Requires a presence handle on the
-  /// config (`beryl.with_presence_handle`); dropped with a warning
-  /// otherwise.
+  /// corresponding `presence_diff` join. This effect requires a presence
+  /// handle on the config (`beryl.with_presence_handle`). Without a handle,
+  /// the runtime drops the effect and logs a warning.
   ///
-  /// Tracking an already-tracked key replaces the previous entry
-  /// atomically: the key is never momentarily absent, and the replacement
-  /// is published as one `presence_diff` carrying both the leave and the
-  /// join. Effects after this one wait for the mutation (see the module
-  /// docs) but no other socket does.
+  /// Tracking an existing key replaces the previous entry atomically. The
+  /// key is never absent during the replacement. One `presence_diff` contains
+  /// both the leave and the join. Later effects wait for the mutation, as
+  /// described in the module documentation. Other sockets do not wait.
   PresenceTrack(topic: String, key: String, meta: Json)
   /// Untrack a presence previously tracked with `PresenceTrack` and
-  /// broadcast the corresponding `presence_diff` leave. Remaining tracked
-  /// keys are untracked automatically when their topic closes — as one
-  /// batch, producing a single aggregate leave diff. Effects after this
-  /// one wait for the mutation (see the module docs) but no other socket
-  /// does. Requires a presence handle (`beryl.with_presence_handle`);
-  /// dropped with a warning otherwise.
+  /// broadcast the corresponding `presence_diff` leave. When the topic
+  /// closes, the runtime removes the remaining tracked keys in one batch and
+  /// produces one aggregate leave diff. Later effects wait for the mutation,
+  /// as described in the module documentation. Other sockets do not wait.
+  /// This effect requires a presence handle (`beryl.with_presence_handle`).
+  /// Without a handle, the runtime drops the effect and logs a warning.
   PresenceUntrack(topic: String, key: String)
-  /// Push a presence snapshot for a topic to this socket. Unlike a payload
-  /// built inside `update` (which sees presence as it was *before* this
-  /// effects list), `encode` runs when the effect is applied — after any
-  /// earlier `PresenceTrack`/`PresenceUntrack` in the same list has
-  /// actually been applied — so the entries already reflect them.
-  /// Requires a presence handle (`beryl.with_presence_handle`); dropped
-  /// with a warning otherwise.
-  /// Like `Push`, dropped when the topic is not joined at that point.
+  /// Push a presence snapshot for a topic to this socket. A payload built
+  /// inside `update` sees presence from *before* this effects list. In
+  /// contrast, `encode` runs when the effect is applied. It runs after earlier
+  /// `PresenceTrack` and `PresenceUntrack` effects in the same list. The
+  /// entries therefore include those changes.
+  /// This effect requires a presence handle (`beryl.with_presence_handle`).
+  /// Without a handle, the runtime drops the effect and logs a warning.
+  /// Like `Push`, the runtime drops it if the topic is not joined.
   PushPresence(
     topic: String,
     event: String,
@@ -209,8 +210,9 @@ pub type Effect {
   /// Broadcast a presence snapshot for a topic to all its subscribers,
   /// with the same apply-time `encode` semantics as `PushPresence`.
   /// Order it after the `PresenceTrack`/`PresenceUntrack` it should
-  /// reflect. Requires a presence handle (`beryl.with_presence_handle`);
-  /// dropped with a warning otherwise.
+  /// reflect. This effect requires a presence handle
+  /// (`beryl.with_presence_handle`). Without a handle, the runtime drops the
+  /// effect and logs a warning.
   BroadcastPresence(
     topic: String,
     event: String,
@@ -222,11 +224,12 @@ pub type Effect {
 }
 
 // nolint: unused_exports -- public socket helper used by downstream applications
-/// A `ReplyOk` when the client supplied a ref; no effects otherwise.
+/// Return a `ReplyOk` effect when the client supplied a ref.
 ///
 /// `Message` inputs carry `Option(ReplyRef)` (refless messages expect no
 /// reply) while the `ReplyOk` effect demands a `ReplyRef`, so every handler
-/// that replies conditionally needs this gate.
+/// that replies conditionally needs this check. This function returns no
+/// effects when the client did not supply a ref.
 pub fn reply_ok(ref: Option(ReplyRef), payload: Json) -> List(Effect) {
   case ref {
     Some(r) -> [ReplyOk(r, payload)]
@@ -234,8 +237,10 @@ pub fn reply_ok(ref: Option(ReplyRef), payload: Json) -> List(Effect) {
   }
 }
 
-/// Connection metadata assembled by the transport before the WebSocket
-/// upgrade, delivered to the app's `init` via `ConnectInfo`.
+/// Connection metadata that the transport builds before the WebSocket
+/// upgrade.
+///
+/// The app's `init` function receives it through `ConnectInfo`.
 pub type ConnectSeed {
   ConnectSeed(
     /// Request path of the upgrade request (e.g. `"/socket"`).
@@ -250,16 +255,16 @@ pub type ConnectSeed {
   )
 }
 
-/// An empty connect seed, for tests and transports with no request data.
+/// Return an empty connect seed for tests and transports with no request data.
 pub fn empty_seed() -> ConnectSeed {
   ConnectSeed(path: "", query: [], headers: [], metadata: [])
 }
 
 /// A typed handle for sending server-side messages to one socket.
 ///
-/// Obtained from `ConnectInfo.self` in `init`. Any process may call
-/// `notify` with it; the message is delivered to the socket's `update` as
-/// an `Info` event. This is an ordinary typed send — no erasure involved.
+/// Get this handle from `ConnectInfo.self` in `init`. Any process can call
+/// `notify` with it. The socket's `update` function receives the message as
+/// an `Info` event. This typed send does not erase the message type.
 pub opaque type Sender(msg) {
   Sender(send: fn(msg) -> Nil)
 }
@@ -269,9 +274,10 @@ pub fn make_sender(send: fn(msg) -> Nil) -> Sender(msg) {
   Sender(send)
 }
 
-/// Send a typed server-side message to a socket. Delivered to the socket's
-/// `update` function as `Info(message)`. Ignored if the socket has since
-/// disconnected.
+/// Send a typed server-side message to a socket.
+///
+/// The socket's `update` function receives `Info(message)`. The runtime
+/// ignores the message if the socket has disconnected.
 pub fn notify(sender: Sender(msg), message: msg) -> Nil {
   sender.send(message)
 }

--- a/packages/beryl/src/beryl/stats.gleam
+++ b/packages/beryl/src/beryl/stats.gleam
@@ -19,19 +19,19 @@ pub opaque type Snapshot {
   )
 }
 
-/// Errors returned while requesting a runtime snapshot.
+/// Errors from a runtime snapshot request.
 pub type SnapshotError {
-  /// The local socket runtime is not currently running.
+  /// The local socket runtime is not running.
   RuntimeUnavailable
-  /// The runtime did not service the request within the bounded timeout.
+  /// The runtime did not process the request before the timeout.
   RequestTimedOut
 }
 
-/// Request a point-in-time snapshot from the local runtime.
+/// Request a snapshot from the local runtime.
 ///
-/// The request waits for at most approximately one second. During a
-/// runtime restart this returns `RuntimeUnavailable` or
-/// `RequestTimedOut`; an overloaded runtime returns `RequestTimedOut`.
+/// The request waits for about one second at most. During a runtime restart,
+/// this function returns `RuntimeUnavailable` or `RequestTimedOut`. An
+/// overloaded runtime returns `RequestTimedOut`.
 /// Neither condition panics. This API reports only the node represented by
 /// `sockets`; aggregate multi-node statistics outside Beryl.
 ///

--- a/packages/beryl/src/beryl/topic.gleam
+++ b/packages/beryl/src/beryl/topic.gleam
@@ -11,18 +11,19 @@ import gleam/list
 import gleam/result
 import gleam/string
 
-/// Topic pattern for routing
+/// A topic pattern for routing.
 pub type TopicPattern {
-  /// Exact match: "room:lobby" only matches "room:lobby"
+  /// Exact match. `"room:lobby"` matches only `"room:lobby"`.
   Exact(String)
-  /// Wildcard suffix: "room:*" matches "room:lobby", "room:123", etc.
+  /// Wildcard suffix. `"room:*"` matches `"room:lobby"`, `"room:123"`,
+  /// and other values with the same prefix.
   Wildcard(prefix: String)
-  /// Segment wildcard: "document:*:ops" matches the same number of ":"
-  /// segments where "*" occupies one complete segment.
+  /// Segment wildcard. `"document:*:ops"` matches topics with the same
+  /// number of `":"` segments. `"*"` occupies one complete segment.
   SegmentWildcard(segments: List(String))
 }
 
-/// Parse a pattern string into TopicPattern
+/// Parse a pattern string into `TopicPattern`.
 ///
 /// ## Examples
 ///
@@ -45,7 +46,7 @@ pub fn parse_pattern(pattern: String) -> TopicPattern {
   Wildcard(string.drop_end(pattern, 1))
 }
 
-/// Check if a topic matches a pattern
+/// Return whether a topic matches a pattern.
 ///
 /// ## Examples
 ///
@@ -111,7 +112,7 @@ pub type ExtractError {
   EmptyNamespace
 }
 
-/// Extract the wildcard portion from a topic
+/// Extract the wildcard part of a topic.
 ///
 /// ## Examples
 ///
@@ -144,8 +145,9 @@ pub fn extract_id(
 
 /// Extract values captured by wildcard segments.
 ///
-/// For legacy prefix wildcards, returns the suffix as a single value.
-/// For segment wildcards, returns each topic segment matched by "*".
+/// For legacy prefix wildcards, this function returns the suffix as one
+/// value. For segment wildcards, it returns each topic segment matched by
+/// `"*"`.
 ///
 /// ## Examples
 ///
@@ -194,7 +196,7 @@ fn collect_wildcard_values(
   })
 }
 
-/// Parse a topic into segments by splitting on ":"
+/// Split a topic into segments at each `":"`.
 ///
 /// ## Examples
 ///
@@ -206,7 +208,7 @@ pub fn segments(topic: String) -> List(String) {
   string.split(topic, ":")
 }
 
-/// Get the first segment (namespace) of a topic
+/// Return the first segment (namespace) of a topic.
 ///
 /// ## Examples
 ///
@@ -222,7 +224,7 @@ pub fn namespace(topic: String) -> Result(String, ExtractError) {
   |> result.replace_error(EmptyNamespace)
 }
 
-/// Build a topic from segments
+/// Build a topic from segments.
 ///
 /// ## Examples
 ///
@@ -234,12 +236,12 @@ pub fn from_segments(parts: List(String)) -> String {
   string.join(parts, ":")
 }
 
-/// Validate a topic string
+/// Validate a topic string.
 ///
-/// Topics must:
-/// - Not be empty
-/// - Not contain control characters (codepoints 0–31 or 127)
-/// - Not start or end with ":"
+/// A topic must:
+/// - not be empty;
+/// - not contain control characters (codepoints 0–31 or 127); and
+/// - not start or end with `":"`.
 pub fn validate(topic: String) -> Result(String, TopicError) {
   use <- bool.guard(when: string.is_empty(topic), return: Error(EmptyTopic))
   use <- bool.guard(
@@ -253,11 +255,11 @@ pub fn validate(topic: String) -> Result(String, TopicError) {
   Ok(topic)
 }
 
-/// Validate a topic pattern string
+/// Validate a topic pattern string.
 ///
-/// Patterns must:
-/// - Not be empty
-/// - Not contain control characters (codepoints 0–31 or 127)
+/// A pattern must:
+/// - not be empty; and
+/// - not contain control characters (codepoints 0–31 or 127).
 ///
 /// The bare pattern `"*"` is valid: it parses to a catch-all wildcard that
 /// matches every topic.
@@ -270,11 +272,11 @@ pub fn validate_pattern(pattern: String) -> Result(String, TopicError) {
   Ok(pattern)
 }
 
-/// Validate an event name string
+/// Validate an event name.
 ///
-/// Event names must:
-/// - Not be empty
-/// - Not contain control characters (codepoints 0–31 or 127)
+/// An event name must:
+/// - not be empty; and
+/// - not contain control characters (codepoints 0–31 or 127).
 pub fn validate_event(event: String) -> Result(String, TopicError) {
   use <- bool.guard(
     when: string.is_empty(event),
@@ -315,10 +317,10 @@ fn has_control_characters(value: String) -> Bool {
 
 /// Errors returned when validating a topic or topic pattern.
 ///
-/// New variants may be added in a minor release as validation gets stricter,
-/// so this type is not treated as closed for exhaustive matching. Match exact
-/// variants only where you act on them differently, and otherwise keep a
-/// catch-all arm (`_ -> ...`) so future variants do not break your code.
+/// A minor release can add variants as validation gets stricter. Do not treat
+/// this type as closed for exhaustive matching. Match exact variants only
+/// when you handle them differently. Otherwise, use a catch-all arm
+/// (`_ -> ...`) so new variants do not break your code.
 pub type TopicError {
   /// The topic or pattern was an empty string.
   EmptyTopic

--- a/packages/beryl/src/beryl/transport.gleam
+++ b/packages/beryl/src/beryl/transport.gleam
@@ -1,4 +1,4 @@
-//// Transport SPI — the contract between beryl core and WebSocket transport
+//// Transport SPI: the contract between beryl core and WebSocket transport
 //// implementations such as the `beryl_mist` package.
 ////
 //// `beryl/transport/server` owns the shared admission, connection, rate,
@@ -17,23 +17,23 @@ import gleam/erlang/process
 import gleam/option.{type Option}
 import gleam/result
 
-/// Runtime handle accepted by transport implementations.
+/// A runtime handle for transport implementations.
 pub type Sockets =
   beryl.Sockets
 
 /// A held connection slot returned by `acquire_connection_slot`.
 ///
-/// Hold it for the lifetime of the connection and pass it to
+/// Hold it for the connection's lifetime. Pass it to
 /// `release_connection_slot` when the connection closes. When no connection
-/// limit is configured the permit is an admit-everything placeholder and
-/// releasing it is a no-op.
+/// limit is configured, the permit allows all connections. Releasing it does
+/// nothing.
 pub opaque type ConnectionPermit {
   ConnectionPermit(inner: Option(connection_limit.Permit))
 }
 
 /// Try to acquire a configured connection slot for a transport.
 ///
-/// Pass the real socket peer IP, never a client-supplied address such as
+/// Pass the real socket peer IP. Do not pass a client-supplied address such as
 /// `X-Forwarded-For`. Return `Error(Nil)` when the configured per-IP or
 /// node-wide limit is already reached.
 pub fn acquire_connection_slot(
@@ -49,8 +49,8 @@ pub fn acquire_connection_slot(
 
 /// Bind an acquired connection slot to the calling connection process.
 ///
-/// The limiter monitors the caller so the slot is reclaimed if the process
-/// dies without running its close path.
+/// The limiter monitors the caller. It reclaims the slot if the process dies
+/// without running its close path.
 pub fn bind_connection_slot(permit: ConnectionPermit) -> Nil {
   connection_limit.bind_optional(permit.inner)
 }
@@ -97,8 +97,10 @@ pub type FrameOutcome {
   FrameDecodeFailed
 }
 
-/// Cheap transport telemetry context. When disabled, starting and stopping an
-/// operation avoid VM clock calls and event construction.
+/// A low-cost transport telemetry context.
+///
+/// When telemetry is disabled, operations avoid VM clock calls and event
+/// construction.
 pub opaque type Telemetry {
   Telemetry(enabled: Bool, transport: telemetry.Transport)
 }
@@ -117,7 +119,9 @@ pub fn telemetry(
   )
 }
 
-/// Start a timed transport operation. Returns a zero sentinel when disabled.
+/// Start a timed transport operation.
+///
+/// Returns zero when telemetry is disabled.
 pub fn telemetry_start(context: Telemetry) -> Int {
   use <- bool.guard(when: !context.enabled, return: 0)
   telemetry.start_time()
@@ -186,9 +190,10 @@ pub fn socket_disconnected(
 
 // --- Inbound routing ---
 
-/// Route a transport-decoded inbound message to the runtime. Decode in
-/// the connection process (see `active_codec`) so parse cost and malformed
-/// input never reach the shared runtime.
+/// Route a transport-decoded inbound message to the runtime.
+///
+/// Decode in the connection process (see `active_codec`). Parse cost and
+/// malformed input then never reach the shared runtime.
 ///
 /// Runtime message-rate limiting applies after routing. If it sheds a
 /// heartbeat, that heartbeat does not refresh the socket's deadline; sustained
@@ -205,8 +210,8 @@ pub fn route_decoded(
 /// Route a transport-decoded binary message while preserving its binary
 /// frame classification for runtime telemetry and rate accounting.
 ///
-/// This is additive to `route_decoded`, whose text semantics are retained for
-/// third-party transport compatibility.
+/// This function supplements `route_decoded`. The text semantics of
+/// `route_decoded` remain unchanged for third-party transport compatibility.
 pub fn route_decoded_binary(
   sockets sockets: Sockets,
   socket_id socket_id: String,
@@ -215,8 +220,9 @@ pub fn route_decoded_binary(
   beryl.app_dispatch(sockets).route_decoded_binary(socket_id, message)
 }
 
-/// Route a raw binary frame, for codecs without a binary decoder (fans out
-/// to the socket's joined topics as `Binary` events delivered to `update`).
+/// Route a raw binary frame for a codec without a binary decoder.
+///
+/// The runtime sends a `Binary` event to `update` for each joined topic.
 pub fn route_binary(
   sockets sockets: Sockets,
   socket_id socket_id: String,
@@ -227,8 +233,9 @@ pub fn route_binary(
 
 // --- Configuration ---
 
-/// The wire codec configured for these sockets. Transports decode inbound
-/// frames with it in the connection process.
+/// Return the wire codec configured for these sockets.
+///
+/// Transports use it to decode inbound frames in the connection process.
 pub fn active_codec(sockets: Sockets) -> codec.Codec {
   beryl.configured_codec(sockets)
 }
@@ -237,7 +244,7 @@ pub fn active_codec(sockets: Sockets) -> codec.Codec {
 
 /// Return the pid of the runtime that owns transport connections.
 ///
-/// On `Ok(pid)`, monitor that exact pid before admission and close the
+/// On `Ok(pid)`, monitor that exact PID before admission and close the
 /// connection on its `Down`. `Error(Nil)` means the runtime is unavailable
 /// (pre-start or a restart window), so the connection must be refused.
 pub fn runtime_pid(sockets: Sockets) -> Result(process.Pid, Nil) {
@@ -247,9 +254,9 @@ pub fn runtime_pid(sockets: Sockets) -> Result(process.Pid, Nil) {
 /// Register a socket and its closer against the captured connection owner.
 ///
 /// Install a monitor for `owner` before calling this function. Admission
-/// succeeds only if that exact runtime instance processes the registration; a
-/// restart cannot redirect it to the successor runtime. On `Error`, the
-/// connection is closed so its bound permit can be released.
+/// succeeds only if that runtime instance processes the registration. A
+/// restart cannot redirect it to the next runtime. On `Error`, this function
+/// closes the connection so its bound permit can be released.
 pub fn admit_socket(
   sockets sockets: Sockets,
   owner owner: process.Pid,

--- a/packages/beryl/src/beryl/transport/origin.gleam
+++ b/packages/beryl/src/beryl/transport/origin.gleam
@@ -13,18 +13,18 @@ import gleam/string
 /// Policy for validating the browser `Origin` header before a WebSocket
 /// upgrade completes.
 ///
-/// The `Origin` check is the primary defence against Cross-Site WebSocket
+/// The `Origin` check is the primary defense against Cross-Site WebSocket
 /// Hijacking (CSWSH): a browser attaches ambient cookies/session credentials
 /// to a WebSocket handshake regardless of which site initiated it, so a socket
 /// that authenticates from those credentials must reject upgrades that
 /// originate from other sites.
 ///
-/// In every policy, a request with **no** `Origin` header is allowed: browsers
-/// always send `Origin` on WebSocket handshakes, so an absent header signals a
-/// non-browser client (native app, server-to-server, CLI) that is not subject
-/// to the browser same-origin model and cannot be tricked into a cross-site
-/// upgrade. The one exception is [`AllowList`](#originpolicy), which requires a
-/// matching `Origin` and therefore rejects absent ones.
+/// Every policy allows a request with **no** `Origin` header, with one
+/// exception described below. Browsers always send `Origin` on WebSocket
+/// handshakes. An absent header therefore indicates a non-browser client,
+/// such as a native app, server, or CLI. The browser same-origin model does
+/// not apply to these clients. [`AllowList`](#originpolicy) is the exception.
+/// It requires a matching `Origin` and rejects an absent header.
 pub type OriginPolicy {
   /// Allow an upgrade only when the request `Origin` authority (host plus any
   /// port, with the scheme stripped) matches the request `Host` authority.
@@ -34,8 +34,8 @@ pub type OriginPolicy {
   /// value with no host) is rejected. Comparison is over the full `host:port`
   /// authority, so a non-default port must match on both sides.
   ///
-  /// Behind a reverse proxy this compares against the `Host` header as the app
-  /// sees it: ensure the proxy forwards the public `Host` unchanged, or use
+  /// Behind a reverse proxy, this compares against the `Host` header that the
+  /// app receives. Configure the proxy to forward the public `Host` unchanged, or use
   /// [`AllowList`](#originpolicy) with the public origins instead. Forwarded
   /// headers such as `X-Forwarded-Host` are not trusted, because clients can
   /// spoof them.
@@ -45,18 +45,18 @@ pub type OriginPolicy {
   /// `"https://app.example.com"`. Requests without an `Origin` header, or with
   /// a non-matching one, are rejected.
   AllowList(List(String))
-  /// Allow every upgrade regardless of `Origin`. This is an explicit opt-out
-  /// of CSWSH protection: only use it for sockets that do not rely on ambient
+  /// Allow every upgrade regardless of `Origin`. This disables CSWSH
+  /// protection. Use it only for sockets that do not rely on ambient
   /// browser credentials (or that authenticate every message independently).
   AllowAll
 }
 
 /// Decide whether an upgrade is allowed under the configured origin policy.
 ///
-/// `origin` and `host` are the request's `Origin` and `Host` header values,
-/// `None` when the header is absent. A request with no `Origin` header is
-/// admitted for `SameOrigin` and `AllowAll` (non-browser clients omit
-/// `Origin`), but rejected for `AllowList`, which requires an explicit match.
+/// `origin` and `host` are the request's `Origin` and `Host` header values.
+/// Use `None` when a header is absent. `SameOrigin` and `AllowAll` admit a
+/// request without an `Origin` header because non-browser clients omit it.
+/// `AllowList` rejects the request because it requires an explicit match.
 pub fn allowed(
   policy policy: OriginPolicy,
   origin origin: Option(String),
@@ -119,11 +119,11 @@ fn origin_authority(origin: String) -> Result(String, Nil) {
 /// Check a client's requested wire protocol version (the `?vsn=` query
 /// parameter sent by Phoenix clients) before upgrading.
 ///
-/// Beryl speaks the Phoenix V2 array framing, so `vsn=2.x` is accepted. A
+/// Beryl uses the Phoenix V2 array framing, so it accepts `vsn=2.x`. A
 /// missing `vsn` (`None`) is accepted for non-Phoenix clients speaking the
 /// configured codec. Anything else (e.g. the V1 object framing's `vsn=1.0.0`)
-/// is rejected — transports fail the handshake with `403 Forbidden` instead
-/// of accepting a connection whose every frame would be undecodable.
+/// is rejected. Transports fail the handshake with `403 Forbidden` instead
+/// of accepting a connection with frames that cannot be decoded.
 pub fn vsn_supported(vsn vsn: Option(String)) -> Bool {
   case vsn {
     Some(version) -> string.starts_with(version, "2.")

--- a/packages/beryl/src/beryl/transport/server.gleam
+++ b/packages/beryl/src/beryl/transport/server.gleam
@@ -36,8 +36,8 @@ import gleam/string
 
 /// Configuration for a WebSocket transport.
 ///
-/// Generic over the server's request body type (`body`), so the same config
-/// value works with any transport built on `gleam/http` requests.
+/// The `body` parameter is the server's request body type. The same
+/// configuration works with any transport built on `gleam/http` requests.
 pub opaque type TransportConfig(body) {
   TransportConfig(
     /// URL path to match for WebSocket upgrade (e.g., "/socket")
@@ -70,14 +70,14 @@ pub type ConnectError {
 // nolint: unused_exports -- transport SPI, consumed by transport packages such as beryl_mist
 /// Create a default transport config with no connect hook.
 ///
-/// The resulting config seeds empty (`[]`) `ConnectSeed.metadata` and applies
+/// The resulting configuration sets `ConnectSeed.metadata` to `[]` and applies
 /// the `origin.SameOrigin` origin policy, which rejects cross-site WebSocket
-/// upgrades before the handshake (CSWSH protection). Same-origin upgrades and
+/// upgrades before the handshake as CSWSH protection. Same-origin upgrades and
 /// non-browser clients (no `Origin` header) are admitted without
 /// configuration.
 ///
 /// Add `with_on_connect` to authenticate connections and/or seed connect
-/// metadata. Use `with_allowed_origins` to pin an explicit allow-list, or
+/// metadata. Use `with_allowed_origins` to set an explicit allow-list. Use
 /// `with_allow_all_origins` to opt out of origin checking entirely.
 pub fn default_config(path: String) -> TransportConfig(body) {
   TransportConfig(
@@ -99,15 +99,15 @@ fn normalize_path(path: String) -> String {
 // nolint: unused_exports -- transport SPI, consumed by transport packages such as beryl_mist
 /// Set a socket-level connect/authentication callback on the transport config.
 ///
-/// The callback receives the HTTP request before the WebSocket upgrade and
+/// The callback receives the HTTP request before the WebSocket upgrade. It
 /// runs once per socket. Return `Ok(metadata)` to allow the connection and
-/// seed `ConnectSeed.metadata` — an ordered list of string pairs delivered to
-/// the app's `init` via `ConnectInfo.seed` — or `Error(ConnectRejected)` to
-/// reject the connection with a 403 Forbidden response before any topic
-/// join occurs.
+/// set `ConnectSeed.metadata`. The metadata is an ordered list of string
+/// pairs delivered to the app's `init` through `ConnectInfo.seed`. Return
+/// `Error(ConnectRejected)` to reject the connection with a 403 Forbidden
+/// response before any topic join.
 ///
-/// Callback order and duplicate keys are preserved verbatim in
-/// `ConnectSeed.metadata`; transports never log metadata values.
+/// `ConnectSeed.metadata` preserves callback order and duplicate keys.
+/// Transports never log metadata values.
 pub fn with_on_connect(
   config: TransportConfig(body),
   callback: fn(Request(body)) -> Result(List(#(String, String)), ConnectError),
@@ -138,11 +138,11 @@ pub fn with_allowed_origins(
 // nolint: unused_exports -- transport SPI, consumed by transport packages such as beryl_mist
 /// Disable `Origin` checking, allowing WebSocket upgrades from any origin.
 ///
-/// This is an explicit opt-out of the default `origin.SameOrigin` CSWSH
-/// protection. Only use it for sockets that do not rely on ambient browser
-/// credentials (cookies, sessions) for authorization, or that authenticate
-/// every message independently. For cookie/session-authenticated apps, prefer
-/// the default `SameOrigin` policy or `with_allowed_origins`.
+/// This disables the default `origin.SameOrigin` CSWSH protection. Use it only
+/// for sockets that do not rely on ambient browser credentials (cookies,
+/// sessions) for authorization, or that authenticate every message
+/// independently. For cookie/session-authenticated apps, prefer the default
+/// `SameOrigin` policy or `with_allowed_origins`.
 pub fn with_allow_all_origins(
   config: TransportConfig(body),
 ) -> TransportConfig(body) {
@@ -154,9 +154,9 @@ pub fn with_allow_all_origins(
 // nolint: unused_exports -- transport SPI, consumed by transport packages such as beryl_mist
 /// Determine whether a request is a WebSocket upgrade request.
 ///
-/// Checks for the standard `Upgrade: websocket` header (case-insensitive).
-/// Use this to distinguish WebSocket handshakes from regular HTTP traffic on
-/// the same listener.
+/// This function checks for the standard `Upgrade: websocket` header without
+/// regard to case. Use it to distinguish WebSocket handshakes from regular
+/// HTTP traffic on the same listener.
 pub fn is_websocket_request(request: Request(body)) -> Bool {
   case request.get_header(request, "upgrade") {
     Ok(value) -> string.lowercase(value) == "websocket"
@@ -194,7 +194,7 @@ pub fn is_websocket_request(request: Request(body)) -> Bool {
 /// headers such as `X-Forwarded-For` must
 /// **not** be trusted or parsed, because clients can set them and would
 /// otherwise spoof their address to bypass the limit. Behind a trusted
-/// reverse proxy, all connections share the proxy's IP — resolve the real
+/// reverse proxy, all connections share the proxy's IP. Resolve the real
 /// client IP at the proxy layer. See the WebSocket transport guide.
 ///
 /// `beryl.with_connection_rate_per_ip` independently caps connection attempts
@@ -209,7 +209,7 @@ pub fn is_websocket_request(request: Request(body)) -> Bool {
 /// node-wide ceiling bounds total resource use when a per-IP limit alone
 /// cannot (many distributed source addresses / IPv6 rotation). It is enforced
 /// per BEAM node, so across a load-balanced cluster the effective ceiling
-/// scales with the node count — use the load balancer's own controls for a
+/// scales with the node count. Use the load balancer's controls for a
 /// cluster-wide cap.
 pub fn upgrade(
   request request: Request(body),
@@ -239,8 +239,10 @@ pub fn upgrade(
 }
 
 // nolint: unused_exports -- transport SPI, consumed by sibling transports
-/// Build a combined request handler that sends upgrade requests through a
-/// transport-specific `upgrade` function and everything else to HTTP.
+/// Build a request handler for WebSocket upgrades and other HTTP requests.
+///
+/// The handler sends upgrade requests to the transport-specific `upgrade`
+/// function. It sends all other requests to HTTP.
 pub fn handler(
   upgrade upgrade: fn(Request(body), fn() -> Response(resp)) -> Response(resp),
   http_fallback http_fallback: fn(Request(body)) -> Response(resp),
@@ -402,9 +404,10 @@ fn finish_upgrade(
 
 // --- Connection lifecycle ---
 
-/// Outbound requests the runtime sends to a connection process. Transports
-/// receive these as their custom/user WebSocket message and act on them:
-/// send the frame, or close the connection.
+/// Outbound requests from the runtime to a connection process.
+///
+/// Transports receive these as custom or user WebSocket messages. They send
+/// the frame or close the connection.
 pub type SendRequest {
   SendText(String)
   SendBinary(BitArray)
@@ -433,13 +436,15 @@ pub opaque type ConnectionState {
 }
 
 // nolint: unused_exports -- transport SPI, consumed by transport packages such as beryl_mist
-/// Assemble the connection seed delivered to an app-dispatch system's
-/// `init` (`ConnectInfo.seed`). Systems that don't use connect metadata simply
-/// ignore it.
+/// Build the connection seed for an app-dispatch system's `init` function.
 ///
-/// `metadata` is the ordered list of string pairs returned by the
-/// configured `on_connect` callback (empty when none is configured or it
-/// returns no metadata); order and duplicate keys are preserved verbatim.
+/// The function receives the seed as `ConnectInfo.seed`. Systems that do not
+/// use connect metadata can ignore it.
+///
+/// `metadata` is the ordered list of string pairs from the configured
+/// `on_connect` callback. It is empty when no callback is configured or the
+/// callback returns no metadata. This function preserves order and duplicate
+/// keys.
 pub fn connect_seed(
   request: Request(body),
   metadata: List(#(String, String)),
@@ -452,15 +457,14 @@ pub fn connect_seed(
   )
 }
 
-/// Initialize a newly upgraded WebSocket connection in its connection
-/// process.
+/// Initialize a new WebSocket connection in its connection process.
 ///
-/// Binds the held connection slot to the calling process (so the slot is
-/// reclaimed even if the process dies without a clean close), monitors the
-/// exact owning runtime, then atomically registers the socket and its
-/// runtime-triggered closer against that owner. A concurrent restart cannot
-/// redirect admission into the successor runtime. When no runtime is
-/// available, or the captured owner changed, the connection closes.
+/// This function binds the held connection slot to the calling process. The
+/// limiter reclaims the slot if the process dies without a clean close. The
+/// function then monitors the owning runtime and atomically registers the
+/// socket and its runtime-triggered closer with that owner. A concurrent
+/// restart cannot redirect admission to the next runtime. The connection
+/// closes if no runtime is available or the captured owner changed.
 ///
 /// Returns the connection state and a selector (extending `base_selector`)
 /// that delivers `SendRequest` values from the runtime; the transport must
@@ -539,8 +543,9 @@ pub fn init_connection(
   #(state, selector)
 }
 
-/// Clean up when a connection closes: release the held connection slot and
-/// announce the disconnect to the runtime.
+/// Clean up a closed connection.
+///
+/// Release the held connection slot and report the disconnect to the runtime.
 pub fn close_connection(state: ConnectionState) -> Nil {
   transport.release_connection_slot(state.connection_permit)
   transport.socket_disconnected(state.sockets, state.socket_id)
@@ -548,8 +553,7 @@ pub fn close_connection(state: ConnectionState) -> Nil {
 
 // --- Inbound frame pipeline ---
 
-/// What a transport should do with its connection after handling an inbound
-/// frame.
+/// What a transport must do after it handles an inbound frame.
 pub type FrameDisposition {
   /// Keep the connection open with the updated state.
   Continue(ConnectionState)
@@ -561,8 +565,9 @@ pub type FrameDisposition {
 /// connection process, so parse cost stays there and only valid,
 /// rate-admitted messages reach the shared runtime.
 ///
-/// Oversized frames return `Stop` (close the connection); over-rate frames
-/// are shed silently; undecodable frames are logged and dropped.
+/// Oversized frames return `Stop` and close the connection. The function
+/// silently drops over-rate frames. It logs and drops frames that it cannot
+/// decode.
 pub fn handle_text_frame(
   state: ConnectionState,
   text: String,
@@ -604,9 +609,9 @@ pub fn handle_text_frame(
 }
 
 // nolint: unused_exports -- transport SPI, consumed by sibling transports
-/// Size-check, rate-check, and decode an inbound binary frame in the
-/// connection process. Codecs without a binary decoder keep the raw
-/// `transport.route_binary` fan-out, routed through the runtime.
+/// Check the size and rate of an inbound binary frame, then decode it in the
+/// connection process. A codec without a binary decoder keeps the raw
+/// `transport.route_binary` fan-out through the runtime.
 pub fn handle_binary_frame(
   state: ConnectionState,
   data: BitArray,

--- a/packages/beryl/src/beryl/wire.gleam
+++ b/packages/beryl/src/beryl/wire.gleam
@@ -1,4 +1,4 @@
-//// Phoenix Wire Protocol — encoding/decoding helpers and the canonical
+//// Phoenix Wire Protocol: encoding/decoding helpers and the canonical
 //// `phoenix_codec()` for `beryl/wire/codec`.
 ////
 //// Phoenix uses a JSON array format: `[join_ref, ref, topic, event, payload]`.
@@ -33,9 +33,11 @@ const max_json_nesting_depth = 64
 
 const max_decode_error_length = 256
 
-/// The canonical Phoenix wire codec. Pass to `beryl.config`.
+/// Return the canonical Phoenix wire codec.
 ///
-/// Handles both the JSON array framing on text frames and the Phoenix V2
+/// Pass this codec to `beryl.config`.
+///
+/// The codec handles JSON array framing on text frames and Phoenix V2
 /// binary framing on binary frames (see `decode_binary_message`). Decoded
 /// binary frames follow the normal inbound path, producing `Join` or
 /// `Message` events according to their event name. The app receives a
@@ -56,7 +58,7 @@ pub fn phoenix_codec() -> Codec {
 /// Parse a JSON string into an `Inbound`.
 ///
 /// Expected format: `[join_ref, ref, topic, event, payload]` where
-/// `join_ref` and `ref` may be `null`.
+/// The `join_ref` and `ref` values can be `null`.
 pub fn decode_message(json_string: String) -> Result(Inbound, DecodeError) {
   case json.parse(from: json_string, using: decode.dynamic) {
     Ok(value) -> decode_inbound_value(value)
@@ -183,11 +185,10 @@ fn phoenix_event_name(kind: InboundKind) -> String {
   }
 }
 
-/// Convert a `Dynamic` (decoded from JSON) back into `json.Json`.
+/// Convert a `Dynamic` value decoded from JSON back to `json.Json`.
 ///
-/// Returns `Error(Nil)` when the value nests deeper than the wire
-/// protocol's maximum JSON depth, or contains something JSON cannot
-/// represent.
+/// Returns `Error(Nil)` when the value exceeds the wire protocol's maximum
+/// JSON depth or contains a value that JSON cannot represent.
 pub fn dynamic_to_json(value: Dynamic) -> Result(json.Json, Nil) {
   dynamic_to_json_limited(value, max_json_nesting_depth)
 }
@@ -297,14 +298,16 @@ pub fn push(topic: String, event: String, payload: json.Json) -> Frame {
   )
 }
 
-/// Create a Phoenix `phx_close` frame, sent when a channel terminates
-/// gracefully. Phoenix mirrors the channel's `join_ref` into the `ref` slot.
+/// Create a Phoenix `phx_close` frame for a normal channel termination.
+///
+/// Phoenix copies the channel's `join_ref` to the `ref` slot.
 pub fn channel_close(join_ref: Option(String), topic: String) -> Frame {
   terminal_event(join_ref, topic, "phx_close")
 }
 
-/// Create a Phoenix `phx_error` frame, sent when a channel terminates
-/// abnormally. Phoenix clients respond by scheduling an automatic rejoin.
+/// Create a Phoenix `phx_error` frame for an abnormal channel termination.
+///
+/// Phoenix clients respond by scheduling an automatic rejoin.
 pub fn channel_error(join_ref: Option(String), topic: String) -> Frame {
   terminal_event(join_ref, topic, "phx_error")
 }
@@ -377,12 +380,12 @@ const expected_binary_message = "Expected Phoenix V2 binary push frame"
 
 /// Decode a Phoenix V2 binary push frame from a client into an `Inbound`.
 ///
-/// The payload remains a `BitArray` wrapped in `Dynamic`, but the decoded
+/// The payload remains a `BitArray` wrapped in `Dynamic`. The decoded
 /// frame follows normal event classification and reaches the app as a
 /// `Join` or `Message` event rather than `Binary`. Decode the payload with
-/// `gleam/dynamic/decode.bit_array` if needed. Zero-length join_ref/ref
-/// components decode as `None`. Reserved protocol events are classified the
-/// same way as on the text framing.
+/// `gleam/dynamic/decode.bit_array` if needed. Zero-length `join_ref` and
+/// `ref` components decode as `None`. Reserved protocol events use the same
+/// classification as text frames.
 pub fn decode_binary_message(data: BitArray) -> Result(Inbound, DecodeError) {
   case data {
     <<
@@ -429,8 +432,8 @@ fn required_utf8(bytes: BitArray, name: String) -> Result(String, DecodeError) {
 
 /// Encode a Phoenix V2 binary server push: `(join_ref, topic, event, payload)`.
 ///
-/// Errors when a metadata component exceeds the framing's 255-byte length
-/// limit.
+/// Returns `Error(Nil)` when a metadata component exceeds the framing's
+/// 255-byte limit.
 pub fn binary_push(
   join_ref join_ref: Option(String),
   topic topic: String,
@@ -458,8 +461,8 @@ pub fn binary_push(
 
 /// Encode a Phoenix V2 binary reply: `(join_ref, ref, topic, status, payload)`.
 ///
-/// Errors when a metadata component exceeds the framing's 255-byte length
-/// limit.
+/// Returns `Error(Nil)` when a metadata component exceeds the framing's
+/// 255-byte limit.
 pub fn binary_reply(
   join_ref join_ref: Option(String),
   ref ref: Option(String),
@@ -495,8 +498,8 @@ pub fn binary_reply(
 
 /// Encode a Phoenix V2 binary broadcast: `(topic, event, payload)`.
 ///
-/// Errors when a metadata component exceeds the framing's 255-byte length
-/// limit.
+/// Returns `Error(Nil)` when a metadata component exceeds the framing's
+/// 255-byte limit.
 pub fn binary_broadcast(
   topic topic: String,
   event event: String,

--- a/packages/beryl/src/beryl/wire/codec.gleam
+++ b/packages/beryl/src/beryl/wire/codec.gleam
@@ -36,11 +36,11 @@ pub type InboundKind {
   Event(String)
 }
 
-/// Normalised inbound message shape.
+/// A normalized inbound message.
 ///
 /// `Inbound` is opaque: construct it with `inbound` and read it with the
-/// `inbound_*` accessors. Keeping the record hidden lets Beryl add fields
-/// (which default sensibly) without breaking every custom codec.
+/// `inbound_*` accessors. The hidden record lets Beryl add fields with
+/// defaults without breaking custom codecs.
 pub opaque type Inbound {
   Inbound(
     join_ref: Option(String),
@@ -51,7 +51,7 @@ pub opaque type Inbound {
   )
 }
 
-/// Construct a normalised inbound message.
+/// Construct a normalized inbound message.
 ///
 /// - `join_ref`: optional client-side reference assigned at join time
 ///   (used by some Phoenix replies; codecs without this concept should
@@ -70,27 +70,27 @@ pub fn inbound(
   Inbound(join_ref:, ref:, topic:, kind:, payload:)
 }
 
-/// The inbound message's join-time client reference, if any.
+/// Return the inbound message's join-time client reference, if any.
 pub fn inbound_join_ref(inbound: Inbound) -> Option(String) {
   inbound.join_ref
 }
 
-/// The inbound message's per-message reference for reply correlation, if any.
+/// Return the inbound message's per-message reply reference, if any.
 pub fn inbound_ref(inbound: Inbound) -> Option(String) {
   inbound.ref
 }
 
-/// The inbound message's subscription topic.
+/// Return the inbound message's subscription topic.
 pub fn inbound_topic(inbound: Inbound) -> String {
   inbound.topic
 }
 
-/// The inbound message's structural kind.
+/// Return the inbound message's structural kind.
 pub fn inbound_kind(inbound: Inbound) -> InboundKind {
   inbound.kind
 }
 
-/// The inbound message's body, for the app to decode.
+/// Return the inbound message body for the app to decode.
 pub fn inbound_payload(inbound: Inbound) -> Dynamic {
   inbound.payload
 }
@@ -114,8 +114,9 @@ pub type ReplyStatus {
   StatusError
 }
 
-/// Format a `DecodeError` as a human-readable string. Used by the
-/// runtime's log messages and by `wire.format_decode_error`.
+/// Format a `DecodeError` as human-readable text.
+///
+/// The runtime log messages and `wire.format_decode_error` use this text.
 pub fn format_decode_error(error: DecodeError) -> String {
   case error {
     InvalidJson(reason) -> "Invalid JSON: " <> reason
@@ -126,9 +127,8 @@ pub fn format_decode_error(error: DecodeError) -> String {
 
 /// A wire codec.
 ///
-/// `Codec` is opaque; build one with `new` (and, for binary support,
-/// `with_binary_decoder`). The runtime reads the codec's behaviour
-/// through the `@internal` accessors below.
+/// `Codec` is opaque. Build one with `new`. For binary support, add
+/// `with_binary_decoder`.
 pub opaque type Codec {
   Codec(
     decode_text: fn(String) -> Result(Inbound, DecodeError),
@@ -150,7 +150,7 @@ pub opaque type Codec {
 
 /// Build a text-only wire codec.
 ///
-/// - `decode_text`: decode raw inbound text into a normalised `Inbound`.
+/// - `decode_text`: decode raw inbound text into a normalized `Inbound`.
 /// - `encode_reply`: encode a reply to a client message:
 ///   `(join_ref, ref, topic, status, response_payload)`.
 /// - `encode_push`: encode a server-initiated push: `(topic, event, payload)`.
@@ -183,11 +183,11 @@ pub fn new(
   )
 }
 
-/// Attach a binary decoder to a codec.
+/// Add a binary decoder to a codec.
 ///
-/// When set, binary WebSocket frames are decoded into a normalised `Inbound`
-/// via `decode_binary` instead of being delivered to the app's `update` as a
-/// raw `Binary` event.
+/// When set, the decoder converts binary WebSocket frames to a normalized
+/// `Inbound` via `decode_binary`. The app's `update` function does not receive
+/// a raw `Binary` event.
 pub fn with_binary_decoder(
   codec: Codec,
   decode_binary: fn(BitArray) -> Result(Inbound, DecodeError),
@@ -195,10 +195,10 @@ pub fn with_binary_decoder(
   Codec(..codec, decode_binary: Some(decode_binary))
 }
 
-/// Attach a topic-close encoder to a codec.
+/// Add a topic-close encoder to a codec.
 ///
-/// When set, the runtime emits this frame to a client whenever one of
-/// its topics terminates gracefully (leave, server shutdown, heartbeat
+/// When set, the runtime sends this frame when one of the client's topics
+/// terminates gracefully (leave, server shutdown, heartbeat
 /// eviction): `(join_ref, topic)`. Phoenix clients rely on `phx_close` to
 /// leave the joined state instead of waiting out push timeouts.
 pub fn with_close_encoder(
@@ -208,10 +208,10 @@ pub fn with_close_encoder(
   Codec(..codec, encode_close: Some(encode_close))
 }
 
-/// Attach a topic-error encoder to a codec.
+/// Add a topic-error encoder to a codec.
 ///
-/// When set, the runtime emits this frame to a client whenever one of
-/// its topics terminates abnormally (crashed or stopped with an error):
+/// When set, the runtime sends this frame when one of the client's topics
+/// terminates abnormally (crashed or stopped with an error):
 /// `(join_ref, topic)`. Phoenix clients rely on `phx_error` to schedule an
 /// automatic rejoin.
 pub fn with_error_encoder(
@@ -350,11 +350,12 @@ pub fn encode_close(
 
 /// Mark a codec's events as topicless.
 ///
-/// Some framings (e.g. Socket.IO-style protocols) do not carry a per-frame
+/// Some framings, such as Socket.IO-style protocols, do not carry a per-frame
 /// topic. When set, an inbound event whose topic is empty is routed to the
-/// socket's single joined topic; with zero or multiple joins it is dropped.
+/// socket's single joined topic. The runtime drops it when the socket has
+/// zero or multiple joins.
 /// Topic-carrying codecs (like the Phoenix codec) must leave this off so
-/// empty-topic frames are rejected instead of guessed at.
+/// the runtime rejects empty-topic frames instead of inferring a topic.
 pub fn with_topicless_events(codec: Codec) -> Codec {
   Codec(..codec, topicless_events: True)
 }

--- a/packages/beryl_ewe/src/beryl_ewe.gleam
+++ b/packages/beryl_ewe/src/beryl_ewe.gleam
@@ -23,7 +23,7 @@ import gleam/http/response.{type Response}
 import gleam/option.{None}
 import gleam/result
 
-/// Upgrade a request to WebSocket if it matches the configured path
+/// Upgrade a request to WebSocket if it matches the configured path.
 ///
 /// Usage in your Ewe handler:
 /// ```gleam
@@ -39,8 +39,8 @@ import gleam/result
 ///
 /// Path matching, origin policy, `?vsn` version negotiation, connection
 /// limits (per-IP and node-wide, rejected with `429 Too Many Requests`), and
-/// the `on_connect` callback are handled by the shared admission pipeline —
-/// see `beryl/transport/server.upgrade` for the full contract. Enforcement
+/// the `on_connect` callback use the shared admission pipeline. See
+/// `beryl/transport/server.upgrade` for the full contract. Enforcement
 /// uses the real socket peer IP from the TCP connection; forwarded headers
 /// such as `X-Forwarded-For` are not trusted.
 pub fn upgrade(
@@ -77,14 +77,13 @@ fn request_ip(request: Request(Connection)) -> Result(String, Nil) {
 /// Build a combined request handler that serves both WebSocket upgrades and
 /// regular HTTP from a single Ewe listener.
 ///
-/// The returned function inspects each request and routes it:
-/// - WebSocket upgrade requests matching the configured socket path are handed
-///   to [`upgrade`](#upgrade) (which also runs any `on_connect` callback).
-/// - Everything else — non-upgrade requests, or upgrades to a different path —
-///   falls through to `http_fallback`.
+/// The returned function inspects and routes each request:
+/// - It passes WebSocket upgrade requests for the configured socket path to
+///   [`upgrade`](#upgrade), which also runs any `on_connect` callback.
+/// - It passes all other requests to `http_fallback`. This includes non-upgrade
+///   requests and upgrades for a different path.
 ///
-/// This removes the boilerplate upgrade guard integrators would otherwise write
-/// by hand:
+/// This removes the need to write an upgrade guard:
 ///
 /// ```gleam
 /// ewe_transport.handler(sockets, server.default_config("/socket"), http_handler)

--- a/packages/beryl_mist/src/beryl_mist.gleam
+++ b/packages/beryl_mist/src/beryl_mist.gleam
@@ -20,7 +20,7 @@ import gleam/option.{None, Some}
 import gleam/result
 import mist.{type Connection, type ResponseData, type WebsocketConnection}
 
-/// Upgrade a request to WebSocket if it matches the configured path
+/// Upgrade a request to WebSocket if it matches the configured path.
 ///
 /// Usage in your Mist handler:
 /// ```gleam
@@ -36,8 +36,8 @@ import mist.{type Connection, type ResponseData, type WebsocketConnection}
 ///
 /// Path matching, origin policy, `?vsn` version negotiation, connection
 /// limits (per-IP and node-wide, rejected with `429 Too Many Requests`), and
-/// the `on_connect` callback are handled by the shared admission pipeline —
-/// see `beryl/transport/server.upgrade` for the full contract. Enforcement
+/// the `on_connect` callback use the shared admission pipeline. See
+/// `beryl/transport/server.upgrade` for the full contract. Enforcement
 /// uses the real socket peer IP from the TCP connection; forwarded headers
 /// such as `X-Forwarded-For` are not trusted.
 pub fn upgrade(
@@ -74,14 +74,13 @@ fn request_ip(request: Request(Connection)) -> Result(String, Nil) {
 /// Build a combined request handler that serves both WebSocket upgrades and
 /// regular HTTP from a single Mist listener.
 ///
-/// The returned function inspects each request and routes it:
-/// - WebSocket upgrade requests matching the configured socket path are handed
-///   to [`upgrade`](#upgrade) (which also runs any `on_connect` callback).
-/// - Everything else — non-upgrade requests, or upgrades to a different path —
-///   falls through to `http_fallback`.
+/// The returned function inspects and routes each request:
+/// - It passes WebSocket upgrade requests for the configured socket path to
+///   [`upgrade`](#upgrade), which also runs any `on_connect` callback.
+/// - It passes all other requests to `http_fallback`. This includes non-upgrade
+///   requests and upgrades for a different path.
 ///
-/// This removes the boilerplate upgrade guard integrators would otherwise write
-/// by hand:
+/// This removes the need to write an upgrade guard:
 ///
 /// ```gleam
 /// mist_transport.handler(sockets, server.default_config("/socket"), http_handler)

--- a/website/src/content/docs/reference/api/beryl-bridge.md
+++ b/website/src/content/docs/reference/api/beryl-bridge.md
@@ -65,11 +65,11 @@ Bridge - Forward an external OTP actor's message stream to a socket via
 
 ### `Bridge`
 
-A handle to a running bridge forwarder process.
+A handle to a running bridge forwarder.
 
- `message` is the type emitted by the external actor and received on the
- bridge's `Subject`. Obtain that subject with `subject` to wire it up to a
- domain actor, and call `stop` to tear the forwarder down.
+ `message` is the type that the external actor sends to the bridge's
+ `Subject`. Get the subject with `subject`. Call `stop` to stop the
+ forwarder.
 
 ```gleam
 pub type Bridge(a)
@@ -89,17 +89,17 @@ pub type StartError {
 
 ##### `ForwarderUnavailable`
 
-The forwarder process did not report its subjects within
- `handshake_timeout_ms` — it failed to spawn or start.
+The forwarder did not report its subjects within
+ `handshake_timeout_ms`. It failed to spawn or start.
 
 ## Functions
 
 ### `pid`
 
-The forwarder process id.
+Return the forwarder process ID.
 
- Exposed for diagnostics and supervision; you normally only need `subject`
- and `stop`.
+ Use this value for diagnostics and supervision. Most callers need only
+ `subject` and `stop`.
 
 ```gleam
 pub fn pid(Bridge(a)) -> process.Pid
@@ -107,22 +107,21 @@ pub fn pid(Bridge(a)) -> process.Pid
 
 ### `start`
 
-Start a bridge that forwards values from an external `Subject` to a
- socket's `update` function as `Info` events.
+Start a bridge from an external `Subject` to a socket's `update` function.
 
- The returned `Bridge` owns a freshly spawned forwarder process. Pass
- `subject(bridge)` to the external/domain actor so it delivers its stream
- to the forwarder; each received value is mapped with `transform` and
- delivered via `socket.notify(sender, transform(value))`.
+ The returned `Bridge` owns a new forwarder process. Pass `subject(bridge)`
+ to the external or domain actor. The forwarder maps each received value
+ with `transform` and sends it as an `Info` event through
+ `socket.notify(sender, transform(value))`.
 
  Use `transform` to translate the domain message into your app's
  server-side `msg` type (the `Info` payload). If no translation is needed,
  pass the identity function `fn(value) { value }`.
 
- Always call `stop` when the owning socket or topic ends — that is the
- per-owner cleanup. The forwarder also monitors the calling process, but
- that monitor is only a backstop: it fires if the owner dies without a
- `stop`, not as a per-topic lifecycle.
+ Always call `stop` when the owning socket or topic ends. The forwarder
+ also monitors the calling process. This monitor stops the forwarder if
+ the owner dies without calling `stop`, but it does not track topic
+ lifecycles.
 
 ```gleam
 pub fn start(
@@ -133,7 +132,7 @@ pub fn start(
 
 ### `stop`
 
-Stop the bridge's forwarder process.
+Stop the bridge's forwarder.
 
  Call this when the owning socket or topic ends. It is safe to call more
  than once and after the forwarder has already exited.
@@ -144,10 +143,10 @@ pub fn stop(Bridge(a)) -> Nil
 
 ### `subject`
 
-The `Subject` the external actor should send its stream to.
+Return the `Subject` that receives the external actor's stream.
 
- Hand this to your domain actor (e.g. as its subscriber) so each emitted
- value is forwarded to the bridged socket.
+ Give this subject to the domain actor, for example as its subscriber.
+ Each value is then sent to the bridged socket.
 
 ```gleam
 pub fn subject(Bridge(a)) -> process.Subject(a)

--- a/website/src/content/docs/reference/api/beryl-channel.md
+++ b/website/src/content/docs/reference/api/beryl-channel.md
@@ -60,17 +60,17 @@ The channel composition surface: a channel is a topic pattern paired
  unrelated `state` and `info` types compose in one list. No value is
  ever erased to `Dynamic` and no unchecked coercion is involved:
  typed `info` values travel inside a closure that only the join which
- created it can open, and the socket that owns the join opens it — or
- drops it unopened, if the join has since ended.
+ created it can open. The socket that owns the join opens it. If the join
+ has ended, the socket drops it unopened.
 
  ## Ordering
 
  Action lists are applied strictly from left to right, and they always
  target the channel's own topic. They lower onto
- beryl's core `Effect` values, which the runtime applies in list order —
- so action order is wire order. An asynchronous presence effect can park
- this socket while other sockets continue; the remaining actions resume
- only after that effect completes.
+ beryl's core `Effect` values, which the runtime applies in list order.
+ Action order is therefore wire order. An asynchronous presence effect can
+ park this socket while other sockets continue. The remaining actions
+ resume only after that effect completes.
 
  A join's actions (see [`with_actions`](#with_actions)) are emitted with
  the join acknowledgment, immediately after it: the socket is already
@@ -89,8 +89,8 @@ The channel composition surface: a channel is a topic pattern paired
 
 One operation on the channel's own topic.
 
- The phase parameter prevents active-only operations from being returned
- by [`on_terminate`](#on_terminate). Put actions in a list in wire order.
+ The phase parameter prevents [`on_terminate`](#on_terminate) from returning
+ active-only operations. Put actions in a list in wire order.
 
 ```gleam
 pub type Action(a)
@@ -109,9 +109,9 @@ pub type Active
 The typed callbacks of one channel, over its private `state` and its
  server-side message type `info`.
 
- Start from [`callbacks`](#callbacks) — which ignores every input and
- stays joined — and override only what the channel cares about. Pass the
- result to [`accept`](#accept) with the initial state.
+ Start with [`callbacks`](#callbacks), which ignores every input and stays
+ joined. Override only the callbacks that the channel needs. Pass the result
+ to [`accept`](#accept) with the initial state.
 
 ```gleam
 pub type Callbacks(a, b)
@@ -121,10 +121,10 @@ pub type Callbacks(a, b)
 
 Why building a channel-system child specification failed.
 
- Handler patterns are validated before the core configuration. Validation
- checks every pattern's syntax in registration order, then checks exact
- duplicates in registration order. Overlapping non-identical patterns are
- allowed because routing takes the first match.
+ The function validates handler patterns before the core configuration. It
+ checks each pattern's syntax in registration order. It then checks for
+ exact duplicates in the same order. Overlapping patterns are allowed when
+ they are not identical because routing uses the first match.
 
 ```gleam
 pub type ChildSpecError {
@@ -166,9 +166,9 @@ pub type Closing
 
 A registered channel: a topic pattern plus its sealed `join` callback.
 
- `Handler` is deliberately not generic. A channel's `state` and `info`
- types are sealed inside the closure captured here, so a single
- `List(Handler)` can hold channels that agree on nothing.
+ `Handler` is not generic. The closure contains the channel's sealed `state`
+ and `info` types. A single `List(Handler)` can therefore hold channels
+ with unrelated types.
 
 ```gleam
 pub type Handler
@@ -176,7 +176,7 @@ pub type Handler
 
 ### `JoinContext`
 
-Everything a `join` callback learns about one join attempt.
+Information about one join attempt.
 
  `params` contains wildcard captures in pattern order and is empty for
  exact patterns. `self` is this channel's generation-scoped
@@ -236,24 +236,24 @@ pub type Next(a)
 
 A typed handle for sending server-side messages to one joined channel.
 
- Obtained from [`JoinContext`](#joincontext) in the `join` callback and safe to
- share with any process. Messages sent through it are delivered to the
- channel's `on_info` callback with their type intact.
+ Get this handle from [`JoinContext`](#joincontext) in the `join` callback.
+ You can share it with any process. The channel's `on_info` callback
+ receives each message with its type intact.
 
- A sender is scoped to the join that produced it. Sending is
- asynchronous and never fails, so it cannot report that the channel is
- gone: liveness is decided where the message is delivered. After a
- normal close — a client leave, a [`close`](#close) result, a socket
- teardown — or after the same topic has been joined again, the message
- is dropped there and is never handed to a different join.
+ A sender is scoped to the join that produced it. Sending is asynchronous
+ and never fails. It cannot report that the channel is gone. The delivery
+ point checks liveness. It drops the message after a normal close, such as
+ a client leave, a [`close`](#close) result, or a socket teardown. It also
+ drops the message after the same topic is joined again. A different join
+ never receives the message.
 
  The one exception is a panic inside [`on_terminate`](#on_terminate).
  Core's policy for a crash while closing a topic is to log it and keep
  the model from before the close, so the channel system keeps that
  instance: a sender created by it can still reach its `on_info` until
  the topic is joined again or the socket ends. Nothing is handed to
- another join in that window either — it is the *same* instance,
- outliving its own termination.
+ another join in that window. It is the *same* instance, outliving its own
+ termination.
 
  ## Cost
 
@@ -334,10 +334,10 @@ pub fn callbacks() -> Callbacks(a, b)
 Build a channel system's supervision child specification for embedding
  in an application's supervision tree.
 
- Like `beryl.child_spec`, this reports only what can be detected before
- the tree is started: the handler table is validated first, then the
- `beryl.Config`. The returned `beryl.Sockets` is usable as soon as the
- owning tree is running.
+ Like `beryl.child_spec`, this function reports only errors that it can
+ detect before the tree starts. It validates the handler table first and
+ then validates `beryl.Config`. You can use the returned `beryl.Sockets`
+ after the owning tree starts.
 
  ## Example
 
@@ -365,7 +365,7 @@ pub fn child_spec(
 
 Leave this channel after applying `actions` in order.
 
- The socket stays connected and its other channels are untouched; this
+ The socket stays connected. Its other channels do not change. This
  channel's [`on_terminate`](#on_terminate) callback still runs.
 
 ```gleam
@@ -405,15 +405,14 @@ pub fn next(
 
 Send a typed server-side message to the channel that owns `sender`.
 
- Each call enqueues exactly one message, and each enqueued message
- produces exactly one `on_info` call — sends are never coalesced, and
- they are delivered in the order the owning socket receives them.
+ Each call enqueues one message. Each enqueued message produces one
+ `on_info` call. The runtime does not combine sends. It delivers them in
+ the order that the owning socket receives them.
 
- This is a fire-and-forget send: it returns as soon as the message is
- enqueued, whether or not the channel is still joined. A message
- enqueued for a channel that has already ended is discarded on arrival
- (see [`Sender`](#sender), which also covers the cost of a delivery and
- the one case where an ended channel still receives one).
+ This is a fire-and-forget send. It returns when the message is enqueued,
+ whether or not the channel is still joined. The runtime discards a message
+ for a channel that has ended. See [`Sender`](#sender) for delivery cost and
+ the one case in which an ended channel can still receive a message.
 
 ```gleam
 pub fn notify(
@@ -458,18 +457,18 @@ pub fn on_message(
 
 ### `on_terminate`
 
-Run cleanup when the channel ends, for any reason: client leave, a
+Run cleanup when the channel ends for any reason: client leave, a
  [`close`](#close) result, a socket teardown, or a disconnect.
 
- The returned closing-phase actions are applied in the turn that closes
- this topic, right after the channel instance is gone. The phase allows
- broadcasts, presence untracking, and presence broadcasts, while making
- pushes, replies, and presence tracking unavailable.
+ The runtime applies the returned closing-phase actions in the turn that
+ closes this topic, after it removes the channel instance. This phase
+ allows broadcasts, presence untracking, and presence broadcasts. It does
+ not allow pushes, replies, or presence tracking.
 
- A panic here is not fatal, but it is not free either: core keeps the
- model from before the close, so this instance stays in the channel
- system's map and its own [`Sender`](#sender) can still reach it until
- the topic is rejoined or the socket ends.
+ A panic here is not fatal. Core keeps the model from before the close.
+ This instance stays in the channel system's map, and its
+ [`Sender`](#sender) can reach it until the topic is rejoined or the socket
+ ends.
 
 ```gleam
 pub fn on_terminate(
@@ -549,7 +548,7 @@ pub fn reject(json.Json) -> JoinResult(a)
 Reply with an error when a client message supplied a reply handle.
 
  [`option.None`](https://hexdocs.pm/gleam_stdlib/gleam/option.html#Option)
- lowers to no effect.
+ produces no effect.
 
 ```gleam
 pub fn reply_error(
@@ -563,7 +562,7 @@ pub fn reply_error(
 Reply successfully when a client message supplied a reply handle.
 
  [`option.None`](https://hexdocs.pm/gleam_stdlib/gleam/option.html#Option)
- lowers to no effect.
+ produces no effect.
 
 ```gleam
 pub fn reply_ok(
@@ -576,8 +575,8 @@ pub fn reply_ok(
 
 Tear down the whole socket, not just this channel.
 
- This deliberately carries no actions: the socket and every channel on
- it are going away, so there is nothing left to apply them to.
+ This result carries no actions. The socket and all its channels are
+ stopping, so no target remains for the actions.
 
 ```gleam
 pub fn stop_socket(socket.StopReason) -> Next(a)
@@ -585,22 +584,22 @@ pub fn stop_socket(socket.StopReason) -> Next(a)
 
 ### `with_actions`
 
-Add ordered actions to run as part of accepting this join.
+Add ordered actions to an accepted join.
 
- They are emitted with the acknowledgment and applied strictly after it,
- so the socket is already subscribed to the topic: a [`push`](#push)
- here cannot overtake its own join reply. If an action lowers to an
+ The runtime emits the actions with the acknowledgment and applies them
+ after it. The socket is therefore already subscribed to the topic. A
+ [`push`](#push) cannot overtake its own join reply. If an action becomes an
  asynchronous presence effect, the runtime may process other sockets
- while this socket waits; a check followed by [`presence_track`](#presence_track)
- is therefore not an atomic cross-socket capacity reservation.
+ while this socket waits. A check followed by
+ [`presence_track`](#presence_track) is not an atomic cross-socket capacity
+ reservation.
 
  Use this function instead of notifying the channel from `join`:
  [`notify`](#notify) schedules a *later* input, while actions preserve
  their declared position immediately after the join acknowledgment.
 
- Existing actions stay ahead of the ones added here. A refused
- join has no topic to act on, so this returns [`reject`](#reject)
- results unchanged.
+ Existing actions stay before the actions added here. A refused join has no
+ topic, so this function returns [`reject`](#reject) results unchanged.
 
 ```gleam
 pub fn with_actions(

--- a/website/src/content/docs/reference/api/beryl-error.md
+++ b/website/src/content/docs/reference/api/beryl-error.md
@@ -28,7 +28,7 @@ pub type StartFailure
 
 ### `describe_start_failure`
 
-Convert a startup failure to a human-readable diagnostic string.
+Return a human-readable description of a startup failure.
 
 ```gleam
 pub fn describe_start_failure(StartFailure) -> String
@@ -36,7 +36,7 @@ pub fn describe_start_failure(StartFailure) -> String
 
 ### `from_actor_start_error`
 
-Convert a `gleam/otp/actor.StartError` into beryl's `StartFailure`.
+Convert a `gleam/otp/actor.StartError` to Beryl's `StartFailure`.
 
 ```gleam
 pub fn from_actor_start_error(actor.StartError) -> StartFailure

--- a/website/src/content/docs/reference/api/beryl-group.md
+++ b/website/src/content/docs/reference/api/beryl-group.md
@@ -46,7 +46,7 @@ pub type Config
 
 ### `GroupError`
 
-Errors from group operations
+Errors from group operations.
 
 ```gleam
 pub type GroupError {
@@ -59,18 +59,18 @@ pub type GroupError {
 
 ##### `GroupAlreadyExists`
 
-The group already exists
+The group already exists.
 
 ##### `GroupNotFound`
 
-The group was not found
+The group was not found.
 
 ### `Groups`
 
-A running Groups instance.
+A running groups instance.
 
- This handle is intentionally opaque so callers cannot forge the backing
- actor subject or depend on its runtime representation.
+ This handle is opaque. Callers cannot forge the actor subject or depend
+ on its runtime representation.
 
  ## Node affinity
 
@@ -85,7 +85,7 @@ pub type Groups
 
 ### `Message`
 
-Messages the groups actor handles
+Messages that the groups actor handles.
 
 ```gleam
 pub type Message
@@ -95,7 +95,7 @@ pub type Message
 
 ### `add`
 
-Add a topic to a group
+Add a topic to a group.
 
  Panics if the groups actor is unavailable or does not reply within the
  configured call timeout (5 seconds by default).
@@ -110,13 +110,14 @@ pub fn add(
 
 ### `broadcast`
 
-Broadcast a message to all topics in a group
+Broadcast a message to all topics in a group.
 
- Sends the message to every topic in the named group via beryl.broadcast().
- The topic lookup runs through the groups actor, then fan-out runs in the
- caller. If the group doesn't exist, this is a silent no-op.
+ This function sends the message to each topic through `beryl.broadcast`.
+ The groups actor performs the topic lookup. The caller performs the
+ fan-out. If the group does not exist, this function does nothing.
 
- Panics if the groups actor is unavailable or does not reply within 5 seconds.
+ Panics if the groups actor is unavailable or does not reply within the
+ configured call timeout.
 
 ```gleam
 pub fn broadcast(
@@ -151,7 +152,7 @@ pub fn child_spec_with_config(Config) -> #(Groups, supervision.ChildSpecificatio
 
 ### `create`
 
-Create a new named group
+Create a named group.
 
  Panics if the groups actor is unavailable or does not reply within the
  configured call timeout (5 seconds by default).
@@ -173,7 +174,7 @@ pub fn default_config() -> Config
 
 ### `delete`
 
-Delete a group
+Delete a group.
 
  Panics if the groups actor is unavailable or does not reply within the
  configured call timeout (5 seconds by default).
@@ -187,7 +188,7 @@ pub fn delete(
 
 ### `list_groups`
 
-List all group names
+Return all group names.
 
  Panics if the groups actor is unavailable or does not reply within the
  configured call timeout (5 seconds by default).
@@ -198,7 +199,7 @@ pub fn list_groups(Groups) -> List(String)
 
 ### `remove`
 
-Remove a topic from a group
+Remove a topic from a group.
 
  Panics if the groups actor is unavailable or does not reply within the
  configured call timeout (5 seconds by default).
@@ -213,7 +214,7 @@ pub fn remove(
 
 ### `topics`
 
-Get all topics in a group
+Return all topics in a group.
 
  Panics if the groups actor is unavailable or does not reply within the
  configured call timeout (5 seconds by default).

--- a/website/src/content/docs/reference/api/beryl-presence-wire.md
+++ b/website/src/content/docs/reference/api/beryl-presence-wire.md
@@ -17,8 +17,8 @@ Phoenix-compatible wire encoding for presence diffs.
 
 Encode a presence diff for one topic as a Phoenix-compatible payload.
 
- The resulting JSON has `joins` and `leaves` maps keyed by presence key,
- where each value contains the tracked metadata under `metas`.
+ The resulting JSON has `joins` and `leaves` maps. Presence keys index the
+ maps. Each value contains the tracked metadata under `metas`.
 
  ```json
  {
@@ -39,17 +39,17 @@ pub fn encode_diff(
 Encode a topic's full presence list as a Phoenix-compatible
  `presence_state` payload.
 
- The resulting JSON is a map keyed by presence key, where each value
- contains the tracked metadata under `metas` — the same shape as one side
- of a `presence_diff`:
+ The resulting JSON is a map indexed by presence key. Each value contains
+ the tracked metadata under `metas`. This is the same shape as one side of
+ a `presence_diff`:
 
  ```json
  { "user:1": { "metas": [{ "status": "online", "phx_ref": "..." }] } }
  ```
 
- Phoenix clients expect a `presence_state` event carrying this payload
- after joining a presence-enabled topic (followed by incremental
- `presence_diff` events). Build the entry list with `presence.list`.
+ Phoenix clients expect a `presence_state` event with this payload after
+ they join a presence-enabled topic. Incremental `presence_diff` events
+ follow it. Build the entry list with `presence.list`.
 
 ```gleam
 pub fn encode_state(List(presence.PresenceEntry)) -> json.Json

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -43,8 +43,8 @@ Presence - Distributed presence tracking backed by a CRDT
 
 Configuration for starting presence.
 
- Build configs with `default_config` and the `with_*` functions so beryl can
- add future options without exposing record fields as public API.
+ Build configurations with `default_config` and the `with_*` functions.
+ Beryl can then add options without exposing record fields as public API.
 
 ```gleam
 pub type Config
@@ -54,8 +54,8 @@ pub type Config
 
 An opaque diff representing presence joins and leaves grouped by topic.
 
- This is passed to `Config.on_diff` and accepted by
- `beryl.broadcast_presence_diff`.
+ Beryl passes this value to `Config.on_diff`.
+ `beryl.broadcast_presence_diff` also accepts it.
 
 ```gleam
 pub type Diff
@@ -63,7 +63,7 @@ pub type Diff
 
 ### `Message`
 
-Messages the presence actor handles
+Messages that the presence actor handles.
 
 ```gleam
 pub type Message
@@ -73,9 +73,9 @@ pub type Message
 
 A running Presence instance.
 
- This handle is intentionally opaque so callers cannot forge actor subjects
- or depend on the runtime representation. It carries the actor's stable
- registered subject and the name of its actor-owned ETS read model.
+ This handle is opaque. Callers cannot forge actor subjects or depend on
+ the runtime representation. It contains the actor's stable registered
+ subject and the name of its actor-owned ETS read model.
 
  ## Node affinity
 
@@ -96,8 +96,8 @@ pub type Presence
 
 A presence entry returned from queries and diff accessors.
 
- This type is intentionally transparent so callers can inspect query results
- and construct entries for `diff`.
+ This type is transparent. Callers can inspect query results and construct
+ entries for `diff`.
 
 ```gleam
 pub type PresenceEntry {
@@ -111,7 +111,7 @@ pub type PresenceEntry {
 
 ### `PresenceUpdateError`
 
-Errors from updating a tracked presence.
+Errors from an update to a tracked presence.
 
 ```gleam
 pub type PresenceUpdateError {
@@ -132,9 +132,8 @@ The ref is unknown, already removed, or was not returned by `track`.
 Build the supervised presence actor.
 
  Add the returned child specification to your application's supervisor.
- The returned handle is name-backed and resumes working after a supervised
- restart. Presence entries and tracking refs are in-memory state and are
- reset by a restart.
+ The returned handle is name-backed and works again after a supervised
+ restart. A restart resets the in-memory presence entries and tracking refs.
 
 ```gleam
 pub fn child_spec(Config) -> #(Presence, supervision.ChildSpecification(process.Subject(Message)))
@@ -144,17 +143,17 @@ pub fn child_spec(Config) -> #(Presence, supervision.ChildSpecification(process.
 
 Count presences in a topic.
 
- Equivalent to `list(presence, topic) |> list.length`, but O(1): it reads
- the materialized count directly from the read model via
+ This is equivalent to `list(presence, topic) |> list.length`, but O(1). It
+ reads the materialized count directly from the read model via
  `ets:lookup_element/4` instead of building (and copying) the entry list
  just to measure it.
 
- Reads the actor-owned read model directly (an ETS snapshot materialized
- after each mutation, merge, or prune) rather than calling the actor, so
- this never waits on the actor mailbox.
+ This function reads the actor-owned read model directly. The read model is
+ an ETS snapshot created after each mutation, merge, or prune. This function
+ does not wait on the actor mailbox.
 
- Returns `Error(Nil)` when the presence read model is unavailable --
- either the presence actor is not running, or this handle is being used
+ Returns `Error(Nil)` when the presence read model is unavailable. This can
+ occur when the presence actor is not running or when this handle is used
  from a process on another BEAM node than the one it was started on (see
  the node affinity note on `Presence`).
 
@@ -169,10 +168,10 @@ pub fn count(
 
 Default configuration (no PubSub).
 
- The broadcast interval defaults to 1500 ms so that adding `with_pubsub`
- yields working two-way replication out of the box; without PubSub the
- interval is unused. Use `with_broadcast_interval(0)` to disable periodic
- broadcasts and control replication manually.
+ The broadcast interval defaults to 1500 ms. Adding `with_pubsub` therefore
+ enables two-way replication without more configuration. Without PubSub,
+ the interval is unused. Use `with_broadcast_interval(0)` to disable
+ periodic broadcasts and control replication manually.
 
 ```gleam
 pub fn default_config(String) -> Config
@@ -182,8 +181,8 @@ pub fn default_config(String) -> Config
 
 Build a presence diff from topic-grouped joins and leaves.
 
- Most applications receive diffs from `Config.on_diff`; this helper is for
- callers that need to construct a diff to pass to `beryl.broadcast_presence_diff`.
+ Most applications receive diffs from `Config.on_diff`. Use this function
+ to construct a diff for `beryl.broadcast_presence_diff`.
 
 ```gleam
 pub fn diff(
@@ -194,7 +193,7 @@ pub fn diff(
 
 ### `diff_joins`
 
-Get presence joins for a topic in this diff.
+Return presence joins for a topic in this diff.
 
 ```gleam
 pub fn diff_joins(
@@ -205,7 +204,7 @@ pub fn diff_joins(
 
 ### `diff_leaves`
 
-Get presence leaves for a topic in this diff.
+Return presence leaves for a topic in this diff.
 
 ```gleam
 pub fn diff_leaves(
@@ -226,12 +225,12 @@ pub fn diff_topics(Diff) -> List(String)
 
 Get presences for a specific key within a topic.
 
- Reads the actor-owned read model directly (an ETS snapshot materialized
- after each mutation, merge, or prune) rather than calling the actor, so
- this never waits on the actor mailbox.
+ This function reads the actor-owned read model directly. The read model is
+ an ETS snapshot created after each mutation, merge, or prune. This function
+ does not wait on the actor mailbox.
 
- Returns `Error(Nil)` when the presence read model is unavailable --
- either the presence actor is not running, or this handle is being used
+ Returns `Error(Nil)` when the presence read model is unavailable. This can
+ occur when the presence actor is not running or when this handle is used
  from a process on another BEAM node than the one it was started on (see
  the node affinity note on `Presence`).
 
@@ -247,12 +246,12 @@ pub fn get_by_key(
 
 List all presences for a topic.
 
- Reads the actor-owned read model directly (an ETS snapshot materialized
- after each mutation, merge, or prune) rather than calling the actor, so
- this never waits on the actor mailbox.
+ This function reads the actor-owned read model directly. The read model is
+ an ETS snapshot created after each mutation, merge, or prune. This function
+ does not wait on the actor mailbox.
 
- Returns `Error(Nil)` when the presence read model is unavailable --
- either the presence actor is not running, or this handle is being used
+ Returns `Error(Nil)` when the presence read model is unavailable. This can
+ occur when the presence actor is not running or when this handle is used
  from a process on another BEAM node than the one it was started on (see
  the node affinity note on `Presence`).
 
@@ -267,14 +266,14 @@ pub fn list(
 
 Track a presence in a topic.
 
- `session_id` identifies the session (e.g. socket) that owns this presence
- and is the value `untrack_all` matches on when the session disconnects.
+ `session_id` identifies the session, such as a socket, that owns this
+ presence. `untrack_all` matches this value when the session disconnects.
 
- Returns a server-generated tracking ref: an opaque, unique handle for this
- specific presence. Pass it to `untrack` to remove exactly this entry later.
- The ref is not the session id — it is minted by the presence actor and is
- only meaningful to that actor. The ref is also merged into object metas as
- `phx_ref` for Phoenix client compatibility.
+ Returns a server-generated tracking ref. It is an opaque, unique handle for
+ this presence. Pass it to `untrack` to remove this entry. The ref is not
+ the session ID. The presence actor creates it, and it is meaningful only
+ to that actor. The ref is also merged into object metas as `phx_ref` for
+ Phoenix client compatibility.
 
  Panics if the presence actor is unavailable or does not reply within the
  configured call timeout (5 seconds by default).
@@ -307,7 +306,7 @@ pub fn untrack(
 
 ### `untrack_all`
 
-Untrack all presences for a session (e.g., when a socket disconnects)
+Untrack all presences for a session, such as when a socket disconnects.
 
  Panics if the presence actor is unavailable or does not reply within the
  configured call timeout (5 seconds by default).
@@ -323,9 +322,9 @@ pub fn untrack_all(
 
 Replace the meta of a presence created by `track`.
 
- The old ref's leave and the new ref's join are emitted together in one
- diff, so subscribers never observe an intermediate state without the
- presence key. Other tracked refs for the same key are left unchanged.
+ One diff contains the old ref's leave and the new ref's join. Subscribers
+ do not observe an intermediate state without the presence key. Other
+ tracked refs for the same key do not change.
 
  Returns the replacement ref, which must be used for subsequent `update`
  or `untrack` calls. Returns `Error(UnknownRef)` when `ref` is
@@ -358,8 +357,9 @@ pub fn with_broadcast_interval(
 
 Set the timeout for synchronous presence mutations, in milliseconds.
 
- This applies to `track`, `untrack`, and `untrack_all`. These functions panic
- if the actor does not reply within this timeout. The default is 5000 ms.
+ This timeout applies to `track`, `untrack`, and `untrack_all`. These
+ functions panic if the actor does not reply before the timeout. The default
+ is 5000 ms.
 
 ```gleam
 pub fn with_call_timeout(
@@ -370,32 +370,30 @@ pub fn with_call_timeout(
 
 ### `with_on_diff`
 
-Set the callback invoked when local changes or remote merges produce a diff.
+Set the callback for diffs from local changes or remote merges.
 
  The callback runs synchronously on the presence actor, for both local
  mutations (`track`/`untrack`/`untrack_all`, and the asynchronous
  mutations the runtime issues for presence effects) and remote merges,
  before the affected topics' read-model snapshots are (re)published and
  before the triggering call replies or the mutation is acknowledged.
- This ordering is identical for local and remote diffs -- there is no
- divergent local-vs-remote behavior.
+ This ordering is the same for local and remote diffs.
 
- One consequence: if the callback reads presence state through the same
+ If the callback reads presence state through the same
  `Presence` handle (`list`, `get_by_key`, `count`) for a topic this diff
- touches, it observes the *previous* snapshot -- the one from before this
- diff -- not the one the diff itself is about to produce. Read the
- entries and counts you need directly from the `Diff` argument (via
+ changes, it observes the *previous* snapshot. It does not observe the
+ snapshot that the diff will produce. Read the entries and counts you need
+ directly from the `Diff` argument (via
  `diff_joins`/`diff_leaves`) instead of re-reading through `presence`
  inside the callback.
 
- Keep the callback fast and non-blocking: it runs on the actor process,
- so a slow or blocking callback delays that topic's read-model publish,
+ Keep the callback fast and non-blocking. It runs on the actor process.
+ A slow or blocking callback delays that topic's read-model publish,
  the reply to (or acknowledgement of) the mutating operation, and every
- other message queued behind it in the actor's mailbox (though concurrent
- `list`/`get_by_key`/`count` reads from other processes are unaffected,
- since those bypass the mailbox entirely). It no longer stalls a Beryl
- runtime wholesale: only the socket whose presence effect is in flight
- waits on it.
+ other message behind it in the actor's mailbox. Concurrent
+ `list`/`get_by_key`/`count` calls from other processes do not use the
+ mailbox and are not delayed. Only the socket with an active presence
+ effect waits for the callback.
 
 ```gleam
 pub fn with_on_diff(

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -17,9 +17,9 @@ PubSub - Distributed publish/subscribe using Erlang pg
 
  The payload is generic: `PubSub(payload)` and `Message(payload)` carry
  whatever Gleam type a given scope is started with. A broadcast sends that
- value as a scope-tagged native BEAM term — there is no encoding step, even
- across nodes, since Erlang's own distribution protocol marshals arbitrary
- terms for you. Use a `gleam/json` payload only when the data is also
+ value as a scope-tagged native BEAM term. There is no encoding step, even
+ across nodes, because Erlang's distribution protocol marshals arbitrary
+ terms. Use a `gleam/json` payload only when the data is also
  destined for a JSON-speaking client (e.g. relayed on to a WebSocket
  browser); payloads that never leave the cluster are cheaper and safer as
  plain Gleam types.
@@ -49,22 +49,22 @@ PubSub - Distributed publish/subscribe using Erlang pg
 
 A PubSub message delivered to subscribers.
 
- This type is intentionally transparent so subscribers can inspect the topic,
- event, payload, and sender metadata delivered to their process mailbox.
+ This type is transparent. Subscribers can inspect the topic, event,
+ payload, and sender metadata in their process mailbox.
 
  ## Frozen wire contract
 
- Beryl sends broadcasts **raw between nodes** via `pg` as a five-element tuple:
- the PubSub scope atom followed by this message's four fields in order. That
- scope-tagged runtime shape forms the frozen wire contract for each `payload`
- type. The contract also applies to `PubSubFrom`.
+ Beryl sends broadcasts **raw between nodes** through `pg` as a five-element
+ tuple. The PubSub scope atom comes first. The four message fields follow in
+ order. This scope-tagged runtime shape is the frozen wire contract for each
+ `payload` type. The contract also applies to `PubSubFrom`.
 
- Because payloads travel as native terms rather than a self-describing
- format like JSON, evolving the *shape* of your own `payload` type is also
- a wire change — version it yourself (e.g. an explicit `v` field) if it
- needs to change across a rolling upgrade. Receive broadcasts with
- `selecting`, which safely folds the subscriber's raw mailbox messages into
- a typed `Selector`; never match on the raw process message yourself.
+ Payloads travel as native terms, not in a self-describing format such as
+ JSON. A change to the *shape* of your `payload` type is therefore a wire
+ change. Add your own version, for example an explicit `v` field, if the
+ shape must change during a rolling upgrade. Receive broadcasts with
+ `selecting`. It safely adds the subscriber's raw mailbox messages to a
+ typed `Selector`. Do not match the raw process message yourself.
 
 ```gleam
 pub type Message(a) {
@@ -81,11 +81,10 @@ pub type Message(a) {
 
 A running PubSub instance.
 
- This handle is intentionally opaque so callers cannot forge pg scopes or
- depend on the runtime representation. `payload` fixes the Gleam type
- every `Message` broadcast through this instance carries. The scope is the
- runtime instance identity, so all handles using one scope must use the same
- payload type.
+ This handle is opaque. Callers cannot forge pg scopes or depend on the
+ runtime representation. `payload` sets the Gleam type for every `Message`
+ sent through this instance. The scope identifies the runtime instance.
+ All handles for one scope must use the same payload type.
 
 ```gleam
 pub type PubSub(a)
@@ -123,30 +122,30 @@ pub type PubSubFrom {
 
 ##### `System`
 
-Broadcast originated from the system (no sender pid)
+The broadcast came from the system and has no sender PID.
 
 ##### `FromPid(process.Pid)`
 
-Broadcast originated from a specific process
+The broadcast came from a specific process.
 
 ##### `FromSocket(
   process.Pid,
   String
 )`
 
-Broadcast originated from a process and should exclude a socket ID
+The broadcast came from a process and must exclude a socket ID.
 
 ### `Subscriber`
 
 A typed subscription handle owned by a single process.
 
- A `Subscriber` bundles the pg scope and owning process while carrying the
- payload type at compile time. Join it to any number of topics with `join`;
- a single `selecting` fold receives their frozen raw `Message(payload)`
+ A `Subscriber` contains the pg scope and owning process. It also carries
+ the payload type at compile time. Join it to any number of topics with
+ `join`. One `selecting` call receives their frozen raw `Message(payload)`
  records as typed values.
 
- Create it in the process that will receive (e.g. an actor's initialiser),
- since a `Subject` only delivers to its owner.
+ Create it in the receiving process, such as an actor's initializer.
+ A `Subject` delivers messages only to its owner.
 
 ```gleam
 pub type Subscriber(a)
@@ -156,7 +155,7 @@ pub type Subscriber(a)
 
 ### `broadcast`
 
-Broadcast a message to all subscribers of a topic (all nodes)
+Broadcast a message to all topic subscribers on all nodes.
 
 ```gleam
 pub fn broadcast(
@@ -169,7 +168,7 @@ pub fn broadcast(
 
 ### `broadcast_from`
 
-Broadcast a message to all subscribers except those from a specific pid
+Broadcast a message to all subscribers except a specific PID.
 
 ```gleam
 pub fn broadcast_from(
@@ -183,8 +182,9 @@ pub fn broadcast_from(
 
 ### `broadcast_from_socket`
 
-Broadcast a message to all subscribers except a process, preserving a socket
- ID that receiving runtimes should exclude locally.
+Broadcast a message to all subscribers except a process.
+
+ Preserve a socket ID that receiving runtimes must exclude locally.
 
 ```gleam
 pub fn broadcast_from_socket(
@@ -199,11 +199,11 @@ pub fn broadcast_from_socket(
 
 ### `config_with_scope`
 
-Create a PubSub configuration with a custom scope name
+Create a PubSub configuration with a custom scope name.
 
  The scope name is converted to an Erlang atom via `binary_to_atom`.
  Atoms are never garbage-collected, so the scope name must be a
- **static, bounded deployment or configuration value** — never raw
+ **static, bounded deployment or configuration value**. Never use raw
  user-derived, per-request, per-tenant, database-derived, or otherwise
  unbounded high-cardinality runtime input. A deployment-controlled value
  is acceptable only when validated or selected from a fixed bounded set.
@@ -211,13 +211,13 @@ Create a PubSub configuration with a custom scope name
  and crash the VM.
 
  ```gleam
- // Correct — static deployment constant
+ // Correct: static deployment constant
  pubsub.config_with_scope("my_app_pubsub")
 
- // Correct — deployment-controlled, selected from a fixed bounded set
+ // Correct: deployment-controlled and selected from a fixed bounded set
  // pubsub.config_with_scope(config.pubsub_scope())
 
- // WRONG — never do this
+ // WRONG: never do this
  // pubsub.config_with_scope(user_request.tenant_id)
  // pubsub.config_with_scope(database_row.name)
  ```
@@ -228,7 +228,7 @@ pub fn config_with_scope(String) -> PubSubConfig
 
 ### `default_config`
 
-Create a default PubSub configuration with scope `beryl_pubsub`
+Create a default PubSub configuration with scope `beryl_pubsub`.
 
 ```gleam
 pub fn default_config() -> PubSubConfig
@@ -238,8 +238,8 @@ pub fn default_config() -> PubSubConfig
 
 Join a topic so this subscriber receives broadcasts sent to it.
 
- A subscriber may join many topics; they all deliver through its one
- subject. Joining is idempotent per topic.
+ A subscriber can join many topics. All topics deliver through its one
+ subject. Joining a topic is idempotent.
 
 ```gleam
 pub fn join(
@@ -261,7 +261,7 @@ pub fn leave(
 
 ### `local_broadcast`
 
-Broadcast a message to local subscribers only (current node)
+Broadcast a message only to subscribers on the current node.
 
 ```gleam
 pub fn local_broadcast(
@@ -278,9 +278,9 @@ Add a subscriber's PubSub message delivery to a `Selector`, alongside a
  process's own subjects.
 
  `pg` tracks bare pids, so broadcasts arrive as raw process messages.
- `selecting` is the one place that validates the subscriber's scope tag and
- four-field arity before recovering its compile-time payload type. Fold it
- once; every joined topic is delivered through the same mailbox.
+ `selecting` validates the subscriber's scope tag and four-field arity
+ before it recovers the compile-time payload type. Add it once. Every
+ joined topic uses the same mailbox.
 
  Subscribers for different scopes may safely use different payload types in
  one process. All subscribers for the same scope must use the same payload
@@ -305,13 +305,13 @@ pub fn selecting(
 
 ### `start`
 
-Start a PubSub instance
+Start a PubSub instance.
 
- This starts a pg scope. If the scope is already started (e.g., by another
- node or previous call), this is a no-op.
+ This starts a pg scope. If another node or an earlier call started the
+ scope, this function does nothing.
 
- `payload` is fixed by how the returned value is used (or annotated) at the
- call site — e.g. `pubsub.start(config) : PubSub(MySyncPayload)`.
+ `payload` is fixed by how the returned value is used or annotated at the
+ call site. For example: `pubsub.start(config) : PubSub(MySyncPayload)`.
  Starting the same scope again returns another handle to the same runtime
  instance, so every use of that scope must choose the same payload type.
 
@@ -323,9 +323,9 @@ pub fn start(PubSubConfig) -> PubSub(a)
 
 Create a subscription handle owned by the current process.
 
- Call it from the process that will receive broadcasts (its own actor
- initialiser or test process), then `join` topics and fold `selecting` into
- that process's `Selector`.
+ Call this function from the process that will receive broadcasts, such as
+ an actor initializer or test process. Then join topics and add `selecting`
+ to that process's `Selector`.
 
  A process may create subscribers for multiple scopes and payload types.
  `selecting` uses each subscriber's scope to keep their raw mailbox messages
@@ -337,7 +337,7 @@ pub fn subscriber(PubSub(a)) -> Subscriber(a)
 
 ### `subscriber_count`
 
-Get the number of subscribers for a topic (all nodes)
+Return the number of topic subscribers on all nodes.
 
 ```gleam
 pub fn subscriber_count(
@@ -348,7 +348,7 @@ pub fn subscriber_count(
 
 ### `subscribers`
 
-Get all subscribers for a topic (all nodes)
+Return all topic subscribers on all nodes.
 
 ```gleam
 pub fn subscribers(

--- a/website/src/content/docs/reference/api/beryl-socket.md
+++ b/website/src/content/docs/reference/api/beryl-socket.md
@@ -14,27 +14,27 @@ Types for building app-side dispatch systems with `beryl.child_spec`.
  With app-side dispatch the application owns routing: beryl delivers
  every wire event for a socket to one `update` function, and the
  function returns the next model plus a list of `Effect`s for beryl to
- apply. There are no channel modules, no registry, and no type erasure —
- each socket has a single `model` and a single `msg` type.
+ apply. There are no channel modules, no registry, and no type erasure.
+ Each socket has a single `model` and a single `msg` type.
 
  ## Effect ordering guarantee
 
  Effects are applied strictly in list order, and every frame for a
- socket is written by the single runtime actor — so list order is wire
- order. An `AcceptJoin` followed by a `Push` in the same list is
+ socket is written by the single runtime actor. List order is therefore
+ wire order. An `AcceptJoin` followed by a `Push` in the same list is
  guaranteed to arrive as the join acknowledgment first and the push
  second.
 
  Most effects are applied in one actor turn. `PresenceTrack` and
  `PresenceUntrack` are the exception: they are applied by the presence
- actor, so beryl holds the rest of the list — and every later input for
- that socket — until the mutation has been applied, then continues
- exactly where it left off. The visible order is unchanged (a
+ actor. Beryl holds the rest of the list and every later input for that
+ socket until the mutation has been applied. It then continues exactly
+ where it left off. The visible order is unchanged (a
  `PushPresence` after a `PresenceTrack` still sees the track), and the
  socket's own inputs still arrive in the order the client sent them.
- What it buys is that no other socket, broadcast, or heartbeat waits on
- that mutation — and, because those keep flowing, a broadcast from
- elsewhere may land between two of this socket's effects.
+ No other socket, broadcast, or heartbeat waits on that mutation. Those
+ continue, so a broadcast from elsewhere may arrive between two effects
+ from this socket.
 
 ## Types
 
@@ -54,8 +54,10 @@ pub type ConnectInfo(a) {
 
 ### `ConnectSeed`
 
-Connection metadata assembled by the transport before the WebSocket
- upgrade, delivered to the app's `init` via `ConnectInfo`.
+Connection metadata that the transport builds before the WebSocket
+ upgrade.
+
+ The app's `init` function receives it through `ConnectInfo`.
 
 ```gleam
 pub type ConnectSeed {
@@ -136,9 +138,9 @@ pub type Effect {
   reply: option.Option(json.Json)
 )`
 
-Accept a pending join. Subscribes the socket to the topic and sends
- the join acknowledgment (with an optional reply payload). Only valid
- while the `Join` input's ref is pending.
+Accept a pending join. This subscribes the socket to the topic and sends
+ the join acknowledgment with an optional reply payload. The effect is
+ valid only while the `Join` input's ref is pending.
 
 ##### `RejectJoin(
   ref: JoinRef,
@@ -168,8 +170,8 @@ Reply with an error to a client message ref.
 )`
 
 Push a server-initiated message to this socket on a joined topic.
- Pushes to topics this socket has not joined (yet) are dropped with a
- warning — order a `Push` after its topic's `AcceptJoin`.
+ The runtime drops pushes to topics that this socket has not joined and
+ logs a warning. Put a `Push` after its topic's `AcceptJoin`.
 
 ##### `Broadcast(
   topic: String,
@@ -195,15 +197,14 @@ Broadcast to every subscriber of a topic except this socket.
 )`
 
 Track this socket's presence under a key in a topic and broadcast the
- corresponding `presence_diff` join. Requires a presence handle on the
- config (`beryl.with_presence_handle`); dropped with a warning
- otherwise.
+ corresponding `presence_diff` join. This effect requires a presence
+ handle on the config (`beryl.with_presence_handle`). Without a handle,
+ the runtime drops the effect and logs a warning.
 
- Tracking an already-tracked key replaces the previous entry
- atomically: the key is never momentarily absent, and the replacement
- is published as one `presence_diff` carrying both the leave and the
- join. Effects after this one wait for the mutation (see the module
- docs) but no other socket does.
+ Tracking an existing key replaces the previous entry atomically. The
+ key is never absent during the replacement. One `presence_diff` contains
+ both the leave and the join. Later effects wait for the mutation, as
+ described in the module documentation. Other sockets do not wait.
 
 ##### `PresenceUntrack(
   topic: String,
@@ -211,12 +212,12 @@ Track this socket's presence under a key in a topic and broadcast the
 )`
 
 Untrack a presence previously tracked with `PresenceTrack` and
- broadcast the corresponding `presence_diff` leave. Remaining tracked
- keys are untracked automatically when their topic closes — as one
- batch, producing a single aggregate leave diff. Effects after this
- one wait for the mutation (see the module docs) but no other socket
- does. Requires a presence handle (`beryl.with_presence_handle`);
- dropped with a warning otherwise.
+ broadcast the corresponding `presence_diff` leave. When the topic
+ closes, the runtime removes the remaining tracked keys in one batch and
+ produces one aggregate leave diff. Later effects wait for the mutation,
+ as described in the module documentation. Other sockets do not wait.
+ This effect requires a presence handle (`beryl.with_presence_handle`).
+ Without a handle, the runtime drops the effect and logs a warning.
 
 ##### `PushPresence(
   topic: String,
@@ -224,14 +225,14 @@ Untrack a presence previously tracked with `PresenceTrack` and
   encode: fn(List(presence.PresenceEntry)) -> json.Json
 )`
 
-Push a presence snapshot for a topic to this socket. Unlike a payload
- built inside `update` (which sees presence as it was *before* this
- effects list), `encode` runs when the effect is applied — after any
- earlier `PresenceTrack`/`PresenceUntrack` in the same list has
- actually been applied — so the entries already reflect them.
- Requires a presence handle (`beryl.with_presence_handle`); dropped
- with a warning otherwise.
- Like `Push`, dropped when the topic is not joined at that point.
+Push a presence snapshot for a topic to this socket. A payload built
+ inside `update` sees presence from *before* this effects list. In
+ contrast, `encode` runs when the effect is applied. It runs after earlier
+ `PresenceTrack` and `PresenceUntrack` effects in the same list. The
+ entries therefore include those changes.
+ This effect requires a presence handle (`beryl.with_presence_handle`).
+ Without a handle, the runtime drops the effect and logs a warning.
+ Like `Push`, the runtime drops it if the topic is not joined.
 
 ##### `BroadcastPresence(
   topic: String,
@@ -242,8 +243,9 @@ Push a presence snapshot for a topic to this socket. Unlike a payload
 Broadcast a presence snapshot for a topic to all its subscribers,
  with the same apply-time `encode` semantics as `PushPresence`.
  Order it after the `PresenceTrack`/`PresenceUntrack` it should
- reflect. Requires a presence handle (`beryl.with_presence_handle`);
- dropped with a warning otherwise.
+ reflect. This effect requires a presence handle
+ (`beryl.with_presence_handle`). Without a handle, the runtime drops the
+ effect and logs a warning.
 
 ##### `KickTopic(topic: String)`
 
@@ -287,9 +289,9 @@ pub type Input(a) {
   ref: JoinRef
 )`
 
-A client asked to join a topic. Answer with `AcceptJoin` or
- `RejectJoin` in the returned effects; a `Join` left unanswered by the
- end of the update turn is rejected automatically (fail closed).
+A client asked to join a topic. Return an `AcceptJoin` or `RejectJoin`
+ effect. The runtime rejects a `Join` that is unanswered at the end of
+ the update turn.
 
 ##### `Message(
   topic: String,
@@ -314,9 +316,9 @@ A binary frame on a joined topic (codecs without a binary decoder
   reason: StopReason
 )`
 
-A joined topic ended (client leave, kick, crash, or socket close).
- Delivered on every exit path — use it to prune per-topic state from
- the model. Frames pushed to the closing topic from this input are
+A joined topic ended because of a client leave, kick, crash, or socket
+ close. The runtime sends this input on every exit path. Use it to remove
+ per-topic state from the model. Frames pushed to the closing topic are
  dropped; broadcasts still reach the topic's remaining subscribers.
 
 ##### `Info(a)`
@@ -329,7 +331,7 @@ A typed server-side message, sent via the socket's `Sender` (see
 A pending join correlation handle.
 
  Pass it back in `AcceptJoin` or `RejectJoin`. A join ref is valid only for
- its pending join and carries a unique runtime token, so a delayed completion
+ its pending join. It carries a unique runtime token. A delayed completion
  for an older same-topic join cannot answer a replacement or retry.
 
 ```gleam
@@ -338,8 +340,10 @@ pub type JoinRef
 
 ### `Next`
 
-The result of one `update` call: the next model plus effects to apply,
- or an instruction to stop the whole socket.
+The result of one `update` call.
+
+ It contains the next model and effects, or an instruction to stop the
+ socket.
 
 ```gleam
 pub type Next(a) {
@@ -369,10 +373,10 @@ Tear down the socket: every joined topic receives a `Closed` input,
 
 A client message reply correlation handle.
 
- Pass it back in `ReplyOk` or `ReplyError`. Reply refs may be stored in the
- model and answered from a later `update` turn (for example, after an async
- lookup completes). They are single-use and remain valid only while the
- topic instance that received the message stays open.
+ Pass it back in `ReplyOk` or `ReplyError`. You can store reply refs in the
+ model and answer them in a later `update` turn, for example after an
+ asynchronous lookup. They are single-use. They remain valid only while
+ the topic instance that received the message stays open.
 
 ```gleam
 pub type ReplyRef
@@ -382,9 +386,9 @@ pub type ReplyRef
 
 A typed handle for sending server-side messages to one socket.
 
- Obtained from `ConnectInfo.self` in `init`. Any process may call
- `notify` with it; the message is delivered to the socket's `update` as
- an `Info` event. This is an ordinary typed send — no erasure involved.
+ Get this handle from `ConnectInfo.self` in `init`. Any process can call
+ `notify` with it. The socket's `update` function receives the message as
+ an `Info` event. This typed send does not erase the message type.
 
 ```gleam
 pub type Sender(a)
@@ -394,8 +398,8 @@ pub type Sender(a)
 
 Why a socket or topic is stopping.
 
- Delivered in `Closed` inputs and accepted by `Stop`. Match with a
- catch-all (`_`) arm: new stop reasons may be added in minor releases.
+ The runtime delivers this reason in `Closed` inputs, and `Stop` accepts it.
+ Match with a catch-all (`_`) arm. Minor releases can add stop reasons.
 
 ```gleam
 pub type StopReason {
@@ -422,15 +426,15 @@ The client failed to send a heartbeat within the configured timeout.
 
 ##### `Errored(String)`
 
-Stopped because of an error (named `Errored` so importing it
- unqualified does not shadow the prelude's `Result` `Error`
- constructor).
+An error stopped the socket or topic. The name `Errored` prevents an
+ unqualified import from shadowing the prelude's `Result` `Error`
+ constructor.
 
 ## Functions
 
 ### `empty_seed`
 
-An empty connect seed, for tests and transports with no request data.
+Return an empty connect seed for tests and transports with no request data.
 
 ```gleam
 pub fn empty_seed() -> ConnectSeed
@@ -438,9 +442,10 @@ pub fn empty_seed() -> ConnectSeed
 
 ### `notify`
 
-Send a typed server-side message to a socket. Delivered to the socket's
- `update` function as `Info(message)`. Ignored if the socket has since
- disconnected.
+Send a typed server-side message to a socket.
+
+ The socket's `update` function receives `Info(message)`. The runtime
+ ignores the message if the socket has disconnected.
 
 ```gleam
 pub fn notify(
@@ -451,11 +456,12 @@ pub fn notify(
 
 ### `reply_ok`
 
-A `ReplyOk` when the client supplied a ref; no effects otherwise.
+Return a `ReplyOk` effect when the client supplied a ref.
 
  `Message` inputs carry `Option(ReplyRef)` (refless messages expect no
  reply) while the `ReplyOk` effect demands a `ReplyRef`, so every handler
- that replies conditionally needs this gate.
+ that replies conditionally needs this check. This function returns no
+ effects when the client did not supply a ref.
 
 ```gleam
 pub fn reply_ok(

--- a/website/src/content/docs/reference/api/beryl-stats.md
+++ b/website/src/content/docs/reference/api/beryl-stats.md
@@ -31,7 +31,7 @@ pub type Snapshot
 
 ### `SnapshotError`
 
-Errors returned while requesting a runtime snapshot.
+Errors from a runtime snapshot request.
 
 ```gleam
 pub type SnapshotError {
@@ -44,11 +44,11 @@ pub type SnapshotError {
 
 ##### `RuntimeUnavailable`
 
-The local socket runtime is not currently running.
+The local socket runtime is not running.
 
 ##### `RequestTimedOut`
 
-The runtime did not service the request within the bounded timeout.
+The runtime did not process the request before the timeout.
 
 ## Functions
 
@@ -80,11 +80,11 @@ pub fn joined_socket_topic_pairs(Snapshot) -> Int
 
 ### `snapshot`
 
-Request a point-in-time snapshot from the local runtime.
+Request a snapshot from the local runtime.
 
- The request waits for at most approximately one second. During a
- runtime restart this returns `RuntimeUnavailable` or
- `RequestTimedOut`; an overloaded runtime returns `RequestTimedOut`.
+ The request waits for about one second at most. During a runtime restart,
+ this function returns `RuntimeUnavailable` or `RequestTimedOut`. An
+ overloaded runtime returns `RequestTimedOut`.
  Neither condition panics. This API reports only the node represented by
  `sockets`; aggregate multi-node statistics outside Beryl.
 

--- a/website/src/content/docs/reference/api/beryl-topic.md
+++ b/website/src/content/docs/reference/api/beryl-topic.md
@@ -54,10 +54,10 @@ The topic does not match the pattern.
 
 Errors returned when validating a topic or topic pattern.
 
- New variants may be added in a minor release as validation gets stricter,
- so this type is not treated as closed for exhaustive matching. Match exact
- variants only where you act on them differently, and otherwise keep a
- catch-all arm (`_ -> ...`) so future variants do not break your code.
+ A minor release can add variants as validation gets stricter. Do not treat
+ this type as closed for exhaustive matching. Match exact variants only
+ when you handle them differently. Otherwise, use a catch-all arm
+ (`_ -> ...`) so new variants do not break your code.
 
 ```gleam
 pub type TopicError {
@@ -79,7 +79,7 @@ The topic, pattern, or event was malformed; the wrapped `String`
 
 ### `TopicPattern`
 
-Topic pattern for routing
+A topic pattern for routing.
 
 ```gleam
 pub type TopicPattern {
@@ -93,22 +93,23 @@ pub type TopicPattern {
 
 ##### `Exact(String)`
 
-Exact match: "room:lobby" only matches "room:lobby"
+Exact match. `"room:lobby"` matches only `"room:lobby"`.
 
 ##### `Wildcard(prefix: String)`
 
-Wildcard suffix: "room:*" matches "room:lobby", "room:123", etc.
+Wildcard suffix. `"room:*"` matches `"room:lobby"`, `"room:123"`,
+ and other values with the same prefix.
 
 ##### `SegmentWildcard(segments: List(String))`
 
-Segment wildcard: "document:*:ops" matches the same number of ":"
- segments where "*" occupies one complete segment.
+Segment wildcard. `"document:*:ops"` matches topics with the same
+ number of `":"` segments. `"*"` occupies one complete segment.
 
 ## Functions
 
 ### `extract_id`
 
-Extract the wildcard portion from a topic
+Extract the wildcard part of a topic.
 
  ## Examples
 
@@ -130,8 +131,9 @@ pub fn extract_id(
 
 Extract values captured by wildcard segments.
 
- For legacy prefix wildcards, returns the suffix as a single value.
- For segment wildcards, returns each topic segment matched by "*".
+ For legacy prefix wildcards, this function returns the suffix as one
+ value. For segment wildcards, it returns each topic segment matched by
+ `"*"`.
 
  ## Examples
 
@@ -149,7 +151,7 @@ pub fn extract_wildcards(
 
 ### `from_segments`
 
-Build a topic from segments
+Build a topic from segments.
 
  ## Examples
 
@@ -164,7 +166,7 @@ pub fn from_segments(List(String)) -> String
 
 ### `matches`
 
-Check if a topic matches a pattern
+Return whether a topic matches a pattern.
 
  ## Examples
 
@@ -186,7 +188,7 @@ pub fn matches(
 
 ### `namespace`
 
-Get the first segment (namespace) of a topic
+Return the first segment (namespace) of a topic.
 
  ## Examples
 
@@ -201,7 +203,7 @@ pub fn namespace(String) -> Result(String, ExtractError)
 
 ### `parse_pattern`
 
-Parse a pattern string into TopicPattern
+Parse a pattern string into `TopicPattern`.
 
  ## Examples
 
@@ -219,7 +221,7 @@ pub fn parse_pattern(String) -> TopicPattern
 
 ### `segments`
 
-Parse a topic into segments by splitting on ":"
+Split a topic into segments at each `":"`.
 
  ## Examples
 
@@ -234,12 +236,12 @@ pub fn segments(String) -> List(String)
 
 ### `validate`
 
-Validate a topic string
+Validate a topic string.
 
- Topics must:
- - Not be empty
- - Not contain control characters (codepoints 0–31 or 127)
- - Not start or end with ":"
+ A topic must:
+ - not be empty;
+ - not contain control characters (codepoints 0–31 or 127); and
+ - not start or end with `":"`.
 
 ```gleam
 pub fn validate(String) -> Result(String, TopicError)
@@ -247,11 +249,11 @@ pub fn validate(String) -> Result(String, TopicError)
 
 ### `validate_event`
 
-Validate an event name string
+Validate an event name.
 
- Event names must:
- - Not be empty
- - Not contain control characters (codepoints 0–31 or 127)
+ An event name must:
+ - not be empty; and
+ - not contain control characters (codepoints 0–31 or 127).
 
 ```gleam
 pub fn validate_event(String) -> Result(String, TopicError)
@@ -259,11 +261,11 @@ pub fn validate_event(String) -> Result(String, TopicError)
 
 ### `validate_pattern`
 
-Validate a topic pattern string
+Validate a topic pattern string.
 
- Patterns must:
- - Not be empty
- - Not contain control characters (codepoints 0–31 or 127)
+ A pattern must:
+ - not be empty; and
+ - not contain control characters (codepoints 0–31 or 127).
 
  The bare pattern `"*"` is valid: it parses to a catch-all wildcard that
  matches every topic.

--- a/website/src/content/docs/reference/api/beryl-transport-origin.md
+++ b/website/src/content/docs/reference/api/beryl-transport-origin.md
@@ -23,18 +23,18 @@ Origin and handshake-version checks for WebSocket upgrades.
 Policy for validating the browser `Origin` header before a WebSocket
  upgrade completes.
 
- The `Origin` check is the primary defence against Cross-Site WebSocket
+ The `Origin` check is the primary defense against Cross-Site WebSocket
  Hijacking (CSWSH): a browser attaches ambient cookies/session credentials
  to a WebSocket handshake regardless of which site initiated it, so a socket
  that authenticates from those credentials must reject upgrades that
  originate from other sites.
 
- In every policy, a request with **no** `Origin` header is allowed: browsers
- always send `Origin` on WebSocket handshakes, so an absent header signals a
- non-browser client (native app, server-to-server, CLI) that is not subject
- to the browser same-origin model and cannot be tricked into a cross-site
- upgrade. The one exception is [`AllowList`](#originpolicy), which requires a
- matching `Origin` and therefore rejects absent ones.
+ Every policy allows a request with **no** `Origin` header, with one
+ exception described below. Browsers always send `Origin` on WebSocket
+ handshakes. An absent header therefore indicates a non-browser client,
+ such as a native app, server, or CLI. The browser same-origin model does
+ not apply to these clients. [`AllowList`](#originpolicy) is the exception.
+ It requires a matching `Origin` and rejects an absent header.
 
 ```gleam
 pub type OriginPolicy {
@@ -56,8 +56,8 @@ Allow an upgrade only when the request `Origin` authority (host plus any
  value with no host) is rejected. Comparison is over the full `host:port`
  authority, so a non-default port must match on both sides.
 
- Behind a reverse proxy this compares against the `Host` header as the app
- sees it: ensure the proxy forwards the public `Host` unchanged, or use
+ Behind a reverse proxy, this compares against the `Host` header that the
+ app receives. Configure the proxy to forward the public `Host` unchanged, or use
  [`AllowList`](#originpolicy) with the public origins instead. Forwarded
  headers such as `X-Forwarded-Host` are not trusted, because clients can
  spoof them.
@@ -71,8 +71,8 @@ Allow an upgrade only when the request `Origin` header matches one of the
 
 ##### `AllowAll`
 
-Allow every upgrade regardless of `Origin`. This is an explicit opt-out
- of CSWSH protection: only use it for sockets that do not rely on ambient
+Allow every upgrade regardless of `Origin`. This disables CSWSH
+ protection. Use it only for sockets that do not rely on ambient
  browser credentials (or that authenticate every message independently).
 
 ## Functions
@@ -81,10 +81,10 @@ Allow every upgrade regardless of `Origin`. This is an explicit opt-out
 
 Decide whether an upgrade is allowed under the configured origin policy.
 
- `origin` and `host` are the request's `Origin` and `Host` header values,
- `None` when the header is absent. A request with no `Origin` header is
- admitted for `SameOrigin` and `AllowAll` (non-browser clients omit
- `Origin`), but rejected for `AllowList`, which requires an explicit match.
+ `origin` and `host` are the request's `Origin` and `Host` header values.
+ Use `None` when a header is absent. `SameOrigin` and `AllowAll` admit a
+ request without an `Origin` header because non-browser clients omit it.
+ `AllowList` rejects the request because it requires an explicit match.
 
 ```gleam
 pub fn allowed(
@@ -99,11 +99,11 @@ pub fn allowed(
 Check a client's requested wire protocol version (the `?vsn=` query
  parameter sent by Phoenix clients) before upgrading.
 
- Beryl speaks the Phoenix V2 array framing, so `vsn=2.x` is accepted. A
+ Beryl uses the Phoenix V2 array framing, so it accepts `vsn=2.x`. A
  missing `vsn` (`None`) is accepted for non-Phoenix clients speaking the
  configured codec. Anything else (e.g. the V1 object framing's `vsn=1.0.0`)
- is rejected — transports fail the handshake with `403 Forbidden` instead
- of accepting a connection whose every frame would be undecodable.
+ is rejected. Transports fail the handshake with `403 Forbidden` instead
+ of accepting a connection with frames that cannot be decoded.
 
 ```gleam
 pub fn vsn_supported(vsn: option.Option(String)) -> Bool

--- a/website/src/content/docs/reference/api/beryl-transport-server.md
+++ b/website/src/content/docs/reference/api/beryl-transport-server.md
@@ -52,8 +52,7 @@ pub type ConnectionState
 
 ### `FrameDisposition`
 
-What a transport should do with its connection after handling an inbound
- frame.
+What a transport must do after it handles an inbound frame.
 
 ```gleam
 pub type FrameDisposition {
@@ -74,9 +73,10 @@ Close the connection (the frame exceeded the configured size cap).
 
 ### `SendRequest`
 
-Outbound requests the runtime sends to a connection process. Transports
- receive these as their custom/user WebSocket message and act on them:
- send the frame, or close the connection.
+Outbound requests from the runtime to a connection process.
+
+ Transports receive these as custom or user WebSocket messages. They send
+ the frame or close the connection.
 
 ```gleam
 pub type SendRequest {
@@ -96,8 +96,8 @@ Runtime-initiated close (e.g. heartbeat eviction).
 
 Configuration for a WebSocket transport.
 
- Generic over the server's request body type (`body`), so the same config
- value works with any transport built on `gleam/http` requests.
+ The `body` parameter is the server's request body type. The same
+ configuration works with any transport built on `gleam/http` requests.
 
 ```gleam
 pub type TransportConfig(a)
@@ -107,8 +107,9 @@ pub type TransportConfig(a)
 
 ### `close_connection`
 
-Clean up when a connection closes: release the held connection slot and
- announce the disconnect to the runtime.
+Clean up a closed connection.
+
+ Release the held connection slot and report the disconnect to the runtime.
 
 ```gleam
 pub fn close_connection(ConnectionState) -> Nil
@@ -116,13 +117,15 @@ pub fn close_connection(ConnectionState) -> Nil
 
 ### `connect_seed`
 
-Assemble the connection seed delivered to an app-dispatch system's
- `init` (`ConnectInfo.seed`). Systems that don't use connect metadata simply
- ignore it.
+Build the connection seed for an app-dispatch system's `init` function.
 
- `metadata` is the ordered list of string pairs returned by the
- configured `on_connect` callback (empty when none is configured or it
- returns no metadata); order and duplicate keys are preserved verbatim.
+ The function receives the seed as `ConnectInfo.seed`. Systems that do not
+ use connect metadata can ignore it.
+
+ `metadata` is the ordered list of string pairs from the configured
+ `on_connect` callback. It is empty when no callback is configured or the
+ callback returns no metadata. This function preserves order and duplicate
+ keys.
 
 ```gleam
 pub fn connect_seed(
@@ -135,14 +138,14 @@ pub fn connect_seed(
 
 Create a default transport config with no connect hook.
 
- The resulting config seeds empty (`[]`) `ConnectSeed.metadata` and applies
+ The resulting configuration sets `ConnectSeed.metadata` to `[]` and applies
  the `origin.SameOrigin` origin policy, which rejects cross-site WebSocket
- upgrades before the handshake (CSWSH protection). Same-origin upgrades and
+ upgrades before the handshake as CSWSH protection. Same-origin upgrades and
  non-browser clients (no `Origin` header) are admitted without
  configuration.
 
  Add `with_on_connect` to authenticate connections and/or seed connect
- metadata. Use `with_allowed_origins` to pin an explicit allow-list, or
+ metadata. Use `with_allowed_origins` to set an explicit allow-list. Use
  `with_allow_all_origins` to opt out of origin checking entirely.
 
 ```gleam
@@ -151,9 +154,9 @@ pub fn default_config(String) -> TransportConfig(a)
 
 ### `handle_binary_frame`
 
-Size-check, rate-check, and decode an inbound binary frame in the
- connection process. Codecs without a binary decoder keep the raw
- `transport.route_binary` fan-out, routed through the runtime.
+Check the size and rate of an inbound binary frame, then decode it in the
+ connection process. A codec without a binary decoder keeps the raw
+ `transport.route_binary` fan-out through the runtime.
 
 ```gleam
 pub fn handle_binary_frame(
@@ -168,8 +171,9 @@ Size-check, rate-check, and decode an inbound text frame in the
  connection process, so parse cost stays there and only valid,
  rate-admitted messages reach the shared runtime.
 
- Oversized frames return `Stop` (close the connection); over-rate frames
- are shed silently; undecodable frames are logged and dropped.
+ Oversized frames return `Stop` and close the connection. The function
+ silently drops over-rate frames. It logs and drops frames that it cannot
+ decode.
 
 ```gleam
 pub fn handle_text_frame(
@@ -180,8 +184,10 @@ pub fn handle_text_frame(
 
 ### `handler`
 
-Build a combined request handler that sends upgrade requests through a
- transport-specific `upgrade` function and everything else to HTTP.
+Build a request handler for WebSocket upgrades and other HTTP requests.
+
+ The handler sends upgrade requests to the transport-specific `upgrade`
+ function. It sends all other requests to HTTP.
 
 ```gleam
 pub fn handler(
@@ -192,15 +198,14 @@ pub fn handler(
 
 ### `init_connection`
 
-Initialize a newly upgraded WebSocket connection in its connection
- process.
+Initialize a new WebSocket connection in its connection process.
 
- Binds the held connection slot to the calling process (so the slot is
- reclaimed even if the process dies without a clean close), monitors the
- exact owning runtime, then atomically registers the socket and its
- runtime-triggered closer against that owner. A concurrent restart cannot
- redirect admission into the successor runtime. When no runtime is
- available, or the captured owner changed, the connection closes.
+ This function binds the held connection slot to the calling process. The
+ limiter reclaims the slot if the process dies without a clean close. The
+ function then monitors the owning runtime and atomically registers the
+ socket and its runtime-triggered closer with that owner. A concurrent
+ restart cannot redirect admission to the next runtime. The connection
+ closes if no runtime is available or the captured owner changed.
 
  Returns the connection state and a selector (extending `base_selector`)
  that delivers `SendRequest` values from the runtime; the transport must
@@ -225,9 +230,9 @@ pub fn init_connection(
 
 Determine whether a request is a WebSocket upgrade request.
 
- Checks for the standard `Upgrade: websocket` header (case-insensitive).
- Use this to distinguish WebSocket handshakes from regular HTTP traffic on
- the same listener.
+ This function checks for the standard `Upgrade: websocket` header without
+ regard to case. Use it to distinguish WebSocket handshakes from regular
+ HTTP traffic on the same listener.
 
 ```gleam
 pub fn is_websocket_request(request.Request(a)) -> Bool
@@ -264,7 +269,7 @@ Run the shared upgrade admission pipeline for a request.
  headers such as `X-Forwarded-For` must
  **not** be trusted or parsed, because clients can set them and would
  otherwise spoof their address to bypass the limit. Behind a trusted
- reverse proxy, all connections share the proxy's IP — resolve the real
+ reverse proxy, all connections share the proxy's IP. Resolve the real
  client IP at the proxy layer. See the WebSocket transport guide.
 
  `beryl.with_connection_rate_per_ip` independently caps connection attempts
@@ -279,7 +284,7 @@ Run the shared upgrade admission pipeline for a request.
  node-wide ceiling bounds total resource use when a per-IP limit alone
  cannot (many distributed source addresses / IPv6 rotation). It is enforced
  per BEAM node, so across a load-balanced cluster the effective ceiling
- scales with the node count — use the load balancer's own controls for a
+ scales with the node count. Use the load balancer's controls for a
  cluster-wide cap.
 
 ```gleam
@@ -299,11 +304,11 @@ pub fn upgrade(
 
 Disable `Origin` checking, allowing WebSocket upgrades from any origin.
 
- This is an explicit opt-out of the default `origin.SameOrigin` CSWSH
- protection. Only use it for sockets that do not rely on ambient browser
- credentials (cookies, sessions) for authorization, or that authenticate
- every message independently. For cookie/session-authenticated apps, prefer
- the default `SameOrigin` policy or `with_allowed_origins`.
+ This disables the default `origin.SameOrigin` CSWSH protection. Use it only
+ for sockets that do not rely on ambient browser credentials (cookies,
+ sessions) for authorization, or that authenticate every message
+ independently. For cookie/session-authenticated apps, prefer the default
+ `SameOrigin` policy or `with_allowed_origins`.
 
 ```gleam
 pub fn with_allow_all_origins(TransportConfig(a)) -> TransportConfig(a)
@@ -335,15 +340,15 @@ pub fn with_allowed_origins(
 
 Set a socket-level connect/authentication callback on the transport config.
 
- The callback receives the HTTP request before the WebSocket upgrade and
+ The callback receives the HTTP request before the WebSocket upgrade. It
  runs once per socket. Return `Ok(metadata)` to allow the connection and
- seed `ConnectSeed.metadata` — an ordered list of string pairs delivered to
- the app's `init` via `ConnectInfo.seed` — or `Error(ConnectRejected)` to
- reject the connection with a 403 Forbidden response before any topic
- join occurs.
+ set `ConnectSeed.metadata`. The metadata is an ordered list of string
+ pairs delivered to the app's `init` through `ConnectInfo.seed`. Return
+ `Error(ConnectRejected)` to reject the connection with a 403 Forbidden
+ response before any topic join.
 
- Callback order and duplicate keys are preserved verbatim in
- `ConnectSeed.metadata`; transports never log metadata values.
+ `ConnectSeed.metadata` preserves callback order and duplicate keys.
+ Transports never log metadata values.
 
 ```gleam
 pub fn with_on_connect(

--- a/website/src/content/docs/reference/api/beryl-transport.md
+++ b/website/src/content/docs/reference/api/beryl-transport.md
@@ -1,6 +1,6 @@
 ---
 title: "beryl/transport"
-description: "Transport SPI — the contract between beryl core and WebSocket transport"
+description: "Transport SPI: the contract between beryl core and WebSocket transport"
 ---
 
 <!--
@@ -9,7 +9,7 @@ description: "Transport SPI — the contract between beryl core and WebSocket tr
   `just docs` (gleam docs build + pnpm -C website generate:reference).
 -->
 
-Transport SPI — the contract between beryl core and WebSocket transport
+Transport SPI: the contract between beryl core and WebSocket transport
  implementations such as the `beryl_mist` package.
 
  `beryl/transport/server` owns the shared admission, connection, rate,
@@ -24,10 +24,10 @@ Transport SPI — the contract between beryl core and WebSocket transport
 
 A held connection slot returned by `acquire_connection_slot`.
 
- Hold it for the lifetime of the connection and pass it to
+ Hold it for the connection's lifetime. Pass it to
  `release_connection_slot` when the connection closes. When no connection
- limit is configured the permit is an admit-everything placeholder and
- releasing it is a no-op.
+ limit is configured, the permit allows all connections. Releasing it does
+ nothing.
 
 ```gleam
 pub type ConnectionPermit
@@ -59,8 +59,10 @@ pub type FrameOutcome {
 
 ### `Telemetry`
 
-Cheap transport telemetry context. When disabled, starting and stopping an
- operation avoid VM clock calls and event construction.
+A low-cost transport telemetry context.
+
+ When telemetry is disabled, operations avoid VM clock calls and event
+ construction.
 
 ```gleam
 pub type Telemetry
@@ -96,7 +98,7 @@ pub type UpgradeOutcome {
 
 ### `Sockets`
 
-Runtime handle accepted by transport implementations.
+A runtime handle for transport implementations.
 
 ```gleam
 pub type Sockets = beryl.Sockets
@@ -108,7 +110,7 @@ pub type Sockets = beryl.Sockets
 
 Try to acquire a configured connection slot for a transport.
 
- Pass the real socket peer IP, never a client-supplied address such as
+ Pass the real socket peer IP. Do not pass a client-supplied address such as
  `X-Forwarded-For`. Return `Error(Nil)` when the configured per-IP or
  node-wide limit is already reached.
 
@@ -121,8 +123,9 @@ pub fn acquire_connection_slot(
 
 ### `active_codec`
 
-The wire codec configured for these sockets. Transports decode inbound
- frames with it in the connection process.
+Return the wire codec configured for these sockets.
+
+ Transports use it to decode inbound frames in the connection process.
 
 ```gleam
 pub fn active_codec(beryl.Sockets) -> codec.Codec
@@ -133,9 +136,9 @@ pub fn active_codec(beryl.Sockets) -> codec.Codec
 Register a socket and its closer against the captured connection owner.
 
  Install a monitor for `owner` before calling this function. Admission
- succeeds only if that exact runtime instance processes the registration; a
- restart cannot redirect it to the successor runtime. On `Error`, the
- connection is closed so its bound permit can be released.
+ succeeds only if that runtime instance processes the registration. A
+ restart cannot redirect it to the next runtime. On `Error`, this function
+ closes the connection so its bound permit can be released.
 
 ```gleam
 pub fn admit_socket(
@@ -154,8 +157,8 @@ pub fn admit_socket(
 
 Bind an acquired connection slot to the calling connection process.
 
- The limiter monitors the caller so the slot is reclaimed if the process
- dies without running its close path.
+ The limiter monitors the caller. It reclaims the slot if the process dies
+ without running its close path.
 
 ```gleam
 pub fn bind_connection_slot(ConnectionPermit) -> Nil
@@ -179,8 +182,9 @@ pub fn release_connection_slot(ConnectionPermit) -> Nil
 
 ### `route_binary`
 
-Route a raw binary frame, for codecs without a binary decoder (fans out
- to the socket's joined topics as `Binary` events delivered to `update`).
+Route a raw binary frame for a codec without a binary decoder.
+
+ The runtime sends a `Binary` event to `update` for each joined topic.
 
 ```gleam
 pub fn route_binary(
@@ -192,9 +196,10 @@ pub fn route_binary(
 
 ### `route_decoded`
 
-Route a transport-decoded inbound message to the runtime. Decode in
- the connection process (see `active_codec`) so parse cost and malformed
- input never reach the shared runtime.
+Route a transport-decoded inbound message to the runtime.
+
+ Decode in the connection process (see `active_codec`). Parse cost and
+ malformed input then never reach the shared runtime.
 
  Runtime message-rate limiting applies after routing. If it sheds a
  heartbeat, that heartbeat does not refresh the socket's deadline; sustained
@@ -214,8 +219,8 @@ pub fn route_decoded(
 Route a transport-decoded binary message while preserving its binary
  frame classification for runtime telemetry and rate accounting.
 
- This is additive to `route_decoded`, whose text semantics are retained for
- third-party transport compatibility.
+ This function supplements `route_decoded`. The text semantics of
+ `route_decoded` remain unchanged for third-party transport compatibility.
 
 ```gleam
 pub fn route_decoded_binary(
@@ -229,7 +234,7 @@ pub fn route_decoded_binary(
 
 Return the pid of the runtime that owns transport connections.
 
- On `Ok(pid)`, monitor that exact pid before admission and close the
+ On `Ok(pid)`, monitor that exact PID before admission and close the
  connection on its `Down`. `Error(Nil)` means the runtime is unavailable
  (pre-start or a restart window), so the connection must be refused.
 
@@ -275,7 +280,9 @@ pub fn telemetry_frame_stop(
 
 ### `telemetry_start`
 
-Start a timed transport operation. Returns a zero sentinel when disabled.
+Start a timed transport operation.
+
+ Returns zero when telemetry is disabled.
 
 ```gleam
 pub fn telemetry_start(Telemetry) -> Int

--- a/website/src/content/docs/reference/api/beryl-wire-codec.md
+++ b/website/src/content/docs/reference/api/beryl-wire-codec.md
@@ -29,9 +29,8 @@ Pluggable wire codec for beryl.
 
 A wire codec.
 
- `Codec` is opaque; build one with `new` (and, for binary support,
- `with_binary_decoder`). The runtime reads the codec's behaviour
- through the `@internal` accessors below.
+ `Codec` is opaque. Build one with `new`. For binary support, add
+ `with_binary_decoder`.
 
 ```gleam
 pub type Codec
@@ -87,11 +86,11 @@ A binary frame.
 
 ### `Inbound`
 
-Normalised inbound message shape.
+A normalized inbound message.
 
  `Inbound` is opaque: construct it with `inbound` and read it with the
- `inbound_*` accessors. Keeping the record hidden lets Beryl add fields
- (which default sensibly) without breaking every custom codec.
+ `inbound_*` accessors. The hidden record lets Beryl add fields with
+ defaults without breaking custom codecs.
 
 ```gleam
 pub type Inbound
@@ -250,8 +249,9 @@ pub fn apply_encode_reply(
 
 ### `format_decode_error`
 
-Format a `DecodeError` as a human-readable string. Used by the
- runtime's log messages and by `wire.format_decode_error`.
+Format a `DecodeError` as human-readable text.
+
+ The runtime log messages and `wire.format_decode_error` use this text.
 
 ```gleam
 pub fn format_decode_error(DecodeError) -> String
@@ -259,7 +259,7 @@ pub fn format_decode_error(DecodeError) -> String
 
 ### `inbound`
 
-Construct a normalised inbound message.
+Construct a normalized inbound message.
 
  - `join_ref`: optional client-side reference assigned at join time
    (used by some Phoenix replies; codecs without this concept should
@@ -281,7 +281,7 @@ pub fn inbound(
 
 ### `inbound_join_ref`
 
-The inbound message's join-time client reference, if any.
+Return the inbound message's join-time client reference, if any.
 
 ```gleam
 pub fn inbound_join_ref(Inbound) -> option.Option(String)
@@ -289,7 +289,7 @@ pub fn inbound_join_ref(Inbound) -> option.Option(String)
 
 ### `inbound_kind`
 
-The inbound message's structural kind.
+Return the inbound message's structural kind.
 
 ```gleam
 pub fn inbound_kind(Inbound) -> InboundKind
@@ -297,7 +297,7 @@ pub fn inbound_kind(Inbound) -> InboundKind
 
 ### `inbound_payload`
 
-The inbound message's body, for the app to decode.
+Return the inbound message body for the app to decode.
 
 ```gleam
 pub fn inbound_payload(Inbound) -> dynamic.Dynamic
@@ -305,7 +305,7 @@ pub fn inbound_payload(Inbound) -> dynamic.Dynamic
 
 ### `inbound_ref`
 
-The inbound message's per-message reference for reply correlation, if any.
+Return the inbound message's per-message reply reference, if any.
 
 ```gleam
 pub fn inbound_ref(Inbound) -> option.Option(String)
@@ -313,7 +313,7 @@ pub fn inbound_ref(Inbound) -> option.Option(String)
 
 ### `inbound_topic`
 
-The inbound message's subscription topic.
+Return the inbound message's subscription topic.
 
 ```gleam
 pub fn inbound_topic(Inbound) -> String
@@ -323,7 +323,7 @@ pub fn inbound_topic(Inbound) -> String
 
 Build a text-only wire codec.
 
- - `decode_text`: decode raw inbound text into a normalised `Inbound`.
+ - `decode_text`: decode raw inbound text into a normalized `Inbound`.
  - `encode_reply`: encode a reply to a client message:
    `(join_ref, ref, topic, status, response_payload)`.
  - `encode_push`: encode a server-initiated push: `(topic, event, payload)`.
@@ -354,11 +354,11 @@ pub fn uses_topicless_events(Codec) -> Bool
 
 ### `with_binary_decoder`
 
-Attach a binary decoder to a codec.
+Add a binary decoder to a codec.
 
- When set, binary WebSocket frames are decoded into a normalised `Inbound`
- via `decode_binary` instead of being delivered to the app's `update` as a
- raw `Binary` event.
+ When set, the decoder converts binary WebSocket frames to a normalized
+ `Inbound` via `decode_binary`. The app's `update` function does not receive
+ a raw `Binary` event.
 
 ```gleam
 pub fn with_binary_decoder(
@@ -369,10 +369,10 @@ pub fn with_binary_decoder(
 
 ### `with_close_encoder`
 
-Attach a topic-close encoder to a codec.
+Add a topic-close encoder to a codec.
 
- When set, the runtime emits this frame to a client whenever one of
- its topics terminates gracefully (leave, server shutdown, heartbeat
+ When set, the runtime sends this frame when one of the client's topics
+ terminates gracefully (leave, server shutdown, heartbeat
  eviction): `(join_ref, topic)`. Phoenix clients rely on `phx_close` to
  leave the joined state instead of waiting out push timeouts.
 
@@ -385,10 +385,10 @@ pub fn with_close_encoder(
 
 ### `with_error_encoder`
 
-Attach a topic-error encoder to a codec.
+Add a topic-error encoder to a codec.
 
- When set, the runtime emits this frame to a client whenever one of
- its topics terminates abnormally (crashed or stopped with an error):
+ When set, the runtime sends this frame when one of the client's topics
+ terminates abnormally (crashed or stopped with an error):
  `(join_ref, topic)`. Phoenix clients rely on `phx_error` to schedule an
  automatic rejoin.
 
@@ -403,11 +403,12 @@ pub fn with_error_encoder(
 
 Mark a codec's events as topicless.
 
- Some framings (e.g. Socket.IO-style protocols) do not carry a per-frame
+ Some framings, such as Socket.IO-style protocols, do not carry a per-frame
  topic. When set, an inbound event whose topic is empty is routed to the
- socket's single joined topic; with zero or multiple joins it is dropped.
+ socket's single joined topic. The runtime drops it when the socket has
+ zero or multiple joins.
  Topic-carrying codecs (like the Phoenix codec) must leave this off so
- empty-topic frames are rejected instead of guessed at.
+ the runtime rejects empty-topic frames instead of inferring a topic.
 
 ```gleam
 pub fn with_topicless_events(Codec) -> Codec

--- a/website/src/content/docs/reference/api/beryl-wire.md
+++ b/website/src/content/docs/reference/api/beryl-wire.md
@@ -1,6 +1,6 @@
 ---
 title: "beryl/wire"
-description: "Phoenix Wire Protocol — encoding/decoding helpers and the canonical"
+description: "Phoenix Wire Protocol: encoding/decoding helpers and the canonical"
 ---
 
 <!--
@@ -9,7 +9,7 @@ description: "Phoenix Wire Protocol — encoding/decoding helpers and the canoni
   `just docs` (gleam docs build + pnpm -C website generate:reference).
 -->
 
-Phoenix Wire Protocol — encoding/decoding helpers and the canonical
+Phoenix Wire Protocol: encoding/decoding helpers and the canonical
  `phoenix_codec()` for `beryl/wire/codec`.
 
  Phoenix uses a JSON array format: `[join_ref, ref, topic, event, payload]`.
@@ -28,8 +28,8 @@ Phoenix Wire Protocol — encoding/decoding helpers and the canonical
 
 Encode a Phoenix V2 binary broadcast: `(topic, event, payload)`.
 
- Errors when a metadata component exceeds the framing's 255-byte length
- limit.
+ Returns `Error(Nil)` when a metadata component exceeds the framing's
+ 255-byte limit.
 
 ```gleam
 pub fn binary_broadcast(
@@ -43,8 +43,8 @@ pub fn binary_broadcast(
 
 Encode a Phoenix V2 binary server push: `(join_ref, topic, event, payload)`.
 
- Errors when a metadata component exceeds the framing's 255-byte length
- limit.
+ Returns `Error(Nil)` when a metadata component exceeds the framing's
+ 255-byte limit.
 
 ```gleam
 pub fn binary_push(
@@ -59,8 +59,8 @@ pub fn binary_push(
 
 Encode a Phoenix V2 binary reply: `(join_ref, ref, topic, status, payload)`.
 
- Errors when a metadata component exceeds the framing's 255-byte length
- limit.
+ Returns `Error(Nil)` when a metadata component exceeds the framing's
+ 255-byte limit.
 
 ```gleam
 pub fn binary_reply(
@@ -74,8 +74,9 @@ pub fn binary_reply(
 
 ### `channel_close`
 
-Create a Phoenix `phx_close` frame, sent when a channel terminates
- gracefully. Phoenix mirrors the channel's `join_ref` into the `ref` slot.
+Create a Phoenix `phx_close` frame for a normal channel termination.
+
+ Phoenix copies the channel's `join_ref` to the `ref` slot.
 
 ```gleam
 pub fn channel_close(
@@ -86,8 +87,9 @@ pub fn channel_close(
 
 ### `channel_error`
 
-Create a Phoenix `phx_error` frame, sent when a channel terminates
- abnormally. Phoenix clients respond by scheduling an automatic rejoin.
+Create a Phoenix `phx_error` frame for an abnormal channel termination.
+
+ Phoenix clients respond by scheduling an automatic rejoin.
 
 ```gleam
 pub fn channel_error(
@@ -100,12 +102,12 @@ pub fn channel_error(
 
 Decode a Phoenix V2 binary push frame from a client into an `Inbound`.
 
- The payload remains a `BitArray` wrapped in `Dynamic`, but the decoded
+ The payload remains a `BitArray` wrapped in `Dynamic`. The decoded
  frame follows normal event classification and reaches the app as a
  `Join` or `Message` event rather than `Binary`. Decode the payload with
- `gleam/dynamic/decode.bit_array` if needed. Zero-length join_ref/ref
- components decode as `None`. Reserved protocol events are classified the
- same way as on the text framing.
+ `gleam/dynamic/decode.bit_array` if needed. Zero-length `join_ref` and
+ `ref` components decode as `None`. Reserved protocol events use the same
+ classification as text frames.
 
 ```gleam
 pub fn decode_binary_message(BitArray) -> Result(codec.Inbound, codec.DecodeError)
@@ -116,7 +118,7 @@ pub fn decode_binary_message(BitArray) -> Result(codec.Inbound, codec.DecodeErro
 Parse a JSON string into an `Inbound`.
 
  Expected format: `[join_ref, ref, topic, event, payload]` where
- `join_ref` and `ref` may be `null`.
+ The `join_ref` and `ref` values can be `null`.
 
 ```gleam
 pub fn decode_message(String) -> Result(codec.Inbound, codec.DecodeError)
@@ -124,11 +126,10 @@ pub fn decode_message(String) -> Result(codec.Inbound, codec.DecodeError)
 
 ### `dynamic_to_json`
 
-Convert a `Dynamic` (decoded from JSON) back into `json.Json`.
+Convert a `Dynamic` value decoded from JSON back to `json.Json`.
 
- Returns `Error(Nil)` when the value nests deeper than the wire
- protocol's maximum JSON depth, or contains something JSON cannot
- represent.
+ Returns `Error(Nil)` when the value exceeds the wire protocol's maximum
+ JSON depth or contains a value that JSON cannot represent.
 
 ```gleam
 pub fn dynamic_to_json(dynamic.Dynamic) -> Result(json.Json, Nil)
@@ -160,9 +161,11 @@ pub fn heartbeat_reply(option.Option(String)) -> codec.Frame
 
 ### `phoenix_codec`
 
-The canonical Phoenix wire codec. Pass to `beryl.config`.
+Return the canonical Phoenix wire codec.
 
- Handles both the JSON array framing on text frames and the Phoenix V2
+ Pass this codec to `beryl.config`.
+
+ The codec handles JSON array framing on text frames and Phoenix V2
  binary framing on binary frames (see `decode_binary_message`). Decoded
  binary frames follow the normal inbound path, producing `Join` or
  `Message` events according to their event name. The app receives a

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -17,13 +17,13 @@ Beryl - Type-safe real-time communication
 
  ## Features
 
- - **Sockets** — App-side dispatch: topic-based WebSocket messaging
+ - **Sockets**: App-side dispatch with topic-based WebSocket messaging
    routed by your `update` function (`beryl`, `beryl/socket`)
- - **PubSub** — Distributed publish/subscribe via Erlang `pg`
+ - **PubSub**: Distributed publish/subscribe via Erlang `pg`
    (`beryl/pubsub`)
- - **Presence** — Distributed presence tracking backed by a causal-context
+ - **Presence**: Distributed presence tracking backed by a causal-context
    CRDT (add-wins observed-remove set) (`beryl/presence`)
- - **Groups** — Named collections of topics for multi-topic broadcasting
+ - **Groups**: Named collections of topics for multi-topic broadcasting
    (`beryl/group`)
 
  ## Quick Start
@@ -73,9 +73,9 @@ Beryl - Type-safe real-time communication
 
 Configuration for an app-side socket runtime.
 
- This type is opaque: construct it with `config` and adjust it with the
- `with_*` builder functions. Keeping it opaque lets Beryl add configuration
- options in the future without a breaking change.
+ This type is opaque. Construct it with `config` and adjust it with the
+ `with_*` functions. Beryl can then add configuration options without a
+ breaking change.
 
 ```gleam
 pub type Config
@@ -85,9 +85,9 @@ pub type Config
 
 Why an eagerly validated `Config` was rejected before any process started.
 
- `child_spec` validates the configuration before allocating names or
- starting the runtime, so an invalid configuration fails fast instead of
- crashing a supervised child at init time.
+ `child_spec` validates the configuration before it allocates names or
+ starts the runtime. It returns an invalid configuration instead of
+ crashing a supervised child during initialization.
 
 ```gleam
 pub type ConfigError {
@@ -105,8 +105,8 @@ pub type ConfigError {
 
 `heartbeat_timeout_ms` was below the minimum. The server derives its
  staleness check interval as `heartbeat_timeout_ms / 2` (integer
- division), so a timeout of 1 would round down to a check interval of 0 —
- which disables heartbeat eviction entirely. The wrapped `Int` is the
+ division). A timeout of 1 would round down to a check interval of 0 and
+ disable heartbeat eviction. The wrapped `Int` is the
  smallest accepted timeout.
 
 ##### `InvalidTopicPattern(
@@ -129,8 +129,8 @@ A per-topic-pattern rate limit used a pattern string that is not a valid
 
 Logging configuration for Beryl diagnostics.
 
- This type is opaque: construct it with `logging_config` and adjust it with
- the `with_*` builder functions so Beryl can add logging options without a
+ This type is opaque. Construct it with `logging_config` and adjust it with
+ the `with_*` functions. Beryl can then add logging options without a
  breaking change.
 
 ```gleam
@@ -155,16 +155,15 @@ pub type LogLevel {
 
 ### `Sockets`
 
-Runtime system handle.
+A runtime system handle.
 
- This opaque handle is returned with the supervised subtree from
- `child_spec` and passed to broadcast, group, and transport functions. Its
- internals are intentionally hidden so Beryl can evolve them without
- breaking application code.
+ `child_spec` returns this opaque handle with the supervised subtree. Pass
+ it to broadcast, group, and transport functions. Beryl hides its internals
+ so they can change without breaking application code.
 
- The handle is deliberately non-generic: an app-side dispatch system is
+ The handle is non-generic. An app-side dispatch system is
  generic over the application's `model`/`msg`, but those types are sealed
- inside the monomorphic closures captured at construction time, so they
+ inside monomorphic closures at construction time. They
  never appear in this handle or in any transport signature.
 
 ```gleam
@@ -200,10 +199,10 @@ The runtime did not acknowledge the stop request within the shutdown
 
 ### `broadcast`
 
-Broadcast a message to all subscribers of a topic
+Broadcast a message to all subscribers of a topic.
 
- This sends the message to all sockets subscribed to the topic. When the
- system was started with PubSub, the broadcast is also distributed to
+ This function sends the message to all sockets subscribed to the topic.
+ When the system was started with PubSub, it also sends the broadcast to
  subscribers on other nodes.
 
  ## Example
@@ -228,7 +227,7 @@ pub fn broadcast(
 
 ### `broadcast_from`
 
-Broadcast a message to all subscribers except one socket
+Broadcast a message to all subscribers except one socket.
 
  Useful for broadcasting a message to everyone except the sender.
  When PubSub is configured, the excluded socket ID is preserved across
@@ -285,9 +284,10 @@ pub fn broadcast_presence_diff(
 
 Build the app-side dispatch supervision child specification.
 
- Add the returned specification to the application's own supervision tree.
- The configuration is validated eagerly, before the application's supervisor
- starts, rather than crashing a supervised child at init time.
+ Add the returned specification to the application's supervision tree.
+ This function validates the configuration before the application's
+ supervisor starts. It returns an error instead of crashing a supervised
+ child during initialization.
 
  The returned `Sockets` handle is name-backed and usable immediately, even
  before the supervision tree that owns the returned child specification is
@@ -321,7 +321,7 @@ pub fn child_spec(
 
 Build a configuration with sensible defaults.
 
- A `codec` is required — beryl no longer ships an implicit Phoenix
+ A `codec` is required. Beryl no longer provides an implicit Phoenix
  default. Pass `wire.phoenix_codec()` to keep Phoenix wire compatibility,
  or your own `Codec` for a custom framing.
 
@@ -348,14 +348,15 @@ pub fn logging_config(
 
 Stop a Beryl system.
 
- This drains the supervised runtime and stops it, delivering `Closed` to
- every joined topic before closing each transport connection. Presence is
- application-owned and is not stopped by this function. The runtime is a
- `Transient` child, so it is not restarted after a graceful stop.
+ This function drains and stops the supervised runtime. It delivers
+ `Closed` to every joined topic before it closes each transport connection.
+ Presence is application-owned and is not stopped by this function. The
+ runtime is a `Transient` child, so it is not restarted after a graceful
+ stop.
 
- `stop` is safe to call more than once and on a handle whose system was
- never started: in those cases it returns `Error(NotRunning)` rather than
- crashing. It returns `Error(StopTimeout)` if the app runtime does not
+ You can call `stop` more than once or use a handle whose system never
+ started. In these cases, it returns `Error(NotRunning)` and does not crash.
+ It returns `Error(StopTimeout)` if the app runtime does not
  acknowledge the stop within the shutdown window. After a successful stop
  the handle should no longer be used.
 
@@ -365,7 +366,7 @@ pub fn stop(Sockets) -> Result(Nil, StopError)
 
 ### `validate_config`
 
-Eagerly validate a [`Config`](#config) without starting anything.
+Validate a [`Config`](#config) without starting any process.
 
  This checks that `heartbeat_timeout_ms` is at least 2 and that every
  per-topic rate-limit pattern is valid.
@@ -450,8 +451,8 @@ pub fn with_frame_rate(
 
 Configure the server-side heartbeat staleness window.
 
- A socket that sends no heartbeat within `timeout_ms` is evicted. The
- runtime checks at half this window, so values below 2 are rejected by
+ The runtime evicts a socket that sends no heartbeat within `timeout_ms`.
+ It checks at half this window, so values below 2 are rejected by
  `validate_config` with `HeartbeatTimeoutTooLow`. The default is 60000 ms.
 
 ```gleam
@@ -463,7 +464,7 @@ pub fn with_heartbeat(
 
 ### `with_join_rate`
 
-Configure per-socket join rate limiting
+Configure per-socket join rate limiting.
 
 ```gleam
 pub fn with_join_rate(
@@ -489,22 +490,23 @@ pub fn with_logging(
 Configure the maximum number of concurrent connections allowed across the
  whole node, regardless of source IP.
 
- A value of 0 (the default) means unlimited. When a limit is set, a transport
- admits a new connection only while the node is below the limit and rejects
- it (before allocating any long-lived per-socket runtime state) otherwise;
- the slot is freed when the connection closes, its process dies, or its
- handshake/setup fails. The check-and-increment is atomic inside the limiter
- actor, so a burst of concurrent opens cannot materially exceed the ceiling.
+ A value of 0, the default, means unlimited. When a limit is set, a
+ transport admits a connection only while the node is below the limit. It
+ rejects other connections before it allocates long-lived per-socket state.
+ The transport frees the slot when the connection closes, its process dies,
+ or its handshake or setup fails. The limiter actor performs the check and
+ increment atomically. Concurrent opens cannot materially exceed the
+ ceiling.
 
  ## Composition with per-IP limits
 
- This node-wide ceiling composes with `with_max_connections_per_ip`: when
- both are set a connection must be under *both* limits to be admitted. The
- per-IP limit throttles any single abusive peer, while this global ceiling
+ This node-wide ceiling works with `with_max_connections_per_ip`. When both
+ are set, a connection must be under *both* limits. The per-IP limit
+ throttles any single abusive peer, while this global ceiling
  bounds the node's total resource use so that many distinct source addresses
- (for example a botnet or IPv6 address rotation) still cannot exhaust the
- node's process, socket, and runtime budget — a case a per-IP limit alone
- cannot stop.
+ (for example, a botnet or IPv6 address rotation) cannot exhaust the node's
+ process, socket, and runtime budget. A per-IP limit alone cannot stop this
+ case.
 
  ## Composition with external load balancers
 
@@ -512,7 +514,7 @@ Configure the maximum number of concurrent connections allowed across the
  load balancer, each node enforces its own limit independently, so the
  cluster's effective ceiling is roughly `max_connections × node_count`
  (subject to how the balancer distributes connections). Size the per-node
- value against a single node's capacity, and use the load balancer's own
+ value against a single node's capacity. Use the load balancer's
  global connection/rate controls when you need a cluster-wide cap.
 
 ```gleam
@@ -527,17 +529,18 @@ pub fn with_max_connections(
 Configure the maximum number of concurrent connections allowed per client
  IP address.
 
- A value of 0 (the default) means unlimited. When a limit is set, a transport
- admits a new connection only while the peer is below the limit and rejects
- it otherwise; the slot is freed when the connection closes.
+ A value of 0, the default, means unlimited. When a limit is set, a
+ transport admits a new connection only while the peer is below the limit.
+ It rejects other connections. The transport frees the slot when the
+ connection closes.
 
  ## Which IP is used
 
  The limit is enforced on the **real socket peer IP** as reported by the
  transport (for the Mist transport, the address of the TCP connection).
- Beryl deliberately does **not** trust or parse forwarded headers such as
- `X-Forwarded-For`, because a client can set them freely and would otherwise
- be able to spoof its address and bypass this limit.
+ Beryl does **not** trust or parse forwarded headers such as
+ `X-Forwarded-For`. A client can set these headers and spoof its address to
+ bypass this limit.
 
  If Beryl runs behind a trusted reverse proxy or load balancer, every
  connection shares the proxy's address, so a per-IP limit throttles all
@@ -572,15 +575,15 @@ pub fn with_max_event_length(
 
 Configure the maximum allowed inbound WebSocket frame size in bytes.
 
- The limit is enforced **post-assembly**: the transport (Mist/gramps)
- buffers and assembles a complete frame first, and only then does Beryl
- measure it and close the connection if it exceeds `max_bytes`. This bounds
+ Beryl enforces the limit **post-assembly**. The transport (Mist/gramps)
+ buffers and assembles a complete frame first. Beryl then measures it and
+ closes the connection if it exceeds `max_bytes`. This bounds
  per-message processing cost (decode, routing, rate-limit accounting), but
  it does **not** by itself bound transport memory. A hostile client can
  declare a huge payload and stream it slowly, or send many fragmented
  continuation frames, and the transport's receive buffer grows before this
- check ever runs — so this setting alone does not stop a single connection
- from exhausting node memory.
+ check runs. This setting alone does not stop one connection from exhausting
+ node memory.
 
  For a true transport memory bound you **must** place an edge proxy or load
  balancer in front of Beryl and configure a WebSocket frame-size limit
@@ -668,7 +671,7 @@ pub fn with_presence_handle(
 
 ### `with_pubsub`
 
-Add PubSub to a configuration for distributed broadcasts
+Add PubSub to a configuration for distributed broadcasts.
 
 ```gleam
 pub fn with_pubsub(
@@ -691,9 +694,9 @@ Configure a per-topic-pattern message rate limit for an app-dispatch
  runtime built with `child_spec`.
 
  Patterns use the same syntax as topic routing (`"room:*"`,
- `"document:*:ops"`, `"*"`). Limits are consulted in the order they were
- added and the first matching pattern wins; topics matching no pattern
- fall back to the global `with_channel_rate` limit. The limiter applies
+ `"document:*:ops"`, `"*"`). The runtime checks limits in the order they
+ were added. The first matching pattern wins. Topics that match no pattern
+ use the global `with_channel_rate` limit. The limiter applies
  only after a socket has joined the topic. A non-positive `per_second`
  explicitly disables limiting for matching topics, including any global
  channel limit, and allocates no bucket.

--- a/website/src/content/docs/reference/api/beryl_ewe.md
+++ b/website/src/content/docs/reference/api/beryl_ewe.md
@@ -32,14 +32,13 @@ Ewe WebSocket Transport - Direct Ewe integration for beryl
 Build a combined request handler that serves both WebSocket upgrades and
  regular HTTP from a single Ewe listener.
 
- The returned function inspects each request and routes it:
- - WebSocket upgrade requests matching the configured socket path are handed
-   to [`upgrade`](#upgrade) (which also runs any `on_connect` callback).
- - Everything else — non-upgrade requests, or upgrades to a different path —
-   falls through to `http_fallback`.
+ The returned function inspects and routes each request:
+ - It passes WebSocket upgrade requests for the configured socket path to
+   [`upgrade`](#upgrade), which also runs any `on_connect` callback.
+ - It passes all other requests to `http_fallback`. This includes non-upgrade
+   requests and upgrades for a different path.
 
- This removes the boilerplate upgrade guard integrators would otherwise write
- by hand:
+ This removes the need to write an upgrade guard:
 
  ```gleam
  ewe_transport.handler(sockets, server.default_config("/socket"), http_handler)
@@ -58,7 +57,7 @@ pub fn handler(
 
 ### `upgrade`
 
-Upgrade a request to WebSocket if it matches the configured path
+Upgrade a request to WebSocket if it matches the configured path.
 
  Usage in your Ewe handler:
  ```gleam
@@ -74,8 +73,8 @@ Upgrade a request to WebSocket if it matches the configured path
 
  Path matching, origin policy, `?vsn` version negotiation, connection
  limits (per-IP and node-wide, rejected with `429 Too Many Requests`), and
- the `on_connect` callback are handled by the shared admission pipeline —
- see `beryl/transport/server.upgrade` for the full contract. Enforcement
+ the `on_connect` callback use the shared admission pipeline. See
+ `beryl/transport/server.upgrade` for the full contract. Enforcement
  uses the real socket peer IP from the TCP connection; forwarded headers
  such as `X-Forwarded-For` are not trusted.
 

--- a/website/src/content/docs/reference/api/beryl_mist.md
+++ b/website/src/content/docs/reference/api/beryl_mist.md
@@ -28,14 +28,13 @@ Mist WebSocket Transport - Direct Mist integration for beryl
 Build a combined request handler that serves both WebSocket upgrades and
  regular HTTP from a single Mist listener.
 
- The returned function inspects each request and routes it:
- - WebSocket upgrade requests matching the configured socket path are handed
-   to [`upgrade`](#upgrade) (which also runs any `on_connect` callback).
- - Everything else — non-upgrade requests, or upgrades to a different path —
-   falls through to `http_fallback`.
+ The returned function inspects and routes each request:
+ - It passes WebSocket upgrade requests for the configured socket path to
+   [`upgrade`](#upgrade), which also runs any `on_connect` callback.
+ - It passes all other requests to `http_fallback`. This includes non-upgrade
+   requests and upgrades for a different path.
 
- This removes the boilerplate upgrade guard integrators would otherwise write
- by hand:
+ This removes the need to write an upgrade guard:
 
  ```gleam
  mist_transport.handler(sockets, server.default_config("/socket"), http_handler)
@@ -54,7 +53,7 @@ pub fn handler(
 
 ### `upgrade`
 
-Upgrade a request to WebSocket if it matches the configured path
+Upgrade a request to WebSocket if it matches the configured path.
 
  Usage in your Mist handler:
  ```gleam
@@ -70,8 +69,8 @@ Upgrade a request to WebSocket if it matches the configured path
 
  Path matching, origin policy, `?vsn` version negotiation, connection
  limits (per-IP and node-wide, rejected with `429 Too Many Requests`), and
- the `on_connect` callback are handled by the shared admission pipeline —
- see `beryl/transport/server.upgrade` for the full contract. Enforcement
+ the `on_connect` callback use the shared admission pipeline. See
+ `beryl/transport/server.upgrade` for the full contract. Enforcement
  uses the real socket peer IP from the TCP connection; forwarded headers
  such as `X-Forwarded-For` are not trusted.
 

--- a/website/src/content/docs/reference/api/index.md
+++ b/website/src/content/docs/reference/api/index.md
@@ -30,10 +30,10 @@ The generator creates pages under `/reference/api/` from Gleam docs metadata. Th
 | [`beryl/socket`](/reference/api/beryl-socket/) | Types for building app-side dispatch systems with `beryl.child_spec`. |
 | [`beryl/stats`](/reference/api/beryl-stats/) | Local runtime statistics. |
 | [`beryl/topic`](/reference/api/beryl-topic/) | Pattern matching for topic routing. |
-| [`beryl/transport`](/reference/api/beryl-transport/) | Transport SPI — the contract between beryl core and WebSocket transport |
+| [`beryl/transport`](/reference/api/beryl-transport/) | Transport SPI: the contract between beryl core and WebSocket transport |
 | [`beryl/transport/origin`](/reference/api/beryl-transport-origin/) | Origin and handshake-version checks for WebSocket upgrades. |
 | [`beryl/transport/server`](/reference/api/beryl-transport-server/) | Server-agnostic WebSocket transport infrastructure. |
-| [`beryl/wire`](/reference/api/beryl-wire/) | Phoenix Wire Protocol — encoding/decoding helpers and the canonical |
+| [`beryl/wire`](/reference/api/beryl-wire/) | Phoenix Wire Protocol: encoding/decoding helpers and the canonical |
 | [`beryl/wire/codec`](/reference/api/beryl-wire-codec/) | Pluggable wire codec for beryl. |
 
 ## `beryl_ewe` `0.2.0`


### PR DESCRIPTION
## Summary

- simplify the root README with ASD-STE100 wording
- simplify public API comments across all three packages
- regenerate API reference pages and add changelog fragments
