### PR TITLE
test: switch test runner from gleeunit to vouch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,9 @@ website/                           # Astro/Starlight docs site (not a member)
 - `gleam_stdlib`, `gleam_erlang`, `gleam_crypto`
 
 #### Development
-- `gleeunit` - Testing framework
+- `vouch` - Test runner (gleeunit-compatible; supports `--filter`, JUnit
+  output, watch mode)
+- `gleeunit` - Assertion library (`gleeunit/should`)
 - git-sourced test helpers: `phoenix_channel_fixtures` (beryl),
   `aquamarine`, `gluegun` (beryl_mist)
 

--- a/DEV.md
+++ b/DEV.md
@@ -135,13 +135,16 @@ pub fn parse(input: String) -> Result(Value, ParseError)
 # Run all tests
 just test
 
-# Run with verbose output
-gleam test -- --verbose
+# Run a subset of tests by name
+gleam test -- --filter=presence
+
+# Rerun tests on file changes
+gleam run -m vouch -- watch
 ```
 
 ### Writing Tests
 
-Tests use the `gleeunit` framework:
+Tests run under the `vouch` runner with `gleeunit/should` assertions:
 
 ```gleam
 import gleeunit/should

--- a/examples/chatrooms/gleam.toml
+++ b/examples/chatrooms/gleam.toml
@@ -17,3 +17,4 @@ mist = ">= 6.0.0 and < 7.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
+vouch = ">= 1.2.0 and < 2.0.0"

