### PR TITLE
docs(tutorial): simplify all chapters to 200 level

### DIFF
--- a/website/src/content/docs/tutorial/composition-raw-dispatch-and-channels.md
+++ b/website/src/content/docs/tutorial/composition-raw-dispatch-and-channels.md
@@ -1,36 +1,35 @@
 ---
 title: "Composition: Raw Dispatch and beryl/channel"
-description: Refactor a socket-wide update function into heterogeneous channel handlers with private state and typed messages.
+description: Move from one socket-wide update function to channel handlers that each keep their own state and message type.
 ---
 
-Elm and Lustre applications compose child logic by making the parent own the
-combined model and message space. The parent stores the child models and adds
-each child message type to a union. It maps child messages into that union and
-routes them to the correct update function.
+In Elm and Lustre, a parent component owns its children. The parent model
+stores each child model. The parent message type has one variant for each child
+message type. The parent update function looks at the message and sends it to
+the correct child.
 
-Raw Beryl supports the same pattern. It is type-safe and gives one update
-complete control across every topic on a socket. Its cost grows with the
-number of unrelated topic families. `beryl/channel` moves that recurring
-router into a public layer while keeping the same core runtime.
+Raw Beryl works the same way. One update function sees every topic on a socket.
+This is type-safe, and it gives you full control. But the work grows with each
+new topic family you add. `beryl/channel` does that routing for you. It runs on
+the same core runtime.
 
-## Raw composition is a parent router
+## Raw dispatch: your update function is the router
 
-Imagine a socket serving polls, document cursors, and account alerts. In raw
-dispatch, the app-defined `Model` must represent all three concerns. The
-app-defined `Message` must include each server-side message. The update function
-then routes:
+Imagine one socket that serves polls, document cursors, and account alerts. In
+raw dispatch, your `Model` must hold state for all three. Your `Message` type
+must include every server-side message for all three. Your update function must
+then route each input:
 
 - `Join` by topic pattern;
-- `Message` and `Binary` by topic and event;
-- `Closed` to the correct cleanup branch;
-- `Info` by the app's message union.
+- `Message` and `Binary` by topic and event name;
+- `Closed` to the correct cleanup code;
+- `Info` by your own message type.
 
-This is the server-side equivalent of a Lustre parent model and parent
-`Message` union. The application performs the mapping rather than a DOM event
-constructor. It works well when one topic family dominates or when behavior
-must coordinate across topics in one ordered effect list.
+This is the same job a Lustre parent does. Here, your code does the mapping
+instead of a DOM event. This works well when one topic family does most of the
+work. It also works well when one effect list must coordinate several topics.
 
-The live-poll example already shows the beginnings of that cost:
+The live-poll example already shows the start of this cost:
 
 ```gleam
 pub type Stage {
@@ -50,17 +49,17 @@ pub type Model {
 
 This excerpt comes from
 [`raw.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/live_poll/src/live_poll/raw.gleam).
-Adding a second unrelated guide topic would widen `Message`, add state or routing
-metadata to `Model`, and add more branches to the same update.
+Add a second, unrelated `guide` topic and three things grow. `Message` gets
+more variants. `Model` gets more fields. The update function gets more
+branches.
 
-That is not a type-safety defect. It is the explicit price of making the app
-own the complete socket router.
+This is not a type-safety problem. It is the price you pay when your app owns
+the full socket router.
 
-## The channel layer supplies the router
+## The channel layer is the router
 
-`beryl/channel` is the recommended default for multi-channel and
-Phoenix-shaped applications. The example's fourth checkpoint starts it
-with:
+For apps with many topic families, or apps shaped like Phoenix Channels, use
+`beryl/channel`. Step 4 of the example starts it like this:
 
 ```gleam
 let assert Ok(#(sockets, spec)) =
@@ -72,11 +71,11 @@ let assert Ok(#(sockets, spec)) =
 
 This excerpt comes from
 [`step_04.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/live_poll/src/live_poll/step_04.gleam).
-`channel.child_spec` accepts the same core `beryl.Config` and returns the same
-kind of `beryl.Sockets` handle and supervised child specification as
-`beryl.child_spec`.
+`channel.child_spec` takes the same `beryl.Config` as `beryl.child_spec`. It
+returns the same two values: a `beryl.Sockets` handle and a child specification
+for your supervisor.
 
-The handler table contains two values:
+You give it a list of handlers. The example has two:
 
 ```gleam
 pub fn handlers(
@@ -88,13 +87,15 @@ pub fn handlers(
 }
 ```
 
-One handler owns `poll:*`. The other owns `guide`. They use different state
-and info types but still fit in `List(channel.Handler)`.
+One handler owns the `poll:*` topics. The other owns `guide`. Each one uses a
+different state type and a different info type. Both still fit in one
+`List(channel.Handler)`. The next sections show how.
 
-## A handler creates one channel instance
+## A handler makes one channel for each join
 
-The poll handler matches a topic pattern and receives a
-`channel.JoinContext`:
+A handler has two parts: a topic pattern and a join function. When a client
+joins a topic that matches the pattern, Beryl calls the join function with a
+`channel.JoinContext`. The join function returns the new channel.
 
 ```gleam
 pub type PollInfo {
@@ -140,46 +141,44 @@ fn poll_channel(
 
 This exact excerpt comes from
 [`channels.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/live_poll/src/live_poll/channels.gleam).
-The concepts now have channel-specific names:
+Read it from the top:
 
-- `channel.Handler` pairs a topic pattern with a join callback.
-- `channel.JoinContext` bundles the concrete topic, wildcard `params`, join
-  payload, connection data, and this join's typed sender.
-- `channel.accept` supplies the channel's initial private state.
-- `channel.Next` returns the next private state and ordered actions.
-- `channel.Action` describes work on this channel's own topic.
+- `channel.handler` pairs the pattern `poll:*` with the join function.
+- `context.params` holds the part of the topic that matched `*`. For
+  `poll:demo`, that is `["demo"]`.
+- `context.self` is a typed sender for this channel. The timer uses it to send
+  `ClosePoll` later.
+- `channel.accept(room)` accepts the join. The argument is the channel's
+  starting state. Here, the state is the room name.
+- Each `on_*` call adds a callback. A callback receives the current state and
+  returns the next state plus a list of actions.
+- `on_terminate` runs when the channel closes. Here, it tells the store that
+  this socket has left the room.
 
-The private state here is a `String` room name. The private info type is
-`PollInfo`, whose only variant is `ClosePoll`. Neither type joins a
-socket-wide union. `on_terminate` releases the room from the shared store.
-The store removes its poll after the last socket leaves.
+The state type is `String`. The info type is `PollInfo`. Neither type appears
+in a socket-wide `Model` or `Message`. They belong to this handler only.
 
-## Closure sealing makes heterogeneous handlers possible
+## How different handlers fit in one list
 
-`channel.Handler` is opaque and non-generic. Internally, `channel.handler`
-captures the typed join callback. `channel.handler` seals the state into the
-typed message, info, and terminate callbacks. Each `channel.next`
-seals the next state into the same callback set.
+`channel.Handler` has no type parameters. This is what lets the poll handler
+and the guide handler share one list.
 
-The layer does not coerce channel state or info messages through `Dynamic`.
-It uses closures to preserve each handler's concrete types. The socket-level
-router owns a sealed envelope for channel info delivery. It adds the topic and
-join generation to the envelope. The router checks this information before the
-owning closure opens the value.
+Here is how it works. `channel.handler` stores your join function inside a
+closure. When the join function runs, `channel.accept` and each `on_*` call
+store the state and callbacks inside more closures. Each `channel.next` does
+the same with the new state. The types stay concrete inside those closures.
+From the outside, every handler has the same type.
 
-This sealing is separate from the core runtime's generic dispatch. At the core
-level, `beryl.child_spec` captures the app's model and message types in
-monomorphic closures. At the channel layer, each handler separately seals its
-private state and info type. Client payloads remain `Dynamic` at the wire
-boundary in both APIs.
+Beryl does not turn your state or info messages into `Dynamic`. Only the
+client payload is `Dynamic`, because it comes from the wire. That is true for
+both APIs.
 
-The layer itself imports and calls Beryl's public core API. It supplies a raw
-`init` and `update` pair to `beryl.child_spec`. It does not bypass the runtime
-or restore the superseded type-erased channel registry described in ADR 0001.
+The channel layer is built on the public core API. It gives `beryl.child_spec`
+its own raw `init` and `update` pair. It does not go around the runtime.
 
-## The second handler proves heterogeneity
+## The second handler
 
-The guide handler does not share the poll handler's state or info type:
+The guide handler uses different types from the poll handler:
 
 ```gleam
 type GuideInfo {
@@ -206,18 +205,18 @@ fn guide_channel() -> channel.Handler {
 }
 ```
 
-This exact excerpt also comes from `channels.gleam`. The guide channel uses
-`Int` state and `GuideInfo`. The poll channel uses `String` state and
-`PollInfo`. The application composes both as handler values without defining
-`Model(PollState, GuideState)` or `Message(PollMessage | GuideMessage)`.
+This exact excerpt also comes from `channels.gleam`. The guide channel uses an
+`Int` for state and `GuideInfo` for info. The poll channel uses a `String` and
+`PollInfo`. You do not write `Model(PollState, GuideState)` or
+`Message(PollMessage | GuideMessage)`. You put the two handlers in a list.
 
-The browser joins `guide` after joining its poll topic. The guide's typed
-message produces a `tip` push, which the client stores as the status
-element's title.
+The browser joins `guide` after it joins its poll topic. The `Ready` message
+becomes a `tip` push. The client stores the tip as the `title` of its status
+element.
 
-## Actions are scoped and phase-typed
+## Actions belong to one channel
 
-Raw `socket.Effect` values name a topic:
+A raw effect names its topic:
 
 ```gleam
 socket.BroadcastFrom(topic, "poll_state", poll.json(state))
@@ -229,27 +228,22 @@ A channel action does not:
 channel.broadcast_from("poll_state", poll.json(state))
 ```
 
-The current channel supplies the topic. That makes most callback code shorter
-and prevents an action from accidentally targeting another topic.
+The channel already knows its topic. Your callback code is shorter, and an
+action cannot go to the wrong topic by mistake.
 
-The restriction is deliberate. Raw dispatch can coordinate across topics in
-one observable effect list. Channel callbacks return actions scoped to their
-own channel. Cross-topic publishing uses the external `beryl.Sockets` APIs or
-an application actor that owns the handle.
+This is a real limit. A raw update function can act on several topics in one
+effect list. A channel callback can act only on its own channel. To publish
+across topics, use the `beryl.Sockets` handle from outside the channel, or from
+an actor that owns the handle.
 
-Channel actions also carry a phase parameter. Active callbacks can reply,
-push, broadcast, track presence, or close. `on_terminate` returns closing
-actions, where replies, pushes, and presence tracking do not type-check.
-Broadcasts and presence cleanup remain available after the runtime removes
-the instance.
+Actions also depend on when they run. In `on_message` and `on_info`, a callback
+can reply, push, broadcast, track presence, or close. In `on_terminate`, the
+channel is closing. A reply, push, or presence track makes no sense there, and
+the compiler rejects them. Broadcast and presence cleanup still work.
 
-The example defines `on_terminate` to release its room from the shared store.
-Its timer-driven `on_info` and client-driven `on_message` return active
-actions. Termination returns only the closing actions allowed in that phase.
+## Actions become effects, in order
 
-## Ordered actions lower to ordered effects
-
-The voting branch returns:
+The vote branch returns:
 
 ```gleam
 Ok(state) ->
@@ -259,29 +253,27 @@ Ok(state) ->
   ])
 ```
 
-The layer lowers these actions one-to-one into core `socket.Effect` values in
-the same order. The same runtime interprets them, so the reply still precedes
-the broadcast.
+The channel layer turns each action into one core `socket.Effect`. It keeps the
+order. The same runtime runs them, so the reply goes out before the broadcast.
 
-Accepted joins can attach actions with `channel.with_actions`. The layer emits
-the join acknowledgment first, then those actions. A push cannot overtake its
-own join acknowledgment.
+A join can also return actions. Use `channel.with_actions` on an accepted join.
+Beryl sends the join acknowledgment first, then those actions. A push can never
+arrive before its own join acknowledgment.
 
