### PR TITLE
docs(runtime): describe per-socket actors

### DIFF
--- a/.changes/unreleased/beryl-make-presence-update-honor.toml
+++ b/.changes/unreleased/beryl-make-presence-update-honor.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Make presence.update honor the configured call timeout."

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -52,7 +52,7 @@
 ////     |> static_supervisor.start()
 ////
 ////   // Broadcast to all subscribers of a topic
-////   beryl.broadcast(sockets, "room:lobby", "announce", payload)
+////   beryl.broadcast(sockets, "room:lobby", "announce", json.object([]))
 //// }
 //// ```
 

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -487,7 +487,7 @@ pub fn with_max_event_length(
 // nolint: unused_exports -- enforced in sibling transport handler tests
 /// Configure the maximum allowed inbound WebSocket frame size in bytes.
 ///
-/// Beryl enforces the limit **post-assembly**. The transport (Mist/gramps)
+/// Beryl enforces the limit **post-assembly**. The transport (Mist or Ewe)
 /// buffers and assembles a complete frame first. Beryl then measures it and
 /// closes the connection if it exceeds `max_bytes`. This bounds
 /// per-message processing cost (decode, routing, rate-limit accounting), but

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -2,12 +2,26 @@
 ////
 //// Wraps the pure `lattice_presence/presence_state` CRDT in an OTP actor that:
 //// - Handles track/update/untrack calls
+//// - Publishes an actor-owned ETS read model
 //// - Periodically broadcasts state via PubSub for cross-node replication
 //// - Receives remote state from PubSub and merges it internally
 //// - Invokes `on_diff` callback when merges produce non-empty diffs
 ////
 //// Presence is independent of the Beryl runtime and runs under your
 //// application's supervision tree.
+////
+//// ## Read consistency
+////
+//// The presence actor is the only writer to a protected ETS read model.
+//// It atomically replaces each topic's snapshot after completing a mutation,
+//// merge, or prune. Synchronous mutations publish before replying, and
+//// runtime mutations acknowledge only after publishing, so a later read
+//// observes the completed mutation without waiting on the actor mailbox.
+////
+//// A read concurrent with a queued or in-progress mutation can observe the
+//// previous or new complete snapshot. Reads of separate topics do not form
+//// one atomic view. If the actor stops, it also destroys the table, and reads
+//// return `Error(Nil)` instead of stale data.
 ////
 //// ## Example
 ////
@@ -901,7 +915,8 @@ pub fn is_running(presence: Presence) -> Bool {
 ///
 /// This function reads the actor-owned read model directly. The read model is
 /// an ETS snapshot created after each mutation, merge, or prune. This function
-/// does not wait on the actor mailbox.
+/// does not wait on the actor mailbox. See the module's **Read consistency**
+/// section for ordering guarantees.
 ///
 /// Returns `Error(Nil)` when the presence read model is unavailable. This can
 /// occur when the presence actor is not running or when this handle is used
@@ -918,7 +933,8 @@ pub fn list(
 ///
 /// This function reads the actor-owned read model directly. The read model is
 /// an ETS snapshot created after each mutation, merge, or prune. This function
-/// does not wait on the actor mailbox.
+/// does not wait on the actor mailbox. See the module's **Read consistency**
+/// section for ordering guarantees.
 ///
 /// Returns `Error(Nil)` when the presence read model is unavailable. This can
 /// occur when the presence actor is not running or when this handle is used
@@ -946,7 +962,8 @@ pub fn get_by_key(
 ///
 /// This function reads the actor-owned read model directly. The read model is
 /// an ETS snapshot created after each mutation, merge, or prune. This function
-/// does not wait on the actor mailbox.
+/// does not wait on the actor mailbox. See the module's **Read consistency**
+/// section for ordering guarantees.
 ///
 /// Returns `Error(Nil)` when the presence read model is unavailable. This can
 /// occur when the presence actor is not running or when this handle is used

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -460,7 +460,7 @@ pub fn with_broadcast_interval(config: Config, interval_ms: Int) -> Config {
 
 /// Set the timeout for synchronous presence mutations, in milliseconds.
 ///
-/// This timeout applies to `track`, `untrack`, and `untrack_all`. These
+/// This timeout applies to `track`, `update`, `untrack`, and `untrack_all`. These
 /// functions panic if the actor does not reply before the timeout. The default
 /// is 5000 ms.
 pub fn with_call_timeout(config: Config, timeout_ms: Int) -> Config {
@@ -779,13 +779,16 @@ pub fn track(
 /// or `untrack` calls. Returns `Error(UnknownRef)` when `ref` is
 /// unknown, already removed, or belongs to the internal runtime.
 ///
-/// Panics if the presence actor is unavailable or does not reply within 5 seconds.
+/// Panics if the presence actor is unavailable or does not reply within the
+/// configured call timeout (5 seconds by default).
 pub fn update(
   presence: Presence,
   ref: String,
   meta: json.Json,
 ) -> Result(String, PresenceUpdateError) {
-  process.call(presence.subject, 5000, fn(reply) { Update(ref, meta, reply) })
+  process.call(presence.subject, presence.call_timeout_ms, fn(reply) {
+    Update(ref, meta, reply)
+  })
 }
 
 /// Untrack a specific presence using the ref returned by `track`.

--- a/packages/beryl/src/beryl/runtime.gleam
+++ b/packages/beryl/src/beryl/runtime.gleam
@@ -1,18 +1,19 @@
-//// Runtime actor for supervised app-side dispatch systems.
+//// Runtime actors for supervised app-side dispatch systems.
 ////
-//// One runtime actor serves every socket started through
-//// `beryl.child_spec`. It is generic over the app's `model` and `msg`
-//// types: per-socket models live in the actor state, typed `Info`
-//// messages arrive through the actor's own mailbox, and no value is ever
-//// type-erased. Transports reach the runtime through monomorphic closures
-//// captured by `beryl.child_spec`, so the frame-level transport SPI stays
-//// unparameterized.
+//// One router actor indexes every socket started through `beryl.child_spec`,
+//// and one socket actor owns each connected socket. Both roles are generic
+//// over the app's `model` and `msg` types: each model lives in its socket
+//// actor, typed `Info` messages arrive through that actor's mailbox, and no
+//// value is ever type-erased. Transports reach the actors through monomorphic
+//// closures captured by `beryl.child_spec`, so the frame-level transport SPI
+//// stays unparameterized.
 ////
-//// The runtime owns inbound decoding and validation, rate limiting,
-//// heartbeat eviction, topic subscriptions, and broadcast fan-out. It
-//// also interprets effects: each `update` returns a list of `Effect`s that
-//// are applied strictly in order within a single actor turn, so effect
-//// list order is wire order.
+//// Transports decode inbound frames before the router forwards them. Socket
+//// actors own protocol validation, rate limiting, heartbeat eviction, topic
+//// membership, and effect interpretation. The router owns the global topic
+//// index and broadcast fan-out. Each `update` returns a list of `Effect`s that
+//// its socket actor applies strictly in order, so effect list order is wire
+//// order.
 
 import beryl/internal
 import beryl/log.{type Logger}

--- a/packages/beryl/src/beryl/transport.gleam
+++ b/packages/beryl/src/beryl/transport.gleam
@@ -1,5 +1,5 @@
 //// Transport SPI: the contract between beryl core and WebSocket transport
-//// implementations such as the `beryl_mist` package.
+//// implementations such as the `beryl_mist` and `beryl_ewe` packages.
 ////
 //// `beryl/transport/server` owns the shared admission, connection, rate,
 //// decode, and telemetry pipeline. This low-level SPI keeps only the hooks a

--- a/packages/beryl/test/presence_test.gleam
+++ b/packages/beryl/test/presence_test.gleam
@@ -639,6 +639,10 @@ pub fn configured_call_timeout_is_used_test() {
     let _ = presence.track(p, "room:lobby", "user:1", "socket-1", json.null())
     Nil
   })
+  assert_crashes(fn() {
+    let _ = presence.update(p, "missing", json.null())
+    Nil
+  })
 }
 
 // ── multiple presence actors: independent, unnamed read tables ─────────────

--- a/website/src/content/docs/architecture/overview.md
+++ b/website/src/content/docs/architecture/overview.md
@@ -3,12 +3,12 @@ title: Architecture Overview
 description: How beryl is organized, the major modules, and where to make changes.
 ---
 
-beryl provides a Phoenix-compatible socket runtime on OTP actors and Erlang
-`pg`. It supports pluggable wire codecs and WebSocket transports. An app can
-pass an `init` and `update` pair to `beryl.child_spec`. It can also pass a typed
-handler table to `channel.child_spec`. The runtime dispatches decoded messages
-and applies the returned effects. Separate actors manage presence and groups.
-Only PubSub sends data across nodes.
+beryl provides a socket runtime on OTP actors and Erlang `pg`, with a built-in
+Phoenix-compatible codec. It supports pluggable wire codecs and WebSocket
+transports. An app can pass an `init` and `update` pair to `beryl.child_spec`.
+It can also pass a typed handler table to `channel.child_spec`. The runtime
+dispatches decoded messages and applies the returned effects. Separate actors
+manage presence and groups. Only PubSub sends data across nodes.
 
 ## How to read these docs
 
@@ -74,7 +74,6 @@ flowchart TB
   PR["presence (app-started)"]
   GR["groups (app-started)"]
   SA -. "async mutation" .-> PR
-  SA -. "group broadcasts" .-> GR
 ```
 
 `child_spec` supervises the router. Transport connections start the socket

--- a/website/src/content/docs/architecture/presence.md
+++ b/website/src/content/docs/architecture/presence.md
@@ -55,7 +55,7 @@ PubSub copies presence state between nodes.
 
 | Function | Description |
 |---|---|
-| `default_config(replica)` | Create a minimal config with no PubSub and no periodic broadcast |
+| `default_config(replica)` | Create a config with no PubSub and a 1500 ms interval that remains unused until PubSub is attached |
 | `with_pubsub(config, ps)` | Attach a PubSub instance for cross-node state replication |
 | `with_broadcast_interval(config, ms)` | Set how often (in ms) the actor broadcasts its CRDT state; `0` disables |
 | `with_on_diff(config, callback)` | Register a callback invoked whenever a local change or merge produces a non-empty diff |
@@ -88,8 +88,8 @@ PubSub copies presence state between nodes.
 
 ## Replication
 
-When you configure `with_pubsub` and `with_broadcast_interval`, the presence
-actor runs a broadcast loop:
+When you configure `with_pubsub`, the presence actor runs a broadcast loop at
+the configured interval, which defaults to 1500 ms:
 
 1. On each tick, the actor checks the `dirty` value. If local state changed,
    it sends `SyncPayload(v, sender, state)` to `"beryl:presence:sync"`.
@@ -100,8 +100,8 @@ actor runs a broadcast loop:
    resulting `Diff`. It calls the function for each merge, so rapid merges do
    not lose diffs.
 
-Set `broadcast_interval_ms` to `0` to disable periodic broadcasts. This is the
-default and is suitable for one-node deployments.
+Use `with_broadcast_interval(0)` to disable periodic broadcasts. Without
+PubSub, the configured interval is unused.
 
 ## Diagram
 

--- a/website/src/content/docs/architecture/presence.md
+++ b/website/src/content/docs/architecture/presence.md
@@ -103,6 +103,10 @@ the configured interval, which defaults to 1500 ms:
 Use `with_broadcast_interval(0)` to disable periodic broadcasts. Without
 PubSub, the configured interval is unused.
 
+Automated tests currently exercise replication with multiple presence actors
+on one BEAM node. [Issue #365](https://github.com/tylerbutler/beryl/issues/365)
+tracks integration coverage across separate distributed Erlang nodes.
+
 ## Diagram
 
 ```mermaid

--- a/website/src/content/docs/architecture/runtime.md
+++ b/website/src/content/docs/architecture/runtime.md
@@ -19,8 +19,9 @@ callback for one socket does not stop other sockets.
 The router manages admission, the topic subscriber index, the PubSub
 subscription, and stats. It only matches and forwards messages. It does not run
 app callbacks. Transport connection processes manage WebSocket state, frame
-limits, decoding, and the local message-rate bucket. The next event uses the
-model returned by `update`.
+limits, and decoding. Each socket actor owns its decoded-message, join, and
+per-channel rate-limit buckets. The next event uses the model returned by
+`update`.
 
 ## What it tracks
 

--- a/website/src/content/docs/choosing-an-api.md
+++ b/website/src/content/docs/choosing-an-api.md
@@ -9,12 +9,13 @@ beryl has one runtime and two ways to program it.
   pattern. Each channel keeps private state and a server-side message type. The
   layer routes each event to the correct channel. **Use this API by default.**
 - **Raw app-side dispatch** (`beryl`): Define one `init` and `update` pair for
-  each socket. Match `socket.Input` values and return ordered effects. The
-  channel layer uses this public core API.
+  the socket system. Beryl runs them separately for each connected socket.
+  Match `socket.Input` values and return ordered effects. The channel layer
+  uses this public core API.
 
 Both APIs use the same runtime, wire codec, presence, PubSub, and abuse
-controls. They have the same wire-level features and performance. The main
-difference is who writes the router.
+controls. They have the same wire-level features. The main difference is who
+writes topic dispatch.
 
 ## Pick in one line
 

--- a/website/src/content/docs/examples.mdx
+++ b/website/src/content/docs/examples.mdx
@@ -5,10 +5,11 @@ description: Four runnable beryl examples, including the channel showcase.
 
 import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
 
-beryl includes four runnable example applications in the
+This page highlights four runnable applications in the
 [`examples/`](https://github.com/tylerbutler/beryl/tree/main/examples)
-directory. Each example uses a Gleam/BEAM backend and a browser frontend. The
-examples show different real-time collaboration patterns.
+directory. The repository also contains the live-poll tutorial, load-test
+server, and shared example helpers. Each featured application uses a
+Gleam/BEAM backend and a browser frontend.
 
 The installed package does not include the examples. Clone the repository:
 
@@ -42,8 +43,8 @@ gleam run
 |---|---|
 | **Channel composition** | One `channel.child_spec` handler table owns `cursor:*`, `room:*`, and the `document:` prefix |
 | **Per-channel state** | Each joined topic keeps its own private state; the layer prunes it on close |
-| **Lifecycle actions** | Join and termination callbacks lower ordered actions without leaving the runtime turn |
-| **Per-pattern rate limits** | `with_topic_rate` gives cursors, chat, and docs different limits |
+| **Lifecycle actions** | Join and termination callbacks return ordered action lists for the runtime to apply |
+| **Per-pattern rate limits** | `with_topic_rate` gives cursor traffic a higher limit than chat and document traffic |
 | **Shared presence** | One ETS-backed session-presence tracker serves cursors and chat, publishing snapshots asynchronously |
 | **Single WebSocket endpoint** | Every embedded app shares `/socket/websocket` |
 
@@ -174,7 +175,7 @@ cd examples/collab_docs && gleam run
 
 | beryl feature | How it's used |
 |---|---|
-| **Segment-shaped topics** | `document:*:*` topics isolate each tenant/document pair; the app validates the shape on join |
+| **Segment-shaped topics** | The `document:*` handler claims the prefix, then validates each `document:<tenant>:<document>` topic on join |
 | **Client-side CRDT merge** | Browser state uses `lattice_core`, `lattice_maps`, and `lattice_registers` with `ORMap(MVRegister(String))` document blocks |
 | **Unordered realtime transport** | Beryl broadcasts document updates while the CRDT handles merge convergence |
 | **Late joiner cache** | Server returns cached merged state in the join reply for new clients |

--- a/website/src/content/docs/guides/authentication.md
+++ b/website/src/content/docs/guides/authentication.md
@@ -109,9 +109,11 @@ Return `Error(server.ConnectRejected)` to send HTTP 403 before the upgrade.
 The app does not receive an unauthenticated connection.
 
 `Ok(metadata)` accepts the connection and hands that list to the app. This is
-how the verified identity crosses the handshake boundary: `on_connect` is the
-only place that sees the token, and everything downstream sees claims. Return
-`Ok([])` to accept a connection with no metadata.
+how the verified identity crosses the handshake boundary. Verify the token in
+`on_connect`, then use claims metadata downstream. `init` still receives the
+original request headers and query through `ConnectInfo.seed`, so do not assume
+the raw token was removed. Return `Ok([])` to accept a connection with no
+metadata.
 
 ## 4. Decode claims into the model in `init`
 
@@ -154,10 +156,10 @@ fn decode_roles(metadata: List(#(String, String))) -> List(String) {
 ```
 
 Signature and expiry checks stay in `on_connect`, where they run once per
-socket. `init` only reads pairs beryl already delivered, so a wrong or expired
-token can never reach it. The `Anonymous` branch covers a socket that connected
-without `on_connect` configured; correct wiring makes it unreachable, and it
-rejects every join.
+socket. This `init` reads only verified metadata, so a wrong or expired token
+cannot produce an authenticated model. The `Anonymous` branch covers a socket
+that connected without `on_connect` configured; correct wiring makes it
+unreachable, and it rejects every join.
 
 The seed's `headers` and `query` remain available to `init`, for request data
 that authentication does not produce — a locale, a client version, a room

--- a/website/src/content/docs/guides/coming-from-phoenix.md
+++ b/website/src/content/docs/guides/coming-from-phoenix.md
@@ -3,10 +3,11 @@ title: Coming from Phoenix
 description: Compare Phoenix Channels modules, callbacks, assigns, and Presence with both beryl APIs.
 ---
 
-beryl speaks the same wire protocol as Phoenix Channels (`phx_join`, refs,
-heartbeats, `presence_state`/`presence_diff`), so Phoenix client libraries
-work without changes. The server programming model is different. This page
-compares the two systems.
+When configured with `wire.phoenix_codec()`, beryl speaks the same wire
+protocol as Phoenix Channels (`phx_join`, refs, heartbeats,
+`presence_state`/`presence_diff`), so Phoenix client libraries work without
+changes. The server programming model is different. This page compares the
+two systems.
 
 beryl gives you two layers, and Phoenix maps onto both:
 
@@ -19,7 +20,8 @@ beryl gives you two layers, and Phoenix maps onto both:
 
 [Choose an API](/choosing-an-api/) compares both APIs. Both support
 colon-delimited topics, wildcard patterns, CRDT presence, `pg` PubSub,
-heartbeats, and the Phoenix JSON array format.
+and heartbeats. Both use the Phoenix JSON array format when configured with
+`wire.phoenix_codec()`.
 
 ## The core difference: processes and state
 

--- a/website/src/content/docs/guides/coming-from-phoenix.md
+++ b/website/src/content/docs/guides/coming-from-phoenix.md
@@ -38,14 +38,22 @@ dispatch has no handler table: one `update` receives every event for the socket
 as `socket.Input(msg)`, and one `model` stores its state. Different socket
 actors run concurrently.
 
-For both beryl APIs:
+This gives beryl a coarser isolation boundary than Phoenix. Different sockets
+have separate actors, but channels on one socket share an actor mailbox,
+execution context, and lifecycle. A slow callback delays every topic on that
+socket. A fault in the socket actor closes all its topics.
 
-- **Run long or blocking work in another process.** A slow callback delays the
-  socket. Return results with `channel.notify` or `socket.notify`.
-- **Crash scope depends on the callback.** A join panic rejects that join; a
-  message panic closes that topic; an `on_info` panic ends the socket; and a
-  terminate panic loses that callback's actions while core teardown continues.
-  See [crash behavior](/guides/channels/#crash-behavior).
+Beryl rescues expected callback crashes with narrower behavior: a join panic
+rejects that join, a message panic closes that topic, an `on_info` panic ends
+the socket, and a terminate panic loses that callback's actions while teardown
+continues. These rescue boundaries limit known callback failures, but they do
+not provide Phoenix's process isolation between joined topics. See
+[crash behavior](/guides/channels/#crash-behavior). Run long or blocking work
+in another process and return results with `channel.notify` or
+`socket.notify`.
+
+[Issue #337](https://github.com/tylerbutler/beryl/issues/337) tracks a
+Phoenix-style process-per-channel prototype.
 
 ## Concept map
 

--- a/website/src/content/docs/guides/coming-from-phoenix.md
+++ b/website/src/content/docs/guides/coming-from-phoenix.md
@@ -14,7 +14,8 @@ beryl gives you two layers, and Phoenix maps onto both:
   recommended default for a Phoenix style app. Register one handler for each
   topic pattern. Each channel has callbacks and private state.
 - **`beryl`, raw app-side dispatch:** This is the core API. Define one `init`
-  and `update` pair for each socket. Your code owns the router.
+  and `update` pair for the socket system. Beryl runs them separately for each
+  connected socket. Your `update` function owns topic dispatch.
 
 [Choose an API](/choosing-an-api/) compares both APIs. Both support
 colon-delimited topics, wildcard patterns, CRDT presence, `pg` PubSub,
@@ -29,14 +30,15 @@ joined topic**. It calls `join`, `handle_in`, `handle_info`, and `terminate`.
 Each callback receives channel state in `socket.assigns`, which is a map of
 atoms to untyped terms.
 
-beryl keeps the routing table but does not start one process for each topic.
-With the channel layer, define handlers, callbacks, and per-topic state. All
-channels on one socket run in sequence in that socket's actor. Each channel state
-is a **value of your type**, not an assigns map. Raw dispatch has no routing
-table. One `update` receives each socket event as `socket.Input(msg)`. One
-`model` stores the per-socket state.
+beryl starts **one socket actor for each connected socket**, not one process
+for each joined topic. A separate router actor maintains the socket and topic
+indexes. With the channel layer, all channels on one socket run in sequence in
+that socket's actor. Each channel has a private state value of your type. Raw
+dispatch has no handler table: one `update` receives every event for the socket
+as `socket.Input(msg)`, and one `model` stores its state. Different socket
+actors run concurrently.
 
-Both APIs have these effects:
+For both beryl APIs:
 
 - **Run long or blocking work in another process.** A slow callback delays the
   socket. Return results with `channel.notify` or `socket.notify`.
@@ -52,7 +54,7 @@ Both APIs have these effects:
 | `socket "/socket", UserSocket` in the Endpoint | `beryl_mist` / `beryl_ewe` mounted on your HTTP server | same |
 | `UserSocket.connect(params, socket)` | transport `on_connect`; request data reaches `join` as `context.seed` | `init(info)` — request data in `info.seed` |
 | `channel "room:*", RoomChannel` routing table | the handler list passed to `channel.child_spec` | topic pattern match in `update`, with `beryl/topic` helpers |
-| One channel process per joined topic | one private state value per joined topic, in the socket actor | one `model` per socket, covering all its topics |
+| One channel process per joined topic | one socket actor per connection, with one private state value per joined topic | one socket actor and one `model` per connection, covering all its topics |
 | `socket.assigns` + `assign/3` | the channel's own `state` type, returned from each callback | your `model`, returned from each `update` |
 | `join/3` callback | the handler's `join` callback | `socket.Join(topic, payload, ref)` |
 | `{:ok, socket}` / `{:ok, reply, socket}` | `channel.accept(state)` / `accept(..) |> channel.with_reply(reply)` | `socket.AcceptJoin(ref, None)` / `socket.AcceptJoin(ref, Some(reply))` |

--- a/website/src/content/docs/guides/error-handling.md
+++ b/website/src/content/docs/guides/error-handling.md
@@ -71,9 +71,10 @@ The client never receives a WebSocket handshake and cannot send any messages.
 
 ## Malformed wire messages
 
-beryl parses incoming Phoenix protocol arrays:
-`[join_ref, ref, topic, event, payload]`. It drops frames that it cannot decode
-and does not send an error. Malformed frames are protocol violations.
+When configured with `wire.phoenix_codec()`, beryl parses Phoenix protocol
+arrays: `[join_ref, ref, topic, event, payload]`. With any codec, it drops
+frames that the active codec cannot decode and does not send an error.
+Malformed frames are protocol violations.
 
 If you need to surface decode errors in your own payload handling, decode the `Dynamic` payload with `gleam/dynamic/decode` and return an explicit `ReplyOk` or `ReplyError`:
 
@@ -260,25 +261,26 @@ If delivery confirmation is important, have the `Info` arm of `update` acknowled
 
 ## Client-visible error shapes
 
-beryl uses the Phoenix wire protocol. Error responses take these shapes:
+With `wire.phoenix_codec()`, error responses take these shapes:
 
 **Join rejected:**
 ```json
 ["1", "1", "room:lobby", "phx_reply", {"status": "error", "response": {}}]
 ```
 
-**Channel error push (server-initiated):**
+**Channel error:**
 ```json
-[null, null, "room:lobby", "phx_error", {}]
+["1", "1", "room:lobby", "phx_error", {}]
 ```
 
 **Channel closed:**
 ```json
-[null, null, "room:lobby", "phx_close", {}]
+["1", "1", "room:lobby", "phx_close", {}]
 ```
 
-Phoenix client libraries handle `phx_error` and `phx_close`. The client marks
-the channel as errored or closed and can try to rejoin.
+Terminal events repeat the topic's join ref in both reference slots. Phoenix
+client libraries handle `phx_error` and `phx_close`. The client marks the
+channel as errored or closed and can try to rejoin.
 
 ## See also
 

--- a/website/src/content/docs/guides/groups.md
+++ b/website/src/content/docs/guides/groups.md
@@ -42,8 +42,9 @@ let assert Ok(_root) =
 ```
 
 `create`, `delete`, `add`, `remove`, `topics`, and `list_groups` panic if the
-actor is unavailable or does not reply within this timeout. `broadcast` is
-fire-and-forget and does not use it.
+actor is unavailable or does not reply within this timeout. `broadcast` first
+performs the same synchronous topic lookup, then sends each topic broadcast
+without waiting for delivery.
 
 ## Creating and deleting groups
 
@@ -177,8 +178,8 @@ clears them.
 
 The registered name is node-local. Keep a `Groups` handle on the node where its
 child specification runs. From another BEAM node, synchronous operations cannot
-reach the owning actor and panic as unavailable, while fire-and-forget
-`broadcast` calls are not delivered. Group definitions and memberships are not
+reach the owning actor and panic as unavailable. `broadcast` also panics during
+its synchronous topic lookup. Group definitions and memberships are not
 replicated between nodes.
 
 See the [Supervision guide](/guides/supervision) for the overall startup pattern.

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -42,8 +42,8 @@ let assert Ok(_root) =
   |> static_supervisor.start()
 ```
 
-Synchronous presence mutations wait up to 5 seconds for the actor by default.
-Use `with_call_timeout` to configure the timeout:
+`track`, `untrack`, and `untrack_all` wait up to 5 seconds for the actor by
+default. Use `with_call_timeout` to configure their timeout:
 
 ```gleam
 let config =
@@ -58,7 +58,8 @@ let assert Ok(_root) =
 
 `track`, `untrack`, and `untrack_all` panic if the actor is unavailable or does
 not reply within this timeout. Presence reads bypass the actor mailbox and do
-not use it.
+not use it. `update` is also synchronous, but it always uses a fixed 5-second
+timeout.
 
 ## Tracking presences
 
@@ -120,15 +121,16 @@ identifies the logical session, not a BEAM process.
 
 ```gleam
 // Get all presences in a topic
-let entries = presence.list(p, "room:lobby")
+let assert Ok(entries) = presence.list(p, "room:lobby")
 // Returns: [PresenceEntry(session_id: "socket_1", key: "user:alice", meta: ...)]
 
 // Get presences for a specific key
-let alice_sessions = presence.get_by_key(p, "room:lobby", "user:alice")
+let assert Ok(alice_sessions) =
+  presence.get_by_key(p, "room:lobby", "user:alice")
 // Returns: [#("socket_1", meta), #("socket_2", meta)]
 
 // Count without materializing the entry list
-let online_count = presence.count(p, "room:lobby")
+let assert Ok(online_count) = presence.count(p, "room:lobby")
 ```
 
 `list`, `get_by_key`, and `count` read an actor-owned ETS snapshot rather than

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -42,8 +42,8 @@ let assert Ok(_root) =
   |> static_supervisor.start()
 ```
 
-`track`, `untrack`, and `untrack_all` wait up to 5 seconds for the actor by
-default. Use `with_call_timeout` to configure their timeout:
+Presence mutations wait up to 5 seconds for the actor by default. Use
+`with_call_timeout` to configure their timeout:
 
 ```gleam
 let config =
@@ -56,10 +56,9 @@ let assert Ok(_root) =
   |> static_supervisor.start()
 ```
 
-`track`, `untrack`, and `untrack_all` panic if the actor is unavailable or does
-not reply within this timeout. Presence reads bypass the actor mailbox and do
-not use it. `update` is also synchronous, but it always uses a fixed 5-second
-timeout.
+`track`, `update`, `untrack`, and `untrack_all` panic if the actor is
+unavailable or does not reply within this timeout. Presence reads bypass the
+actor mailbox and do not use it.
 
 ## Tracking presences
 

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -136,6 +136,11 @@ Erlang distribution between the nodes, `pg` merges their process groups and
 sends messages to subscribers across the cluster. Beryl PubSub needs no
 additional configuration, but it does not connect the nodes for you.
 
+Automated tests currently exercise distributed behavior with multiple actors
+on one BEAM node. [Issue #365](https://github.com/tylerbutler/beryl/issues/365)
+tracks integration coverage across separate distributed Erlang nodes for
+PubSub delivery and presence convergence.
+
 ## Integration with beryl channels
 
 The channel system uses PubSub internally for distributed broadcasts when configured:

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -131,9 +131,10 @@ let count = pubsub.subscriber_count(ps, "room:lobby")
 
 ## Distributed operation
 
-Erlang `pg` works across connected nodes. When nodes join a cluster, `pg`
-merges their process groups. It then sends messages to subscribers on all
-nodes. PubSub needs no extra cluster configuration.
+Erlang `pg` works across connected nodes. After your application establishes
+Erlang distribution between the nodes, `pg` merges their process groups and
+sends messages to subscribers across the cluster. Beryl PubSub needs no
+additional configuration, but it does not connect the nodes for you.
 
 ## Integration with beryl channels
 

--- a/website/src/content/docs/guides/websocket.md
+++ b/website/src/content/docs/guides/websocket.md
@@ -221,7 +221,9 @@ Server replies:
 
 1. Client connects via WebSocket to the configured path
 2. `on_connect` callback runs (if configured) — reject returns 403
-3. Transport generates a unique socket ID, builds the `ConnectSeed`, and announces the socket to the runtime, which calls your `init`
+3. The transport connection process builds the `ConnectSeed`, generates a
+   unique socket ID, and starts a socket actor. The router admits and monitors
+   that actor, which runs your `init`.
 4. Client sends `phx_join` messages to subscribe to topics — each arrives at `update` as a `Join` event
 5. Messages are routed through the runtime to `update` as `Message` events
 6. On disconnect, `update` receives a `Closed` event for every joined topic

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -241,7 +241,7 @@ import { Aside } from '@astrojs/starlight/components';
 	</article>
 	<article class="beryl-feature">
 		<h3>Phoenix-compatible wire</h3>
-		<p>Use Phoenix client libraries with beryl's JSON array format. Mist provides WebSocket support. Phoenix users can <a href="/guides/coming-from-phoenix/">compare the concepts</a>.</p>
+		<p>Configure beryl's Phoenix codec to use Phoenix client libraries and JSON array framing. Mist and Ewe provide WebSocket transports. Phoenix users can <a href="/guides/coming-from-phoenix/">compare the concepts</a>.</p>
 		<a class="beryl-feature__link" href="/guides/websocket/">WebSocket guide →</a>
 	</article>
 </div>

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -25,7 +25,7 @@ indicators. beryl provides:
 - **Presence:** Track connected users across nodes with a conflict-free CRDT.
 - **PubSub:** Publish and subscribe across nodes with Erlang `pg` process groups.
 - **Groups:** Put topics in named groups for multi-topic broadcasts.
-- **WebSocket transport:** Use Mist with the Phoenix-compatible JSON protocol.
+- **WebSocket transport:** Use Mist or Ewe with a pluggable wire codec.
 
 ## Two layers, one runtime
 
@@ -122,10 +122,11 @@ database.
 
 ### Phoenix wire protocol compatibility
 
-beryl uses the Phoenix Channels JSON array format:
-`[join_ref, ref, topic, event, payload]`. Existing Phoenix client libraries can
-use this format. The [Coming from Phoenix](/guides/coming-from-phoenix/) guide
-compares Phoenix modules, callbacks, and assigns with both beryl APIs.
+The built-in `wire.phoenix_codec()` uses the Phoenix Channels JSON array
+format: `[join_ref, ref, topic, event, payload]`. Existing Phoenix client
+libraries can use this format. The
+[Coming from Phoenix](/guides/coming-from-phoenix/) guide compares Phoenix
+modules, callbacks, and assigns with both beryl APIs.
 
 ## Next steps
 

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -102,8 +102,10 @@ fn update(model: Model, ev: socket.Input(Nil)) -> socket.Next(Model) {
 
 ### Built on OTP
 
-An OTP actor runs each `beryl.Sockets` handle. A separate OTP actor manages the
-presence CRDT. PubSub uses Erlang `pg`.
+Each `beryl.Sockets` handle identifies one router actor and one actor for each
+connected socket. The socket actor owns that socket's model and runs its
+callbacks, while the router maintains the socket and topic indexes. A separate
+OTP actor manages the presence CRDT. PubSub uses Erlang `pg`.
 
 ### CRDT-backed presence
 

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -330,7 +330,8 @@ Replace the meta of a presence created by `track`.
  or `untrack` calls. Returns `Error(UnknownRef)` when `ref` is
  unknown, already removed, or belongs to the internal runtime.
 
- Panics if the presence actor is unavailable or does not reply within 5 seconds.
+ Panics if the presence actor is unavailable or does not reply within the
+ configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn update(
@@ -357,7 +358,7 @@ pub fn with_broadcast_interval(
 
 Set the timeout for synchronous presence mutations, in milliseconds.
 
- This timeout applies to `track`, `untrack`, and `untrack_all`. These
+ This timeout applies to `track`, `update`, `untrack`, and `untrack_all`. These
  functions panic if the actor does not reply before the timeout. The default
  is 5000 ms.
 

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -13,12 +13,26 @@ Presence - Distributed presence tracking backed by a CRDT
 
  Wraps the pure `lattice_presence/presence_state` CRDT in an OTP actor that:
  - Handles track/update/untrack calls
+ - Publishes an actor-owned ETS read model
  - Periodically broadcasts state via PubSub for cross-node replication
  - Receives remote state from PubSub and merges it internally
  - Invokes `on_diff` callback when merges produce non-empty diffs
 
  Presence is independent of the Beryl runtime and runs under your
  application's supervision tree.
+
+ ## Read consistency
+
+ The presence actor is the only writer to a protected ETS read model.
+ It atomically replaces each topic's snapshot after completing a mutation,
+ merge, or prune. Synchronous mutations publish before replying, and
+ runtime mutations acknowledge only after publishing, so a later read
+ observes the completed mutation without waiting on the actor mailbox.
+
+ A read concurrent with a queued or in-progress mutation can observe the
+ previous or new complete snapshot. Reads of separate topics do not form
+ one atomic view. If the actor stops, it also destroys the table, and reads
+ return `Error(Nil)` instead of stale data.
 
  ## Example
 
@@ -150,7 +164,8 @@ Count presences in a topic.
 
  This function reads the actor-owned read model directly. The read model is
  an ETS snapshot created after each mutation, merge, or prune. This function
- does not wait on the actor mailbox.
+ does not wait on the actor mailbox. See the module's **Read consistency**
+ section for ordering guarantees.
 
  Returns `Error(Nil)` when the presence read model is unavailable. This can
  occur when the presence actor is not running or when this handle is used
@@ -227,7 +242,8 @@ Get presences for a specific key within a topic.
 
  This function reads the actor-owned read model directly. The read model is
  an ETS snapshot created after each mutation, merge, or prune. This function
- does not wait on the actor mailbox.
+ does not wait on the actor mailbox. See the module's **Read consistency**
+ section for ordering guarantees.
 
  Returns `Error(Nil)` when the presence read model is unavailable. This can
  occur when the presence actor is not running or when this handle is used
@@ -248,7 +264,8 @@ List all presences for a topic.
 
  This function reads the actor-owned read model directly. The read model is
  an ETS snapshot created after each mutation, merge, or prune. This function
- does not wait on the actor mailbox.
+ does not wait on the actor mailbox. See the module's **Read consistency**
+ section for ordering guarantees.
 
  Returns `Error(Nil)` when the presence read model is unavailable. This can
  occur when the presence actor is not running or when this handle is used

--- a/website/src/content/docs/reference/api/beryl-transport.md
+++ b/website/src/content/docs/reference/api/beryl-transport.md
@@ -10,7 +10,7 @@ description: "Transport SPI: the contract between beryl core and WebSocket trans
 -->
 
 Transport SPI: the contract between beryl core and WebSocket transport
- implementations such as the `beryl_mist` package.
+ implementations such as the `beryl_mist` and `beryl_ewe` packages.
 
  `beryl/transport/server` owns the shared admission, connection, rate,
  decode, and telemetry pipeline. This low-level SPI keeps only the hooks a

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -63,7 +63,7 @@ Beryl - Type-safe real-time communication
      |> static_supervisor.start()
 
    // Broadcast to all subscribers of a topic
-   beryl.broadcast(sockets, "room:lobby", "announce", payload)
+   beryl.broadcast(sockets, "room:lobby", "announce", json.object([]))
  }
  ```
 

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -575,7 +575,7 @@ pub fn with_max_event_length(
 
 Configure the maximum allowed inbound WebSocket frame size in bytes.
 
- Beryl enforces the limit **post-assembly**. The transport (Mist/gramps)
+ Beryl enforces the limit **post-assembly**. The transport (Mist or Ewe)
  buffers and assembles a complete frame first. Beryl then measures it and
  closes the connection if it exceeds `max_bytes`. This bounds
  per-message processing cost (decode, routing, rate-limit accounting), but

--- a/website/src/content/docs/reference/index.md
+++ b/website/src/content/docs/reference/index.md
@@ -31,10 +31,15 @@ reference, and client compatibility notes.
 | `beryl/topic` | Topic parsing, wildcard matching, segment extraction | Dynamic routing, multi-tenant patterns |
 | `beryl/pubsub` | Distributed PubSub backed by Erlang `pg`, with typed subscribers and topic joins/leaves | Multi-node fan-out, cluster broadcasts, custom background consumers |
 | `beryl/presence` | OTP actor wrapping the presence CRDT, plus opaque `Diff` accessors | Tracking who is online |
+| `beryl/presence/wire` | Phoenix-compatible presence state and diff encoders | Sending presence payloads to Phoenix clients |
 | `beryl/group` | Named sets of topics for bulk broadcast | Rooms with multiple sub-topics |
+| `beryl/error` | Shared opaque error helpers | Handling Beryl-owned startup errors |
+| `beryl/stats` | Local runtime snapshots | Reporting connected sockets, memberships, and active topics |
 | `beryl/wire` | Phoenix-compatible codec and Dynamic→JSON helpers | Phoenix clients, payload relays, protocol debugging |
 | `beryl/wire/codec` | Pluggable codec contract for text and binary frames | Custom wire formats |
 | `beryl/transport` | Transport SPI: socket lifecycle, inbound routing, and edge rate limiting | Writing a custom transport package |
+| `beryl/transport/origin` | Origin and Phoenix version checks | Validating WebSocket upgrades |
+| `beryl/transport/server` | Server-agnostic connection and frame pipeline | Implementing a WebSocket transport |
 | `beryl_mist` | Mist WebSocket upgrade and request handler integration (separate `beryl_mist` package) | Wiring beryl to a Mist HTTP server |
 | `beryl_ewe` | Ewe WebSocket transport integration (separate `beryl_ewe` package) | Wiring beryl to an Ewe HTTP server |
 
@@ -63,8 +68,8 @@ the same core effects.
 
 ## Phoenix wire protocol reference
 
-beryl uses the Phoenix Channels JSON array format. Each frame has five
-elements:
+With `wire.phoenix_codec()`, beryl uses the Phoenix Channels JSON array format.
+Each frame has five elements:
 
 ```
 [join_ref, ref, topic, event, payload]
@@ -165,6 +170,9 @@ beryl follows [Semantic Versioning](https://semver.org/) but is **not yet 1.0**.
 - **Patch version bumps** (`0.x.y → 0.x.y+1`) fix bugs without intentional breakage.
 - Public API is defined as the exports of the modules listed in the module map
   above, including `beryl/channel`.
-- The internal modules `beryl/connection_limit`, `beryl/internal`, `beryl/log`, `beryl/rate_limit`, and `beryl/runtime` are intentionally hidden from downstream packages. Transports integrate through the public `beryl/transport` SPI; `beryl_mist` is the supported Mist WebSocket transport.
+- The internal modules `beryl/app_supervisor`, `beryl/connection_limit`,
+  `beryl/internal`, `beryl/log`, `beryl/rate_limit`, `beryl/runtime`, and
+  `beryl/telemetry` are intentionally hidden from downstream packages.
+  Transports integrate through the public `beryl/transport` SPI.
 
 Check [GitHub releases](https://github.com/tylerbutler/beryl/releases) before upgrading to a new minor version.

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -12,9 +12,8 @@ message arrives.
 
 **Checks:**
 
-1. **Check that Mist is listening.** Confirm that the HTTP server started
-   without an error. `mist.serve` and `mist.serve_ssl` return a `Result`.
-   Handle the `Error` case.
+1. **Check that Mist is listening.** Confirm that `mist.start` returned
+   `Ok(_)`. Handle the `Error` case.
 
 2. **Path mismatch.** The Phoenix JS client appends `/websocket` to the socket path you pass:
    ```js
@@ -155,7 +154,7 @@ receive the event.
 **Checks:**
 
 1. **Check the exact topic string.**
-   `beryl.broadcast("room:lobby", ...)` sends only to sockets on
+   `beryl.broadcast(sockets, "room:lobby", ...)` sends only to sockets on
    `"room:lobby"`. Wildcard patterns route incoming messages. They do not
    select broadcast targets.
 
@@ -189,11 +188,11 @@ recent joins or leaves.
    The runtime applies presence effects asynchronously. Do not call the
    synchronous public presence API inside `init` or `update`.
 
-2. **Cross-node sync.** If running multiple nodes, each node must be configured with the same PubSub instance and each presence actor needs a unique replica ID. The CRDT merges state over PubSub; without PubSub, nodes have independent state.
+2. **Cross-node sync.** If running multiple nodes, each node must use the same
+   PubSub scope and each presence actor needs a unique replica ID. The CRDT
+   merges state over PubSub; without PubSub, nodes have independent state.
 
 3. **`on_diff` not broadcasting.** If clients rely on receiving `presence_diff` events, confirm `on_diff` is configured and calls `beryl.broadcast_presence_diff`. See the [Presence guide](/guides/presence).
-
-4. **CRDT compaction.** The CRDT can accumulate causal history. Call `presence.compact` (on the state layer) if memory usage grows unexpectedly over a long uptime.
 
 ---
 
@@ -220,7 +219,10 @@ recent joins or leaves.
 
 **Checks:**
 
-1. **Client heartbeat interval vs. server timeout.** The Phoenix JS client sends heartbeats every 30 s by default. The beryl default server timeout is 60 s, which gives a safe margin. If you've lowered `heartbeat_timeout_ms`, ensure the client interval is at least half the server timeout.
+1. **Client heartbeat interval vs. server timeout.** The Phoenix JS client
+   sends heartbeats every 30 s by default. The beryl default server timeout is
+   60 s, which gives a safe margin. If you lower `heartbeat_timeout_ms`, keep
+   the client interval at or below half the server timeout.
 
 2. **Load balancer idle timeout.** Some load balancers (AWS ALB, nginx) have their own WebSocket idle timeouts. Set the load balancer timeout to be longer than the client heartbeat interval, or configure load-balancer-level keepalives.
 
@@ -235,7 +237,9 @@ between nodes.
 
 **Checks:**
 
-1. **Nodes are clustered.** beryl PubSub uses Erlang `pg`, which requires Erlang distribution. Confirm nodes can reach each other: `Node.list()` in the Erlang shell should return connected nodes.
+1. **Nodes are clustered.** beryl PubSub uses Erlang `pg`, which requires
+   Erlang distribution. Confirm nodes can reach each other: `nodes().` in the
+   Erlang shell should return connected nodes.
 
 2. **Same pg scope.** All nodes must use the same `pg` scope name. `pubsub.default_config()` uses the default scope. If you customized it, make sure all nodes use the same value.
 
@@ -292,11 +296,11 @@ This prevents proxy idle disconnects.
    After 3 restarts in 5 seconds, the supervisor stops and sends the failure to
    the process that called `child_spec`. Check the logs for the first crash.
 
-2. **Check for an app panic.** The runtime catches crashes in `init` and
-   `update` and limits them to one socket or topic. They do not stop the
-   runtime. A runtime stop indicates a crash outside those paths. Check
-   indirect callbacks, such as presence `on_diff`, for `let assert`.
+2. **Check the failure scope.** Beryl catches crashes in `init` and `update`
+   and limits them to one socket or topic. A fault elsewhere in a socket actor
+   closes only that socket. If every connection closes, inspect the router and
+   supervisor logs for the first fault.
 
 3. **Rejoin after a restart.** A restarted runtime has no socket state.
-   Connected clients see their topics close or stop receiving replies. The
-   Phoenix JS client reconnects and rejoins.
+   Transports close their connections when the router dies. The Phoenix JS
+   client reconnects and rejoins after the replacement router starts.

--- a/website/src/content/docs/tutorial/composition-raw-dispatch-and-channels.md
+++ b/website/src/content/docs/tutorial/composition-raw-dispatch-and-channels.md
@@ -97,6 +97,10 @@ The poll handler matches a topic pattern and receives a
 `channel.JoinContext`:
 
 ```gleam
+pub type PollInfo {
+  ClosePoll
+}
+
 fn poll_channel(
   polls: store.Store,
   clock: timer.Timer,
@@ -109,7 +113,7 @@ fn poll_channel(
     }
     store.join(polls, room)
     timer.after(clock, duration_ms, fn() {
-      channel.notify(context.self, ClosePoll(room))
+      channel.notify(context.self, ClosePoll)
     })
 
     channel.accept(room)
@@ -117,7 +121,7 @@ fn poll_channel(
       handle_message(polls, room, message)
     })
     |> channel.on_info(fn(room, message) {
-      let ClosePoll(_topic) = message
+      let ClosePoll = message
       case store.close(polls, room) {
         store.ClosedNow(state) ->
           channel.next(room, [


### PR DESCRIPTION
## Summary

- review all 54 website pages and align factual claims with the current implementation
- document the router and per-socket actor topology, including its coarser isolation boundary compared with Phoenix
- link the Phoenix comparison to the per-channel actor prototype tracked in #337
- fix `presence.update` to honor `with_call_timeout` and add regression coverage
- correct presence defaults, group broadcast semantics, PubSub clustering, Phoenix frame examples, authentication lifetime, heartbeat guidance, and example inventory
- update the public module map and regenerate API references from corrected source comments