--- a/examples/chatrooms/manifest.toml
+++ b/examples/chatrooms/manifest.toml
@@ -7,10 +7,11 @@
 # You should check this file into your source control repository.
 
 packages = [
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
   { name = "beryl", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
   { name = "beryl_mist", version = "0.3.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
-  { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
+  { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
   { name = "exception", version = "2.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "6BDEA95248093599391C3B5DF1835C5C6A86C353C2F99CE539B450E3432FE117" },
   { name = "gleam_crypto", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "2DE9E4EF53CF6FEE049D4F765731F7178F7A11AEFAE00EEE63BF7536B354AD3F" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
@@ -27,6 +28,7 @@ packages = [
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
+  { name = "vouch", version = "1.2.0", build_tools = ["gleam"], requirements = ["argv", "gleam_stdlib"], otp_app = "vouch", source = "hex", outer_checksum = "5DB5887CF32274B4783146C86CF61CE55A2C85ED6FE0E73F2D3777F46491209A" },
 ]
 
 [requirements]
@@ -40,3 +42,4 @@ gleam_otp = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 mist = { version = ">= 6.0.0 and < 7.0.0" }
+vouch = { version = ">= 1.2.0 and < 2.0.0" }

--- a/examples/chatrooms/test/chatrooms_test.gleam
+++ b/examples/chatrooms/test/chatrooms_test.gleam
@@ -1,7 +1,7 @@
-import gleeunit
+import vouch
 
 /// Test entrypoint: gleeunit discovers and runs every `*_test` module in
 /// this package.
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }

--- a/examples/collab_docs/client/gleam.toml
+++ b/examples/collab_docs/client/gleam.toml
@@ -13,3 +13,4 @@ lattice_registers = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
+vouch = ">= 1.2.0 and < 2.0.0"

--- a/examples/collab_docs/client/manifest.toml
+++ b/examples/collab_docs/client/manifest.toml
@@ -7,6 +7,7 @@
 # You should check this file into your source control repository.
 
 packages = [
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_stdlib", version = "1.0.5", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CEE5B6C076A85B45F60C585F4316C63EC8B7127C119D5738C3958A9C4D50404E" },
   { name = "gleeunit", version = "1.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "EC31ABA74256AEA531EDF8169931D775BBB384FED0A8A1BDC4DD9354E3E21826" },
@@ -15,6 +16,7 @@ packages = [
   { name = "lattice_maps", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core", "lattice_counters", "lattice_registers", "lattice_sets"], otp_app = "lattice_maps", source = "hex", outer_checksum = "9CB3F090BEF40C96C5EEEE9CEE4FA9B16C600802A234B8F2AAF9C25B5B46667B" },
   { name = "lattice_registers", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], otp_app = "lattice_registers", source = "hex", outer_checksum = "4B85A3925CDC563DE102A5B59CDDCA68EBBB877C25602C4551B15C8DE3D8A295" },
   { name = "lattice_sets", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], otp_app = "lattice_sets", source = "hex", outer_checksum = "BA81DF518B2A25D9E77012262D08D06B959BD7A6C22B98D4F82550823A1E98AF" },
+  { name = "vouch", version = "1.2.0", build_tools = ["gleam"], requirements = ["argv", "gleam_stdlib"], otp_app = "vouch", source = "hex", outer_checksum = "5DB5887CF32274B4783146C86CF61CE55A2C85ED6FE0E73F2D3777F46491209A" },
 ]
 
 [requirements]
@@ -24,3 +26,4 @@ gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 lattice_core = { version = ">= 1.0.0 and < 2.0.0" }
 lattice_maps = { version = ">= 1.0.0 and < 2.0.0" }
 lattice_registers = { version = ">= 1.0.0 and < 2.0.0" }
+vouch = { version = ">= 1.2.0 and < 2.0.0" }

--- a/examples/collab_docs/client/test/collab_docs_client_test.gleam
+++ b/examples/collab_docs/client/test/collab_docs_client_test.gleam
@@ -1,9 +1,9 @@
 import collab_docs_client as client
-import gleeunit
 import gleeunit/should
+import vouch
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }
 
 pub fn independent_adds_converge_test() {

--- a/examples/collab_docs/gleam.toml
+++ b/examples/collab_docs/gleam.toml
@@ -21,3 +21,4 @@ lattice_maps = ">= 1.0.0 and < 2.0.0"
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
 lattice_registers = ">= 1.0.0 and < 2.0.0"
+vouch = ">= 1.2.0 and < 2.0.0"

--- a/examples/collab_docs/manifest.toml
+++ b/examples/collab_docs/manifest.toml
@@ -7,10 +7,11 @@
 # You should check this file into your source control repository.
 
 packages = [
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
   { name = "beryl", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
   { name = "beryl_mist", version = "0.3.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
-  { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
+  { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
   { name = "exception", version = "2.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "6BDEA95248093599391C3B5DF1835C5C6A86C353C2F99CE539B450E3432FE117" },
   { name = "gleam_crypto", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "2DE9E4EF53CF6FEE049D4F765731F7178F7A11AEFAE00EEE63BF7536B354AD3F" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
@@ -32,6 +33,7 @@ packages = [
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
+  { name = "vouch", version = "1.2.0", build_tools = ["gleam"], requirements = ["argv", "gleam_stdlib"], otp_app = "vouch", source = "hex", outer_checksum = "5DB5887CF32274B4783146C86CF61CE55A2C85ED6FE0E73F2D3777F46491209A" },
 ]
 
 [requirements]
@@ -49,3 +51,4 @@ lattice_core = { version = ">= 1.0.0 and < 2.0.0" }
 lattice_maps = { version = ">= 1.0.0 and < 2.0.0" }
 lattice_registers = { version = ">= 1.0.0 and < 2.0.0" }
 mist = { version = ">= 6.0.0 and < 7.0.0" }
+vouch = { version = ">= 1.2.0 and < 2.0.0" }

--- a/examples/collab_docs/test/collab_docs_test.gleam
+++ b/examples/collab_docs/test/collab_docs_test.gleam
@@ -1,5 +1,5 @@
-import gleeunit
+import vouch
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }

--- a/examples/cursors/gleam.toml
+++ b/examples/cursors/gleam.toml
@@ -18,3 +18,4 @@ envoy = ">= 1.2.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
+vouch = ">= 1.2.0 and < 2.0.0"

--- a/examples/cursors/manifest.toml
+++ b/examples/cursors/manifest.toml
@@ -7,10 +7,11 @@
 # You should check this file into your source control repository.
 
 packages = [
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
   { name = "beryl", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
   { name = "beryl_mist", version = "0.3.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
-  { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
+  { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
   { name = "exception", version = "2.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "6BDEA95248093599391C3B5DF1835C5C6A86C353C2F99CE539B450E3432FE117" },
   { name = "gleam_crypto", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "2DE9E4EF53CF6FEE049D4F765731F7178F7A11AEFAE00EEE63BF7536B354AD3F" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
@@ -27,6 +28,7 @@ packages = [
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
+  { name = "vouch", version = "1.2.0", build_tools = ["gleam"], requirements = ["argv", "gleam_stdlib"], otp_app = "vouch", source = "hex", outer_checksum = "5DB5887CF32274B4783146C86CF61CE55A2C85ED6FE0E73F2D3777F46491209A" },
 ]
 
 [requirements]
@@ -41,3 +43,4 @@ gleam_otp = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 mist = { version = ">= 6.0.0 and < 7.0.0" }
+vouch = { version = ">= 1.2.0 and < 2.0.0" }

--- a/examples/cursors/test/cursors_test.gleam
+++ b/examples/cursors/test/cursors_test.gleam
@@ -1,7 +1,7 @@
-import gleeunit
+import vouch
 
 /// Test entrypoint: gleeunit discovers and runs every `*_test` module in
 /// this package.
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }

--- a/examples/load_test/gleam.toml
+++ b/examples/load_test/gleam.toml
@@ -20,3 +20,4 @@ envoy = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
+vouch = ">= 1.2.0 and < 2.0.0"

--- a/examples/load_test/manifest.toml
+++ b/examples/load_test/manifest.toml
@@ -7,13 +7,14 @@
 # You should check this file into your source control repository.
 
 packages = [
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
   { name = "beryl", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
   { name = "beryl_ewe", version = "0.2.0", build_tools = ["gleam"], requirements = ["beryl", "ewe", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], source = "local", path = "../../packages/beryl_ewe" },
   { name = "beryl_mist", version = "0.3.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "compresso", version = "0.1.0", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_stdlib", "gleam_yielder", "logging"], otp_app = "compresso", source = "hex", outer_checksum = "8BE29A1EDA42F70826ED148EAE40C46BB3FC18E78FE472663DB01DD4A38172D4" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
   { name = "ewe", version = "4.0.1", build_tools = ["gleam"], requirements = ["compresso", "exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "logging", "websocks"], otp_app = "ewe", source = "hex", outer_checksum = "1A6CBE2E07B7E784F9B9503C94C0F23CDD644AC5EA4E1B957F3A5550541699DB" },
-  { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
+  { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
   { name = "exception", version = "2.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "6BDEA95248093599391C3B5DF1835C5C6A86C353C2F99CE539B450E3432FE117" },
   { name = "gleam_crypto", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "2DE9E4EF53CF6FEE049D4F765731F7178F7A11AEFAE00EEE63BF7536B354AD3F" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
@@ -31,6 +32,7 @@ packages = [
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
+  { name = "vouch", version = "1.2.0", build_tools = ["gleam"], requirements = ["argv", "gleam_stdlib"], otp_app = "vouch", source = "hex", outer_checksum = "5DB5887CF32274B4783146C86CF61CE55A2C85ED6FE0E73F2D3777F46491209A" },
   { name = "websocks", version = "3.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_stdlib"], otp_app = "websocks", source = "hex", outer_checksum = "C70340E5B6C3390383ADA17029DCA6F8903863A7AD8CD8E1520EDCC4FE70D6FD" },
 ]
 
@@ -48,3 +50,4 @@ gleam_otp = { version = ">= 0.12.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 mist = { version = ">= 6.0.0 and < 7.0.0" }
+vouch = { version = ">= 1.2.0 and < 2.0.0" }

--- a/examples/load_test/test/load_test_test.gleam
+++ b/examples/load_test/test/load_test_test.gleam
@@ -11,19 +11,19 @@ import gleam/erlang/process
 import gleam/option.{type Option, None, Some}
 import gleam/otp/static_supervisor
 import gleam/string
-import gleeunit
 import gleeunit/should
 import load_test/app as load_app
 import load_test/channel
 import load_test/ewe as ewe_http
 import load_test/http
 import load_test/mist as mist_http
+import vouch
 
 @external(erlang, "load_test_test_ffi", "run_after")
 fn run_after(run: fn() -> value, cleanup: fn() -> Nil) -> value
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }
 
 fn start_system() -> beryl.Sockets {

--- a/examples/showcase/gleam.toml
+++ b/examples/showcase/gleam.toml
@@ -22,3 +22,4 @@ envoy = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
+vouch = ">= 1.2.0 and < 2.0.0"

--- a/examples/showcase/manifest.toml
+++ b/examples/showcase/manifest.toml
@@ -7,13 +7,14 @@
 # You should check this file into your source control repository.
 
 packages = [
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
   { name = "beryl", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
   { name = "beryl_mist", version = "0.3.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "chatrooms", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "beryl_mist", "example_helpers", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../chatrooms" },
   { name = "collab_docs", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "beryl_mist", "example_helpers", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_core", "lattice_maps", "mist"], source = "local", path = "../collab_docs" },
   { name = "cursors", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "beryl_mist", "envoy", "example_helpers", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../cursors" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
-  { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
+  { name = "example_helpers", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
   { name = "exception", version = "2.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "6BDEA95248093599391C3B5DF1835C5C6A86C353C2F99CE539B450E3432FE117" },
   { name = "gleam_crypto", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "2DE9E4EF53CF6FEE049D4F765731F7178F7A11AEFAE00EEE63BF7536B354AD3F" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
@@ -35,6 +36,7 @@ packages = [
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
+  { name = "vouch", version = "1.2.0", build_tools = ["gleam"], requirements = ["argv", "gleam_stdlib"], otp_app = "vouch", source = "hex", outer_checksum = "5DB5887CF32274B4783146C86CF61CE55A2C85ED6FE0E73F2D3777F46491209A" },
 ]
 
 [requirements]
@@ -53,3 +55,4 @@ gleam_otp = { version = ">= 0.12.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 mist = { version = ">= 6.0.0 and < 7.0.0" }
+vouch = { version = ">= 1.2.0 and < 2.0.0" }

--- a/examples/showcase/test/showcase_test.gleam
+++ b/examples/showcase/test/showcase_test.gleam
@@ -1,7 +1,7 @@
-import gleeunit
+import vouch
 
 /// Test entrypoint: gleeunit discovers and runs every `*_test` module in
 /// this package.
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }

--- a/packages/beryl/gleam.toml
+++ b/packages/beryl/gleam.toml
@@ -31,6 +31,7 @@ gleeunit = ">= 1.0.0 and < 2.0.0"
 envoy = ">= 1.2.0 and < 2.0.0"
 phoenix_channel_fixtures = { git = "https://github.com/tylerbutler/phoenix_channel_fixtures.git", ref = "7daccb856d17db6278980277237c201b2acdcdf1" }
 glinter = ">= 2.19.0 and < 3.0.0"
+vouch = ">= 1.2.0 and < 2.0.0"
 
 [tools.licence_audit]
 allow = ["Apache-2.0", "MIT"]

--- a/packages/beryl/manifest.toml
+++ b/packages/beryl/manifest.toml
@@ -28,6 +28,7 @@ packages = [
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
+  { name = "vouch", version = "1.2.0", build_tools = ["gleam"], requirements = ["argv", "gleam_stdlib"], otp_app = "vouch", source = "hex", outer_checksum = "5DB5887CF32274B4783146C86CF61CE55A2C85ED6FE0E73F2D3777F46491209A" },
 ]
 
 [requirements]
@@ -44,3 +45,4 @@ lattice_presence = { version = ">= 1.0.0 and < 2.0.0" }
 palabres = { version = ">= 1.0.4 and < 2.0.0" }
 phoenix_channel_fixtures = { git = "https://github.com/tylerbutler/phoenix_channel_fixtures.git", ref = "7daccb856d17db6278980277237c201b2acdcdf1" }
 telemetry = { version = ">= 1.4.2 and < 2.0.0" }
+vouch = { version = ">= 1.2.0 and < 2.0.0" }

--- a/packages/beryl/test/app_presence_async_test.gleam
+++ b/packages/beryl/test/app_presence_async_test.gleam
@@ -25,12 +25,12 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/otp/actor
 import gleam/string
-import gleeunit
 import gleeunit/should
 import test_helpers
+import vouch
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }
 
 // ── Gate ────────────────────────────────────────────────────────────────────

--- a/packages/beryl/test/app_presence_test.gleam
+++ b/packages/beryl/test/app_presence_test.gleam
@@ -16,12 +16,12 @@ import gleam/json
 import gleam/list
 import gleam/option.{None, Some}
 import gleam/string
-import gleeunit
 import gleeunit/should
 import test_helpers
+import vouch
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }
 
 /// Encode presence entries as `{session_id: meta}` — the examples'

--- a/packages/beryl/test/beryl_test.gleam
+++ b/packages/beryl/test/beryl_test.gleam
@@ -10,8 +10,8 @@ import gleam/json
 import gleam/option
 import gleam/otp/actor
 import gleam/string
-import gleeunit
 import gleeunit/should
+import vouch
 
 fn text_frame(frame: codec.Frame) -> String {
   let assert codec.TextFrame(text) = frame
@@ -19,7 +19,7 @@ fn text_frame(frame: codec.Frame) -> String {
 }
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }
 
 // Topic pattern tests

--- a/packages/beryl/test/channel_api_test.gleam
+++ b/packages/beryl/test/channel_api_test.gleam
@@ -14,11 +14,11 @@ import gleam/list
 import gleam/option
 import gleam/result
 import gleam/string
-import gleeunit
 import gleeunit/should
+import vouch
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }
 
 /// A channel-local server-side message type, used to prove typed `info`

--- a/packages/beryl/test/channel_doc_example_test.gleam
+++ b/packages/beryl/test/channel_doc_example_test.gleam
@@ -7,11 +7,11 @@ import beryl/channel
 import beryl/wire
 import gleam/json
 import gleam/otp/static_supervisor
-import gleeunit
 import gleeunit/should
+import vouch
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }
 
 pub type Note {

--- a/packages/beryl/test/channel_guide_example_test.gleam
+++ b/packages/beryl/test/channel_guide_example_test.gleam
@@ -14,11 +14,11 @@ import beryl/channel
 import beryl/wire
 import gleam/json
 import gleam/otp/static_supervisor
-import gleeunit
 import gleeunit/should
+import vouch
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/beryl/test/channel_readme_example_test.gleam
+++ b/packages/beryl/test/channel_readme_example_test.gleam
@@ -11,11 +11,11 @@ import beryl/channel
 import beryl/wire
 import gleam/json
 import gleam/otp/static_supervisor
-import gleeunit
 import gleeunit/should
+import vouch
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }
 
 pub fn room() -> channel.Handler {

--- a/packages/beryl/test/channel_validation_test.gleam
+++ b/packages/beryl/test/channel_validation_test.gleam
@@ -6,11 +6,11 @@ import beryl
 import beryl/channel
 import beryl/topic
 import beryl/wire
-import gleeunit
 import gleeunit/should
+import vouch
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }
 
 fn stub(pattern: String) -> channel.Handler {

--- a/packages/beryl/test/presence_replication_test.gleam
+++ b/packages/beryl/test/presence_replication_test.gleam
@@ -3,13 +3,13 @@ import beryl/pubsub
 import gleam/erlang/process
 import gleam/json
 import gleam/list
-import gleeunit
 import gleeunit/should
 import lattice_presence/presence_state
 import test_helpers
+import vouch
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }
 
 // ── Helper ──────────────────────────────────────────────────────────

--- a/packages/beryl/test/presence_test.gleam
+++ b/packages/beryl/test/presence_test.gleam
@@ -5,12 +5,12 @@ import gleam/list
 import gleam/option.{None}
 import gleam/otp/static_supervisor
 import gleam/string
-import gleeunit
 import gleeunit/should
 import test_helpers
+import vouch
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }
 
 fn test_config(replica: String) -> presence.Config {

--- a/packages/beryl_ewe/gleam.toml
+++ b/packages/beryl_ewe/gleam.toml
@@ -19,6 +19,7 @@ gleeunit = ">= 1.0.0 and < 2.0.0"
 gleam_json = ">= 3.1.0 and < 4.0.0"
 gleam_otp = ">= 1.2.0 and < 2.0.0"
 glinter = ">= 2.19.0 and < 3.0.0"
+vouch = ">= 1.2.0 and < 2.0.0"
 
 [tools.licence_audit]
 allow = ["Apache-2.0", "MIT"]

--- a/packages/beryl_ewe/manifest.toml
+++ b/packages/beryl_ewe/manifest.toml
@@ -34,6 +34,7 @@ packages = [
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
+  { name = "vouch", version = "1.2.0", build_tools = ["gleam"], requirements = ["argv", "gleam_stdlib"], otp_app = "vouch", source = "hex", outer_checksum = "5DB5887CF32274B4783146C86CF61CE55A2C85ED6FE0E73F2D3777F46491209A" },
   { name = "websocks", version = "3.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_stdlib"], otp_app = "websocks", source = "hex", outer_checksum = "C70340E5B6C3390383ADA17029DCA6F8903863A7AD8CD8E1520EDCC4FE70D6FD" },
 ]
 
@@ -48,3 +49,4 @@ gleam_otp = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glinter = { version = ">= 2.19.0 and < 3.0.0" }
+vouch = { version = ">= 1.2.0 and < 2.0.0" }

--- a/packages/beryl_ewe/test/beryl_ewe_test.gleam
+++ b/packages/beryl_ewe/test/beryl_ewe_test.gleam
@@ -1,7 +1,7 @@
-import gleeunit
+import vouch
 
-/// Test entrypoint: gleeunit discovers and runs every `*_test` module in
+/// Test entrypoint: vouch discovers and runs every `*_test` module in
 /// this package.
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }

--- a/packages/beryl_mist/gleam.toml
+++ b/packages/beryl_mist/gleam.toml
@@ -21,6 +21,7 @@ gleam_otp = ">= 1.2.0 and < 2.0.0"
 aquamarine = { git = "https://github.com/tylerbutler/aquamarine.git", ref = "main" }
 gluegun = { git = "https://github.com/tylerbutler/gluegun.git", ref = "532af1ac0308ff93c8a957467dbb638859593c93" }
 glinter = ">= 2.19.0 and < 3.0.0"
+vouch = ">= 1.2.0 and < 2.0.0"
 
 [tools.licence_audit]
 allow = ["Apache-2.0", "MIT"]

--- a/packages/beryl_mist/manifest.toml
+++ b/packages/beryl_mist/manifest.toml
@@ -40,6 +40,7 @@ packages = [
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
+  { name = "vouch", version = "1.2.0", build_tools = ["gleam"], requirements = ["argv", "gleam_stdlib"], otp_app = "vouch", source = "hex", outer_checksum = "5DB5887CF32274B4783146C86CF61CE55A2C85ED6FE0E73F2D3777F46491209A" },
   { name = "websocks", version = "4.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_stdlib"], otp_app = "websocks", source = "hex", outer_checksum = "89B0C31A032CBE28D4C5FB5CC25A8A690669FEBA501C63F99A4E8F5748750B2A" },
 ]
 
@@ -56,3 +57,4 @@ gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glinter = { version = ">= 2.19.0 and < 3.0.0" }
 gluegun = { git = "https://github.com/tylerbutler/gluegun.git", ref = "532af1ac0308ff93c8a957467dbb638859593c93" }
 mist = { version = ">= 6.0.0 and < 7.0.0" }
+vouch = { version = ">= 1.2.0 and < 2.0.0" }

--- a/packages/beryl_mist/test/beryl_mist_test.gleam
+++ b/packages/beryl_mist/test/beryl_mist_test.gleam
@@ -1,7 +1,7 @@
-import gleeunit
+import vouch
 
-/// Test entrypoint: gleeunit discovers and runs every `*_test` module in
+/// Test entrypoint: vouch discovers and runs every `*_test` module in
 /// this package.
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }

--- a/packages/beryl_mist/test/client_contract_test.gleam
+++ b/packages/beryl_mist/test/client_contract_test.gleam
@@ -17,10 +17,11 @@ import gleam/option.{Some}
 import gleam/otp/actor
 import gleam/otp/static_supervisor.{type Supervisor}
 import gleam/result
-import gleeunit
 import gleeunit/should
+import gluegun/connection
 import gluegun/websocket
 import mist
+import vouch
 
 const socket_path = "/socket/websocket"
 
@@ -43,7 +44,7 @@ type TestEvent {
 fn stop_supervisor(pid: process.Pid) -> Nil
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }
 
 pub fn start_test_server_uses_dynamic_port_test() {
@@ -258,7 +259,10 @@ pub fn gluegun_raw_malformed_frame_gets_error_reply_test() {
       host: "127.0.0.1",
       port: server.port,
       path: socket_path,
-      options: websocket.options(),
+      // Short frame timeout: this test waits out the full receive window, and
+      // gluegun's 5s default collides with vouch's 5s per-test timeout.
+      options: websocket.options()
+        |> websocket.with_timeout(connection.Milliseconds(receive_timeout_ms)),
       callback: fn(socket) {
         let assert Ok(Nil) = websocket.send_text(socket, "not json")
         websocket.receive_app_frame(socket)

--- a/packages/beryl_mist/test/phoenix_contract_test.gleam
+++ b/packages/beryl_mist/test/phoenix_contract_test.gleam
@@ -14,12 +14,12 @@ import gleam/json.{type Json}
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
-import gleeunit
 import gleeunit/should
 import mist
+import vouch
 
 pub fn main() {
-  gleeunit.main()
+  vouch.main()
 }
 
 type WebsocketClient


### PR DESCRIPTION
Switches test running in all packages and examples to [vouch](https://hex.pm/packages/vouch), a gleeunit-compatible runner with test filtering, JUnit/JSONL/teamcity output, parallel execution, and watch mode.

## Changes

- Add `vouch` 1.2.0 as a dev dependency to the three packages and the six example apps with tests
- Swap every test entrypoint `main()` from `gleeunit.main()` to `vouch.main()` (package entrypoints plus the per-module mains)
- Keep `gleeunit` as a dev dep — test files still use `gleeunit/should` assertions, which vouch runs unchanged
- Fix `gluegun_raw_malformed_frame_gets_error_reply_test`: it intentionally waits out gluegun's 5000ms default receive timeout, which collided exactly with vouch's 5000ms per-test timeout. The test now uses the file's existing 1s `receive_timeout_ms`, and finishes ~4s faster
- Update CLAUDE.md/DEV.md testing docs (`--filter` and watch-mode examples replace `--verbose`, which vouch does not support)

## Verification

- `trellis run test` — all 7 test targets pass under vouch
- `trellis run check` and `trellis run format` — clean
- `trellis changelog check --base main` — no releasable package changes, so no fragment needed