-## Pick one API per endpoint
+## Pick one API for each endpoint
 
-Raw dispatch remains the clearest teaching example and the core programming
-model. Choose it for a single topic family, a compact protocol, or direct
-cross-topic coordination.
+Raw dispatch is the core programming model and the clearest one to learn from.
+Choose it when you have one topic family, a small protocol, or work that spans
+topics.
 
-Choose `beryl/channel` by default when a socket serves several topic
-namespaces, when porting Phoenix Channels, or when handlers should keep
-private state and info types. The two APIs share the wire codec, runtime,
-presence, PubSub, abuse controls, and transport. Pick one programming model
-for a socket endpoint. Do not embed hand-written raw update logic inside a
-channel system.
+Choose `beryl/channel` when a socket serves several topic namespaces, when you
+port Phoenix Channels, or when each handler should keep its own state and info
+types. Both APIs share the wire codec, runtime, presence, PubSub, abuse
+controls, and transport. Use one API for each socket endpoint. Do not mix raw
+update logic into a channel system.
 
-The final chapter follows both APIs below their callbacks into the shared runtime
-and explains where the Elm analogy stops helping.
+The next chapter follows both APIs down into the shared runtime. It shows where
+the Elm analogy stops.
 
 ## Sources and further reading
 
@@ -299,9 +291,9 @@ cd examples/live_poll && gleam run -m live_poll/step_04
 ```
 
 Open `http://localhost:8104` in two tabs, join `demo`, and vote. Replies and
-peer broadcasts behave as in step 03, but `beryl/channel` now owns routing and
-private channel state. Select **Close poll now** or wait 60 seconds. The
-browser also joins the heterogeneous `guide` handler. Inspect the status
-paragraph's `title` attribute to see its typed info message.
+peer broadcasts work as in step 03. Now `beryl/channel` owns the routing and
+the channel state. Select **Close poll now** or wait 60 seconds. The browser
+also joins the `guide` channel. Inspect the `title` attribute of the status
+paragraph to see its typed info message.
 
 Next: [Where the analogy ends](/tutorial/where-the-analogy-ends/).

--- a/website/src/content/docs/tutorial/index.md
+++ b/website/src/content/docs/tutorial/index.md
@@ -3,12 +3,11 @@ title: Build a Live Poll
 description: Learn Beryl by building a live poll from raw dispatch through channels, runtime boundaries, and supervision.
 ---
 
-This tutorial introduces Beryl through one live-poll application. If you want
-the short version first, start with the [Quick Start](/quick-start/). The prose
-and excerpts use the runnable
+This tutorial teaches Beryl by building one app: a live poll. If you want a
+shorter path, start with the [Quick Start](/quick-start/). All prose and code
+excerpts come from the runnable
 [`examples/live_poll/`](https://github.com/tylerbutler/beryl/tree/main/examples/live_poll)
-project as the source of truth. Beryl is pre-1.0, so treat the API as evolving
-rather than stable.
+project. Beryl is pre-1.0. Expect the API to change.
 
 ## Sequence
 
@@ -19,8 +18,8 @@ rather than stable.
 5. [Where the analogy ends](/tutorial/where-the-analogy-ends/)
 6. [Supervising Beryl](/tutorial/supervising-beryl/)
 
-Each chapter stands on its own, but the checkpoints build from read-only raw
-dispatch to a production-shaped channel system.
+You can read each chapter on its own. The checkpoints build on each other. They
+start with a read-only poll and end with a supervised channel system.
 
 ## Runnable checkpoints
 
@@ -35,54 +34,57 @@ Run each command from the repository root:
 | 5 | `cd examples/live_poll && gleam run -m live_poll/step_05` | `http://localhost:8105` |
 | 6 | `cd examples/live_poll && gleam run -m live_poll/step_05` | `http://localhost:8105` |
 
-Stop a checkpoint with Ctrl-C before starting the next one. The browser client
+Stop a checkpoint with Ctrl-C before you start the next one. The browser client
 loads Phoenix JavaScript 1.7.20 from unpkg, so the first page load needs
-internet access. The Gleam server and Beryl runtime stay local.
+internet access. The Gleam server and the Beryl runtime run on your machine.
 
 ## Example layout
 
-The five `step_0N.gleam` files are short entry modules, not complete
-applications. They select a configuration and assemble shared modules:
+The five `step_0N.gleam` files are short entry modules. Each one picks a
+configuration and starts the shared modules:
 
-- `raw.gleam` contains the raw `init`, `Model`, `Message`, `socket.Input` router,
-  and ordered `socket.Effect` lists used by steps 1 through 3.
-- `channels.gleam` contains the two heterogeneous `channel.Handler` values
-  used by steps 4 and 5.
-- `poll.gleam` defines the typed poll domain and decodes client `Dynamic`
-  payloads into domain commands.
-- `store.gleam` owns poll state in a Gleam OTP actor.
+- `raw.gleam` has the raw `init`, `Model`, `Message`, and `update` function
+  used by steps 1 through 3.
+- `channels.gleam` has the two `channel.Handler` values used by steps 4 and 5.
+- `poll.gleam` defines the poll types and turns client `Dynamic` payloads into
+  poll commands.
+- `store.gleam` keeps poll state in a Gleam OTP actor.
 - `timer.gleam` runs delayed callbacks from its own actor.
-- `server.gleam` starts the Beryl child specification and Mist transport,
-  serves the browser client, and optionally serves `/healthz`.
-- `test/live_poll_test.gleam` checks the poll domain and protocol decoder.
+- `server.gleam` starts the Beryl child specification and the Mist transport,
+  serves the browser client, and can serve `/healthz`.
+- `test/live_poll_test.gleam` tests the poll types and the protocol decoder.
 
-Read the shared files with the step module. A step file shows which behavior is
-enabled. It does not duplicate the runtime, domain, or browser code.
+Read each step module together with the shared files. A step file shows which
+behavior is on. It does not repeat the runtime, poll, or browser code.
 
 ## Terminology
 
-The tutorial keeps Beryl's terms distinct:
+The tutorial uses these terms, and keeps them separate:
 
-- A **socket** is one client connection known to the Beryl runtime.
-- A **topic** is a string subscription within a socket, such as `poll:demo`.
-- Raw dispatch uses an app-defined **Model**, `socket.Input`, `socket.Next`,
-  `socket.Effect`, and a socket-scoped `socket.Sender`.
-- A **channel** is one accepted topic instance managed by
-  `beryl/channel`. A **handler** matches a topic pattern and constructs that
-  channel's private **state**, callbacks, and typed info path.
-- A channel callback returns ordered **actions** scoped to its own topic.
-- The **runtime** uses one router actor and one actor for each connected
-  socket. The socket actor stores its model and interprets effects. The router
-  maintains the socket index and handles broadcast fan-out.
+- A **socket** is one client connection that the Beryl runtime knows about.
+- A **topic** is a string that a socket subscribes to, such as `poll:demo`.
+- **Raw dispatch** is the core API. Your app defines a **Model** and an update
+  function. The update function receives a `socket.Input`, and returns a
+  `socket.Next` with a list of `socket.Effect` values. A `socket.Sender` lets
+  other code send typed messages to one socket.
+- A **channel** is one accepted topic on one socket, managed by
+  `beryl/channel`. A **handler** matches a topic pattern and builds that
+  channel: its private **state**, its callbacks, and its typed info messages.
+- A channel callback returns a list of **actions**. Each action applies to the
+  callback's own topic.
+- The **runtime** has one router actor and one actor for each connected socket.
+  The socket actor holds the model and runs effects. The router keeps the
+  socket index and fans out broadcasts.
 - A Gleam OTP `process.Subject` is a typed address for a process mailbox. A
-  Beryl `socket.Sender` is narrower. It delivers typed `Info` only to its
-  owning socket update. The runtime ignores delivery after disconnect.
-Do not substitute `Subject`, `Sender`, `socket`, `topic`, `channel`, or
-`handler` for one another. They name different boundaries.
+  Beryl `socket.Sender` is narrower. It delivers typed `Info` only to the
+  socket that owns it. After the socket disconnects, the runtime drops the
+  message.
 
-Raw dispatch is the clearest teaching example and Beryl's core. For
-multi-channel and Phoenix-shaped applications, `beryl/channel` is the
-recommended default.
+Do not use `Subject`, `Sender`, `socket`, `topic`, `channel`, or `handler` in
+place of one another. Each one names a different boundary.
+
+Raw dispatch is Beryl's core, and the clearest way to learn it. For apps with
+many channels, or apps shaped like Phoenix, use `beryl/channel`.
 
 ## Official comparison material
 

--- a/website/src/content/docs/tutorial/one-update-function-many-socket-events.md
+++ b/website/src/content/docs/tutorial/one-update-function-many-socket-events.md
@@ -3,14 +3,16 @@ title: One Update Function, Many Socket Events
 description: Handle joins, messages, binary frames, closes, replies, and ordered effects in one typed update function.
 ---
 
-A WebSocket connection handles more than application commands. Clients join
-topics, send text events, send binary frames, leave, disconnect, and expect
-replies correlated to earlier frames. Server processes also need a typed path
-back into the same socket logic. Raw Beryl puts all of those cases in one
-exhaustive `socket.Input` match.
+A WebSocket connection does more than carry app commands. A client joins
+topics. It sends text events and binary frames. It leaves, or it disconnects.
+It expects a reply to some of the frames it sent. Your server processes also
+need a typed way to send messages into the same socket logic. Raw Beryl puts
+all of these cases in one `socket.Input` type. Your update function matches
+every variant.
 
-The result resembles an Elm or OTP update loop, but the inputs include
-protocol capabilities and an intentionally untyped wire boundary.
+The result looks like an Elm or OTP update loop. The difference is in the
+inputs. They include protocol features, and the client payload arrives with
+no type.
 
 ## The five inputs
 
@@ -28,23 +30,24 @@ pub type Input(message) {
 
 This excerpt comes from
 [`packages/beryl/src/beryl/socket.gleam`](https://github.com/tylerbutler/beryl/blob/main/packages/beryl/src/beryl/socket.gleam).
-Each variant marks a different boundary:
+Each variant comes from a different place:
 
-- `Join` asks the application to accept or reject one topic subscription.
+- `Join` asks your app to accept or reject one topic subscription.
 - `Message` delivers a client event on a topic the socket has joined.
-- `Binary` holds binary data associated with a joined topic.
-- `Closed` reports that a joined topic ended.
-- `Info` wraps the app-defined typed `message` sent through this socket's
+- `Binary` delivers binary data for a topic the socket has joined.
+- `Closed` tells you that a joined topic has ended.
+- `Info` wraps your own typed `message`. It arrives through this socket's
   `Sender`.
 
-A socket is the client connection. A topic is one subscription string inside
-that socket. Raw dispatch has no channel object. The application's `Model`
-and update function route topic strings themselves.
+A socket is one client connection. A topic is one subscription string inside
+that socket, such as `poll:demo`. Raw dispatch has no channel object. Your
+`Model` and update function route topic strings themselves.
 
-## A join ref is a capability
+## A join ref is a one-time token
 
-The `ref` in `Join(topic, payload, ref)` is an opaque `socket.JoinRef`. Return
-that exact value in `socket.AcceptJoin` or `socket.RejectJoin`. These exact
+`Join(topic, payload, ref)` gives you a `socket.JoinRef`. You cannot make one
+yourself, and you cannot read its contents. You can only pass it back. Return
+the same value in `socket.AcceptJoin` or `socket.RejectJoin`. These exact
 excerpts come from the join branch in `raw.gleam`:
 
 ```gleam
@@ -65,34 +68,34 @@ socket.Next(model, [
 
 See the complete branch in
 [`raw.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/live_poll/src/live_poll/raw.gleam).
-`room_name` accepts only a non-empty `poll:<room>` topic. The code does not
-reconstruct a ref from the topic or from Phoenix wire fields.
+`room_name` accepts a topic only when it has the form `poll:<room>` and the
+room is not empty. The code never builds a ref from the topic string or from
+Phoenix wire fields.
 
-That restriction is part of the contract. A `JoinRef` encodes unique runtime
-identity and is valid only for its pending join. A delayed answer for an older
-attempt cannot accept a replacement join on the same topic.
+This limit is part of the contract. A `JoinRef` holds a unique runtime token.
+It is valid only for the one join that is waiting for an answer. Suppose a
+client joins a topic, then joins the same topic again. A late answer for the
+first join cannot accept the second one.
 
-Beryl join handling is fail-closed. If the update turn does not return either
-`AcceptJoin(ref, ...)` or `RejectJoin(ref, ...)` for the pending ref, the
-runtime rejects the join automatically. Forgetting a branch cannot leave a
-half-open subscription.
+Beryl also protects you when you forget a case. If your update turn does not
+return `AcceptJoin(ref, ...)` or `RejectJoin(ref, ...)` for the waiting ref,
+the runtime rejects the join. A missing branch cannot leave a join half open.
 
-## Reply refs have a different lifetime
+## Reply refs live longer
 
-`Message` includes `Option(socket.ReplyRef)`. A client frame may omit its
-message ref. In that case, the client does not expect a correlated reply.
-When a ref is present, the application can return `ReplyOk` or `ReplyError`.
+`Message` includes `Option(socket.ReplyRef)`. A client can send a frame with no
+message ref. Then the client does not expect a reply. When the ref is present,
+your app can return `ReplyOk` or `ReplyError`.
 
-`ReplyRef` differs from `JoinRef`:
+A `ReplyRef` is not the same as a `JoinRef`:
 
-- it correlates a client message rather than deciding a join;
-- it may be stored and answered in a later update turn;
-- it is single-use;
-- it stays valid only while the topic instance that received the message
-  remains open.
+- it matches a reply to a client message; it does not decide a join;
+- you can store it in your model and answer it in a later update turn;
+- you can use it only one time;
+- it stays valid only while the topic that received the message stays open.
 
-The example uses `socket.reply_ok`, which turns `None` into an empty effect
-list:
+The example uses `socket.reply_ok`. When the ref is `None`, this helper returns
+an empty effect list:
 
 ```gleam
 poll.GetState ->
@@ -102,21 +105,20 @@ poll.GetState ->
   )
 ```
 
-That excerpt comes from `handle_command` in `raw.gleam`. For error replies,
-the example uses a small local helper that emits `ReplyError` only for
+This excerpt comes from `handle_command` in `raw.gleam`. For error replies, the
+example has a small local helper. It returns `ReplyError` only when the ref is
 `Some(ref)`.
 
-Treat both ref types as protocol capabilities. Do not compare or synthesize
-their underlying Phoenix fields. Pass the opaque value back to Beryl while
-its operation remains valid.
+Treat both ref types as tokens. Do not compare them. Do not build them from
+Phoenix fields. Pass the value back to Beryl while it is still valid.
 
-## `Dynamic` stops at the wire boundary
+## `Dynamic` stops at the wire
 
-Client JSON enters `Join` and `Message` as `Dynamic`. That is intentional:
-the remote client chooses the payload, so Gleam cannot assign it an
-application type before validation.
+Client JSON arrives in `Join` and `Message` as `Dynamic`. `Dynamic` is Gleam's
+type for data of unknown shape. This is on purpose. The remote client chooses
+the payload, so Gleam cannot give it an app type before your code checks it.
 
-The example decodes at the domain boundary in
+The example decodes the payload in
 [`poll.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/live_poll/src/live_poll/poll.gleam):
 
 ```gleam
@@ -140,20 +142,19 @@ pub fn command(event: String, payload: Dynamic) -> Command {
 }
 ```
 
-After this function, `handle_command` matches `poll.GetState`,
-`poll.Vote(choice)`, `poll.Close`, or `poll.Unsupported`. Invalid JSON shapes
-do not leak into the store actor. The wire payload remains `Dynamic`. The
-domain command does not.
+After this function, `handle_command` matches on `poll.GetState`,
+`poll.Vote(choice)`, `poll.Close`, or `poll.Unsupported`. Bad JSON never
+reaches the store actor. The wire payload is `Dynamic`. The domain command is
+not.
 
-This boundary does not imply that Beryl erases the application's model or
-typed server messages. The core runtime is generic over `model` and `message`.
-`beryl.child_spec` captures concrete typed closures while exposing a
-non-generic transport handle. Beryl limits `Dynamic` to data that arrived from
-the wire.
+This does not mean Beryl loses your types. The core runtime is generic over
+your `model` and `message` types. `beryl.child_spec` keeps your typed
+functions inside closures. The transport handle it returns has no type
+parameters. Only data from the wire is `Dynamic`.
 
-## Ordered effects produce ordered frames
+## Effects run in list order
 
-The voting branch shows why an update returns a list:
+The vote branch shows why an update returns a list:
 
 ```gleam
 Ok(state) ->
@@ -166,31 +167,31 @@ Ok(state) ->
   )
 ```
 
-This exact excerpt appears in `raw.gleam`. When `reply` is present, Beryl
-interprets the list as:
+This exact excerpt comes from `raw.gleam`. When `reply` is present, Beryl
+runs the list as:
 
 1. send `ReplyOk` to the browser that voted;
-2. broadcast `poll_state` to every other socket subscribed to the topic.
+2. broadcast `poll_state` to every other socket on the topic.
 
-The socket actor applies effects strictly in list order and writes the
-frames, so list order is wire order for that socket. This is Beryl's
-contract. The comparison does not assume an ordering contract for Lustre
-effects.
+The socket actor runs the effects in list order and writes the frames in the
+same order. For one socket, list order is wire order. This is a Beryl
+guarantee. Lustre makes no such promise for its effects.
 
-Join acceptance uses the same rule. If one update returns
-`[AcceptJoin(ref, None), Push(topic, "ready", payload)]`, the acknowledgment
-reaches the wire before the push. The runtime would otherwise drop a push to
-an unjoined topic.
+The same rule applies to a join. If one update returns
+`[AcceptJoin(ref, None), Push(topic, "ready", payload)]`, the join
+acknowledgment reaches the wire before the push. This matters. The runtime
+drops a push to a topic that is not joined yet.
 
-The guarantee also applies to presence effects. The runtime can pause the rest
-of one socket's list while the separate presence actor applies a mutation.
-Other sockets continue. The waiting socket resumes its remaining effects in
-order.
+The rule also applies to presence effects. A separate presence actor applies
+presence changes. The runtime can pause the rest of one socket's list while
+that actor works. Other sockets keep going. When the presence actor is done,
+the paused socket runs its remaining effects in order.
 
-## `Binary`, `Closed`, and unmatched messages still need branches
+## `Binary`, `Closed`, and unknown messages still need a branch
 
-The example does not use binary frames, but its update remains exhaustive.
-This excerpt also releases the shared poll after the room's last socket leaves:
+The example does not use binary frames. Its update function still matches
+every variant. The `Closed` branch also releases the shared poll after the last
+socket leaves the room:
 
 ```gleam
 socket.Closed(topic, _reason) -> {
@@ -203,19 +204,19 @@ socket.Closed(topic, _reason) -> {
 socket.Binary(_, _) -> socket.Next(model, [])
 ```
 
-`Closed` runs on every topic exit path, including a client leave, socket
-disconnect, server kick, heartbeat timeout, or shutdown. Raw applications
-must remove per-topic state there. The example's store reference-counts
-joined sockets and deletes an empty room, so client-chosen room names do not
-accumulate forever. The runtime drops frames pushed to the closing topic from
-the `Closed` turn. Broadcasts can still reach other subscribers.
+`Closed` runs each time a topic ends, for any reason. The client can leave.
+The socket can disconnect. The server can kick the client. A heartbeat can
+time out. The server can shut down. In raw dispatch, this is where you remove
+per-topic state. The example's store counts the sockets in each room. When the
+count reaches zero, it deletes the room. Client-chosen room names do not pile
+up forever. In the `Closed` turn, the runtime drops pushes to the closing
+topic. Broadcasts still reach the other subscribers.
 
-Ignoring `Binary` is an explicit application choice. A codec with a binary
-decoder can classify binary protocol messages. Otherwise, Beryl can deliver
-raw binary data for joined topics. An exhaustive branch documents what this
-poll supports.
+The example ignores `Binary` on purpose. A codec with a binary decoder can
+turn binary frames into protocol messages. Without one, Beryl delivers the raw
+bytes for joined topics. The empty branch documents what this poll supports.
 
-The `Message` branch also checks that the model recorded the topic:
+The `Message` branch also checks that the model knows the topic:
 
 ```gleam
 case set.contains(model.topics, topic), room_name(topic) {
@@ -225,23 +226,23 @@ case set.contains(model.topics, topic), room_name(topic) {
 }
 ```
 
-The runtime already routes client messages only to joined topics. The model
-check keeps the application's own routing state explicit and makes cleanup in
-`Closed` visible.
+The runtime already sends client messages only for joined topics. The model
+check makes the app's own routing state visible. It also shows why `Closed`
+must clean up.
 
-## Two tabs expose the semantics
+## Two tabs show the difference
 
-One tab can hide the difference between reply and broadcast. With two tabs in
-the same room, the origin receives its correlated reply while the peer
-receives `BroadcastFrom`. Both render the same updated poll state, but they
-arrive through distinct Phoenix mechanisms.
+With one tab, a reply and a broadcast look the same. With two tabs in the same
+room, they do not. The tab that voted gets its reply. The other tab gets
+`BroadcastFrom`. Both tabs show the same new poll state. They receive it
+through two different Phoenix paths.
 
-That split is useful when designing larger protocols. Replies complete a
-specific client request. Pushes are server-initiated frames to one socket.
-Broadcasts fan out by topic. A topic is the routing key. It is not a socket,
-channel, `Subject`, or `Sender`.
+This split helps when you design a larger protocol. A reply answers one client
+request. A push is a server-sent frame to one socket. A broadcast goes to every
+socket on a topic. The topic is the routing key. It is not a socket, a
+channel, a `Subject`, or a `Sender`.
 
-The next chapter adds `Info(message)`, the remaining input variant, and compares its
+The next chapter adds `Info(message)`, the last input variant. It compares the
 socket-scoped `Sender` with a general OTP `Subject`.
 
 ## Sources and further reading
@@ -259,7 +260,7 @@ cd examples/live_poll && gleam run -m live_poll/step_02
 
 Open `http://localhost:8102` in two tabs. Join `demo` in both, then vote in
 one tab. The voting tab updates from its `ReplyOk`. The other tab updates
-from `BroadcastFrom`. Alternate votes between tabs and confirm both totals
-stay in sync. **Close poll now** remains unavailable in this checkpoint.
+from `BroadcastFrom`. Vote in each tab in turn and confirm both totals stay
+the same. **Close poll now** is not available in this checkpoint.
 
 Next: [Typed messages from the rest of your Gleam system](/tutorial/typed-messages-from-your-gleam-system/).

--- a/website/src/content/docs/tutorial/supervising-beryl.md
+++ b/website/src/content/docs/tutorial/supervising-beryl.md
@@ -3,19 +3,20 @@ title: Supervising Beryl
 description: Place Beryl in an OTP supervision tree and understand restart, shutdown, and ownership boundaries.
 ---
 
-`beryl.child_spec` does not start a socket runtime. It returns a stable
-`beryl.Sockets` handle and a child specification for your application's OTP
-supervisor. `channel.child_spec` returns the same pair after building the raw
-router for its handler table.
+`beryl.child_spec` does not start anything. It returns two values. The first is
+a `beryl.Sockets` handle. The second is a child specification. A child
+specification tells an OTP supervisor how to start and restart a process. Your
+application adds it to its own supervisor. `channel.child_spec` returns the same
+two values. It builds the raw router from your handlers first.
 
-That distinction determines startup order, restart behavior, and shutdown. The
-handle identifies a socket system across runtime restarts, while the child
-specification captures the code and configuration needed to rebuild that
-system.
+This split decides three things: what starts first, what happens after a crash,
+and what happens at shutdown. The handle names one socket system. It stays valid
+when the runtime restarts. The child specification holds the code and
+configuration the supervisor needs to build that system again.
 
 ## Put the child specification in your application tree
 
-The live-poll example starts Beryl under a root supervisor before starting the
+The live-poll example starts Beryl under a root supervisor. Then it starts the
 Mist listener:
 
 ```gleam
@@ -37,17 +38,15 @@ The supervisor code comes from
 [`server.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/live_poll/src/live_poll/server.gleam).
 The server then passes `sockets` to `mist_transport.upgrade`.
 
-Starting the supervisor before the listener matters. You receive the
-name-backed handle when `child_spec` returns, but no runtime process exists
-until a supervisor starts `spec`. Before startup, Beryl rejects connection
-admission. Fire-and-forget operations through the handle do nothing rather
-than sending to a missing process.
+The order matters. You get the handle when `child_spec` returns. But no runtime
+process exists until a supervisor starts `spec`. Before that, Beryl refuses new
+connections. Calls through the handle that do not wait for a reply, such as a
+broadcast, do nothing. They do not crash because the process is missing.
 
-`child_spec` validates the configuration and handler table before returning
-`spec`. If it returns an error, there is no child specification to add to the
-supervision tree.
+`child_spec` checks the configuration and the handler list before it returns
+`spec`. If it returns an error, there is nothing to add to the supervisor.
 
-## Beryl owns a nested subtree
+## Beryl owns a small tree of its own
 
 The child specification adds a Beryl subtree to your application:
 
@@ -61,99 +60,95 @@ transport connection
 └── socket actor (one per connection, monitored by the router)
 ```
 
-The nested supervisor uses `OneForOne` with a tolerance of 3 restarts in 5
-seconds. The router stores the socket actor index and topic subscriber sets.
-Each socket actor stores one model, its channel instances, topic membership,
-and pending protocol capabilities. Socket actors are not supervisor children.
-The transport connection starts each one, and the router monitors it. When
-connection limits are enabled, the limiter runs beside the router in the
-subtree.
+The Beryl subtree has its own supervisor. That supervisor uses `OneForOne`. It
+allows 3 restarts in 5 seconds. The router actor keeps the list of socket
+actors and the set of subscribers for each topic. Each socket actor keeps one
+model, its channel instances, its joined topics, and its pending reply
+capabilities. Socket actors are not children of the supervisor. The transport
+connection starts each one, and the router monitors it. If you enable
+connection limits, the limiter runs next to the router.
 
-Marking the router as significant gives graceful shutdown a precise boundary.
-When the router stops normally, the nested supervisor shuts down the rest of
-the Beryl subtree, including the limiter. The parent application's supervisor
-and sibling children keep running.
+The router is marked as *significant*. This gives shutdown a clear edge. When
+the router stops normally, the Beryl supervisor stops the rest of the subtree,
+including the limiter. Your application supervisor and its other children keep
+running.
 
-The `Transient` restart policy separates a crash from an intentional stop. An
-abnormal router exit triggers a restart. A successful `beryl.stop` ends the
-subtree without asking the parent supervisor to bring it back.
+The `Transient` restart policy tells a crash and a normal stop apart. If the
+router crashes, the supervisor restarts it. If `beryl.stop` succeeds, the
+subtree ends and the parent supervisor does not restart it.
 
-## The handle survives, but socket state does not
+## The handle survives a restart. Socket state does not.
 
-`beryl.Sockets` uses registered process names rather than storing one router
-pid. A restarted router registers the same name, so application code can keep
-the original handle. The child specification still holds the typed `init` and
-`update` closures, or the channel router built from your handlers. The new
-router starts with the same dispatch code.
+`beryl.Sockets` holds registered process names, not a process id. A restarted
+router registers the same names. Your code can keep the same handle. The child
+specification still holds your typed `init` and `update` functions, or the
+channel router built from your handlers. The new router runs the same code.
 
-The new router does not recover the old runtime state. A restart discards:
+The new router does not get the old state back. A restart discards:
 
-- connected socket records and per-socket models;
+- connected socket records and their models;
 - channel instances and their private state;
 - joined topics, pending joins, and reply capabilities;
 - local subscriber maps and heartbeat timestamps.
 
-Socket actors and transport connection processes monitor the router that
-admitted them. If that router dies, the actors stop and the transports close
-their WebSockets. Clients must reconnect and rejoin. This gives the replacement
-router fresh socket actors, models, and channel state. Phoenix clients already
-implement reconnect and rejoin behavior.
+Socket actors and transport connections monitor the router that admitted them.
+If that router dies, the socket actors stop and the transports close their
+WebSockets. Clients must reconnect and join again. The new router then gets
+fresh socket actors, models, and channel state. Phoenix clients already know
+how to reconnect and rejoin.
 
-Keep shared domain state outside the Beryl runtime when it must survive a
-runtime restart. The live poll stores room totals in `store.Store`, an
-application-owned actor. A database or another supervised domain process can
-serve the same role.
+If state must survive a restart, keep it outside the Beryl runtime. The live
+poll keeps room totals in `store.Store`, an actor your application owns. A
+database or another supervised process works the same way.
 
 ## A restart window is an unavailable window
 
-The stable handle prevents stale-pid failures. It does not make a restart
-atomic from the caller's perspective. During the interval between the old
-runtime exiting and its replacement registering:
+The stable handle means you never hold a dead process id. It does not make a
+restart invisible. Between the old runtime exiting and the new one registering:
 
-- transports reject new connection admission;
-- broadcasts through the handle and notifications through socket or channel
-  senders do nothing;
+- transports refuse new connections;
+- broadcasts through the handle do nothing, and so do notifications through
+  socket or channel senders;
 - `beryl.stop` can return `Error(beryl.NotRunning)`.
 
-Returning from a broadcast or notification call does not confirm delivery. If
-an event must survive a restart, store it in a durable queue or domain process
-and retry after the socket reconnects. A best-effort broadcast is not a
-durable message.
+When a broadcast or notification call returns, that does not mean the message
+arrived. If an event must survive a restart, store it in a durable queue or a
+domain process. Send it again after the socket reconnects. A best-effort
+broadcast is not a durable message.
 
-With connection limits enabled, the limiter survives an ordinary router
-restart because `OneForOne` restarts only the failed router child. The
-replacement router continues to use the same limiter.
+If you enable connection limits, the limiter survives a normal router restart.
+`OneForOne` restarts only the router. The new router uses the same limiter.
 
-## Restart intensity escalates repeated failures
+## Repeated failures move up the tree
 
-The internal supervisor permits 3 router restarts within 5 seconds. A fourth
-failure in that window exhausts its restart budget. The Beryl subtree then
-exits abnormally, and your application supervisor decides whether to restart
-the whole subtree.
+The Beryl supervisor allows 3 router restarts in 5 seconds. A fourth failure in
+that window uses up the budget. The whole Beryl subtree then exits with an
+error. Your application supervisor decides what to do next. It may restart the
+subtree, or it may give up.
 
-If the parent restarts the subtree, both the router and optional limiter get
-new processes. The original `Sockets` handle remains valid because the subtree
-reuses its allocated names.
+If the parent restarts the subtree, the router and the optional limiter both get
+new processes. The original `Sockets` handle still works. The subtree registers
+the same names again.
 
-This escalation prevents an internal supervisor from retrying a persistent
-fault forever without involving the application's supervision strategy. Logs
-from the first router failure remain the place to diagnose the cause.
+This rule stops the Beryl supervisor from retrying the same fault forever. Your
+own supervision strategy gets a say. To find the cause, read the logs from the
+first router failure.
 
-## Callback crashes usually do not invoke supervision
+## A callback crash usually does not reach the supervisor
 
-Part 5 described Beryl's scoped callback rescue. A panic in raw `update` or a
-channel callback rejects a join or closes the affected topic or socket while
-the socket actor continues when the scope permits. A fault outside the rescue
-boundary stops that socket actor, and the router removes it. The supervisor
-only responds when the router exits.
+Chapter 5 described how Beryl catches panics in callbacks. A panic in raw
+`update` or in a channel callback has a small effect. It rejects the join, or
+it closes the topic or socket that caused it. The socket actor keeps running
+when the scope allows. A fault outside that catch stops the socket actor, and
+the router removes it. The supervisor acts only when the router itself exits.
 
-That separation avoids restarting every connection because one callback
-panicked. Repeated callback panics do not consume the router's restart budget.
-They appear as repeated scoped failures in logs and client behavior.
+This keeps one bad callback from restarting every connection. Repeated callback
+panics do not use the router's restart budget. You see them as repeated small
+failures in logs and in client behavior.
 
 ## Graceful shutdown drains the runtime
 
-Use `beryl.stop(sockets)` when your application needs to stop only Beryl:
+Use `beryl.stop(sockets)` when your application must stop only Beryl:
 
 ```gleam
 case beryl.stop(sockets) {
@@ -163,36 +158,36 @@ case beryl.stop(sockets) {
 }
 ```
 
-Before it closes transport connections, the router asks each socket actor to
-deliver `Closed` to every joined raw topic or call each channel's
-`on_terminate`. `stop` waits for the socket actors, router, and optional
-limiter to terminate. It does not stop the application supervisor or unrelated
-sibling children.
+First, the router asks each socket actor to clean up. In raw dispatch, each
+joined topic gets `Closed`. In `beryl/channel`, each channel runs
+`on_terminate`. Then the router closes the transport connections. `stop` waits
+for the socket actors, the router, and the optional limiter to end. It does not
+stop your application supervisor or its other children.
 
-`NotRunning` means the supervisor never started this handle, the system has
-already stopped, or the call raced a restart window. `StopTimeout` means the
-router did not acknowledge the drain or the subtree did not terminate within
-the shutdown window.
+`NotRunning` means one of three things: the supervisor never started this
+handle, the system already stopped, or the call happened during a restart
+window. `StopTimeout` means the router did not confirm the drain, or the
+subtree did not end before the deadline.
 
-Beryl does not stop application-owned dependencies such as the poll store,
-timer, presence actor, or group actor. Their lifecycle belongs to the
-application process or supervisor that started them. Shutting down the
-application's root supervisor tears down Beryl with the rest of that tree.
+Beryl does not stop processes your application owns. The poll store, the timer,
+the presence actor, and the group actor all belong to the process or supervisor
+that started them. When your root supervisor shuts down, it stops Beryl with the
+rest of the tree.
 
-## Design the ownership before opening the listener
+## Decide who owns what before you open the listener
 
-A production startup path needs four explicit ownership decisions:
+A production startup path makes four decisions, in this order:
 
 1. Build Beryl's handle and child specification.
-2. Start application-owned domain actors from a long-lived application
-   process or under their own supervision arrangement.
-3. Add Beryl's specification to the application supervisor and start it.
+2. Start your domain actors from a long-lived application process, or under
+   their own supervisor.
+3. Add Beryl's specification to your application supervisor and start it.
 4. Start the HTTP/WebSocket listener with the running `Sockets` handle.
 
-The result has clear recovery boundaries. Beryl supervision restores the
-router. Clients restore socket actors and ephemeral subscriptions by
-reconnecting. Application-owned processes or storage preserve domain state.
-Graceful shutdown drains socket callbacks without stopping unrelated services.
+Each part then has a clear recovery path. Beryl's supervisor restores the
+router. Clients restore socket actors and subscriptions when they reconnect.
+Your own processes or storage keep the domain state. Graceful shutdown drains
+socket callbacks without stopping unrelated services.
 
 ## Sources and further reading
 
@@ -209,6 +204,6 @@ cd examples/live_poll && gleam run -m live_poll/step_05
 
 The checkpoint creates the `Sockets` handle and specification, starts the
 supervision tree, and then starts Mist on `http://localhost:8105`. Stop it with
-Ctrl-C to terminate the application process and its linked tree.
+Ctrl-C to end the application process and its linked tree.
 
 Back to the [tutorial overview](/tutorial/).

--- a/website/src/content/docs/tutorial/the-elm-architecture-without-a-dom.md
+++ b/website/src/content/docs/tutorial/the-elm-architecture-without-a-dom.md
@@ -3,66 +3,64 @@ title: The Elm Architecture, Without a DOM
 description: Learn Beryl's model-update architecture by building the first read-only stage of a live poll.
 ---
 
-Lustre and Gleam OTP actors apply the same programming model to different
-domains. Each starts with state, receives a typed message, and runs one
-function that decides the next state and any work to perform. Lustre uses that
-model to manage a user interface. An OTP actor uses it to manage a concurrent
-process. Beryl applies it to realtime socket traffic.
+Lustre and Gleam OTP actors use the same programming model. Each one starts
+with some state. Each one receives a typed message. Each one runs one function
+that returns the next state and any work to do. Lustre uses this model to run
+a user interface. An OTP actor uses it to run a concurrent process. Beryl uses
+it to handle realtime socket traffic.
 
-The domain determines the last step. Lustre renders a view. An actor continues
-with its next state or stops. Beryl returns protocol effects such as accepting
-a join, replying, or broadcasting. Beryl also initializes state once for each
-connected socket rather than once for a browser application or actor process.
+The last step is different in each case. Lustre renders a view. An actor keeps
+its next state or stops. Beryl returns protocol effects. An effect can accept a
+join, send a reply, or broadcast a message. Beryl also creates state once for
+each connected socket, not once for the whole application.
 
-We will start with Beryl's core API so that state, inputs, and effects stay
-visible. After comparing the Lustre and OTP forms, we will define that API and
-map its terms onto the same model.
+We start with Beryl's core API. It keeps state, inputs, and effects in plain
+view. First we compare the Lustre and OTP forms. Then we show the Beryl API
+and map its terms onto the same model.
 
 ## What we are building
 
-We will build a room-scoped live poll. A browser joins a topic such as
-`poll:demo`, reads the current totals, votes for Gleam or Erlang, and sees
-votes from other tabs. Later articles add automatic closing and a second kind
+We will build a live poll with rooms. A browser joins a topic such as
+`poll:demo`. It reads the current totals, votes for Gleam or Erlang, and sees
+votes from other tabs. Later chapters add automatic closing and a second kind
 of subscription.
 
-A **topic** is the string address of one subscription inside a WebSocket
-connection. In `poll:demo`, `poll` identifies the kind of subscription and
-`demo` identifies the room. One socket can join several topics, and Beryl uses
-the topic string to route messages and broadcasts.
+A **topic** is a string. It names one subscription inside a WebSocket
+connection. In `poll:demo`, `poll` is the kind of subscription and `demo` is
+the room. One socket can join many topics. Beryl uses the topic string to route
+messages and broadcasts.
 
-Beryl does not use the word channel for this subscription. Beryl reserves
-that word for a separate API built on top of topics. A later article
-introduces that API. For now, the browser joins a topic, and the application
-routes its string address.
+Beryl does not call this subscription a channel. In Beryl, a **channel** is a
+separate API built on top of topics. A later chapter introduces that API. For
+now, the browser joins a topic, and your application routes it by its string.
 
-A poll makes the architecture visible without much domain code. Each browser
-connection needs socket-local state, while every browser in the same room
-shares one poll. A vote also produces two different kinds of output: a reply
-to the browser that voted and a broadcast to the other subscribers. Those
-requirements give us concrete reasons to use models, typed messages, topic
-routing, effects, and an application-owned OTP actor.
+A poll is a good example because it needs little domain code. Each browser
+connection needs its own state. All browsers in the same room share one poll.
+A vote also produces two kinds of output: a reply to the voter and a broadcast
+to everyone else. These needs give us real reasons to use models, typed
+messages, topic routing, effects, and an OTP actor that your application owns.
 
-This article ends with the smallest useful checkpoint. The server accepts a
+This chapter ends with the smallest useful checkpoint. The server accepts a
 `poll:*` join and returns the current poll state. Voting, broadcasts, timers,
-and channel composition come later, after the core state-transition model is
-clear.
+and channels come later, after the core loop is clear.
 
 ## One model, different domains
 
 The shared model has four parts:
 
-1. initialize some state;
-2. define the messages or inputs that can arrive;
+1. create some state;
+2. define the messages, or inputs, that can arrive;
 3. handle one input against the current state;
-4. return the next state and describe what happens next.
+4. return the next state and say what happens next.
 
-Lustre, OTP actors, and Beryl assign different names and runtime behavior to
-the fourth part. The state transition stays recognizable across all three.
+Lustre, OTP actors, and Beryl use different names for the fourth part. They
+also do different things with it. Parts one to three look the same in all
+three.
 
 ## Start with the familiar Lustre loop
 
-The canonical Lustre example has four application pieces. Here is the
-overview's counter with full function annotations:
+The standard Lustre example has four pieces. Here is the counter from the
+Lustre overview, with full type annotations:
 
 ```gleam
 fn init(_flags: Nil) -> Int {
@@ -84,14 +82,14 @@ fn update(model: Int, message: Message) -> Int {
 ```
 
 The [Lustre for Elm developers](https://lustre.hexdocs.pm/cheatsheets/elm.html)
-guide makes the model type explicit:
+guide names the model type:
 
 ```gleam
 type Model =
   Int
 ```
 
-The view uses qualified module calls:
+The view calls each module by name:
 
 ```gleam
 fn view(model: Int) -> element.Element(Message) {
@@ -105,24 +103,24 @@ fn view(model: Int) -> element.Element(Message) {
 }
 ```
 
-`init` creates the first model. `Message` lists everything that can drive
-application state. `update` computes the next model. `view` turns that model
-into elements that can produce more messages.
+`init` creates the first model. `Message` lists every event that can change
+the state. `update` computes the next model. `view` turns the model into
+elements. Those elements can send more messages.
 
-Some work cannot happen inside a state transition. A browser may need to make
-an HTTP request, start a timer, or interact with JavaScript. Lustre represents
-that work as an `Effect(Message)`. An update returns the next model and an
-effect value. The Lustre runtime performs the work and can feed its result
-back into `update` as another `Message`.
+Some work cannot happen inside `update`. A browser may need to send an HTTP
+request, start a timer, or call JavaScript. Lustre calls this work an
+`Effect(Message)`. An update returns the next model and an effect. The Lustre
+runtime does the work. It can then send the result back to `update` as a new
+`Message`.
 
-An OTP actor keeps the same state transition. Instead of a browser event loop,
-the transition runs inside a concurrent process.
+An OTP actor uses the same loop. The loop runs inside a concurrent process
+instead of a browser.
 
 ## The same loop inside an OTP actor
 
-A Gleam OTP actor applies the same state transition to a process mailbox. It
-owns state and processes messages sequentially. Keeping the counter from the
-Lustre example makes the change of runtime easier to see:
+A Gleam OTP actor is a process with a mailbox. It owns some state. It handles
+one message at a time, in order. We keep the same counter so the only change is
+the runtime:
 
 ```gleam
 type Message {
@@ -138,13 +136,13 @@ fn on_message(count: Int, message: Message) -> actor.Next(Int, Message) {
 }
 ```
 
-The model is still an `Int`, and the messages are still `Incr` and `Decr`.
-The difference is where they come from and what happens to the result. A
-Lustre runtime receives interface messages and passes the next model to
-`view`. An actor receives messages from its mailbox and uses `actor.continue`
-to replace its process state.
+The model is still an `Int`. The messages are still `Incr` and `Decr`. Two
+things change: where messages come from, and what happens to the result. Lustre
+gets messages from the interface and passes the next model to `view`. An actor
+gets messages from its mailbox and calls `actor.continue` to store the next
+state.
 
-The common model becomes clearer side by side:
+Here are the two side by side:
 
 | Lustre | Gleam OTP actor |
 |---|---|
@@ -154,34 +152,33 @@ The common model becomes clearer side by side:
 | next model and effects | `actor.Next` plus sends performed by the handler |
 | `view` | no equivalent |
 
-A Lustre message usually represents a user-interface event or the result of an
-effect. An actor message represents communication between concurrent
-processes. Both feed a typed state transition. Lustre's runtime uses the
-result to update an interface. The actor runtime uses `actor.Next` to continue
-or stop the process.
+A Lustre message is usually an interface event or the result of an effect. An
+actor message comes from another process. Both go through the same kind of
+typed transition. Lustre uses the result to update the screen. The actor
+runtime uses `actor.Next` to continue or stop the process.
 
-A `process.Subject(message)` is the typed address used to send these messages
-to the actor's mailbox.
+To send a message to an actor, you use a `process.Subject(message)`. A subject
+is a typed address for the actor's mailbox.
 
-We can now carry the same model into Beryl and give each role a
-socket-specific meaning.
+Now we can carry the same model into Beryl and give each part a socket
+meaning.
 
 ## Beryl applies the loop to sockets
 
-Beryl offers two ways to program a socket endpoint. The recommended channel
-layer routes events to handlers selected by topic. Underneath it, the raw
-app-side dispatch API gives every event for a socket to one application
-`update` function.
+Beryl gives you two ways to program a socket endpoint. The channel layer is
+the recommended one. It routes each event to a handler based on the topic.
+Under it sits the raw app-side dispatch API. Raw dispatch gives every event on
+a socket to one `update` function that you write.
 
-"Raw dispatch" means the application owns that routing. Your code receives
-joins, client messages, binary frames, close events, and typed server
-messages as `socket.Input` values. Your code then decides how each input
+"Raw dispatch" means your application does the routing. Your code receives
+joins, client messages, binary frames, close events, and typed server messages.
+Each one arrives as a `socket.Input` value. Your code decides how each input
 changes the socket's model. Beryl still owns the WebSocket transport, wire
 decoding, protocol checks, and effect execution.
 
-We begin with raw dispatch because it exposes the complete state-transition
-loop. A later article moves the same poll to the recommended channel layer and
-shows which routing work moves from the application into the layer.
+We start with raw dispatch because it shows the full loop. A later chapter
+moves the same poll to the channel layer. That chapter shows which routing work
+moves out of your code.
 
 The three domains now line up:
 
@@ -192,7 +189,7 @@ The three domains now line up:
 | transition | `update` | `on_message` handler | `update` |
 | next step | model and optional effect | `actor.Next` | `socket.Next(model, effects)` |
 
-Beryl asks the application for `init` and `update`. This exact excerpt comes
+Beryl asks your application for `init` and `update`. This exact excerpt comes
 from `step_01.gleam`:
 
 ```gleam
@@ -203,14 +200,14 @@ beryl.child_spec(
 )
 ```
 
-That exact assembly appears in
+You can see it in
 [`step_01.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/live_poll/src/live_poll/step_01.gleam).
-`beryl.child_spec` captures the app's concrete model and message types in
-typed closures and returns a non-generic `beryl.Sockets` handle plus a child
-specification. The shared runtime remains generic internally. It does not
-round-trip the app model or app message through `Dynamic`.
+`beryl.child_spec` returns two values. The first is a `beryl.Sockets` handle.
+The second is a child specification for your supervisor. Your model and message
+types stay inside the closures you pass in. Beryl never converts them to
+`Dynamic`.
 
-The live-poll example's raw types are:
+The live-poll example defines these raw types:
 
 ```gleam
 pub type Message {
@@ -228,38 +225,36 @@ pub fn init(info: socket.ConnectInfo(Message)) -> #(Model, List(socket.Effect)) 
 
 This excerpt comes from
 [`raw.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/live_poll/src/live_poll/raw.gleam).
-The names carry specific meanings:
+Each name has one meaning:
 
-- `Model` is application-defined state for one connected socket.
-- `Message` is the application's domain-specific type for server-side events.
-  The poll defines `ClosePoll` because a timer needs to tell a socket that one
-  of its polls has expired. Another application would define variants from its
-  own domain.
-- `socket.Effect` describes work for Beryl to interpret after `init` or
-  `update`.
-- `socket.ConnectInfo.self` is the socket-scoped sender. It is not a general
-  process `Subject`.
+- `Model` is the state your application keeps for one connected socket.
+- `Message` is your own type for server-side events. The poll defines
+  `ClosePoll` because a timer must tell a socket that one of its polls has
+  ended. Another application would define its own variants.
+- `socket.Effect` describes work for Beryl to do after `init` or `update`.
+- `socket.ConnectInfo.self` is a sender for this socket only. It is not a
+  general process `Subject`.
 
-The type parameter connects the server-message path:
-`ConnectInfo(Message)` supplies a `Sender(Message)`, and Beryl delivers values
-sent through that sender as `Info(Message)`. Client frames follow a separate
-path through the `Join`, `Message`, and `Binary` variants of `socket.Input`.
-The app-defined `Message` type never represents decoded client data.
+The type parameter links the server-message path together.
+`ConnectInfo(Message)` gives you a `Sender(Message)`. When you send a value
+through that sender, Beryl delivers it to `update` as `Info(Message)`. Client
+frames take a different path. They arrive as the `Join`, `Message`, and
+`Binary` variants of `socket.Input`. Your `Message` type never holds decoded
+client data.
 
-The `update` function returns
-`fn(Model, socket.Input(Message)) -> socket.Next(Model)` and exhaustively matches
-the input inside that closure. Beryl uses `socket.Input(Message)` where Lustre
-uses `Message` and an actor uses its mailbox message type. Some input variants
-carry client data. `Info(Message)` holds the app's typed server-side data.
-`socket.Next(model, effects)` continues with the next model. `socket.Stop(reason)`
-stops the whole socket.
+The `update` function has the type
+`fn(Model, socket.Input(Message)) -> socket.Next(Model)`. It matches every
+input variant. Beryl uses `socket.Input(Message)` where Lustre uses `Message`
+and an actor uses its mailbox message. Some input variants carry client data.
+`Info(Message)` carries your typed server-side data. `socket.Next(model,
+effects)` continues with the next model. `socket.Stop(reason)` stops the whole
+socket.
 
 ## There is no view
 
-With the state and input terms mapped, the final difference is output. Beryl
-does not derive output from the model by rendering it. The application returns
-an ordered list of `socket.Effect` values. This exact excerpt comes from
-`raw.gleam`:
+We have mapped state and input. The last difference is output. Beryl does not
+render the model. Instead, your application returns an ordered list of
+`socket.Effect` values. This exact excerpt comes from `raw.gleam`:
 
 ```gleam
 socket.Next(
@@ -268,48 +263,48 @@ socket.Next(
 )
 ```
 
-The complete example registers the room in its store. This branch then accepts
-a valid `poll:*` join and records the topic in the socket's model. Other effects
-can reply to a client message, push to this socket, broadcast to subscribers,
-update presence, or close a topic.
+Before this line, the full example registers the room in its store. This branch
+then accepts a valid `poll:*` join and adds the topic to the socket's model.
+Other effects can reply to a client message, push to this socket, broadcast to
+subscribers, update presence, or close a topic.
 
-The absence of `view` changes how you reason about output. A model change does
-not imply a wire frame. A wire frame appears only when an effect requests one.
-The model can also track facts that never need to leave the server, such as
-the set of topics joined by this socket.
+Without `view`, you think about output in a new way. A change to the model
+does not send a wire frame. A wire frame goes out only when an effect asks for
+one. The model can also hold facts that never leave the server. The set of
+topics this socket has joined is one example.
 
 ## Initialization belongs to the socket
 
-Lustre initializes one application model. A typical OTP actor initializes one
-actor state value. Beryl calls raw `init` once for every admitted socket connection. One socket
-actor stores the returned `Model` and runs that socket's updates. A separate
-router actor maintains the socket index and routes frames and broadcasts. The
-distinction becomes important for blocking work and crash behavior, which the
-fifth chapter covers.
+Lustre creates one application model. An OTP actor usually creates one state
+value. Beryl calls raw `init` once for every socket that connects. One socket
+actor stores that socket's `Model` and runs its updates. A separate router
+actor keeps the list of sockets and routes frames and broadcasts. This split
+matters for blocking work and crashes. Chapter 5 covers both.
 
-The live poll now gives us a reason to add an application-owned actor. Every
-browser connected to a room must see the same totals, so those totals cannot
-belong to one socket's `Model`. The example captures a shared `store.Store`
-actor in the update closure. Every browser socket gets its own raw `Model`,
-while all sockets send poll operations to the same store. Per-socket state and
-shared domain state remain separate.
+The live poll now needs an actor that your application owns. Every browser in
+a room must see the same totals. So the totals cannot live in one socket's
+`Model`. The example puts them in a shared `store.Store` actor and captures it
+in the update closure. Each browser socket gets its own raw `Model`. All
+sockets send poll operations to the same store. Per-socket state and shared
+domain state stay apart.
 
 ## The first mismatch is useful
 
-The Elm architecture supplies a vocabulary for pure state transitions, but
-Beryl is not a frontend framework:
+The Elm architecture gives us words for pure state transitions. But Beryl is
+not a frontend framework:
 
-- no `view` function exists;
+- there is no `view` function;
 - `init` runs once per socket;
-- client input arrives through `socket.Input`;
+- client input arrives as `socket.Input`;
 - output is an explicit list of `socket.Effect` values;
-- one socket actor stores each socket model and runs its updates.
+- one socket actor stores each socket's model and runs its updates.
 
-Raw dispatch exposes these facts with little machinery. It is Beryl's core
-and the clearest place to learn joins, replies, close events, and effect order.
-For an application with several channel families, you will usually move to
-`beryl/channel`, the recommended default for multi-channel and Phoenix-shaped
-systems. Chapter 4 performs that refactor without changing the wire protocol.
+Raw dispatch shows these facts with little extra code. It is Beryl's core. It
+is the clearest place to learn joins, replies, close events, and effect order.
+When an application has several channel families, you will usually move to
+`beryl/channel`. That is the recommended default for multi-channel and
+Phoenix-shaped systems. Chapter 4 makes that move without changing the wire
+protocol.
 
 ## Sources and further reading
 
@@ -327,8 +322,8 @@ cd examples/live_poll && gleam run -m live_poll/step_01
 ```
 
 Open `http://localhost:8101`, keep the room as `demo`, and select **Join
-poll**. The client joins `poll:demo`, requests `get_state`, and displays an
-open poll with zero votes. Voting and **Close poll now** are unavailable in
-this read-only checkpoint, so those pushes time out without changing state.
+poll**. The client joins `poll:demo`, requests `get_state`, and shows an open
+poll with zero votes. Voting and **Close poll now** do not work yet in this
+read-only checkpoint. Those pushes time out and do not change state.
 
 Next: [One update function, many socket events](/tutorial/one-update-function-many-socket-events/).

--- a/website/src/content/docs/tutorial/typed-messages-from-your-gleam-system.md
+++ b/website/src/content/docs/tutorial/typed-messages-from-your-gleam-system.md
@@ -3,18 +3,20 @@ title: Typed Messages From Your Gleam System
 description: Send typed server-side events from actors and timers into the socket update loop.
 ---
 
-Client frames are only one source of socket work. A database worker may
-finish, a timer may expire, or an application actor may publish a domain
-event. Beryl routes those server-side events through `socket.Sender(Message)`
-and delivers them to the owning update function as `socket.Info(Message)`.
+Client frames are not the only source of socket work. A database worker can
+finish. A timer can expire. An actor in your app can publish an event. Beryl
+calls these server-side events. It routes them through a
+`socket.Sender(Message)`. The socket's update function receives them as
+`socket.Info(Message)`.
 
-The design resembles a typed OTP send, but a Beryl sender has a narrower
-contract than `process.Subject`.
+This looks like a typed OTP send. But a Beryl sender can do less than a
+`process.Subject`. This chapter shows the difference.
 
 ## The OTP baseline
 
-A Gleam OTP actor receives typed messages through a `process.Subject`. The
-example's store wraps its subject in an opaque handle:
+A Gleam OTP actor is a process with a mailbox. It receives typed messages
+through a `process.Subject`. The example's store keeps its subject inside an
+opaque type, so callers cannot use the subject directly:
 
 ```gleam
 pub opaque type Store {
@@ -36,12 +38,12 @@ type Message {
 
 This excerpt comes from
 [`store.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/live_poll/src/live_poll/store.gleam).
-The store's `Subject(Message)` addresses the actor's mailbox. `Join` and
-`Leave` track active sockets. Other messages carry reply subjects because
-`Get`, `Vote`, and `Close` are synchronous calls from the wrapper API.
+The `Subject(Message)` is the address of the actor's mailbox. `Join` and
+`Leave` count the active sockets in a room. `Get`, `Vote`, and `Close` carry a
+`reply` subject. The caller waits for an answer on that subject.
 
-The actor handler receives its current `Dict` state and one `Message`, then
-returns `actor.Next`:
+The actor's handler receives its current state and one `Message`. It returns
+`actor.Next`:
 
 ```gleam
 Vote(room, choice, reply) -> {
@@ -61,13 +63,13 @@ Vote(room, choice, reply) -> {
 }
 ```
 
-The subject can carry any protocol the actor accepts. It does not carry
-Beryl's socket lifecycle rules.
+A subject can carry any message type the actor accepts. It knows nothing about
+Beryl sockets or when they close.
 
 ## A socket sender has one destination
 
-Raw Beryl `init` receives `socket.ConnectInfo(Message)`. Its `self` field is a
-`socket.Sender(Message)`:
+When a socket connects, Beryl calls your raw `init` with a
+`socket.ConnectInfo(Message)`. Its `self` field is a `socket.Sender(Message)`:
 
 ```gleam
 pub type Model {
@@ -79,9 +81,9 @@ pub fn init(info: socket.ConnectInfo(Message)) -> #(Model, List(socket.Effect)) 
 }
 ```
 
-The application defines `Message` as its domain-specific vocabulary for
-server-side events in the socket's update loop. The poll defines one such
-event. It tells a socket that a timer has expired for one topic:
+You define `Message`. It is the set of server-side events your update function
+can receive. The poll defines one event. It tells a socket that the timer for
+one topic has expired:
 
 ```gleam
 pub type Message {
@@ -89,18 +91,17 @@ pub type Message {
 }
 ```
 
-This `Message` is distinct from the `socket.Message` input variant, which
-contains a decoded client event. A chat application might instead define
-`NewChatMessage`, `UserBanned`, or other variants produced by its own actors
-and workers.
+Do not confuse this `Message` with `socket.Message`. `socket.Message` is an
+input variant that holds a decoded client event. Your own `Message` holds
+events from your actors and workers. A chat app might define `NewChatMessage`
+or `UserBanned` here.
 
-The example stores `info.self` in each socket's `Model`. Beryl constructs that
-sender when the socket connects. The sender wraps that socket actor's subject
-and captures the socket ID. The actor uses this ID to reject a notification
-after the socket has closed. The sender remains an opaque `socket.Sender`
-rather than exposing the subject.
+The example stores `info.self` in the socket's `Model`. Beryl makes the sender
+when the socket connects. It knows which socket actor it belongs to. If that
+socket has closed, the sender drops the message. You never see the subject
+inside it.
 
-The same application-defined type appears throughout the path:
+Your `Message` type appears at each step of the path:
 
 <!-- snippet-check: skip -->
 ```gleam
@@ -110,11 +111,10 @@ socket.Input(Message)
 socket.Info(ClosePoll(topic))
 ```
 
-Calling `socket.notify(sender, ClosePoll(topic))` sends the typed value to the
-socket actor. Beryl passes it to that socket's update function as
-`Info(ClosePoll(topic))`.
+To send an event, call `socket.notify(sender, ClosePoll(topic))`. Beryl
+delivers it to the socket's update function as `Info(ClosePoll(topic))`.
 
-Its update handles the message with this exact excerpt:
+The update function handles it like this:
 
 ```gleam
 socket.Info(ClosePoll(topic)) ->
@@ -133,20 +133,19 @@ socket.Info(ClosePoll(topic)) ->
 
 These excerpts come from
 [`raw.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/live_poll/src/live_poll/raw.gleam).
-`ClosePoll` stays typed from the call to `socket.notify` through the
-`Info(ClosePoll(topic))` match. It does not become `Dynamic`.
+`ClosePoll` keeps its type from `socket.notify` to the `Info` match. It never
+becomes `Dynamic`.
 
-The sender is narrower than a general `process.Subject`:
+A sender can do less than a `process.Subject`:
 
-- it only permits values of the raw app's `Message` type;
-- it only targets the socket update that created it;
-- the runtime wraps delivery as `socket.Info(Message)`;
-- it ignores delivery if that socket has disconnected;
-- it does not expose mailbox selection or a general request/reply protocol.
+- It accepts only values of your `Message` type.
+- It sends only to the socket that made it.
+- Beryl wraps each value as `socket.Info(Message)`.
+- It drops the value if the socket has disconnected.
+- It has no request/reply protocol and no mailbox selection.
 
-Use `Subject` when you are defining an actor protocol. Use `socket.Sender`
-when another process needs to feed typed information into one socket's update
-loop.
+Use a `Subject` when you define an actor's protocol. Use a `socket.Sender`
+when another process must send a typed event into one socket.
 
 ## The timer stays outside the runtime
 
@@ -169,10 +168,10 @@ pub fn after(timer: Timer, milliseconds: Int, action: fn() -> Nil) -> Nil {
 
 This exact excerpt comes from
 [`timer.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/live_poll/src/live_poll/timer.gleam).
-The timer actor owns delayed callback execution. It does not block Beryl's
-socket actor for 60 seconds.
+The timer actor runs the callback after the delay. The socket actor does not
+wait 60 seconds. It stays free to handle other work.
 
-When a timed raw socket accepts a poll topic, it schedules a callback:
+When a timed socket accepts a poll topic, it schedules a callback:
 
 ```gleam
 case stage {
@@ -184,37 +183,36 @@ case stage {
 }
 ```
 
-`step_03` passes `60_000` as `duration_ms`. After 60 seconds the timer actor
-runs the callback, `socket.notify` sends `ClosePoll(topic)`, and Beryl invokes
-the socket update with `Info(ClosePoll(topic))`.
+`step_03` sets `duration_ms` to `60_000`. After 60 seconds, the timer actor
+runs the callback. The callback calls `socket.notify`. Beryl then calls the
+socket's update function with `Info(ClosePoll(topic))`.
 
-The send is fire-and-forget. `socket.notify` returns `Nil`. It does not report
-whether the socket remains connected. If the browser closed during the
-minute, Beryl ignores the delivery. The timer actor does not need to monitor
-the socket or clean up a failed request.
+`socket.notify` is fire-and-forget. It returns `Nil`. It does not tell you if
+the socket is still connected. If the browser closed during that minute, Beryl
+drops the message. The timer actor does not need to watch the socket or clean
+up after it.
 
-## Domain state remains in the store actor
+## Domain state stays in the store actor
 
-The raw `Model` tracks the socket's sender and joined topics. It does not own
-poll totals. Both client `Message` inputs and timer-driven `Info` inputs call
-the shared `store.Store`.
+The raw `Model` holds the sender and the set of joined topics. It does not hold
+vote counts. Both client events and timer events call the shared
+`store.Store`.
 
-That split gives each piece one job:
+Each part has one job:
 
-- Beryl's logical per-socket `Model` tracks connection-local facts.
-- The store actor serializes shared poll mutations by room.
-- The timer actor schedules delayed work.
-- `socket.Sender` reconnects external work to one socket update.
+- The socket `Model` holds facts about one connection.
+- The store actor applies poll changes one at a time for each room.
+- The timer actor runs delayed work.
+- The `socket.Sender` sends the result back into one socket.
 
-`store.Store` is also the persistence boundary. Socket code calls `get`, `vote`,
-and `close` without knowing that the current actor keeps a `Dict` in memory.
-The actor could keep serializing those operations while storing polls in
-[Stóráil](https://hexdocs.pm/storail/) or a database. These are separate
-decisions. The actor orders concurrent updates. The storage backend
-determines whether state survives an application restart. A production
-backend also needs an explicit policy for I/O latency and write failures.
+`store.Store` also hides where the data lives. Socket code calls `get`, `vote`,
+and `close`. It does not know that the actor keeps a `Dict` in memory. The
+actor could keep polls in [Stóráil](https://hexdocs.pm/storail/) or a database
+instead. The actor still puts the updates in order. The storage decides if
+the data survives a restart. A real backend also needs a plan for slow I/O and
+failed writes.
 
-Closing returns a descriptive result:
+The close operation returns a result that says what happened:
 
 ```gleam
 pub type CloseResult {
@@ -230,15 +228,15 @@ pub fn close(poll: Poll) -> CloseResult {
 }
 ```
 
-`ClosedNow` tells the caller to broadcast `poll_closed`. `AlreadyClosed`
-suppresses a duplicate broadcast. Each accepted socket join schedules its own
-timer, so two tabs can schedule two close messages for the same room. Only
-the first close message changes the store.
+`ClosedNow` tells the caller to broadcast `poll_closed`. `AlreadyClosed` tells
+the caller not to broadcast again. Each socket join sets its own timer. Two
+tabs on the same room set two timers. Only the first `ClosePoll` changes the
+store.
 
-## Close now uses the same state transition
+## Close now uses the same state change
 
-In the timed stage, the client can send `close_poll`. The raw handler calls
-the same `store.close` function and returns ordered effects:
+In the timed stage, a client can send `close_poll`. The raw handler calls the
+same `store.close` function. It returns effects in order:
 
 ```gleam
 Timed -> {
@@ -258,47 +256,44 @@ Timed -> {
 }
 ```
 
-The reply to the requesting client precedes the broadcast in the effect list.
-Beryl applies effects strictly in list order, and the runtime's writes preserve
-that wire order. The delayed timer may later deliver another typed `Info`, but
-the idempotent store prevents a second close broadcast.
+The reply comes before the broadcast in the list. Beryl runs effects in list
+order. The wire sees them in that order too. The timer can still send a later
+`Info`. But `store.close` is safe to call twice, so there is no second
+broadcast.
 
-This ordering guarantee belongs to Beryl's `socket.Effect` interpreter. The
-comparison with Lustre and OTP does not imply that their effects or process
-sends share the same cross-abstraction ordering rules.
+This order guarantee is a Beryl rule. Lustre effects and OTP sends have their
+own rules. Do not assume they order work the same way.
 
-## `Info` has socket-wide scope
+## `Info` is not scoped to a topic
 
-`Info(Message)` does not carry a topic automatically. The app message must include
-the routing information it needs. The example defines
-`ClosePoll(topic: String)` because one raw socket may join several poll topics.
+An `Info(Message)` does not carry a topic. Your message must carry the routing
+data it needs. The example defines `ClosePoll(topic: String)` because one raw
+socket can join several poll topics.
 
-This lack of topic scoping has a crash consequence. Beryl can attribute a
-crashing `Message` or `Binary` callback to a topic and close only that topic.
-A crashing `Info` callback has no protocol topic to attribute, so the runtime
-tears down that socket. Chapter 5 covers the complete scoped rescue
-behavior.
+This has one effect on crashes. When a `Message` or `Binary` callback crashes,
+Beryl knows the topic. It closes only that topic. When an `Info` callback
+crashes, Beryl has no topic. It closes the whole socket. Chapter 5 explains the
+full crash behavior.
 
-This design also adds a composition cost. If several raw topic families need
-unrelated server message types, the app must put them in one socket-wide `Message`
-union and route each variant. `beryl/channel` removes that shared union by
-giving each accepted channel instance a private info type.
+It also has a cost when you compose. If several topic families need different
+server-side events, you must put them all in one `Message` type. Your update
+function must route each variant. `beryl/channel` removes this shared type.
+Each channel gets its own private info type.
 
-## Choosing the boundary
+## Choose the boundary
 
-Keep slow or independently supervised work in your own processes. Send a
-small typed result into Beryl when the socket update needs to decide what
-state or effects come next. Each socket actor executes its update callbacks in
-sequence, so sleeping, blocking I/O, or long computation inside `update`
-delays that socket's messages, effects, and heartbeat checks. Other sockets
-continue.
+Keep slow work in your own processes. Keep work that needs its own supervisor
+there too. Send a small typed result into Beryl when the socket must decide on
+new state or effects. Each socket actor runs its update callbacks one at a
+time. If `update` sleeps, blocks on I/O, or does long work, that socket's
+messages, effects, and heartbeat checks wait. Other sockets are not affected.
 
-`socket.Sender` provides the typed return path without turning Beryl into the
-owner of your job, store, or timer. The application still decides how to
+`socket.Sender` gives you a typed way back into the socket. Beryl does not
+become the owner of your job, store, or timer. Your app still decides how to
 supervise those processes.
 
-The next chapter moves from one socket-wide model and message union to
-heterogeneous channel handlers with private state and private info types.
+The next chapter moves from one socket-wide `Model` and `Message` to channel
+handlers. Each handler keeps its own state and info types.
 
 ## Sources and further reading
 
@@ -313,10 +308,9 @@ heterogeneous channel handlers with private state and private info types.
 cd examples/live_poll && gleam run -m live_poll/step_03
 ```
 
-Open `http://localhost:8103`, join `demo`, and vote. Select **Close poll
-now** to close immediately, or leave the poll open for 60 seconds. In either
-case the client receives the closed state and voting becomes disabled. If you
-close the browser before the timer fires, Beryl ignores its later
-`socket.notify` delivery.
+Open `http://localhost:8103`, join `demo`, and vote. Select **Close poll now**
+to close the poll at once, or wait 60 seconds. In both cases, the client
+receives the closed state and voting stops. If you close the browser before
+the timer fires, Beryl drops the later `socket.notify` message.
 
 Next: [Composition: raw dispatch and `beryl/channel`](/tutorial/composition-raw-dispatch-and-channels/).

--- a/website/src/content/docs/tutorial/where-the-analogy-ends.md
+++ b/website/src/content/docs/tutorial/where-the-analogy-ends.md
@@ -3,17 +3,19 @@ title: Where the Analogy Ends
 description: Follow a frame through Beryl and learn where frontend model-update ideas stop matching runtime behavior.
 ---
 
-Model-update vocabulary helps organize Beryl application code, but it can
-mislead you about execution. Beryl creates one actor for each socket model,
-but it does not render output from state or restart socket state after an
-actor crash. A router actor maintains the socket index and handles fan-out.
-Each socket actor calls the application update and interprets ordered effects.
+The model-update words from the last chapters help you organize your code.
+But they can give you the wrong idea about how Beryl runs that code. Beryl
+gives each socket its own actor. An actor is a process with a mailbox that
+handles one message at a time. But Beryl does not draw a view from your model.
+It does not bring your socket state back after a crash. One router actor keeps
+the list of sockets and sends broadcasts to them. Each socket actor calls your
+update function and runs the effects it returns, in order.
 
 The production decisions start where the frontend analogy ends.
 
 ## Follow one frame
 
-For a text frame, the path is:
+A frame is one WebSocket message. For a text frame, the path is:
 
 ```text
 transport connection
@@ -25,53 +27,53 @@ transport connection
   -> encoded wire frame or broadcast fan-out
 ```
 
-The transport owns the WebSocket connection and edge controls. It checks the
-frame size and frame-rate bucket, decodes the frame with the configured codec,
-and sends the decoded value to the router. Malformed input and decode cost
-stay in the connection process.
+The transport owns the WebSocket connection. It does the first checks: is the
+frame too large, and is the client sending too many frames? Then it decodes the
+frame with your wire codec and sends the result to the router. Bad input and
+decode work stay in the connection process. They do not reach your code.
 
-The router forwards the decoded value to the socket actor. That actor validates
-protocol state and constructs a `socket.Input`. Raw dispatch receives that
-input directly. `beryl/channel` supplies the app-side router, locates the live
-channel instance, calls its callback, and lowers channel actions to core
+The router sends the decoded value to the socket actor. That actor checks the
+protocol state and builds a `socket.Input`. With raw dispatch, your update
+function receives that input. With `beryl/channel`, the channel layer finds the
+live channel for that topic, calls its callback, and turns the actions into core
 effects.
 
-The socket actor then interprets effects in list order. Replies and pushes
-become encoded frames. It sends broadcasts to the router for local fan-out and
-optional PubSub delivery.
+The socket actor then runs the effects in list order. A reply or push becomes an
+encoded frame. A broadcast goes to the router. The router sends it to the local
+sockets, and to PubSub if you configured it.
 
-This path contains one intentional `Dynamic` boundary: decoded client
-payloads. The core runtime's app model and message types stay captured in
-typed closures. The channel layer adds separate closure sealing for each
-handler's private state and info type.
+The client payload is the only `Dynamic` value on this path. Your model and
+message types stay inside typed closures. The channel layer does the same for
+each handler's state and info type.
 
 ## Each socket model has one actor
 
-Raw `init` runs once per socket and returns one app-defined `Model`. A channel
-router creates one private state value per accepted topic. Those values are
-logically separate, and one socket actor stores all values for its socket.
+Raw `init` runs once for each socket. It returns one `Model`. With channels,
+each accepted topic gets its own state value. Those values are separate from
+each other, but one socket actor stores all of them for its socket.
 
-The socket actor processes its mailbox in sequence. This gives it a consistent
-view of its model, pending and joined topics, and heartbeat timestamp without
-locks. The router has a separate mailbox for the socket index and topic
-subscriber sets. A blocking update delays only its socket, but it also delays
-that socket's later messages, effects, and heartbeat checks.
+The socket actor handles its mailbox one message at a time. So it always has a
+consistent view of its model, its topics, and its heartbeat time. It needs no
+locks. The router has its own mailbox for the socket list and topic subscriber
+sets. If your update function blocks, only that socket waits. But that socket's
+later messages, effects, and heartbeat checks also wait.
 
 The live-poll example follows that rule:
 
-- `store.Store` serializes shared poll state in its own actor;
+- `store.Store` keeps the shared poll state in its own actor;
 - `timer.Timer` waits and runs delayed callbacks in its own actor;
-- Beryl callbacks make short calls, choose the next state, and return effects.
+- Beryl callbacks make short calls, pick the next state, and return effects.
 
-If an external operation needs more time, run it under application
-supervision and send a typed result through `socket.Sender` or
+If some work takes a long time, do not run it in a callback. Run it under your
+own supervision. Then send a typed result back through `socket.Sender` or
 `channel.Sender`.
 
-## Beryl rescues callback crashes with a scope
+## Beryl catches callback crashes, and the effect depends on the input
 
-"Let it crash" would make one callback fault close every topic on its socket.
-Beryl rescues application callback crashes and applies behavior based on the
-input that failed:
+In Erlang, "let it crash" means: let a process die and let its supervisor
+restart it. If Beryl did that here, one bad callback would close every topic on
+its socket. Instead, Beryl catches the crash. What happens next depends on
+which input failed:
 
 | Callback or raw input | Runtime behavior |
 |---|---|
@@ -81,44 +83,45 @@ input that failed:
 | `Info`, or channel `on_info` | Tear down that socket |
 | `Closed`, or channel `on_terminate` | Log the crash and continue teardown |
 
-Other socket actors continue. A fault elsewhere in that socket actor stops
-only that actor. The router monitors it, closes the connection, and removes
-its index entries. Beryl truncates and depth-limits crash descriptions before
-logging.
+Other socket actors keep running. If a socket actor crashes somewhere else,
+only that actor stops. The router sees this, closes the connection, and removes
+the socket from its list. Beryl cuts long crash descriptions before it logs
+them.
 
-The `on_terminate` case has a narrow channel-layer edge. A panic discards the
-router update and actions that the callback returns. Its generation-scoped
-sender can still reach the old sealed instance. This access ends when the
-client joins the topic again or the socket ends. Client traffic cannot reach
-the instance because the topic has closed. Keep termination callbacks small
-and free of partial application work.
+The `on_terminate` case has one small edge in the channel layer. If the
+callback panics, Beryl drops the router update and the actions it returned.
+The channel's sender can still reach the old channel until the client joins the
+topic again or the socket ends. Client traffic cannot reach it, because the
+topic is closed. Keep `on_terminate` small. Do not do half-finished work there.
 
-This policy contains app callback failures without pretending every failure
-has the same scope.
+This policy contains crashes in your callbacks. It does not pretend that every
+crash has the same size.
 
 ## Supervision restores dispatch, not sessions
 
-`beryl.child_spec` and `channel.child_spec` return a child specification for
-your application's supervisor. The supervisor restarts the router under the
-same name-backed `beryl.Sockets` handle. Router death stops all socket actors,
-so connected clients close, reconnect, and rejoin with new models and channel
-state. A socket actor crash closes only its connection and does not restart the
-router.
+`beryl.child_spec` and `channel.child_spec` return a child specification. You
+put it in your application's supervisor. If the router dies, the supervisor
+restarts it under the same `beryl.Sockets` handle. When the router dies, all
+socket actors stop too. Connected clients see the connection close. They
+reconnect and join again with new models and new channel state. If one socket
+actor crashes, only its connection closes. The router does not restart.
 
-Keep durable or reconstructable domain state in application-owned storage, as
-the example does with `store.Store`. The next chapter covers the supervision
-tree, restart windows, restart intensity, and graceful shutdown.
+Keep domain state that must survive in storage that your app owns. The example
+does this with `store.Store`. The next chapter covers the supervision tree,
+restart windows, restart intensity, and graceful shutdown.
 
-## Heartbeats test connection liveness
+## Heartbeats test that a connection is alive
 
-Phoenix clients send heartbeat frames on the `phoenix` topic. Beryl handles
-them inside each socket actor. The application update does not receive them.
-Each actor records a monotonic last-seen timestamp and runs its own recurring
-check. There is no global heartbeat sweep.
+Phoenix clients send a heartbeat frame on the `phoenix` topic at a regular
+interval. Beryl handles heartbeats inside each socket actor. Your update
+function does not see them. Each actor records the time of the last heartbeat
+and runs its own timer to check it. There is no global check across all
+sockets.
 
-Eviction closes the transport and delivers `Closed(topic,
-HeartbeatTimeout)` for every joined topic. Raw dispatch can prune its model.
-The channel layer invokes `on_terminate` for each accepted instance.
+If a socket misses its heartbeat, Beryl closes the transport. It then delivers
+`Closed(topic, HeartbeatTimeout)` for every joined topic. Raw dispatch can
+remove the topic from its model. The channel layer calls `on_terminate` for
+each channel.
 
 The final checkpoint sets:
 
@@ -136,80 +139,83 @@ beryl.config(wire.phoenix_codec())
 
 This exact excerpt comes from
 [`step_05.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/live_poll/src/live_poll/step_05.gleam).
-These values make the example production-shaped, not universally correct.
-Choose limits from expected traffic and deployment capacity.
+These values make the example look like a production app. They are not correct
+for every app. Choose your limits from the traffic you expect and the capacity
+you have.
 
 ## PubSub and presence sit outside the MVU analogy
 
-PubSub distributes broadcasts between BEAM nodes through Erlang `pg`. The
-remote payload and subscriber contract belong to distributed messaging, not
-to a local model-update-view loop. The router fans a received broadcast out to
-local socket actors.
+PubSub sends broadcasts between BEAM nodes. It uses Erlang `pg`, the built-in
+process group library. A remote payload and its subscribers are a distributed
+messaging problem, not part of a local model-update-view loop. When the router
+receives a broadcast, it sends it to the local socket actors.
 
-Presence is an application-owned actor backed by a CRDT state. Presence
-effects can pause the remaining effects for one socket while the presence
-actor applies a mutation. Other sockets, heartbeats, broadcasts, and shutdown
-work continue. When the mutation completes, the waiting socket resumes its
-list in the original order.
+Presence tracks which clients are on a topic. It is an actor that your app
+owns. It stores a CRDT, which is a data structure that many nodes can change
+and still agree on. A presence effect can pause the rest of the effect list
+for one socket while the presence actor applies the change. Other sockets,
+heartbeats, broadcasts, and shutdown keep going. When the change is done, the
+socket runs the rest of its list in the original order.
 
-Neither PubSub nor presence is a hidden field in the socket `Model`. Their
-lifecycle and distributed semantics need separate design:
+PubSub and presence are not hidden fields in your socket `Model`. Each one has
+its own lifecycle and its own distributed rules. Design them on their own:
 
 - configure PubSub when broadcasts must cross nodes;
-- start and supervise presence when clients need replicated membership;
-- keep synchronous capacity or authorization state in an application-owned
-  process when a check and mutation must be atomic.
+- start and supervise presence when clients need a shared member list;
+- keep capacity or authorization state in a process your app owns when a check
+  and a change must happen together.
 
-The Elm analogy explains state transitions. It does not explain cluster
-membership, CRDT convergence, or supervision.
+The Elm analogy explains state changes. It does not explain cluster membership,
+CRDT agreement, or supervision.
 
 ## Raw dispatch or channels
 
 Both APIs use the same transport, runtime, codec, presence, PubSub, and abuse
-controls. Choose based on where you want routing and composition to live.
+controls. Choose based on where you want the routing to live.
 
 Use raw dispatch when:
 
 - the endpoint serves one topic family;
 - one socket-wide model is natural;
-- callbacks need direct cross-topic effects in one ordered list;
-- explicit routing is worth the control.
+- callbacks need effects on several topics in one ordered list;
+- you want to write the routing yourself.
 
-Use `beryl/channel` by default when:
+Use `beryl/channel` when:
 
 - the endpoint serves several topic namespaces;
 - the design follows Phoenix Channels;
-- each channel should own private state and a private info type;
-- handler values are the useful unit of composition.
+- each channel should own its own state and info type;
+- you want to compose handlers as values.
 
-Raw dispatch remains the clearest teaching example and Beryl's core.
-`beryl/channel` is the recommended default for multi-channel and
-Phoenix-shaped applications. The layer narrows actions to the current topic
-and uses phase types during close. Raw effects can name any topic, so
-cross-topic coordination stays ordinary app code.
+Raw dispatch is the core programming model and the clearest one to learn from.
+For apps with many channels, or apps shaped like Phoenix, use `beryl/channel`.
+Channel actions apply only to the current topic, and only some actions are
+allowed during close. Raw effects can name any topic, so work across topics is
+normal app code.
 
 ## The boundaries to remember
 
-The preceding chapters began with a familiar update loop. The production model needs
-the mismatches kept in view:
+The earlier chapters started with a familiar update loop. In production, keep
+these differences in view:
 
 - Beryl has no `view`.
 - Raw `init` runs once per socket.
-- One actor stores each socket model; a separate router indexes sockets and
-  subscribers.
-- Client payload stays `Dynamic` until application decoding succeeds.
-- `JoinRef` and `ReplyRef` are protocol capabilities, not data to rebuild.
-- Effect list order is observable wire order.
-- Raw effects can coordinate across topics. Channel actions are topic-scoped
-  and phase-typed.
-- Callback crashes are rescued with input-specific scope.
-- A supervised runtime restart restores dispatch but loses live socket state.
+- One actor stores each socket model. A separate router stores the socket list
+  and the subscribers.
+- Client payload stays `Dynamic` until your code decodes it.
+- `JoinRef` and `ReplyRef` are protocol tokens. Do not try to rebuild them.
+- The order of your effect list is the order on the wire.
+- Raw effects can work across topics. Channel actions apply to one topic, and
+  the close phase allows fewer of them.
+- Beryl catches callback crashes. The size of the cleanup depends on the input.
+- A supervisor restart brings dispatch back. It does not bring live socket
+  state back.
 
-Those constraints tell you where to put state and work. Keep connection-local
-facts in raw models or channel state. Keep shared domain state in
-application-owned processes. Decode at the wire boundary. Return short,
-ordered effect lists. Let supervision restore services while clients restore
-ephemeral subscriptions by reconnecting.
+These rules tell you where to put state and work. Keep facts about one
+connection in raw models or channel state. Keep shared domain state in
+processes your app owns. Decode at the wire boundary. Return short, ordered
+effect lists. Let supervision restore services. Let clients restore their
+subscriptions when they reconnect.
 
 ## Sources and further reading
 
@@ -227,7 +233,7 @@ cd examples/live_poll && gleam run -m live_poll/step_05
 ```
 
 Open `http://localhost:8105`, join `demo`, vote from two tabs, and close the
-poll now or wait 60 seconds. The behavior matches step 04 while the runtime
+poll now or wait 60 seconds. The behavior matches step 04, but the runtime now
 uses the heartbeat and abuse-control settings shown above. In another shell,
 run `curl http://localhost:8105/healthz`. The expected response is `ok`.
 


### PR DESCRIPTION
## Summary
- Rewrite the tutorial index and all six chapters at a 200 level, following ASD-STE100: short active-voice sentences, one idea per sentence, terms defined on first use.
- Drop 400-level jargon (monomorphic closures, closure sealing, phase-typed actions, lowering, heterogeneous handlers, idempotent, restart intensity) in favour of plain wording.
- Prose only. Every code excerpt is byte-identical and `pnpm check:snippets` passes.

## Test plan
- [x] `pnpm -C website check:snippets`
- [x] Diff contains no changed code-fence lines