### PR TITLE
docs(website): replace jargon with plain terms

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,8 @@
-# Copilot instructions for Beryl
+# Copilot instructions for beryl
 
 ## Project shape
 
-Beryl is a Gleam library for type-safe realtime channels and presence on the Erlang/BEAM target.
+beryl is a Gleam library for type-safe realtime channels and presence on the Erlang/BEAM target.
 
 - `packages/beryl/src/beryl.gleam` is the main public API for configuring a supervised app-dispatch system with `child_spec`, stopping it, and broadcasting.
 - `packages/beryl/src/beryl/event.gleam` defines typed app events/effects; `packages/beryl/src/beryl/runtime.gleam` owns socket/topic lifecycle and dispatches every event through the app's `update`.
@@ -57,4 +57,8 @@ Example Playwright runs can create untracked test artifacts; clean those before 
 
 - Keep the public API small and document public functions with `///` comments.
 - Use `Result` for fallible APIs and preserve exhaustive pattern matching.
+- Write the product name as `beryl` in prose, including at sentence starts and
+  in headings; preserve exact code identifiers and quoted text.
+- Use sentence case for website page titles, section headings, callout titles,
+  and sidebar labels.
 - Follow existing event/effect handling patterns in `event` and `runtime` when adding app-dispatch behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,8 @@ not available in pure Gleam.
 
 - **Result types over exceptions** — all fallible APIs return `Result`
 - **Exhaustive pattern matching** — Gleam enforces this; handle all cases
+- **Sentence-case website headings** — use sentence case for page titles,
+  section headings, callout titles, and sidebar labels
 - **`///` doc comments** on all public functions
 - **`@internal` annotation** — hides functions from public docs while keeping
   them accessible to sibling modules within the same package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
-# AGENTS.md — Working in the Beryl Codebase
+# AGENTS.md — Working in the beryl codebase
 
 ## Project Summary
 
-Beryl is a Gleam library for type-safe real-time channels and presence on the
+beryl is a Gleam library for type-safe real-time channels and presence on the
 Erlang/BEAM runtime. It's a trellis-managed monorepo with three packages — two
 of them currently publishable, since `beryl_ewe` is release-excluded — plus
 runnable examples and an Astro/Starlight documentation website.
@@ -146,6 +146,9 @@ not available in pure Gleam.
 - **Exhaustive pattern matching** — Gleam enforces this; handle all cases
 - **Sentence-case website headings** — use sentence case for page titles,
   section headings, callout titles, and sidebar labels
+- **Lowercase product name** — write the product name as `beryl` in prose,
+  including at sentence starts and in headings; preserve exact code identifiers
+  and quoted text
 - **`///` doc comments** on all public functions
 - **`@internal` annotation** — hides functions from public docs while keeping
   them accessible to sibling modules within the same package

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,10 @@ installed in CI via `.github/actions/mise`.
 - Follow `gleam format` output
 - Keep public API minimal
 - Document public functions with `///` comments
+- Write the product name as `beryl` in prose, including at sentence starts and
+  in headings; preserve exact code identifiers and quoted text
+- Use sentence case for website page titles, section headings, callout titles,
+  and sidebar labels
 - beryl's internal modules (`connection_limit`, `internal`, `log`,
   `rate_limit`, `runtime`, `telemetry`) must not be imported by other
   packages; transports use the `beryl/transport` SPI

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -9,37 +9,37 @@ web
 ## Users
 
 The primary users are Gleam developers on the Erlang/BEAM target who are
-evaluating or learning Beryl. They arrive from Hex, the Gleam package index,
-GitHub, or word of mouth to decide whether Beryl fits a realtime feature and
+evaluating or learning beryl. They arrive from Hex, the Gleam package index,
+GitHub, or word of mouth to decide whether beryl fits a realtime feature and
 to learn how to build their first channel. They are technical, skim-read, and
 use documentation quality as evidence of library maturity.
 
 ## Product Purpose
 
-Beryl provides type-safe realtime channels, presence, and PubSub for Gleam on
+beryl provides type-safe realtime channels, presence, and PubSub for Gleam on
 the BEAM. It gives developers a direct path from a typed application model to
 Phoenix-compatible WebSocket behavior without requiring an Elixir or Phoenix
 application.
 
-The website is Beryl's public product surface. It must help a curious developer
+The website is beryl's public product surface. It must help a curious developer
 understand the library, choose an API, and reach a working first channel with
-little friction. Success means that developers can evaluate Beryl accurately,
+little friction. Success means that developers can evaluate beryl accurately,
 run an example, and apply the documented model in their own supervised Gleam
 application.
 
 ## Positioning
 
-Beryl combines typed app-dispatch and channel APIs with Phoenix-compatible wire
+beryl combines typed app-dispatch and channel APIs with Phoenix-compatible wire
 behavior on Gleam and the Erlang/BEAM runtime. The type-safe application model,
 public transport SPI, and Phoenix protocol compatibility are one system rather
 than separate integrations.
 
 ## Operating Context
 
-Developers evaluate Beryl through the Astro and Starlight website in `website/`,
+Developers evaluate beryl through the Astro and Starlight website in `website/`,
 the generated API reference, GitHub source, and runnable examples. They add a
-Beryl package to a Gleam application, choose raw app dispatch or
-`beryl/channel`, select a wire codec and WebSocket transport, place Beryl's
+beryl package to a Gleam application, choose raw app dispatch or
+`beryl/channel`, select a wire codec and WebSocket transport, place beryl's
 child specification in an OTP supervision tree, and connect a compatible
 client.
 
@@ -50,15 +50,15 @@ complete application flows.
 
 ## Capabilities and Constraints
 
-- Beryl supports typed socket events and effects, channels, presence, PubSub,
+- beryl supports typed socket events and effects, channels, presence, PubSub,
   groups, runtime statistics, wire codecs, and pluggable WebSocket transports.
 - The built-in codec implements the Phoenix wire format.
-- Beryl targets Erlang/BEAM. Transport packages must depend only on the public
-  transport SPI and must not import Beryl's internal runtime modules.
+- beryl targets Erlang/BEAM. Transport packages must depend only on the public
+  transport SPI and must not import beryl's internal runtime modules.
 - Configuration APIs are opaque and use builder functions.
 - Fallible public APIs return `Result`; public behavior must preserve exhaustive
   matching and typed boundaries.
-- Beryl is pre-1.0. The website must describe evolving APIs accurately and must
+- beryl is pre-1.0. The website must describe evolving APIs accurately and must
   not imply stability guarantees that do not exist.
 - The website uses Astro and Starlight and must preserve link validation,
   generated reference content, keyboard navigation, and screen-reader support.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 </tr></table>
 
 > [!IMPORTANT]
-> Beryl is not yet 1.0. Minor releases can change the API or remove features.
-> Treat Beryl as experimental. Try it and send feedback.
+> beryl is not yet 1.0. Minor releases can change the API or remove features.
+> Treat beryl as experimental. Try it and send feedback.
 
 ## Install
 
-GitHub hosts the current Beryl packages. Hex does not. Add these dependencies
+GitHub hosts the current beryl packages. Hex does not. Add these dependencies
 to `gleam.toml`:
 
 ```toml
@@ -27,7 +27,7 @@ layer. `beryl_mist` provides the [Mist](https://hex.pm/packages/mist)
 WebSocket transport. `beryl_ewe` provides an
 [Ewe](https://hex.pm/packages/ewe) transport with the same API.
 
-Beryl supports only the **Erlang/BEAM** runtime. It does not support
+beryl supports only the **Erlang/BEAM** runtime. It does not support
 JavaScript.
 
 ## Quick start
@@ -87,7 +87,7 @@ pub fn main() {
 
 `mist_transport.handler` combines the WebSocket upgrade and your HTTP handler
 in one Mist request handler. It sends WebSocket upgrades on the configured
-path to Beryl. It sends all other requests to the HTTP fallback. To control
+path to beryl. It sends all other requests to the HTTP fallback. To control
 the upgrade decision, use `mist_transport.upgrade` and
 `beryl/transport/server.is_websocket_request`.
 
@@ -102,9 +102,9 @@ For a full example with Phoenix JS client code, see the
 
 ## Ecosystem
 
-Beryl is a server runtime for real-time applications. It manages socket
+beryl is a server runtime for real-time applications. It manages socket
 registration, broadcasts, presence, groups, PubSub, and transport integration.
-Beryl has a pluggable wire codec. Shared conformance fixtures keep its Phoenix
+beryl has a pluggable wire codec. Shared conformance fixtures keep its Phoenix
 codec compatible with Roost and Aquamarine.
 
 ```mermaid
@@ -228,20 +228,20 @@ notes. Releases use
 
 ## Security
 
-Beryl uses **Erlang distribution** for PubSub and presence replication. You
+beryl uses **Erlang distribution** for PubSub and presence replication. You
 must trust **every node in the cluster**. Application and channel authorization
 protect against untrusted WebSocket clients. They do **not** protect against a
-hostile Erlang distribution peer. Such a peer can inject internal Beryl
+hostile Erlang distribution peer. Such a peer can inject internal beryl
 traffic and presence state.
 
-Read **[SECURITY.md](SECURITY.md)** before you run Beryl in production. It
+Read **[SECURITY.md](SECURITY.md)** before you run beryl in production. It
 explains:
 
 - The Erlang distribution **trust boundary** and the effect of a compromised
   peer.
 - Distribution security: a strong protected cookie, TLS distribution,
   EPMD and port firewall rules, and closed cluster membership.
-- Why Beryl trusts internal PubSub and presence messages but validates and
+- Why beryl trusts internal PubSub and presence messages but validates and
   rate-limits client WebSocket messages.
 - The atom-table limit for `pubsub.config_with_scope`. Do not pass values from
   users to this function.
@@ -252,9 +252,9 @@ origin checks, see the
 
 ### Required: an edge proxy frame-size limit
 
-Beryl applies the `with_max_inbound_frame_bytes` limit **after frame
+beryl applies the `with_max_inbound_frame_bytes` limit **after frame
 assembly**. The WebSocket transport (Mist/gramps) buffers and assembles a full
-frame before Beryl measures it. Beryl then rejects an oversized frame. This
+frame before beryl measures it. beryl then rejects an oversized frame. This
 limit controls the processing cost of one message. It does **not** limit
 transport memory.
 
@@ -265,15 +265,15 @@ A hostile client can exhaust node memory through one connection in two ways:
 - It can send many fragmented continuation frames that the transport puts in
   one buffer.
 
-In both cases, the transport receive buffer has no size limit before Beryl
-checks the frame size. **Beryl's per-IP connection limit
+In both cases, the transport receive buffer has no size limit before beryl
+checks the frame size. **beryl's per-IP connection limit
 (`with_max_connections_per_ip`), per-connection frame-rate limit
 (`with_frame_rate`), and per-socket message-rate limit (`with_message_rate`)
 do not prevent this attack**. These limits run after frame assembly. The
 buffer can grow in one accepted connection before dispatch.
 
 To limit transport memory in production, you **must** put an edge proxy or load
-balancer in front of Beryl. You can use nginx, HAProxy, Envoy, or a cloud load
+balancer in front of beryl. You can use nginx, HAProxy, Envoy, or a cloud load
 balancer. Configure:
 
 - A **maximum WebSocket frame or message size** that is not greater than the
@@ -281,7 +281,7 @@ balancer. Configure:
 - A matching **request or body size limit** for the first HTTP upgrade request.
 
 Set the proxy to reject oversized frames before the BEAM node buffers them.
-Use Beryl's in-process limit as a second control for message processing cost.
+Use beryl's in-process limit as a second control for message processing cost.
 Do not use it as a memory limit.
 
 ## Development

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ coordinate a fix and disclosure timeline with you.
 
 ## Trust boundary
 
-Beryl runs on the Erlang/BEAM runtime and uses **Erlang distribution** for its
+beryl runs on the Erlang/BEAM runtime and uses **Erlang distribution** for its
 distributed features:
 
 - **PubSub** (`beryl/pubsub`) is backed by Erlang's `pg` process groups.

--- a/docs/adr/0001-type-erased-channel-registry.md
+++ b/docs/adr/0001-type-erased-channel-registry.md
@@ -5,11 +5,11 @@
 Superseded (2026-07-21) by [ADR 0002](0002-app-side-dispatch.md). ADR 0002
 replaced the channel-module registry with app-side dispatch. We retain this
 document to explain why we chose type erasure at the time. It does not describe
-Beryl's current public API.
+beryl's current public API.
 
 ## Context
 
-Beryl uses the registered channel module as its unit of composition. The
+beryl uses the registered channel module as its unit of composition. The
 library dispatches events, as Phoenix does. Applications register channels
 with distinct `assigns` and `info` types. The following problem results from
 that design.
@@ -34,7 +34,7 @@ heterogeneity because it has no existential types or type classes.
    and crosses component boundaries with `Dynamic` plus decoders
    ([`on_attribute_change`](https://github.com/lustre-labs/lustre/blob/v5.7.1/src/lustre/component.gleam#L118-L138)).
 
-2. **App-side dispatch (fully Elm/Lustre).** Beryl delivers wire events to
+2. **App-side dispatch (fully Elm/Lustre).** beryl delivers wire events to
    one app-written update function. That function routes topics. This option
    is fully type-safe, but it moves the per-channel lifecycle, authorization,
    rate limiting, and presence into application code.
@@ -46,8 +46,8 @@ heterogeneity because it has no existential types or type classes.
 
 ## Decision
 
-Keep design 3. Beryl compiles before the application's channel types exist,
-so Beryl cannot define their union. Only the application can define it, which
+Keep design 3. beryl compiles before the application's channel types exist,
+so beryl cannot define their union. Only the application can define it, which
 creates the cost in design 1. Gleam and BEAM libraries use erased internals
 behind typed facades. See [`gleam_otp`'s actor
 `erase`](https://github.com/gleam-lang/otp/blob/v1.2.0/src/gleam/otp/actor.gleam#L518-L519),

--- a/docs/adr/0002-app-side-dispatch.md
+++ b/docs/adr/0002-app-side-dispatch.md
@@ -95,10 +95,10 @@ the generated [API reference](https://beryl.tylerbutler.com/reference/api/);
   stays outside the shared runtime. The indivisible asynchronous read-model
   and effect bundle remains deferred to a later change.
 - Supervision is explicit through the sole runtime entry point:
-  `child_spec` returns the Beryl subtree (runtime plus an optional
-  connection limiter) for the caller's own supervisor. Beryl owns only
-  that subtree. Beryl borrows supplied presence and PubSub handles and
-  separately started groups. `stop` drains and terminates only the Beryl
+  `child_spec` returns the beryl subtree (runtime plus an optional
+  connection limiter) for the caller's own supervisor. beryl owns only
+  that subtree. beryl borrows supplied presence and PubSub handles and
+  separately started groups. `stop` drains and terminates only the beryl
   subtree. It does not terminate the application's root or sibling processes.
   See
   [Supervision](/guides/supervision/) for the full contract, including what

--- a/docs/adr/0004-channel-process-fault-boundaries.md
+++ b/docs/adr/0004-channel-process-fault-boundaries.md
@@ -12,7 +12,7 @@ change while proposed.
 
 ## Context
 
-Beryl currently runs one supervised runtime actor per socket system. That
+beryl currently runs one supervised runtime actor per socket system. That
 actor owns every connected socket's raw model, every joined channel's sealed
 state, protocol capabilities, topic membership, and effect interpretation.
 Application callbacks run in that actor.
@@ -94,7 +94,7 @@ The answer must cover both public programming models:
 - raw dispatch, where one model spans a socket and all its topics;
 - `beryl/channel`, where each accepted topic has private state and callbacks.
 
-It must also preserve Beryl's existing protocol and type-safety contracts:
+It must also preserve beryl's existing protocol and type-safety contracts:
 
 - Phoenix-compatible text and binary framing;
 - exact `JoinRef` and `ReplyRef` capability identity;
@@ -127,7 +127,7 @@ Costs:
 
 - application callbacks do not use BEAM process boundaries for isolation;
 - a blocking callback delays unrelated sockets in the same runtime;
-- rescue policy becomes part of Beryl's correctness surface;
+- rescue policy becomes part of beryl's correctness surface;
 - runtime-wide state and callback execution share one throughput bottleneck;
 - Phoenix-shaped APIs have different server-side failure semantics from
   Phoenix even though the wire protocol matches.
@@ -164,7 +164,7 @@ Costs:
 - the process count grows with concurrent connections.
 
 This option gives raw dispatch a natural fault boundary. The boundary is
-coarser than the Phoenix Channels boundary. It is also coarser than Beryl's
+coarser than the Phoenix Channels boundary. It is also coarser than beryl's
 current topic-scoped rescue for message and binary callbacks.
 
 ### 3. Use one process per socket and one process per channel
@@ -178,7 +178,7 @@ A possible topology is:
 
 ```text
 application supervisor
-└── Beryl subtree
+└── beryl subtree
     ├── control plane and PubSub integration
     ├── connection limiter (optional)
     ├── socket session supervisor
@@ -302,7 +302,7 @@ Build the smallest runtime path that can:
 - preserve ordered effects for one socket;
 - route external broadcasts and PubSub messages;
 - close the transport when the socket actor exits;
-- stop all socket actors during graceful Beryl shutdown.
+- stop all socket actors during graceful beryl shutdown.
 
 ### Prototype B: process per channel
 
@@ -336,7 +336,7 @@ focused tests for:
 - runtime, session, and worker shutdown order;
 - PubSub delivery during socket or channel teardown;
 - connection-limit release after abnormal process exit;
-- restart-intensity exhaustion in the enclosing Beryl subtree.
+- restart-intensity exhaustion in the enclosing beryl subtree.
 
 No option is acceptable if it weakens capability identity, generation checks,
 wire ordering, or transport ownership.

--- a/docs/architecture-deck.md
+++ b/docs/architecture-deck.md
@@ -17,7 +17,7 @@ Type-safe realtime channels & presence on the BEAM
 
 <!--
 Speaker notes:
-Opening frame. Beryl provides Phoenix-compatible realtime messaging and
+Opening frame. beryl provides Phoenix-compatible realtime messaging and
 presence as a type-safe Gleam library on the Erlang VM. Explain the deck in
 this order: the purpose, the module map, the runtime effect interpreter, and
 the connection lifecycle. The lifecycle includes connect, join, event,
@@ -53,7 +53,7 @@ Speaker notes:
 Read the diagram from top to bottom. A raw WebSocket frame enters the
 transport. The wire codec converts bytes into typed messages. One OTP runtime
 actor for each app sends typed `Input` values to the app's `update` function
-and applies the returned `Effect` list. Beryl has no channel registry or
+and applies the returned `Effect` list. beryl has no channel registry or
 per-channel callback modules. One `update` function handles all relevant
 topics and routes them by matching the topic string. PubSub is the only
 primitive that crosses node boundaries. All layers above PubSub are local to
@@ -107,12 +107,12 @@ mailbox in sequence. Effects apply in strict list order within one turn.
 
 <!--
 Speaker notes:
-This slide replaces the former coordinator and channel registry model. Beryl
+This slide replaces the former coordinator and channel registry model. beryl
 does not need a registry because it does not look up per-topic handlers. One
 `update` function handles each event for each socket on this runtime.
 
 The runtime owns four types of state. Socket state contains the app's `model`,
-not a Beryl `assigns` record. The app contract contains `init`, `update`, and
+not a beryl `assigns` record. The app contract contains `init`, `update`, and
 the `Effect` list that `update` returns. PubSub subscriptions receive
 broadcasts. The heartbeat timer removes dead sockets.
 
@@ -129,7 +129,7 @@ scale across nodes through `pg`.
 ```mermaid
 flowchart LR
   subgraph App["your application supervision tree"]
-    AppSup["application supervisor"] --> Sup["Beryl subtree supervisor<br/>OneForOne"]
+    AppSup["application supervisor"] --> Sup["beryl subtree supervisor<br/>OneForOne"]
     Sup --> Rt["runtime<br/>Transient · significant"]
     Sup --> Lim["connection limiter (optional)"]
   end
@@ -137,7 +137,7 @@ flowchart LR
 
 - `child_spec` returns a child specification for the runtime subtree and a stable handle
 - Add the subtree to *your* application supervisor
-- Beryl **borrows** PubSub, presence, and groups. They are not children of this subtree.
+- beryl **borrows** PubSub, presence, and groups. They are not children of this subtree.
 
 <!--
 Speaker notes:
@@ -147,7 +147,7 @@ optional connection limiter sibling), then hands back a
 `ChildSpecification` that the caller passes to `static_supervisor.add`. The
 application supervisor owns the lifecycle. Presence, PubSub, and groups are
 not part of this tree. The application starts and owns them, and the runtime
-borrows their handles. `beryl.stop` terminates only Beryl's subtree. It does
+borrows their handles. `beryl.stop` terminates only beryl's subtree. It does
 not terminate the PubSub instance, presence actor, or group actors.
 -->
 
@@ -352,7 +352,7 @@ typed `Subscriber(payload)` handle with `pubsub.subscriber`, `join`, and
 
 Repeat the originating-socket exclusion rule from the previous slide. Also
 explain the scope atom. Erlang atoms provide namespaces for groups, and the
-default scope is `beryl_pubsub`. This permits multiple Beryl instances to
+default scope is `beryl_pubsub`. This permits multiple beryl instances to
 coexist. Do not derive the scope from user input because the VM does not
 garbage-collect atoms.
 -->
@@ -390,7 +390,7 @@ Speaker notes:
 Presence reports who is connected across the cluster. It stays consistent
 without a central coordinator or database. Each node runs a presence actor
 that holds one replica of an add-wins OR-set CRDT from `lattice_presence`.
-The application starts and supervises this actor outside Beryl's subtree.
+The application starts and supervises this actor outside beryl's subtree.
 
 Public presence calls are synchronous. An application-owned worker performs
 them outside the shared socket runtime and then broadcasts the result. On a
@@ -436,7 +436,7 @@ data, the same codec encodes runtime replies and pushes. The runtime then gives
 them to the socket's send function.
 
 `Codec` is a data value, not fixed runtime logic. An application can change
-framing without changing the runtime or application code. Beryl has no
+framing without changing the runtime or application code. beryl has no
 implicit wire default. Callers pass a codec to `beryl.config`. Use
 `wire.phoenix_codec()` for Phoenix JSON and V2 binary compatibility.
 

--- a/docs/security/frame-buffering-followup.md
+++ b/docs/security/frame-buffering-followup.md
@@ -6,11 +6,11 @@ This document tracks the upstream part of GitHub issue #198,
 ## Summary of the gap
 
 `beryl.with_max_inbound_frame_bytes` is enforced **post-assembly**: it runs in
-Beryl's transport callback only after Mist/gramps has buffered and
+beryl's transport callback only after Mist/gramps has buffered and
 reassembled a complete `Text`/`Binary` frame. The transport buffers
 incomplete, slowly streamed, or fragmented (continuation) payloads without a
 **configurable pre-buffer size cap**. Therefore, one connection can increase
-the BEAM receive buffer without triggering Beryl's frame-size or message-rate
+the BEAM receive buffer without triggering beryl's frame-size or message-rate
 checks. One connection can exhaust the node's memory.
 
 Mist's only size limit, `max_body_limit`, applies to HTTP request bodies
@@ -18,7 +18,7 @@ Mist's only size limit, `max_body_limit`, applies to HTTP request bodies
 
 ## Code locations
 
-### Beryl (the limit is enforced too late)
+### beryl (the limit is enforced too late)
 
 - `src/beryl/transport/mist.gleam:445-463`: `on_message` measures
   `string.byte_size(text)` / `bit_array.byte_size(data)` and calls
@@ -29,7 +29,7 @@ Mist's only size limit, `max_body_limit`, applies to HTTP request bodies
 - `src/beryl.gleam`: `with_max_inbound_frame_bytes` doc comment (now corrected
   to state the post-assembly semantics and the edge-proxy requirement).
 
-### mist 6.0.3 (buffers before Beryl ever sees a frame)
+### mist 6.0.3 (buffers before beryl ever sees a frame)
 
 - `build/packages/mist/src/mist/internal/websocket.gleam:43`: `WebsocketState`
   carries a `buffer: BitArray` field.
@@ -68,7 +68,7 @@ Mist's only size limit, `max_body_limit`, applies to HTTP request bodies
      declarations.
    - Add a cumulative cap in `aggregate_frames` / the mist buffering loop so
      fragmented continuation frames cannot exceed the same limit in aggregate.
-   - Thread the limit through `mist`'s WebSocket handler config so Beryl can
+   - Thread the limit through `mist`'s WebSocket handler config so beryl can
      set it from `with_max_inbound_frame_bytes`.
    - This is the only option that gives an in-process memory limit. It
      requires PRs to gramps and mist and a released version update.

--- a/docs/talks/beryl-interview/deck.md
+++ b/docs/talks/beryl-interview/deck.md
@@ -194,14 +194,14 @@ PubSub                Erlang pg lifecycle
 
 Explain the actual tree:
 - `beryl.child_spec(config, init:, update:)` returns a stable `Sockets`
-  handle plus the Beryl subtree's child specification.
+  handle plus the beryl subtree's child specification.
 - The runtime is the significant transient child. A genuine runtime crash is
   restarted under the same registered name; the optional limiter is its
   sibling.
 - Transports monitor the exact runtime pid. If it dies, existing WebSockets
   close instead of becoming zombies attached to a successor.
 - `beryl.stop` drains only this subtree. Presence and groups are borrowed,
-  application-owned actors, and PubSub is backed by `pg`; Beryl does not stop
+  application-owned actors, and PubSub is backed by `pg`; beryl does not stop
   any of them.
 
 LIKELY QUESTION: "What happens to in-flight state after a restart?" Explain
@@ -457,7 +457,7 @@ Demo script, about two minutes:
 1. Open two browser windows side by side, join the same room. Move the
    mouse. The cursor appears in the other window. Pause before you explain it.
 2. "Each tab is one WebSocket whose connection process handles edge work,
-   while Beryl's shared runtime holds a separate typed model for each socket."
+   while beryl's shared runtime holds a separate typed model for each socket."
    (Refer to the processes slide without claiming an app actor for each socket.)
 3. Point at the code. `broadcast_from` sends to everyone except the sender,
    so the sender does not receive its own cursor event.
@@ -634,7 +634,7 @@ Erlang distribution trusts every cluster node; keep the cluster closed
 
 <!--
 Introduce the slide with this security boundary: "Each real-time endpoint is
-an open TCP connection. Beryl supplies abuse controls and documents their
+an open TCP connection. beryl supplies abuse controls and documents their
 limits."
 
 BUILT IN (config on the transport, name the real APIs):
@@ -652,7 +652,7 @@ STILL ON YOU. State two boundaries:
    a complete frame before beryl measures it. A hostile client can
    declare a huge frame, or stream endless fragments, and increase the
    buffer BEFORE the check runs. In production, you MUST cap frame
-   size at an edge proxy (nginx/HAProxy/Envoy). Beryl's limit is
+   size at an edge proxy (nginx/HAProxy/Envoy). beryl's limit is
    defense-in-depth for processing cost, not a memory bound. The
    upstream fix (cap-before-buffer in mist/gramps) is tracked publicly.
 2. Erlang distribution, which provides the clustering from the pg slide,

--- a/examples/collab_docs/README.md
+++ b/examples/collab_docs/README.md
@@ -9,7 +9,7 @@ dispatch and client-side CRDT state.
 |---|---|
 | Segment wildcard topics | The server routes `document:*:*` topics so each tenant/document pair gets an isolated topic. |
 | Client-side CRDT merge | The browser keeps document blocks with the `lattice_core`, `lattice_maps`, and `lattice_registers` packages as an `ORMap(MVRegister(String))`. |
-| Unordered realtime transport | Beryl carries serialized document state updates between clients without requiring total message ordering. |
+| Unordered realtime transport | beryl carries serialized document state updates between clients without requiring total message ordering. |
 | Late joiner cache | The server caches merged document state and returns it in the join reply for newly connected clients. |
 | Conflict UI | Concurrent edits to the same block render explicit conflict cards with each version. |
 

--- a/examples/cursors/PRODUCT.md
+++ b/examples/cursors/PRODUCT.md
@@ -8,20 +8,20 @@ web
 
 ## Users
 
-Gleam developers evaluating or learning Beryl's realtime collaboration
+Gleam developers evaluating or learning beryl's realtime collaboration
 capabilities. They use the demo to see the library in action and inspect a
 small, runnable implementation.
 
 ## Product Purpose
 
-Demonstrate how Beryl combines typed channel events, presence, PubSub, and a
+Demonstrate how beryl combines typed channel events, presence, PubSub, and a
 WebSocket transport to build a realtime collaborative experience. Success
 means developers can run the example quickly, understand the data flow, and
 adapt the patterns in their own applications.
 
 ## Positioning
 
-The demo is an executable reference for Beryl's type-safe Gleam APIs rather
+The demo is an executable reference for beryl's type-safe Gleam APIs rather
 than a standalone collaboration product.
 
 ## Operating Context
@@ -33,7 +33,7 @@ ephemeral room events.
 ## Capabilities and Constraints
 
 - The browser uses vanilla JavaScript, CSS, and the Phoenix JavaScript client.
-- The server uses Beryl's app-side dispatch with the Mist transport.
+- The server uses beryl's app-side dispatch with the Mist transport.
 - The example has no frontend build step and should remain dependency-light.
 - Realtime events are ephemeral; the demo does not persist room history.
 

--- a/examples/example_helpers/src/example_helpers/session_presence.gleam
+++ b/examples/example_helpers/src/example_helpers/session_presence.gleam
@@ -2,7 +2,7 @@
 ////
 //// Mutations and counts use constant-time ETS operations, so app-side
 //// dispatch never waits on another actor. A small publisher process enqueues
-//// current snapshots through normal Beryl broadcasts requested after each
+//// current snapshots through normal beryl broadcasts requested after each
 //// mutation.
 
 import beryl

--- a/examples/live_poll/gleam.toml
+++ b/examples/live_poll/gleam.toml
@@ -1,6 +1,6 @@
 name = "live_poll"
 version = "0.1.0"
-description = "Runnable checkpoints for the Beryl live-poll tutorial"
+description = "Runnable checkpoints for the beryl live-poll tutorial"
 gleam = ">= 1.13.0"
 target = "erlang"
 

--- a/examples/live_poll/src/live_poll/server.gleam
+++ b/examples/live_poll/src/live_poll/server.gleam
@@ -71,7 +71,7 @@ fn client_html(guide: Bool) -> String {
 <head>
   <meta charset=\"utf-8\">
   <meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">
-  <title>Beryl live poll</title>
+  <title>beryl live poll</title>
   <style>
     body{font:16px system-ui;max-width:42rem;margin:3rem auto;padding:0 1rem}
     fieldset{display:grid;gap:.75rem;border:1px solid #bbb;border-radius:.5rem;padding:1rem}

--- a/examples/load_test/README.md
+++ b/examples/load_test/README.md
@@ -1,4 +1,4 @@
-# Beryl benchmark server
+# beryl benchmark server
 
 This headless application is the target for the repository's Phoenix V2
 [k6 load suite](../../load/README.md). It exposes the same channel contract
@@ -33,7 +33,7 @@ Both servers bind to `127.0.0.1:8000` by default. They provide:
 | Route | Behavior |
 |---|---|
 | `/health` | `200`, `content-type: application/json`, `{"status":"ok"}` |
-| `/stats` | Local Beryl socket runtime and BEAM runtime JSON described below |
+| `/stats` | Local beryl socket runtime and BEAM runtime JSON described below |
 | WebSocket `/socket` | Phoenix V2 benchmark channels |
 | Any other route | `404` with an empty body |
 
@@ -51,7 +51,7 @@ Unknown inbound events return `{"reason":"unknown_event"}`.
 
 Missing integer variables and values that `gleam/int.parse` cannot parse use
 the listed default. The application does not otherwise range-check them before
-passing them to Beryl; invalid heartbeat values can prevent the supervised
+passing them to beryl; invalid heartbeat values can prevent the supervised
 server from starting. Rate and connection values at or below zero disable
 their limit. All heartbeat durations are milliseconds, all rates are events
 per second, and string limits are bytes.
@@ -83,7 +83,7 @@ rate is non-positive, the limit is disabled regardless of its burst value.
 | `BERYL_MAX_EVENT_LENGTH` | `64` | Maximum client event-name length in bytes |
 | `BERYL_MAX_INBOUND_FRAME_BYTES` | `1048576` | Maximum assembled inbound frame size in bytes (1 MiB) |
 | `BERYL_MAX_JOINED_TOPICS_PER_SOCKET` | `1000` | Maximum simultaneous joined topics per socket |
-| `BERYL_TELEMETRY` | `false` | Enables Beryl telemetry for `1`, `true`, `yes`, or `on`, case-insensitively |
+| `BERYL_TELEMETRY` | `false` | Enables beryl telemetry for `1`, `true`, `yes`, or `on`, case-insensitively |
 
 If `BERYL_TELEMETRY` is missing it is false; any value not in the four-value
 true set is also false. Enabling it only emits events. This fixture does not
@@ -123,7 +123,7 @@ The numbers above illustrate the JSON shape, not expected values.
 | Status | Body | Cause |
 |---:|---|---|
 | `200` | Object shown above | Both snapshots succeeded |
-| `503` | `{"error":"runtime_unavailable"}` | Beryl socket runtime unavailable |
+| `503` | `{"error":"runtime_unavailable"}` | beryl socket runtime unavailable |
 | `503` | `{"error":"runtime_stats_unavailable"}` | BEAM snapshot FFI failed |
 | `504` | `{"error":"runtime_timeout"}` | Socket runtime snapshot request timed out |
 

--- a/examples/load_test/gleam.toml
+++ b/examples/load_test/gleam.toml
@@ -1,6 +1,6 @@
 name = "load_test"
 version = "0.1.0"
-description = "Headless benchmark target for Beryl's k6 workloads"
+description = "Headless benchmark target for beryl's k6 workloads"
 gleam = ">= 1.7.0"
 target = "erlang"
 

--- a/examples/showcase/package.json
+++ b/examples/showcase/package.json
@@ -2,7 +2,7 @@
   "name": "showcase",
   "version": "1.0.0",
   "private": true,
-  "description": "All Beryl example channels composed on one socket with app-side dispatch.",
+  "description": "All beryl example channels composed on one socket with app-side dispatch.",
   "scripts": {
     "test": "npx playwright test"
   },

--- a/load/README.md
+++ b/load/README.md
@@ -151,7 +151,7 @@ The mixed profile uses k6's built-in `http_req_duration` and
 as time values, so k6 reports their usual time statistics and percentiles.
 
 Client results show symptoms, not necessarily server saturation. Correlate
-them with the benchmark server's `/stats`, Beryl telemetry, host CPU/network
+them with the benchmark server's `/stats`, beryl telemetry, host CPU/network
 data, file descriptors, ports, proxy/NAT utilization, and generator health.
 
 Interpret the summary in this order:
@@ -236,10 +236,10 @@ Treat these as checks, not universal tuning values:
   caps ports, and `+K true` requests kernel polling. Do not size them from
   connection count alone or assume kernel polling helps every platform.
 - Monitor NAT/proxy connection tables. `SOURCE_IP` is metadata; it does not
-  change network identity. Beryl's per-IP limit sees the TCP peer, so all
+  change network identity. beryl's per-IP limit sees the TCP peer, so all
   clients behind one proxy share a bucket.
 - Set an edge WebSocket frame/message limit at or below
-  `BERYL_MAX_INBOUND_FRAME_BYTES`, plus a matching upgrade/body limit. Beryl
+  `BERYL_MAX_INBOUND_FRAME_BYTES`, plus a matching upgrade/body limit. beryl
   measures after frame assembly and does not bound transport/proxy buffering.
 
 Do not copy `sysctl`, `+P`, or `+Q` values blindly. Increase a limit only after
@@ -317,7 +317,7 @@ has an explicit rationale. Never derive a gate from one favorable run.
 | Broadcast delivery failures | Use a group size of at least 2, keep expected recipients between 1 and group size minus 1, ensure complete generator-local groups/divisible VUs, and allow enough warmup and delivery time |
 | Join rejection in normal profiles | Confirm the topic, target `BERYL_*` guardrails, proxy peer-IP behavior, and server logs |
 | Server exits or never becomes healthy | Inspect startup logs for bind/port conflicts, invalid heartbeat configuration, missing dependencies, or the wrong transport entry point; `/health` proves only that HTTP can answer |
-| WebSocket failures or dropped iterations at high rate | Check generator VUs/CPU, ephemeral ports, FDs, NAT/proxy tables, listener backlogs, and target `/stats` before attributing failure to Beryl |
+| WebSocket failures or dropped iterations at high rate | Check generator VUs/CPU, ephemeral ports, FDs, NAT/proxy tables, listener backlogs, and target `/stats` before attributing failure to beryl |
 | `/stats` returns `503` or `504` | Preserve it as unavailable/overloaded telemetry; do not convert it to zeros |
 | Summary file missing or owned unexpectedly | `load-run` mounts the repository and runs k6 as the current UID/GID; ensure the parent of `SUMMARY_PATH` exists and is writable, use a path under the mounted repository, and give every host/run a unique path |
 

--- a/packages/beryl/README.md
+++ b/packages/beryl/README.md
@@ -14,7 +14,7 @@ CRDT-backed presence, pg-based PubSub, and built-in abuse controls.
 
 To serve sockets over WebSockets, pair it with a transport package such as
 [`beryl_mist`](https://github.com/tylerbutler/beryl/tree/main/packages/beryl_mist).
-Beryl packages are currently distributed from GitHub, not Hex:
+beryl packages are currently distributed from GitHub, not Hex:
 
 ```toml
 [dependencies]

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -1,4 +1,4 @@
-//// Beryl - Type-safe real-time communication
+//// beryl - Type-safe real-time communication
 ////
 //// A standalone Gleam library for building real-time applications on the BEAM.
 //// Provides app-side WebSocket dispatch, distributed presence tracking,
@@ -79,7 +79,7 @@ import gleam/otp/static_supervisor
 import gleam/otp/supervision
 import gleam/result
 
-/// Logging verbosity for Beryl's internal loggers.
+/// Logging verbosity for beryl's internal loggers.
 ///
 /// The variants carry a `Level` suffix so `ErrorLevel` does not shadow the
 /// prelude's `Result` `Error` constructor when imported unqualified.
@@ -90,14 +90,14 @@ pub type LogLevel {
   ErrorLevel
 }
 
-/// Logging configuration for Beryl diagnostics.
+/// Logging configuration for beryl diagnostics.
 ///
 /// This type is opaque. Construct it with `logging_config` and adjust it with
-/// the `with_*` functions. Beryl can then add logging options without a
+/// the `with_*` functions. beryl can then add logging options without a
 /// breaking change.
 pub opaque type LoggingConfig {
   LoggingConfig(
-    /// Minimum level emitted by Beryl's namespaced loggers.
+    /// Minimum level emitted by beryl's namespaced loggers.
     level: LogLevel,
     /// Whether debug diagnostics may include bounded payload/frame previews.
     include_payloads: Bool,
@@ -109,7 +109,7 @@ pub opaque type LoggingConfig {
 /// Configuration for an app-side socket runtime.
 ///
 /// This type is opaque. Construct it with `config` and adjust it with the
-/// `with_*` functions. Beryl can then add configuration options without a
+/// `with_*` functions. beryl can then add configuration options without a
 /// breaking change.
 pub opaque type Config {
   Config(
@@ -168,7 +168,7 @@ pub opaque type Config {
     max_joined_topics_per_socket: Int,
     /// Whether beryl emits `:telemetry` events (default: false).
     telemetry: Bool,
-    /// Logging configuration for Beryl diagnostics
+    /// Logging configuration for beryl diagnostics
     logging: LoggingConfig,
     /// Per-topic-pattern message rate limits (app-dispatch systems only).
     /// Ordered; the first matching pattern wins. `None` is an explicit
@@ -200,7 +200,7 @@ pub fn logging_config(
 
 /// Build a configuration with sensible defaults.
 ///
-/// A `codec` is required. Beryl no longer provides an implicit Phoenix
+/// A `codec` is required. beryl no longer provides an implicit Phoenix
 /// default. Pass `wire.phoenix_codec()` to keep Phoenix wire compatibility,
 /// or your own `Codec` for a custom framing.
 pub fn config(codec: codec.Codec) -> Config {
@@ -308,11 +308,11 @@ pub fn with_heartbeat(config: Config, timeout_ms timeout_ms: Int) -> Config {
 ///
 /// The limit is enforced on the **real socket peer IP** as reported by the
 /// transport (for the Mist transport, the address of the TCP connection).
-/// Beryl does **not** trust or parse forwarded headers such as
+/// beryl does **not** trust or parse forwarded headers such as
 /// `X-Forwarded-For`. A client can set these headers and spoof its address to
 /// bypass this limit.
 ///
-/// If Beryl runs behind a trusted reverse proxy or load balancer, every
+/// If beryl runs behind a trusted reverse proxy or load balancer, every
 /// connection shares the proxy's address, so a per-IP limit throttles all
 /// clients as a single IP. In that topology you must resolve the real client
 /// IP yourself at the proxy layer (for example, by enforcing limits there). A
@@ -333,7 +333,7 @@ pub fn with_max_connections_per_ip(
 /// `per_second` as the burst capacity.
 ///
 /// Unlike per-connection frame and message buckets, this allowance is keyed by
-/// the real socket peer IP and lives in Beryl's supervised connection limiter.
+/// the real socket peer IP and lives in beryl's supervised connection limiter.
 /// Disconnecting or restarting the app runtime therefore does not refresh it.
 /// Idle IP buckets are removed once their allowance has fully refilled.
 ///
@@ -383,7 +383,7 @@ pub fn with_max_connections(
   Config(..config, max_connections: max_connections)
 }
 
-/// Configure Beryl's internal logging.
+/// Configure beryl's internal logging.
 pub fn with_logging(config: Config, logging: LoggingConfig) -> Config {
   Config(..config, logging: logging)
 }
@@ -487,8 +487,8 @@ pub fn with_max_event_length(
 // nolint: unused_exports -- enforced in sibling transport handler tests
 /// Configure the maximum allowed inbound WebSocket frame size in bytes.
 ///
-/// Beryl enforces the limit **post-assembly**. The transport (Mist or Ewe)
-/// buffers and assembles a complete frame first. Beryl then measures it and
+/// beryl enforces the limit **post-assembly**. The transport (Mist or Ewe)
+/// buffers and assembles a complete frame first. beryl then measures it and
 /// closes the connection if it exceeds `max_bytes`. This bounds
 /// per-message processing cost (decode, routing, rate-limit accounting), but
 /// it does **not** by itself bound transport memory. A hostile client can
@@ -498,8 +498,8 @@ pub fn with_max_event_length(
 /// node memory.
 ///
 /// For a true transport memory bound you **must** place an edge proxy or load
-/// balancer in front of Beryl and configure a WebSocket frame-size limit
-/// there (and a matching request/body size limit). Beryl's connection,
+/// balancer in front of beryl and configure a WebSocket frame-size limit
+/// there (and a matching request/body size limit). beryl's connection,
 /// frame-rate, and message-rate limits all run after frame assembly and do not
 /// mitigate this vector. See the README's "Security" section.
 ///
@@ -524,7 +524,7 @@ pub fn with_max_joined_topics_per_socket(
 /// Warn when an app-side socket runtime starts with every abuse control
 /// disabled.
 ///
-/// Beryl ships with rate and connection limits off (like Phoenix) because
+/// beryl ships with rate and connection limits off (like Phoenix) because
 /// no default is right for every deployment — but running that way in
 /// production leaves the server open to trivial floods, so the choice
 /// should be a visible one. Called while building the `child_spec` subtree.
@@ -568,7 +568,7 @@ pub fn frame_limits(channels: Sockets) -> Option(rate_limit.RateLimitConfig) {
 /// A runtime system handle.
 ///
 /// `child_spec` returns this opaque handle with the supervised subtree. Pass
-/// it to broadcast, group, and transport functions. Beryl hides its internals
+/// it to broadcast, group, and transport functions. beryl hides its internals
 /// so they can change without breaking application code.
 ///
 /// The handle is non-generic. An app-side dispatch system is
@@ -667,7 +667,7 @@ pub type ConfigError {
   InvalidTopicPattern(pattern: String, reason: topic.TopicError)
 }
 
-/// Errors when stopping a Beryl system with [`stop`](#stop).
+/// Errors when stopping a beryl system with [`stop`](#stop).
 pub type StopError {
   /// The handle referred to a system that was not running: it was never
   /// started (for example, a `child_spec` handle whose supervisor was never
@@ -695,7 +695,7 @@ pub fn validate_config(config: Config) -> Result(Nil, ConfigError) {
   })
 }
 
-/// Stop a Beryl system.
+/// Stop a beryl system.
 ///
 /// This function drains and stops the supervised runtime. It delivers
 /// `Closed` to every joined topic before it closes each transport connection.
@@ -709,17 +709,17 @@ pub fn validate_config(config: Config) -> Result(Nil, ConfigError) {
 /// acknowledge the stop within the shutdown window. After a successful stop
 /// the handle should no longer be used.
 pub fn stop(sockets: Sockets) -> Result(Nil, StopError) {
-  // The app-side dispatch limiter is supervised inside the Beryl subtree,
+  // The app-side dispatch limiter is supervised inside the beryl subtree,
   // so it is not stopped directly here; it is torn down with the subtree.
   stop_app_subtree(sockets.app, sockets.connection_limiter)
 }
 
-/// Gracefully stop only the nested Beryl subtree and wait for it to
+/// Gracefully stop only the nested beryl subtree and wait for it to
 /// terminate.
 ///
 /// The runtime is the subtree's significant transient child, so draining and
 /// stopping it (normal termination) auto-shuts down the subtree supervisor and
-/// its sibling limiter. To honour "wait for only the Beryl subtree to
+/// its sibling limiter. To honour "wait for only the beryl subtree to
 /// terminate", the runtime and the optional limiter processes are monitored
 /// before the drain and their `Down` messages are awaited afterwards; the
 /// application's parent supervisor and sibling children are never touched.
@@ -841,7 +841,7 @@ pub fn child_spec(
   // The subtree is a `Transient` child of the application's supervisor: a
   // graceful `beryl.stop` auto-shuts the subtree down with reason `shutdown`,
   // which a transient child treats as normal, so the parent does not restart
-  // Beryl. A genuine crash (subtree restart intensity exceeded) still gets
+  // beryl. A genuine crash (subtree restart intensity exceeded) still gets
   // restarted by the parent.
   #(
     subtree.handle,
@@ -854,7 +854,7 @@ pub fn child_spec(
 /// started yet.
 ///
 /// `handle` is the stable, non-generic `Sockets` returned to callers before
-/// startup. `start_supervisor` starts the nested Beryl subtree; the generic
+/// startup. `start_supervisor` starts the nested beryl subtree; the generic
 /// `init`/`update` closures are captured inside it, so `AppSubtree` itself
 /// stays non-generic.
 type AppSubtree {
@@ -872,7 +872,7 @@ type AppSubtree {
 /// the subtree starts: the runtime is reached through its registered name and
 /// the limiter through `connection_limit.from_name`, so the handle keeps
 /// working across supervised runtime restarts. There is no unsupervised app
-/// runtime — the runtime always runs under the nested Beryl supervisor, with
+/// runtime — the runtime always runs under the nested beryl supervisor, with
 /// the `init`/`update` closures captured in the child specification. A runtime
 /// crash therefore restarts dispatch automatically (per-socket state is
 /// dropped). The runtime child is `Transient` so a graceful `stop` is not
@@ -928,7 +928,7 @@ fn build_app_subtree(
   })
 }
 
-/// Start the nested Beryl subtree: a one-for-one supervisor owning the runtime
+/// Start the nested beryl subtree: a one-for-one supervisor owning the runtime
 /// as a transient child, with the optional connection limiter as a sibling.
 fn child_spec_supervisor(
   config: Config,
@@ -949,7 +949,7 @@ fn child_spec_supervisor(
     })
     |> supervision.restart(supervision.Transient)
     // The runtime is the subtree's significant child: a graceful stop (normal
-    // termination) auto-shuts down the whole Beryl subtree — including the
+    // termination) auto-shuts down the whole beryl subtree — including the
     // sibling limiter — while an abnormal crash is restarted in place under
     // the same name (dispatch resumes with fresh per-socket state).
     |> supervision.significant(True)

--- a/packages/beryl/src/beryl/error.gleam
+++ b/packages/beryl/src/beryl/error.gleam
@@ -26,7 +26,7 @@ pub fn describe_start_failure(failure: StartFailure) -> String {
   }
 }
 
-/// Convert a `gleam/otp/actor.StartError` to Beryl's `StartFailure`.
+/// Convert a `gleam/otp/actor.StartError` to beryl's `StartFailure`.
 pub fn from_actor_start_error(error: actor.StartError) -> StartFailure {
   case error {
     actor.InitTimeout -> StartFailure(StartTimedOut)

--- a/packages/beryl/src/beryl/group.gleam
+++ b/packages/beryl/src/beryl/group.gleam
@@ -4,7 +4,7 @@
 //// Useful for scenarios like broadcasting to all channels in a "team" or
 //// sending a system-wide notification.
 ////
-//// Groups are independent of the Beryl runtime and run under your
+//// Groups are independent of the beryl runtime and run under your
 //// application's supervision tree.
 ////
 //// ## Example

--- a/packages/beryl/src/beryl/internal.gleam
+++ b/packages/beryl/src/beryl/internal.gleam
@@ -8,7 +8,7 @@ import palabres
 import palabres/level
 import palabres/options
 
-/// Logging verbosity for Beryl's internal helpers.
+/// Logging verbosity for beryl's internal helpers.
 pub type LogLevel {
   Debug
   Info
@@ -16,7 +16,7 @@ pub type LogLevel {
   ErrorLevel
 }
 
-/// Logging configuration shared by internal Beryl modules.
+/// Logging configuration shared by internal beryl modules.
 pub type LoggingConfig {
   LoggingConfig(
     level: LogLevel,
@@ -25,10 +25,10 @@ pub type LoggingConfig {
   )
 }
 
-/// Configure the global palabres logger from a Beryl logging configuration.
+/// Configure the global palabres logger from a beryl logging configuration.
 ///
 /// Palabres is a singleton configured once at startup; the level set here is
-/// global across every Beryl logger. Called when a runtime starts.
+/// global across every beryl logger. Called when a runtime starts.
 pub fn configure(config: LoggingConfig) -> Nil {
   options.defaults()
   |> options.level(to_palabres_level(config.level))
@@ -69,7 +69,7 @@ pub fn logger(name: String) -> Logger {
   log.new(name)
 }
 
-/// Build a named logger using the supplied Beryl logging configuration.
+/// Build a named logger using the supplied beryl logging configuration.
 ///
 /// The level is applied globally via `configure`; the returned logger only
 /// carries its name.

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -7,7 +7,7 @@
 //// - Receives remote state from PubSub and merges it internally
 //// - Invokes `on_diff` callback when merges produce non-empty diffs
 ////
-//// Presence is independent of the Beryl runtime and runs under your
+//// Presence is independent of the beryl runtime and runs under your
 //// application's supervision tree.
 ////
 //// ## Read consistency
@@ -96,7 +96,7 @@ type State =
 
 /// An opaque diff representing presence joins and leaves grouped by topic.
 ///
-/// Beryl passes this value to `Config.on_diff`.
+/// beryl passes this value to `Config.on_diff`.
 /// `beryl.broadcast_presence_diff` also accepts it.
 pub opaque type Diff {
   Diff(
@@ -197,7 +197,7 @@ pub type SyncPayload {
 /// Configuration for starting presence.
 ///
 /// Build configurations with `default_config` and the `with_*` functions.
-/// Beryl can then add options without exposing record fields as public API.
+/// beryl can then add options without exposing record fields as public API.
 pub opaque type Config {
   Config(
     /// PubSub instance for cross-node replication

--- a/packages/beryl/src/beryl/pubsub.gleam
+++ b/packages/beryl/src/beryl/pubsub.gleam
@@ -44,7 +44,7 @@ import gleam/list
 ///
 /// ## Frozen wire contract
 ///
-/// Beryl sends broadcasts **raw between nodes** through `pg` as a five-element
+/// beryl sends broadcasts **raw between nodes** through `pg` as a five-element
 /// tuple. The PubSub scope atom comes first. The four message fields follow in
 /// order. This scope-tagged runtime shape is the frozen wire contract for each
 /// `payload` type. The contract also applies to `PubSubFrom`.

--- a/packages/beryl/src/beryl/socket.gleam
+++ b/packages/beryl/src/beryl/socket.gleam
@@ -16,7 +16,7 @@
 ////
 //// Most effects are applied in one actor turn. `PresenceTrack` and
 //// `PresenceUntrack` are the exception: they are applied by the presence
-//// actor. Beryl holds the rest of the list and every later input for that
+//// actor. beryl holds the rest of the list and every later input for that
 //// socket until the mutation has been applied. It then continues exactly
 //// where it left off. The visible order is unchanged (a
 //// `PushPresence` after a `PresenceTrack` still sees the track), and the

--- a/packages/beryl/src/beryl/stats.gleam
+++ b/packages/beryl/src/beryl/stats.gleam
@@ -33,7 +33,7 @@ pub type SnapshotError {
 /// this function returns `RuntimeUnavailable` or `RequestTimedOut`. An
 /// overloaded runtime returns `RequestTimedOut`.
 /// Neither condition panics. This API reports only the node represented by
-/// `sockets`; aggregate multi-node statistics outside Beryl.
+/// `sockets`; aggregate multi-node statistics outside beryl.
 ///
 /// Poll no more frequently than roughly once per second.
 pub fn snapshot(sockets: beryl.Sockets) -> Result(Snapshot, SnapshotError) {

--- a/packages/beryl/src/beryl/transport/origin.gleam
+++ b/packages/beryl/src/beryl/transport/origin.gleam
@@ -119,7 +119,7 @@ fn origin_authority(origin: String) -> Result(String, Nil) {
 /// Check a client's requested wire protocol version (the `?vsn=` query
 /// parameter sent by Phoenix clients) before upgrading.
 ///
-/// Beryl uses the Phoenix V2 array framing, so it accepts `vsn=2.x`. A
+/// beryl uses the Phoenix V2 array framing, so it accepts `vsn=2.x`. A
 /// missing `vsn` (`None`) is accepted for non-Phoenix clients speaking the
 /// configured codec. Anything else (e.g. the V1 object framing's `vsn=1.0.0`)
 /// is rejected. Transports fail the handshake with `403 Forbidden` instead

--- a/packages/beryl/src/beryl/wire/codec.gleam
+++ b/packages/beryl/src/beryl/wire/codec.gleam
@@ -39,7 +39,7 @@ pub type InboundKind {
 /// A normalized inbound message.
 ///
 /// `Inbound` is opaque: construct it with `inbound` and read it with the
-/// `inbound_*` accessors. The hidden record lets Beryl add fields with
+/// `inbound_*` accessors. The hidden record lets beryl add fields with
 /// defaults without breaking custom codecs.
 pub opaque type Inbound {
   Inbound(

--- a/packages/beryl/test/app_logging_test.gleam
+++ b/packages/beryl/test/app_logging_test.gleam
@@ -15,7 +15,7 @@ import gleeunit/should
 import test_helpers
 
 /// Palabres's level is a global, singleton setting (see
-/// `beryl/internal.configure`); restore it to Beryl's own default so a
+/// `beryl/internal.configure`); restore it to beryl's own default so a
 /// `DebugLevel` test doesn't leak verbosity into tests that run after it.
 fn restore_default_logging_level() -> Nil {
   internal.configure(internal.LoggingConfig(

--- a/packages/beryl/test/app_supervision_test.gleam
+++ b/packages/beryl/test/app_supervision_test.gleam
@@ -1,7 +1,7 @@
 //// Nested-subtree lifecycle semantics for app-side dispatch systems
-//// (ADR 0002 phase 2, task 2): the Beryl runtime is a significant transient
+//// (ADR 0002 phase 2, task 2): the beryl runtime is a significant transient
 //// child under a one-for-one subtree with `auto_shutdown`, so a graceful
-//// `beryl.stop` tears down only Beryl's subtree (runtime + optional limiter)
+//// `beryl.stop` tears down only beryl's subtree (runtime + optional limiter)
 //// without restarting under, or disturbing, an embedding application's parent
 //// and sibling children. A runtime crash restarts dispatch under the same
 //// handle while the limiter survives, and connection owners that monitor the
@@ -67,7 +67,7 @@ fn admit(
   )
 }
 
-// ── stop targets only the Beryl subtree ─────────────────────────────────────
+// ── stop targets only the beryl subtree ─────────────────────────────────────
 
 pub fn stop_shuts_down_only_beryl_subtree_test() {
   let sibling_name = process.new_name("sibling_worker")
@@ -98,10 +98,10 @@ pub fn stop_shuts_down_only_beryl_subtree_test() {
   let assert Ok(_) = beryl.app_limiter_pid(sockets)
   process.is_alive(h.runtime_pid(sockets)) |> should.be_true
 
-  // Stop only the Beryl subtree.
+  // Stop only the beryl subtree.
   beryl.stop(sockets) |> should.equal(Ok(Nil))
 
-  // Beryl's runtime and limiter are gone and stay gone (the parent must not
+  // beryl's runtime and limiter are gone and stay gone (the parent must not
   // restart the transient subtree after a graceful stop).
   beryl.app_runtime_pid(sockets) |> should.be_error
   beryl.app_limiter_pid(sockets) |> should.be_error
@@ -289,7 +289,7 @@ pub fn runtime_crash_during_stop_does_not_hide_later_exhaustion_test() {
 
   // The crash during stop counts as the first failure in the nested
   // supervisor's restart window. Three more rapid crashes must therefore
-  // exhaust it and restart the whole Beryl subtree under the application root.
+  // exhaust it and restart the whole beryl subtree under the application root.
   process.kill(runtime2)
   let runtime3 = wait_for_new_runtime(sockets, runtime2)
   process.kill(runtime3)
@@ -691,7 +691,7 @@ pub fn application_root_shutdown_tears_down_beryl_subtree_test() {
   let runtime = h.runtime_pid(sockets)
   let limiter = limiter_pid(sockets)
 
-  // The application root goes down; the embedded Beryl subtree, linked under
+  // The application root goes down; the embedded beryl subtree, linked under
   // it, is torn down with it (unlink first so the test process survives).
   process.unlink(root.pid)
   process.kill(root.pid)
@@ -702,7 +702,7 @@ pub fn application_root_shutdown_tears_down_beryl_subtree_test() {
   beryl.app_runtime_pid(sockets) |> should.be_error
 }
 
-// ── a partial startup failure leaks no Beryl processes ──────────────────────
+// ── a partial startup failure leaks no beryl processes ──────────────────────
 
 pub fn partial_startup_failure_tears_down_beryl_subtree_test() {
   let assert Ok(#(sockets, beryl_spec)) =
@@ -714,7 +714,7 @@ pub fn partial_startup_failure_tears_down_beryl_subtree_test() {
     )
 
   // A sibling that always fails to start. The supervisor tears down the
-  // already-started Beryl subtree and exits, so the doomed startup is run in
+  // already-started beryl subtree and exits, so the doomed startup is run in
   // an unlinked child process to keep its failure signal off the test.
   let failing =
     supervision.worker(fn() -> Result(
@@ -733,7 +733,7 @@ pub fn partial_startup_failure_tears_down_beryl_subtree_test() {
     Nil
   })
 
-  // Whether or not the doomed supervisor reported an error, no Beryl runtime
+  // Whether or not the doomed supervisor reported an error, no beryl runtime
   // or limiter is left running.
   test_helpers.wait_until(
     fn() { beryl.app_runtime_pid(sockets) |> result.is_error },

--- a/packages/beryl/test/transport_server_rate_test.gleam
+++ b/packages/beryl/test/transport_server_rate_test.gleam
@@ -27,7 +27,7 @@ import gleeunit/should
 import test_helpers
 
 /// Palabres's level is a global, singleton setting (see
-/// `beryl/internal.configure`); restore it to Beryl's own default so a
+/// `beryl/internal.configure`); restore it to beryl's own default so a
 /// `DebugLevel` test doesn't leak verbosity into tests that run after it.
 fn restore_default_logging_level() -> Nil {
   internal.configure(internal.LoggingConfig(

--- a/packages/beryl_ewe/README.md
+++ b/packages/beryl_ewe/README.md
@@ -10,7 +10,7 @@ real-time sockets.
 
 ## Installation
 
-Beryl packages are currently distributed from GitHub, not Hex:
+beryl packages are currently distributed from GitHub, not Hex:
 
 ```toml
 [dependencies]

--- a/packages/beryl_mist/README.md
+++ b/packages/beryl_mist/README.md
@@ -10,7 +10,7 @@ real-time sockets.
 
 ## Installation
 
-Beryl packages are currently distributed from GitHub, not Hex:
+beryl packages are currently distributed from GitHub, not Hex:
 
 ```toml
 [dependencies]

--- a/packages/beryl_mist/test/client_contract_test.gleam
+++ b/packages/beryl_mist/test/client_contract_test.gleam
@@ -265,7 +265,7 @@ pub fn gluegun_raw_malformed_frame_gets_error_reply_test() {
       },
     )
 
-  // Current Beryl contract: malformed text frames time out rather than reply.
+  // Current beryl contract: malformed text frames time out rather than reply.
   result |> should.be_error
 
   stop_test_server(server)

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -75,7 +75,7 @@ export default defineConfig({
 			],
 			sidebar: [
 				{
-					label: "Start Here",
+					label: "Start here",
 					items: [
 						{
 							label: "What is beryl?",
@@ -90,7 +90,7 @@ export default defineConfig({
 							slug: "choosing-an-api",
 						},
 						{
-							label: "Quick Start",
+							label: "Quick start",
 							slug: "quick-start",
 						},
 						{
@@ -103,27 +103,27 @@ export default defineConfig({
 					label: "Tutorial",
 					items: [
 						{
-							label: "Build a Live Poll",
+							label: "Build a live poll",
 							slug: "tutorial",
 						},
 						{
-							label: "1. Elm Architecture Without a DOM",
+							label: "1. Elm Architecture without a DOM",
 							slug: "tutorial/the-elm-architecture-without-a-dom",
 						},
 						{
-							label: "2. One Update Function",
+							label: "2. One update function",
 							slug: "tutorial/one-update-function-many-socket-events",
 						},
 						{
-							label: "3. Typed System Messages",
+							label: "3. Typed system messages",
 							slug: "tutorial/typed-messages-from-your-gleam-system",
 						},
 						{
-							label: "4. Raw Dispatch and Channels",
+							label: "4. Raw dispatch and channels",
 							slug: "tutorial/composition-raw-dispatch-and-channels",
 						},
 						{
-							label: "5. Runtime Boundaries",
+							label: "5. Runtime boundaries",
 							slug: "tutorial/where-the-analogy-ends",
 						},
 						{
@@ -136,14 +136,14 @@ export default defineConfig({
 					label: "Guides",
 					items: [
 						{
-							label: "Core Concepts",
+							label: "Core concepts",
 							items: [
 								{
-									label: "Raw Dispatch",
+									label: "Raw dispatch",
 									slug: "guides/dispatch",
 								},
 								{
-									label: "Channel Handlers",
+									label: "Channel handlers",
 									slug: "guides/channels",
 								},
 								{
@@ -165,7 +165,7 @@ export default defineConfig({
 							collapsed: true,
 							items: [
 								{
-									label: "WebSocket Transport",
+									label: "WebSocket transport",
 									slug: "guides/websocket",
 								},
 								{
@@ -173,7 +173,7 @@ export default defineConfig({
 									slug: "guides/authentication",
 								},
 								{
-									label: "Backend Integration",
+									label: "Backend integration",
 									slug: "guides/backend-integration",
 								},
 								{
@@ -183,7 +183,7 @@ export default defineConfig({
 							],
 						},
 						{
-							label: "Running in Production",
+							label: "Running in production",
 							collapsed: true,
 							items: [
 								{
@@ -191,7 +191,7 @@ export default defineConfig({
 									slug: "guides/supervision",
 								},
 								{
-									label: "Error Handling",
+									label: "Error handling",
 									slug: "guides/error-handling",
 								},
 								{
@@ -199,7 +199,7 @@ export default defineConfig({
 									slug: "guides/observability",
 								},
 								{
-									label: "Production Hardening",
+									label: "Production hardening",
 									slug: "guides/production-hardening",
 								},
 							],
@@ -210,7 +210,7 @@ export default defineConfig({
 					label: "Reference",
 					items: [
 						{
-							label: "API Overview",
+							label: "API overview",
 							slug: "reference",
 						},
 						{
@@ -245,11 +245,11 @@ export default defineConfig({
 							slug: "architecture/message-lifecycle",
 						},
 						{
-							label: "Socket Processes & Restarts",
+							label: "Socket processes & restarts",
 							slug: "architecture/runtime",
 						},
 						{
-							label: "Broadcasts Across Nodes",
+							label: "Broadcasts across nodes",
 							slug: "architecture/pubsub-and-distribution",
 						},
 						{
@@ -257,7 +257,7 @@ export default defineConfig({
 							slug: "architecture/presence",
 						},
 						{
-							label: "WebSocket Frames & Transports",
+							label: "WebSocket frames & transports",
 							slug: "architecture/wire-and-transport",
 						},
 					],

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -139,11 +139,11 @@ export default defineConfig({
 							label: "Core Concepts",
 							items: [
 								{
-									label: "App-Side Dispatch",
+									label: "Raw Dispatch",
 									slug: "guides/dispatch",
 								},
 								{
-									label: "Sockets and Topics",
+									label: "Channel Handlers",
 									slug: "guides/channels",
 								},
 								{
@@ -241,15 +241,15 @@ export default defineConfig({
 							slug: "architecture/overview",
 						},
 						{
-							label: "Message Lifecycle",
+							label: "How beryl handles a message",
 							slug: "architecture/message-lifecycle",
 						},
 						{
-							label: "Runtime & Supervision",
+							label: "Socket Processes & Restarts",
 							slug: "architecture/runtime",
 						},
 						{
-							label: "PubSub & Distribution",
+							label: "Broadcasts Across Nodes",
 							slug: "architecture/pubsub-and-distribution",
 						},
 						{
@@ -257,7 +257,7 @@ export default defineConfig({
 							slug: "architecture/presence",
 						},
 						{
-							label: "Wire & Transport",
+							label: "WebSocket Frames & Transports",
 							slug: "architecture/wire-and-transport",
 						},
 					],

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1,9 +1,3 @@
 [build]
   command = "pnpm build:site"
   publish = "dist"
-  # Always build non-production deploys (deploy previews, branch deploys) so PR
-  # previews never get skipped. On production, skip only when nothing under
-  # website/ changed AND there is a valid, distinct cached ref to diff against
-  # (on a first build Netlify sets CACHED_COMMIT_REF == COMMIT_REF, which would
-  # otherwise diff a commit against itself, find no change, and cancel).
-  ignore = "if [ \"$CONTEXT\" != \"production\" ]; then exit 1; fi; if [ -z \"$CACHED_COMMIT_REF\" ] || [ \"$CACHED_COMMIT_REF\" = \"$COMMIT_REF\" ]; then exit 1; fi; git diff --quiet \"$CACHED_COMMIT_REF\" \"$COMMIT_REF\" -- website/"

--- a/website/scripts/generate-reference.mjs
+++ b/website/scripts/generate-reference.mjs
@@ -343,7 +343,7 @@ ${moduleRows}`;
 	);
 
 	return `---
-title: API Reference
+title: API reference
 description: API reference generated from Gleam docs metadata.
 ---
 

--- a/website/scripts/generate-reference.test.mjs
+++ b/website/scripts/generate-reference.test.mjs
@@ -128,7 +128,7 @@ test("generates an index and one page per module", async () => {
 		assert.equal(result.pageCount, 3);
 
 		const index = await readFile(path.join(outputDir, "index.md"), "utf8");
-		assert.match(index, /title: API Reference/);
+		assert.match(index, /title: API reference/);
 		assert.match(index, /`beryl` `9\.9\.9`/);
 		// Modules are sorted alphabetically: beryl before beryl/channel.
 		assert.ok(index.indexOf("/reference/api/beryl/") < index.indexOf("/reference/api/beryl-channel/"));

--- a/website/src/content/docs/architecture/message-lifecycle.md
+++ b/website/src/content/docs/architecture/message-lifecycle.md
@@ -1,11 +1,11 @@
 ---
-title: Message Lifecycle
+title: How beryl handles a message
 ---
 
 This page follows a message from the WebSocket connection to the client. Each
 diagram shows one phase of beryl's message processing.
 
-## Connect and init
+## Connect and initialize a socket
 
 When a client requests a WebSocket upgrade, Mist creates a unique socket ID. It
 builds a `ConnectSeed` from the path, query, and headers. Mist then sends the
@@ -56,9 +56,9 @@ sequenceDiagram
   Socket-->>Client: phx_reply (ok/error)
 ```
 
-The runtime rejects a `Join` that has no answer. Thus, beryl fails closed.
+The runtime automatically rejects a `Join` that has no answer.
 
-## Handle an inbound event
+## Handle a client event
 
 After a successful join, `update` receives each later topic frame as a
 `Message` event. The effects list can send a reply, push, broadcast, or presence
@@ -77,7 +77,7 @@ sequenceDiagram
   Socket-->>Client: apply effects in order (ReplyOk, Push, ...)
 ```
 
-## Broadcast fan-out
+## Send one event to many sockets
 
 A broadcast sends a message to each socket on a topic. `Broadcast` and
 `beryl.broadcast` include the source socket. `BroadcastFrom` and
@@ -94,12 +94,12 @@ sequenceDiagram
   participant Subs as subscriber socket actors
   Origin->>Socket: Broadcast(topic, event, payload)
   Socket->>Router: broadcast
-  Router-->>Subs: fan out
-  Router->>PS: broadcast_from (cluster fan-out)
+  Router-->>Subs: send to local subscribers
+  Router->>PS: broadcast_from (send to other nodes)
   PS-->>Router: deliver to each remote router
 ```
 
-## Heartbeat and eviction
+## Detect an inactive connection
 
 Clients send a `heartbeat` frame on the `"phoenix"` topic at set intervals. The
 socket actor replies and records the time. Each socket actor has a timer that
@@ -115,7 +115,7 @@ sequenceDiagram
   Socket->>Socket: close after deadline (Closed(HeartbeatTimeout) to app)
 ```
 
-## Disconnect and close
+## Disconnect a socket
 
 When a client closes the WebSocket, Mist notifies the router. The router
 forwards the close to the socket actor. The actor sends `Closed(topic, reason)`
@@ -139,7 +139,7 @@ sequenceDiagram
 The same `Closed` path is used for client leaves, heartbeat timeouts,
 `KickTopic`, and graceful `beryl.stop` shutdown.
 
-## Where the channel layer fits
+## How channel handlers use this path
 
 `beryl/channel` supplies the `init` and `update` pair in these diagrams. Its
 `init` builds one channel model for each socket. Its `update` maps each input
@@ -149,10 +149,10 @@ to the live channel instance for that topic.
 |---|---|
 | `Join(topic, payload, ref)` | First matching handler wins; its join result emits `AcceptJoin` followed by ordered join actions, or `RejectJoin`. No match is refused with `{"reason": "unmatched topic"}` |
 | `Message(topic, ..)` / `Binary(topic, ..)` | Delivered to the live instance for that topic |
-| `Info(envelope)` | Topic and join generation are checked before the sealed typed value is opened; stale mail is dropped |
+| `Info(envelope)` | The runtime checks the topic and join generation, then drops messages sent to an older join |
 | `Closed(topic, reason)` | Calls `on_terminate` and lowers its actions after the topic is already unsubscribed |
 
-Termination has one edge case. The router removes the instance in the model
+Termination has one special case. The router removes the instance in the model
 returned by the `Closed` turn. If `on_terminate` panics, the core discards that
 model and keeps the old model. The retained instance can receive its own
 generation-scoped `channel.notify` mail. Client messages cannot reach the
@@ -164,15 +164,14 @@ Each channel action maps to one core effect. The runtime preserves their order.
 An asynchronous presence effect can pause one socket while other sockets
 continue.
 
-## Concurrency note
+## Message order
 
 Each socket actor processes its mailbox in sequence. The router processes
-index updates and broadcasts in its own mailbox. Tests must select the exact
-message shape and drain queued messages.
+index updates and broadcasts in its own mailbox. Tests must select the exact message and clear any queued test messages.
 
-## Where this lives
+## Source files
 
-- `packages/beryl_mist/src/beryl_mist.gleam`: connect/close, edge decoding, frame routing
+- `packages/beryl_mist/src/beryl_mist.gleam`: connect, close, decode, and route frames
 - `src/beryl/runtime.gleam`: event dispatch, effect application, heartbeat timer
 - `src/beryl/wire.gleam`, `src/beryl/wire/codec.gleam`: decode/encode frames
-- `src/beryl/pubsub.gleam`: fan-out
+- `src/beryl/pubsub.gleam`: send broadcasts to subscribers

--- a/website/src/content/docs/architecture/overview.md
+++ b/website/src/content/docs/architecture/overview.md
@@ -1,6 +1,6 @@
 ---
-title: Architecture Overview
-description: How beryl is organized, the major modules, and where to make changes.
+title: How beryl Works
+description: Follow data through beryl, find each process, and locate its source module.
 ---
 
 beryl provides a socket runtime on OTP actors and Erlang `pg`, with a built-in
@@ -10,17 +10,17 @@ It can also pass a typed handler table to `channel.child_spec`. The runtime
 dispatches decoded messages and applies the returned effects. Separate actors
 manage presence and groups. Only PubSub sends data across nodes.
 
-## How to read these docs
+## Choose a page
 
 Each page describes one subsystem and lists its source files.
 
-- [Message Lifecycle](/architecture/message-lifecycle): how a frame travels from WebSocket to your `update` function and back
-- [Runtime & Supervision](/architecture/runtime): the router, per-socket actors, typed dispatch, and built-in supervision
-- [PubSub & Distribution](/architecture/pubsub-and-distribution): Erlang `pg` groups, broadcast semantics, and cross-node delivery
+- [How beryl handles a message](/architecture/message-lifecycle): how a frame travels from WebSocket to your `update` function and back
+- [Socket Processes & Restarts](/architecture/runtime): the router, one process per socket, typed messages, and restart behavior
+- [Broadcasts Across Nodes](/architecture/pubsub-and-distribution): Erlang `pg` groups, sender exclusion, and delivery between nodes
 - [Presence](/architecture/presence): CRDT-backed presence tracking, diffs, and replication
-- [Wire & Transport](/architecture/wire-and-transport): codec contract, Phoenix framing, and the Mist WebSocket adapter
+- [WebSocket Frames & Transports](/architecture/wire-and-transport): message encoding, Phoenix frames, and the Mist WebSocket adapter
 
-## The layer stack
+## How data moves through beryl
 
 ```mermaid
 flowchart TB
@@ -47,24 +47,24 @@ flowchart TB
 | Module | Responsibility | Page |
 |---|---|---|
 | `beryl` | Public entry-point: `config/1`, `child_spec/3`, `broadcast/4`, `broadcast_from/5`, `stop/1` | — |
-| `beryl/channel` | Recommended channel layer: supervised startup, handler validation, typed per-topic state, lifecycle callbacks, senders, and ordered actions | [Channels](/guides/channels/) |
+| `beryl/channel` | Recommended channel layer: supervised startup, handler validation, typed per-topic state, join and close callbacks, senders, and ordered actions | [Channels](/guides/channels/) |
 | `beryl/socket` | The app-facing dispatch types: `Input`, `Next`, `Effect`, `JoinRef`/`ReplyRef`, `ConnectInfo`/`ConnectSeed`, typed `Sender`/`notify` | [Runtime](/architecture/runtime) |
-| `beryl/runtime` | Router and socket actors: subscriber index, per-socket models, event dispatch, effect interpreter, heartbeat enforcement | [Runtime](/architecture/runtime) |
-| `beryl/pubsub` | Distributed pub-sub via Erlang `pg`; subscribe, broadcast, and broadcast_from | [PubSub & Distribution](/architecture/pubsub-and-distribution) |
+| `beryl/runtime` | Router and socket actors: subscriber index, per-socket models, event delivery, returned effects, and heartbeat enforcement | [Runtime](/architecture/runtime) |
+| `beryl/pubsub` | Distributed publish and subscribe through Erlang `pg` | [Broadcasts Across Nodes](/architecture/pubsub-and-distribution) |
 | `beryl/presence` | OTP actor wrapping an add-wins OR-set CRDT; track/untrack, cross-node diff broadcast, `on_diff` callbacks | [Presence](/architecture/presence) |
 | `beryl/presence/wire` | Phoenix-compatible JSON encoding for presence diffs (`joins`/`leaves` maps) | [Presence](/architecture/presence) |
-| `beryl/wire` | Pluggable codec surface; ships `phoenix_codec()` for `[join_ref, ref, topic, event, payload]` framing | [Wire & Transport](/architecture/wire-and-transport) |
-| `beryl/wire/codec` | `Codec` type contract: `decode_text`, `decode_binary`, `encode_*`; lets you swap framing | [Wire & Transport](/architecture/wire-and-transport) |
-| `beryl/transport` | Frame-level transport SPI consumed by transport packages | [Wire & Transport](/architecture/wire-and-transport) |
-| `beryl_mist` / `beryl_ewe` | WebSocket adapters: assign socket IDs, register send functions, decode frames at the edge, route to the runtime | [Wire & Transport](/architecture/wire-and-transport) |
+| `beryl/wire` | Message encoding; includes `phoenix_codec()` for `[join_ref, ref, topic, event, payload]` frames | [WebSocket Frames & Transports](/architecture/wire-and-transport) |
+| `beryl/wire/codec` | `Codec` functions such as `decode_text`, `decode_binary`, and `encode_*` | [WebSocket Frames & Transports](/architecture/wire-and-transport) |
+| `beryl/transport` | Public interface used by WebSocket transport packages | [WebSocket Frames & Transports](/architecture/wire-and-transport) |
+| `beryl_mist` / `beryl_ewe` | WebSocket adapters that assign socket IDs, register send functions, decode frames, and route messages | [WebSocket Frames & Transports](/architecture/wire-and-transport) |
 | `beryl/group` | Named topic collections managed by an OTP actor; supports grouped broadcast | (none) |
 | `beryl/topic` | Topic pattern matching: exact strings, `"ns:*"` prefix wildcards, and segment wildcards (`"document:*:ops"`) | (none) |
 | `beryl/error` | Opaque `StartFailure` type that hides OTP's `actor.StartError` from public APIs | (none) |
 | `beryl/rate_limit` | Token-bucket rate limiter; keyed per socket, per socket+topic, or per topic pattern | (none) |
-| `beryl/log` | Internal logging shim over `palabres`; thin named-logger surface, not public API | (none) |
+| `beryl/log` | Internal named loggers built on `palabres`; not public API | (none) |
 | `beryl/internal` | Shared internal utilities (logging config, crash rescue); not public API | (none) |
 
-## Process & supervision at a glance
+## Process ownership and restart behavior
 
 ```mermaid
 flowchart TB
@@ -81,11 +81,11 @@ actors, which monitor the router and are monitored by it. The application
 starts and owns the presence and group actors. See the
 [Supervision guide](/guides/supervision/).
 
-## Where things live
+## Source files
 
 Core source files are under `packages/beryl/src/beryl/`. Transport source files
 are under `packages/beryl_mist/` and `packages/beryl_ewe/`. Start with
-[Runtime & Supervision](/architecture/runtime) to learn the runtime. See
-[Message Lifecycle](/architecture/message-lifecycle) for the message path. See
-[PubSub & Distribution](/architecture/pubsub-and-distribution) for cross-node
+[Socket Processes & Restarts](/architecture/runtime) to learn how beryl runs sockets. See
+[How beryl handles a message](/architecture/message-lifecycle) for the message path. See
+[Broadcasts Across Nodes](/architecture/pubsub-and-distribution) for cross-node
 behavior.

--- a/website/src/content/docs/architecture/overview.md
+++ b/website/src/content/docs/architecture/overview.md
@@ -1,5 +1,5 @@
 ---
-title: How beryl Works
+title: How beryl works
 description: Follow data through beryl, find each process, and locate its source module.
 ---
 

--- a/website/src/content/docs/architecture/presence.md
+++ b/website/src/content/docs/architecture/presence.md
@@ -4,7 +4,7 @@ title: Presence
 
 ## How presence stores changes
 
-Beryl presence uses an OTP actor and
+beryl presence uses an OTP actor and
 [`lattice_presence/presence_state`](https://hex.pm/packages/lattice_presence).
 an **add-wins, observed-remove conflict-free replicated data type (CRDT)**.
 Each cluster node keeps one copy. Nodes can merge their copies in any order.

--- a/website/src/content/docs/architecture/presence.md
+++ b/website/src/content/docs/architecture/presence.md
@@ -2,25 +2,25 @@
 title: Presence
 ---
 
-## Model
+## How presence stores changes
 
-Beryl presence is an OTP actor that wraps
+Beryl presence uses an OTP actor and
 [`lattice_presence/presence_state`](https://hex.pm/packages/lattice_presence).
-It uses an **add-wins, observed-remove CRDT**. Each cluster node keeps one CRDT
-replica. Replicas can merge in any order without coordination. Concurrent joins
-and leaves converge to the same result.
+an **add-wins, observed-remove conflict-free replicated data type (CRDT)**.
+Each cluster node keeps one copy. Nodes can merge their copies in any order.
+Joins and leaves that happen at the same time produce the same final result.
 
 Each tracked entry has a **replica name**, set by the `replica` argument to
 `default_config/1`. Use a unique name for each cluster node. The CRDT uses this
 name to identify remote state.
 
-## How Beryl apps use it
+## Add presence to an app
 
 The application builds the presence actor with `presence.child_spec`. Add the
 child to the supervision tree. Then pass its handle to `beryl.Config` with
 `with_presence_handle`.
 
-App-side dispatch uses `PresenceTrack`, `PresenceUntrack`, `PushPresence`, and
+Raw dispatch uses `PresenceTrack`, `PresenceUntrack`, `PushPresence`, and
 `BroadcastPresence` effects. The runtime sends mutations to the presence actor. The actor acknowledges a
 mutation after it updates the CRDT and ETS read model. Until then, the runtime
 pauses later effects and inputs for that socket. Other sockets, broadcasts,
@@ -38,7 +38,7 @@ application actors and other out-of-band workflows. Public `list`,
 `get_by_key`, and `count` calls read ETS directly and retain immediate
 read-after-write behavior.
 
-## API surface
+## Presence functions
 
 ### Starting presence
 
@@ -86,7 +86,7 @@ PubSub copies presence state between nodes.
 | `diff_joins(diff, topic)` | Get joined entries for a topic |
 | `diff_leaves(diff, topic)` | Get departed entries for a topic |
 
-## Replication
+## Sync between nodes
 
 When you configure `with_pubsub`, the presence actor runs a broadcast loop at
 the configured interval, which defaults to 1500 ms:
@@ -107,7 +107,7 @@ Automated tests currently exercise replication with multiple presence actors
 on one BEAM node. [Issue #365](https://github.com/tylerbutler/beryl/issues/365)
 tracks integration coverage across separate distributed Erlang nodes.
 
-## Diagram
+## Request and sync flow
 
 ```mermaid
 sequenceDiagram
@@ -131,7 +131,7 @@ sequenceDiagram
   Pres-->>App: on_diff(diff)
 ```
 
-## Where this lives
+## Source files
 
 | File | Role |
 |---|---|

--- a/website/src/content/docs/architecture/pubsub-and-distribution.md
+++ b/website/src/content/docs/architecture/pubsub-and-distribution.md
@@ -1,5 +1,5 @@
 ---
-title: Broadcasts Across Erlang Nodes
+title: Broadcasts across Erlang nodes
 ---
 
 ## How distribution works

--- a/website/src/content/docs/architecture/pubsub-and-distribution.md
+++ b/website/src/content/docs/architecture/pubsub-and-distribution.md
@@ -1,8 +1,8 @@
 ---
-title: PubSub & Distribution
+title: Broadcasts Across Erlang Nodes
 ---
 
-## Foundation
+## How distribution works
 
 Beryl's PubSub layer uses Erlang's
 [`pg`](https://www.erlang.org/doc/man/pg.html) process groups. A subscriber
@@ -18,13 +18,13 @@ isolated namespaces. Different scopes can safely carry different payload types
 into one process mailbox; all handles for one scope must use the same payload
 type.
 
-## The FFI Boundary
+## How Gleam calls Erlang `pg`
 
-The Gleam module `beryl/pubsub` sends low-level `pg` operations to
-`src/beryl_pubsub_ffi.erl` through `@external` declarations. The FFI file maps
-Gleam calls to `pg` BIFs.
+The Gleam module `beryl/pubsub` calls
+`src/beryl_pubsub_ffi.erl` through `@external` declarations. This small Erlang
+module translates Gleam calls into built-in `pg` functions.
 
-**Public surface of `beryl/pubsub`:**
+**PubSub functions:**
 
 | Function | Description |
 |---|---|
@@ -42,9 +42,10 @@ Gleam calls to `pg` BIFs.
 
 `pg` sends each broadcast as the scope atom followed by the four
 `Message(payload)` fields (`topic`, `event`, `payload`, `from`). This
-five-element tuple is a frozen wire contract. The scoped and previously
-unscoped shapes cannot communicate during a rolling upgrade. Applications must
-also version payload changes that cross nodes.
+five-element tuple is a fixed message format between nodes. Nodes that use the
+old four-element format cannot communicate with nodes that use the current
+format during an upgrade. Applications must also version payload changes that
+cross nodes.
 
 The `PubSubFrom` type tags each message with its origin so downstream receivers can inspect whether a message came from the system, a specific process, or a process with an associated socket:
 
@@ -56,7 +57,7 @@ pub type PubSubFrom {
 }
 ```
 
-## Exclusion Semantics
+## Exclude the sender
 
 `broadcast_from` and `broadcast_from_socket` exclude the sender. The source
 process does not receive its broadcast. This prevents an echo to the source
@@ -65,13 +66,13 @@ socket.
 - `broadcast_from(ps, from, ...)` skips delivery to the process whose `Pid` matches `from`.
 - `broadcast_from_socket(ps, from, except_socket_id, ...)` also skips delivery to `from`, and includes `FromSocket(from, except_socket_id)` in the message so that any remote runtime receiving it can optionally suppress re-delivery to a matching socket ID on their node.
 
-:::caution[Regression-prone contract]
+:::caution[Keep sender-exclusion tests]
 Channel behavior depends on sender exclusion. If code changes or skips the
 `pid == from` comparison, senders receive their own messages. Keep the
 `broadcast_from` exclusion tests when you change PubSub code.
 :::
 
-## Distribution Diagram
+## Cross-node example
 
 ```mermaid
 flowchart LR
@@ -90,7 +91,7 @@ When socket A sends a message on Node 1, its runtime calls `broadcast_from`.
 The function iterates through the `pg` group members. Erlang distribution sends
 the message to members on Node 2. You do not need another message bus.
 
-## Trust Model
+## Secure cluster connections
 
 Treat all Erlang distribution traffic as **trusted cluster input**. A peer can
 run arbitrary code on connected nodes. The beryl capabilities below are only
@@ -115,7 +116,7 @@ Refer to the [Production Hardening guide](/guides/production-hardening/#erlang-c
 for the full cluster security requirements (network isolation, mutually
 verified TLS distribution, EPMD port restrictions, and cookie handling).
 
-## Where this lives
+## Source files
 
 | File | Role |
 |---|---|

--- a/website/src/content/docs/architecture/pubsub-and-distribution.md
+++ b/website/src/content/docs/architecture/pubsub-and-distribution.md
@@ -4,7 +4,7 @@ title: Broadcasts across Erlang nodes
 
 ## How distribution works
 
-Beryl's PubSub layer uses Erlang's
+beryl's PubSub layer uses Erlang's
 [`pg`](https://www.erlang.org/doc/man/pg.html) process groups. A subscriber
 joins a named `pg` group in the PubSub scope. For each broadcast, beryl finds
 the group members and sends the message to them.

--- a/website/src/content/docs/architecture/runtime.md
+++ b/website/src/content/docs/architecture/runtime.md
@@ -1,5 +1,5 @@
 ---
-title: Runtime & Supervision
+title: Socket Processes & Restarts
 ---
 
 The runtime uses one router actor and one actor for each connected socket.
@@ -9,7 +9,7 @@ functions run in that socket actor. The application owns separate supervised
 children for presence and groups. PubSub wraps Erlang `pg` and is not a runtime
 child.
 
-## Role
+## How the processes divide the work
 
 Each socket actor stores the app model, wire-send functions, joined topics, and
 heartbeat time for one socket. It processes mailbox messages in sequence. This
@@ -23,7 +23,7 @@ limits, and decoding. Each socket actor owns its decoded-message, join, and
 per-channel rate-limit buckets. The next event uses the model returned by
 `update`.
 
-## What it tracks
+## Data stored for each socket
 
 A socket actor maintains, for its one socket:
 
@@ -33,31 +33,31 @@ A socket actor maintains, for its one socket:
 
 The router maintains:
 
-- **Topic → subscriber sets** — maps each active topic string to the set of socket IDs currently joined on it, used for broadcast fan-out. Updated by cast from the socket actors as they join and leave.
+- **Topic → subscriber sets** — maps each active topic string to the socket IDs currently joined on it. Socket actors update this map when they join and leave.
 - **The actor table** — socket ID → socket actor, with a monitor per actor so a crashed actor's entries are swept rather than leaked.
 
-## Typed dispatch without erasure
+## How beryl preserves app types
 
-The router and socket actors are generic over the app's `model` and `msg` types.
-`beryl.child_spec` captures those types in monomorphic closures. The public
-`Sockets` handle and transport SPI do not need type parameters. The runtime
-still keeps typed state. This path uses no unchecked casts, `Dynamic`
-round-trips, or identity FFI. PubSub validates its raw mailbox record before
-its internal payload coercion.
+The router and socket actors use the app's `model` and `msg` types.
+`beryl.child_spec` stores typed functions in closures. The public `Sockets`
+handle and transport interface do not need type parameters, but the runtime
+still keeps typed state. It does not use unchecked casts or convert app state
+to `Dynamic`. PubSub validates each raw mailbox message before converting its
+internal payload.
 
 Server-side messages work the same way: `init` receives a typed `Sender(msg)` whose closure captures the message type, and `socket.notify` delivers messages that arrive in `update` as `Info(msg)` — an ordinary typed send.
 
 `channel.child_spec` uses this same mechanism. Its generic router
 captures each handler's private state and server-message type in closures,
-while the socket-level message is a sealed, generation-stamped envelope.
-The envelope's topic and generation are checked before the typed value is
-opened, so stale mail cannot reach a later join.
+while the socket-level message records its topic and join generation. The
+runtime checks both values before delivery, so a message for an older join
+cannot reach a later join.
 
-## Input dispatch
+## How incoming frames reach your app
 
 Inbound WebSocket frames follow a two-step path:
 
-1. **Decode at the edge** — the transport decodes raw frames in the connection process using the configured codec (see [Wire & Transport](/architecture/wire-and-transport)), so parse cost and malformed input never reach the runtime.
+1. **Decode in the connection process** — the transport decodes raw frames with the configured codec (see [WebSocket Frames & Transports](/architecture/wire-and-transport)), so malformed input never reaches the runtime.
 2. **Route to update** — the decoded message is sent to the router, which forwards it to the socket's actor; the actor turns it into an `Input` for the socket's `update` function:
    - `phx_join` → validates the topic (length, control characters, reserved `beryl:` prefix, join rate, topic cap), then delivers `Join(topic, payload, ref)`. The join is held pending until the update's effects answer it; an unanswered join is rejected (fail closed).
    - Any other event on a joined topic → `Message(topic, event, payload, ref)`.
@@ -65,7 +65,7 @@ Inbound WebSocket frames follow a two-step path:
    - `phx_leave` → acks the leave, then delivers `Closed(topic, Normal)`.
    - Binary frames → decoded through the codec's binary decoder when present and routed with binary message classification; otherwise delivered raw as `Binary(topic, data)` to each joined topic.
 
-## Effect ordering
+## Order of replies, pushes, and broadcasts
 
 The runtime applies effects in list order. The same actor interprets the list
 and writes the frames. Thus, list order is wire order. An `AcceptJoin` reaches
@@ -80,7 +80,7 @@ that socket. Then it resumes at the next effect. The socket keeps its effect
 order. Other sockets, broadcasts, heartbeat checks, and shutdown work continue.
 An unrelated broadcast can occur between two effects from the paused socket.
 
-## Crash containment
+## What closes after a callback crash
 
 The runtime catches crashes in app callbacks. A `Join` crash rejects that join.
 A topic `Message` or `Binary` crash closes only that topic. An `Info` crash
@@ -89,16 +89,12 @@ and teardown continues. An `init` crash prevents socket registration. The
 runtime limits and truncates crash descriptions before logging. Other sockets
 continue.
 
-This is a deliberate trade-off with OTP's usual "let it crash" model. Even
-with per-socket actors, letting an app callback crash reach the actor would
-widen the blast radius from the crashed scope (one topic, one join) to the
-whole socket — every joined topic torn down and the connection closed for a
-fault one topic's handler caused. Beryl uses a crash boundary only where it
-can discard the callback result and reject or tear down the narrowest
-affected scope; it never continues with a partial result. Faults outside
-those explicit boundaries still crash the socket's actor — which the router's
-monitor sweeps, closing only that socket — and faults in the router itself
-invoke supervision.
+This differs from OTP's usual "let it crash" model. If a callback crash stopped
+the socket actor, one topic error would close every topic on that socket.
+Beryl instead discards the callback result and closes only the affected join,
+topic, or socket. It never continues with a partial result. Other faults can
+still stop the socket actor, which closes that socket. A router fault invokes
+supervision.
 
 For the channel layer, those scopes map to `join`, `on_message` /
 `on_info`, and `on_terminate`. A terminate panic discards that
@@ -106,7 +102,7 @@ router update, so its actions are lost and the old instance remains reachable
 only through its own typed sender until rejoin or socket teardown. Core still
 finishes closing the topic and continues closing sibling channels.
 
-## Heartbeat enforcement
+## Detect inactive sockets
 
 Each socket actor checks its heartbeat every `heartbeat_timeout_ms / 2`. There
 is no global sweep. The actor compares the current monotonic time with its
@@ -116,7 +112,7 @@ Removal sends
 transport closer and removes all socket state. `child_spec` rejects timeouts
 below 2 because integer division would set the check interval to zero.
 
-## Supervision
+## Restart behavior
 
 `child_spec` has no unsupervised mode. The router always starts under an internal one-for-one supervisor with a **3 restarts / 5 seconds** tolerance. Socket actors are not supervisor children: each is started by the transport's connection process at admission, monitored by the router (a crashed actor's entries are swept, closing only that socket), and monitors the router in return, stopping on its `Down`:
 
@@ -140,11 +136,11 @@ flowchart TB
   completes in-flight presence work, then stops the socket actors. It kills an
   actor that remains blocked in an app callback.
 
-PubSub is **not** part of this tree. Erlang `pg` manages its lifecycle.
+PubSub is **not** part of this tree. Erlang `pg` starts and stops it.
 Presence and groups provide child specifications for the application
 supervision tree. See the [Supervision guide](/guides/supervision/).
 
-## Where this lives
+## Source files
 
-- `src/beryl/runtime.gleam` — the router and socket-actor roles of one actor implementation: socket/model tracking, event dispatch, the effect interpreter, per-socket heartbeat timers, crash rescue, admission, and the drain.
-- `src/beryl.gleam` — `child_spec`, the supervised child specification, and the monomorphic closure record over the generic runtime (including the transport-side socket-actor start).
+- `src/beryl/runtime.gleam` — socket and model tracking, event delivery, returned effects, heartbeat timers, crash handling, admission, and shutdown.
+- `src/beryl.gleam` — `child_spec`, the supervised child specification, and the typed functions used to start the runtime and socket actors.

--- a/website/src/content/docs/architecture/runtime.md
+++ b/website/src/content/docs/architecture/runtime.md
@@ -1,5 +1,5 @@
 ---
-title: Socket Processes & Restarts
+title: Socket processes & restarts
 ---
 
 The runtime uses one router actor and one actor for each connected socket.

--- a/website/src/content/docs/architecture/runtime.md
+++ b/website/src/content/docs/architecture/runtime.md
@@ -91,7 +91,7 @@ continue.
 
 This differs from OTP's usual "let it crash" model. If a callback crash stopped
 the socket actor, one topic error would close every topic on that socket.
-Beryl instead discards the callback result and closes only the affected join,
+beryl instead discards the callback result and closes only the affected join,
 topic, or socket. It never continues with a partial result. Other faults can
 still stop the socket actor, which closes that socket. A router fault invokes
 supervision.

--- a/website/src/content/docs/architecture/wire-and-transport.md
+++ b/website/src/content/docs/architecture/wire-and-transport.md
@@ -1,12 +1,12 @@
 ---
-title: Wire & Transport
+title: WebSocket Frames & Transports
 ---
 
-The wire and transport layer connects raw WebSocket frames to the runtime. A
-pluggable **codec** converts bytes to structured messages. The **Mist
-transport** manages the socket lifecycle.
+This part of beryl converts raw WebSocket frames into app messages. A
+**codec** defines how to decode and encode messages. A **transport** connects
+beryl to a WebSocket server such as Mist or Ewe.
 
-## Codec abstraction
+## Choose or build a codec
 
 A `Codec` is opaque. Use the public factory and builder functions in
 `beryl/wire/codec`, or use `wire.phoenix_codec()`. The runtime receives
@@ -39,7 +39,7 @@ beryl.config(wire.phoenix_codec())
 Pass a custom `Codec` to `beryl.config(codec)` to use another protocol. You do
 not need to change the runtime or app logic.
 
-## Frame shapes
+## Phoenix frame format
 
 Phoenix uses a JSON array for every message on the wire:
 
@@ -51,7 +51,7 @@ The `join_ref` and `ref` fields are nullable strings that link requests and
 replies. `topic` is the subscription key, such as `"room:lobby"`. `event` names
 the protocol action or user event.
 
-### Key functions in `beryl/wire`
+### Decode and encode frames
 
 **`decode_message(json_string)`** parses a raw JSON string into an `Inbound`.
 It returns `InvalidJson` or `InvalidFormat` for malformed input.
@@ -69,7 +69,7 @@ frame. The `payload` field is
 `"phoenix"`, event `"phx_reply"`, status `"ok"`, and an empty response object.
 The client sends heartbeats with topic `"phoenix"` and event `"heartbeat"`.
 
-## Shared transport core
+## How transports handle a connection
 
 `beryl/transport/server` manages admission, connections, and frames.
 `beryl_mist` and `beryl_ewe` provide the server-specific upgrade, frame-send,
@@ -97,7 +97,7 @@ and peer-IP functions:
    checks the full `Origin` header before the handshake. It returns HTTP 403
    for a missing or non-matching origin.
 
-### Key functions
+### Configure the server transport
 
 **`server.default_config(path)`**: creates a `TransportConfig` with no connect hook and the default same-origin policy.
 
@@ -111,7 +111,7 @@ and peer-IP functions:
 
 **`handler(channels, config, http_fallback)`**: returns a combined request handler that routes WebSocket upgrade requests to `upgrade` and everything else to `http_fallback`. Removes boilerplate from application code.
 
-## Diagram
+## Frame path
 
 ```mermaid
 flowchart LR
@@ -124,13 +124,13 @@ flowchart LR
   RT --> EN["encode reply/push"] --> CORE --> ADAPTER --> CL["client"]
 ```
 
-## Where this lives
+## Source files
 
 | Module | Path |
 |---|---|
-| Codec abstraction | `src/beryl/wire/codec.gleam` |
+| Codec configuration | `src/beryl/wire/codec.gleam` |
 | Phoenix wire helpers | `src/beryl/wire.gleam` |
-| Shared server pipeline | `src/beryl/transport/server.gleam` |
+| Shared server connection handling | `src/beryl/transport/server.gleam` |
 | Origin policy | `src/beryl/transport/origin.gleam` |
 | Mist transport | `packages/beryl_mist/src/beryl_mist.gleam` |
 | Ewe transport | `packages/beryl_ewe/src/beryl_ewe.gleam` |

--- a/website/src/content/docs/architecture/wire-and-transport.md
+++ b/website/src/content/docs/architecture/wire-and-transport.md
@@ -1,5 +1,5 @@
 ---
-title: WebSocket Frames & Transports
+title: WebSocket frames & transports
 ---
 
 This part of beryl converts raw WebSocket frames into app messages. A

--- a/website/src/content/docs/architecture/wire-and-transport.md
+++ b/website/src/content/docs/architecture/wire-and-transport.md
@@ -30,7 +30,7 @@ The public codec builders configure these behaviors:
 
 Build a custom text codec with `codec.new(...)`, then add optional behavior with builders such as `codec.with_binary_decoder`, `codec.with_close_encoder`, `codec.with_error_encoder`, and `codec.with_topicless_events`. The built-in `wire.phoenix_codec()` configures Phoenix text and V2 binary framing.
 
-Each Beryl `Config` requires a codec. There is no default:
+Each beryl `Config` requires a codec. There is no default:
 
 ```gleam
 beryl.config(wire.phoenix_codec())

--- a/website/src/content/docs/choosing-an-api.md
+++ b/website/src/content/docs/choosing-an-api.md
@@ -1,6 +1,6 @@
 ---
 title: Choose an API
-description: Compare beryl's channel layer and raw app-side dispatch APIs.
+description: Compare beryl's channel handlers and raw dispatch API.
 ---
 
 beryl has one runtime and two ways to program it.
@@ -8,16 +8,16 @@ beryl has one runtime and two ways to program it.
 - **The channel layer** (`beryl/channel`): Register one handler for each topic
   pattern. Each channel keeps private state and a server-side message type. The
   layer routes each event to the correct channel. **Use this API by default.**
-- **Raw app-side dispatch** (`beryl`): Define one `init` and `update` pair for
+- **Raw dispatch** (`beryl`): Define one `init` and `update` pair for
   the socket system. Beryl runs them separately for each connected socket.
   Match `socket.Input` values and return ordered effects. The channel layer
   uses this public core API.
 
-Both APIs use the same runtime, wire codec, presence, PubSub, and abuse
-controls. They have the same wire-level features. The main difference is who
-writes topic dispatch.
+Both APIs use the same socket processes, message format, presence, PubSub,
+connection limits, and rate limits. They support the same client features.
+The main difference is who routes topics.
 
-## Pick in one line
+## Choose by app structure
 
 | If your app… | Use |
 |---|---|
@@ -29,7 +29,7 @@ writes topic dispatch.
 | needs total control over routing and effect order | [Raw dispatch](/guides/dispatch/) |
 | wants one model that spans every topic on a socket | [Raw dispatch](/guides/dispatch/) |
 
-## Side by side
+## Compare the APIs
 
 |  | Channel layer | Raw dispatch |
 |---|---|---|
@@ -43,7 +43,7 @@ writes topic dispatch.
 | Cross-topic effects | External `Sockets` APIs only | Direct, in any effect list |
 | Routing code as channels grow | Handler list stays the same shape | More topic families require more branches |
 
-## What the layer buys you
+## Use channel handlers for separate topic features
 
 To add a topic family to raw dispatch, extend the socket model and message
 union. Then add router branches. With the channel layer, add one handler to the
@@ -53,16 +53,16 @@ The layer gives each channel a private state type and server-side message type.
 Unrelated channels do not need a shared `Model` or `Msg`. A library can publish
 a channel value for direct use.
 
-## What raw dispatch buys you
+## Use raw dispatch for socket-wide control
 
 One `update` sees all events for a socket. An event on one topic can broadcast
 on another topic in the same ordered effect list. Channel actions apply only to
 their own topic. Use the `Sockets` handle for cross-topic publishing.
 
-Raw dispatch is the smaller API surface: no handler table and no routing
-rules other than the ones you write.
+Raw dispatch has fewer concepts: no handler table and no routing rules other
+than the ones you write.
 
-## Mixing them
+## Use one API for each socket endpoint
 
 Select one API for each socket endpoint. The channel layer owns the
 socket-level model and message type. This design lets each channel keep private
@@ -75,6 +75,6 @@ format, join rules, presence payloads, and client code.
 ## Next steps
 
 - [Channels](/guides/channels/) — the full channel-layer guide
-- [App-Side Dispatch](/guides/dispatch/) — the full raw-dispatch guide
+- [Raw Dispatch](/guides/dispatch/) — route socket events in one update function
 - [Quick Start](/quick-start/) — a working server on either layer
 - [Coming from Phoenix](/guides/coming-from-phoenix/) — the concept map for both

--- a/website/src/content/docs/choosing-an-api.md
+++ b/website/src/content/docs/choosing-an-api.md
@@ -9,7 +9,7 @@ beryl has one runtime and two ways to program it.
   pattern. Each channel keeps private state and a server-side message type. The
   layer routes each event to the correct channel. **Use this API by default.**
 - **Raw dispatch** (`beryl`): Define one `init` and `update` pair for
-  the socket system. Beryl runs them separately for each connected socket.
+  the socket system. beryl runs them separately for each connected socket.
   Match `socket.Input` values and return ordered effects. The channel layer
   uses this public core API.
 

--- a/website/src/content/docs/examples.mdx
+++ b/website/src/content/docs/examples.mdx
@@ -177,7 +177,7 @@ cd examples/collab_docs && gleam run
 |---|---|
 | **Segment-shaped topics** | The `document:*` handler claims the prefix, then validates each `document:<tenant>:<document>` topic on join |
 | **Client-side CRDT merge** | Browser state uses `lattice_core`, `lattice_maps`, and `lattice_registers` with `ORMap(MVRegister(String))` document blocks |
-| **Unordered realtime transport** | Beryl broadcasts document updates while the CRDT handles merge convergence |
+| **Unordered realtime transport** | beryl broadcasts document updates while the CRDT handles merge convergence |
 | **Late joiner cache** | Server returns cached merged state in the join reply for new clients |
 | **Conflict resolution UI** | Concurrent edits to the same block render explicit conflict cards with all versions |
 

--- a/website/src/content/docs/examples.mdx
+++ b/website/src/content/docs/examples.mdx
@@ -63,7 +63,7 @@ Server (Gleam)
 
 ---
 
-## Collaborative Cursors
+## Collaborative cursors
 
 **Source**: [`examples/cursors`](https://github.com/tylerbutler/beryl/tree/main/examples/cursors)
 
@@ -102,7 +102,7 @@ Server (Gleam)
 
 ---
 
-## Chat Rooms
+## Chat rooms
 
 **Source**: [`examples/chatrooms`](https://github.com/tylerbutler/beryl/tree/main/examples/chatrooms)
 
@@ -158,7 +158,7 @@ Server (Gleam)
 
 ---
 
-## Collaborative Documents
+## Collaborative documents
 
 **Source**: [`examples/collab_docs`](https://github.com/tylerbutler/beryl/tree/main/examples/collab_docs)
 

--- a/website/src/content/docs/examples.mdx
+++ b/website/src/content/docs/examples.mdx
@@ -37,18 +37,18 @@ gleam run
 # Open http://localhost:8000
 ```
 
-### What it demonstrates
+### Features used
 
 | beryl feature | How it's used |
 |---|---|
 | **Channel composition** | One `channel.child_spec` handler table owns `cursor:*`, `room:*`, and the `document:` prefix |
 | **Per-channel state** | Each joined topic keeps its own private state; the layer prunes it on close |
-| **Lifecycle actions** | Join and termination callbacks return ordered action lists for the runtime to apply |
+| **Join and close actions** | Join and termination callbacks return actions that beryl runs in list order |
 | **Per-pattern rate limits** | `with_topic_rate` gives cursor traffic a higher limit than chat and document traffic |
 | **Shared presence** | One ETS-backed session-presence tracker serves cursors and chat, publishing snapshots asynchronously |
 | **Single WebSocket endpoint** | Every embedded app shares `/socket/websocket` |
 
-### Architecture
+### How it fits together
 
 ```text
 Browser (Phoenix JS clients across /cursors, /chat, /docs)
@@ -76,19 +76,19 @@ gleam run
 # Open http://localhost:8000 in multiple browser tabs
 ```
 
-### What it demonstrates
+### Features used
 
 | beryl feature | How it's used |
 |---|---|
 | **Raw dispatch** | One socket-wide model handles the `cursor:*` topic family |
 | **Topic routing** | The update function matches `cursor:*` directly with `beryl/topic` |
 | **Session presence (ETS)** | The example-local `session_presence` tracker stores connected users and their username + color metadata in ETS |
-| **`broadcast_from`** | Fans out cursor moves to all *other* clients, excluding the sender |
+| **`broadcast_from`** | Sends cursor moves to all *other* clients, excluding the sender |
 | **Rate limiting** | `beryl.with_message_rate` throttles high-frequency cursor events |
 | **WebSocket transport** | `mist_transport.upgrade` handles Phoenix-compatible WebSocket requests |
 | **Phoenix JS client** | Frontend uses the official `phoenix` package over the standard wire protocol |
 
-### Architecture
+### How it fits together
 
 ```
 Browser (vanilla JS + Phoenix JS client)
@@ -115,7 +115,7 @@ gleam run
 # Open http://localhost:8001?token=beryl-demo in multiple browser tabs
 ```
 
-### What it demonstrates
+### Features used
 
 This example uses parts of the beryl API that the cursor example does not use:
 
@@ -131,7 +131,7 @@ This example uses parts of the beryl API that the cursor example does not use:
 | **Multiple topics** | `lobby` and `room:*` handlers compose in one `channel.child_spec` table |
 | **Rate limiting** | `with_join_rate` (5/sec) and `with_channel_rate` (10/sec/channel) |
 
-### Architecture
+### How it fits together
 
 ```
 Browser (vanilla JS + Phoenix JS client, token auth)
@@ -158,7 +158,7 @@ Server (Gleam)
 
 ---
 
-## Collaborative CRDT Docs
+## Collaborative Documents
 
 **Source**: [`examples/collab_docs`](https://github.com/tylerbutler/beryl/tree/main/examples/collab_docs)
 
@@ -171,7 +171,7 @@ cd examples/collab_docs && gleam run
 # Open http://localhost:8002 in multiple browser tabs
 ```
 
-### What it demonstrates
+### Features used
 
 | beryl feature | How it's used |
 |---|---|
@@ -181,7 +181,7 @@ cd examples/collab_docs && gleam run
 | **Late joiner cache** | Server returns cached merged state in the join reply for new clients |
 | **Conflict resolution UI** | Concurrent edits to the same block render explicit conflict cards with all versions |
 
-### Architecture
+### How it fits together
 
 ```
 Browser (vanilla JS + Phoenix JS client + lattice CRDT packages)
@@ -190,12 +190,12 @@ Server (Gleam)
   ├── Mist HTTP — serves HTML + static files
   ├── beryl/channel — document:* handler with tenant/document validation
   ├── document cache — merged state for late joiners
-  └── beryl pubsub — fan-out of CRDT updates
+  └── beryl pubsub — sends CRDT updates to subscribers
 ```
 
 ---
 
-## Choosing a starting point
+## Choose an example
 
 | Starting point | Go here |
 |---|---|

--- a/website/src/content/docs/guides/authentication.md
+++ b/website/src/content/docs/guides/authentication.md
@@ -1,5 +1,5 @@
 ---
-title: Authenticate WebSocket Connections
+title: Authenticate WebSocket connections
 description: Verify tokens in on_connect, store verified identity data, and authorize topic joins.
 ---
 

--- a/website/src/content/docs/guides/authentication.md
+++ b/website/src/content/docs/guides/authentication.md
@@ -1,18 +1,19 @@
 ---
-title: Authentication
-description: Verify real tokens in on_connect, decode claims into your model in init, and authorize joins.
+title: Authenticate WebSocket Connections
+description: Verify tokens in on_connect, store verified identity data, and authorize topic joins.
 ---
 
-beryl authenticates a connection once in the transport `on_connect` hook. This
-happens before any topic join. This guide reads a token from the handshake and
-verifies it into typed **claims**. It stores the claims in the socket model.
-Then `update` uses them to authorize topic joins.
+beryl authenticates a connection once in the transport `on_connect` hook,
+before any topic join. This guide reads a token from the WebSocket request and
+verifies it as typed **claims**, which are identity and authorization data. It
+stores the claims in the socket model. Then `update` uses them to authorize
+topic joins.
 
 For the mechanics of `with_on_connect` and rejection behavior, see the
-[WebSocket Transport guide](/guides/websocket#authentication). This page focuses
-on wiring *real* auth end to end.
+[WebSocket Transport guide](/guides/websocket#authenticate-before-the-upgrade). This page focuses
+on complete token verification.
 
-## 1. Model your claims
+## 1. Define the verified identity data
 
 Decode the token into a typed record. Do not use raw token strings in app
 logic:
@@ -26,7 +27,7 @@ pub type Claims {
 Store the claims in the per-socket model. Each `Join` and `Message` branch can
 then read them without another authentication check.
 
-## 2. Read the token from the handshake
+## 2. Read the token from the WebSocket request
 
 Browsers cannot set custom headers on a WebSocket handshake, so browser
 clients usually send a token in a **query parameter**; server clients can use
@@ -59,7 +60,7 @@ fn bearer_token(header: Result(String, Nil)) -> Result(String, Nil) {
 }
 ```
 
-The same shape applies to the `ConnectSeed` delivered to `init` — read
+Use the same approach for the `ConnectSeed` delivered to `init`. Read
 `seed.headers` and `seed.query` (both `List(#(String, String))`) with
 `list.key_find` instead of `request.get_header`/`request.get_query`.
 
@@ -108,14 +109,14 @@ fn claims_metadata(claims: Claims) -> List(#(String, String)) {
 Return `Error(server.ConnectRejected)` to send HTTP 403 before the upgrade.
 The app does not receive an unauthenticated connection.
 
-`Ok(metadata)` accepts the connection and hands that list to the app. This is
-how the verified identity crosses the handshake boundary. Verify the token in
-`on_connect`, then use claims metadata downstream. `init` still receives the
+`Ok(metadata)` accepts the connection and hands that list to the app. This passes the verified identity from the transport to the application.
+Verify the token in `on_connect`, then use the claims metadata in `init` and
+`update`. `init` still receives the
 original request headers and query through `ConnectInfo.seed`, so do not assume
 the raw token was removed. Return `Ok([])` to accept a connection with no
 metadata.
 
-## 4. Decode claims into the model in `init`
+## 4. Build the socket model from verified data
 
 `on_connect` accepts or rejects the connection. `init` builds the socket state.
 The claims `on_connect` verified reach `init` as `ConnectInfo.seed.metadata`,
@@ -157,15 +158,15 @@ fn decode_roles(metadata: List(#(String, String))) -> List(String) {
 
 Signature and expiry checks stay in `on_connect`, where they run once per
 socket. This `init` reads only verified metadata, so a wrong or expired token
-cannot produce an authenticated model. The `Anonymous` branch covers a socket
-that connected without `on_connect` configured; correct wiring makes it
-unreachable, and it rejects every join.
+cannot produce an authenticated model. The `Anonymous` branch covers a socket that connected without `on_connect`
+configured. With the configuration above, the branch is unreachable and
+rejects every join.
 
 The seed's `headers` and `query` remain available to `init`, for request data
-that authentication does not produce — a locale, a client version, a room
+that authentication does not produce, such as a locale, client version, or room
 preselected in the URL.
 
-## 5. Authorize the topic at join
+## 5. Authorize each topic join
 
 The model already contains the claims. `update` only decides whether the user
 can join the topic:
@@ -203,28 +204,27 @@ fn forbidden() -> json.Json {
 }
 ```
 
-## With the channel layer
+## Use authentication with `beryl/channel`
 
 Transport authentication is the same for the channel layer.
 `with_on_connect` validates the handshake before the upgrade. A channel system
 has no app-level `init`. Each handler receives the same `ConnectSeed` as
 `channel.JoinContext.seed`, so read the verified identity from
-`seed.metadata` with the same `model_from_metadata` shape. Apply topic
+`seed.metadata` with a function like `model_from_metadata`. Apply topic
 authorization and store the typed claims with `channel.accept`.
 
 Put signature and expiry checks in `with_on_connect`. In each join callback,
 only read the metadata and apply authorization rules.
-See [JoinContext and the typed sender](/guides/channels/#joincontext-and-the-typed-sender).
+See [Use the typed sender](/guides/channels/#read-joincontext-and-use-its-typed-sender).
 
-## Notes
+## Authentication rules
 
-- **Verify once, trust everywhere.** Do the expensive signature/expiry check at
-  connect time and return the result as `on_connect` metadata; the `Join` arms
-  of `update` should only apply cheap authorization rules against the
-  already-decoded claims in the model.
+- **Verify once per connection.** Check the signature and expiry at connect
+  time and return the result as `on_connect` metadata. The `Join` branches in
+  `update` should only apply authorization rules to the verified claims.
 - **Cookie sessions need origin checks.** If you authenticate from a cookie
   instead of a token, always pair it with `with_allowed_origins` to prevent
   Cross-Site WebSocket Hijacking. See
-  [Origin validation and CSWSH](/guides/websocket#origin-validation-and-cswsh).
-- **Rejection shape.** For the client-visible error when a join or connection is
-  refused, see [Error Handling](/guides/error-handling#connection-level-authentication-rejection).
+  [Block Cross-Site WebSocket Hijacking](/guides/websocket#block-cross-site-websocket-hijacking-cswsh).
+- **Rejection response.** For the client-visible error when a join or connection is
+  refused, see [Reject a connection during authentication](/guides/error-handling#reject-a-connection-during-authentication).

--- a/website/src/content/docs/guides/backend-integration.md
+++ b/website/src/content/docs/guides/backend-integration.md
@@ -1,17 +1,17 @@
 ---
-title: Backend Integration
-description: Use Beryl alongside an existing backend that owns auth and persistence and publishes over an internal endpoint.
+title: Connect Beryl to an Existing Backend
+description: Keep authentication and database writes in your backend, then send real-time updates through Beryl.
 ---
 
 Beryl does not need to manage your full application. An existing Phoenix,
-Rails, or Gleam backend can manage **authentication and persistence**. Beryl can
-provide only real-time fan-out.
+Rails, or Gleam backend can manage **authentication and database writes**.
+Beryl can send real-time updates to connected clients.
 
 This guide uses this design:
 
 1. The backend authenticates users and issues a token.
 2. Beryl verifies the token when the socket connects.
-3. The backend calls an internal publish endpoint when domain data changes.
+3. The backend calls an internal publish endpoint when application data changes.
 4. The endpoint sends the change with `beryl.broadcast`.
 
 ```text
@@ -24,7 +24,7 @@ Either API can provide the `beryl.Sockets` handle.
 `beryl.child_spec` and `channel.child_spec` return the same handle type.
 `beryl.broadcast` works the same with both APIs.
 
-## The internal publish endpoint
+## Add a private publish endpoint
 
 Run the endpoint on the Mist listener that serves the WebSocket transport.
 Protect it with a shared secret. Only the backend must be able to publish.
@@ -107,7 +107,7 @@ fn read_publish_request(
 }
 ```
 
-## Guarding the endpoint
+## Protect the endpoint
 
 ```gleam
 import gleam/crypto
@@ -124,7 +124,7 @@ fn authorized_internal(req: Request(mist.Connection)) -> Bool {
 }
 ```
 
-Keep this endpoint on a private network or behind trusted ingress. Do not let
+Keep this endpoint on a private network or behind a trusted proxy. Do not let
 browsers access it.
 
 ## Response helpers
@@ -150,21 +150,21 @@ fn not_found() -> Response(mist.ResponseData) {
 }
 ```
 
-## Socket-local integrations
+## Send typed updates to one socket
 
 Use `beryl.broadcast` when the backend sends JSON payloads by topic.
 
-For typed updates from a long-lived domain actor, use the socket's
-`socket.Sender(msg)` with `beryl/bridge`. The bridge forwards the actor's
-subject to `socket.Info(msg)`.
+For typed updates from a long-lived application actor, use the socket's
+`socket.Sender(msg)` with `beryl/bridge`. The bridge forwards messages from the
+actor to `socket.Info(msg)`.
 
-## Why this split works
+## Benefits
 
 - **One source of truth:** Your backend manages authentication and the
   database. Beryl sends updates to connected clients.
 - **Publish from trusted processes:** An HTTP handler, worker, or webhook
   consumer can publish.
-- **Distributed fan-out:** With PubSub, one `beryl.broadcast` reaches
-  subscribers across the cluster.
+- **Cluster-wide delivery:** With PubSub, one `beryl.broadcast` reaches
+  subscribers on every connected node.
 
 For connect-time verification of the tokens your backend issues, see [Authentication](/guides/authentication/).

--- a/website/src/content/docs/guides/backend-integration.md
+++ b/website/src/content/docs/guides/backend-integration.md
@@ -1,16 +1,16 @@
 ---
 title: Connect beryl to an existing backend
-description: Keep authentication and database writes in your backend, then send real-time updates through Beryl.
+description: Keep authentication and database writes in your backend, then send real-time updates through beryl.
 ---
 
-Beryl does not need to manage your full application. An existing Phoenix,
+beryl does not need to manage your full application. An existing Phoenix,
 Rails, or Gleam backend can manage **authentication and database writes**.
-Beryl can send real-time updates to connected clients.
+beryl can send real-time updates to connected clients.
 
 This guide uses this design:
 
 1. The backend authenticates users and issues a token.
-2. Beryl verifies the token when the socket connects.
+2. beryl verifies the token when the socket connects.
 3. The backend calls an internal publish endpoint when application data changes.
 4. The endpoint sends the change with `beryl.broadcast`.
 
@@ -161,7 +161,7 @@ actor to `socket.Info(msg)`.
 ## Benefits
 
 - **One source of truth:** Your backend manages authentication and the
-  database. Beryl sends updates to connected clients.
+  database. beryl sends updates to connected clients.
 - **Publish from trusted processes:** An HTTP handler, worker, or webhook
   consumer can publish.
 - **Cluster-wide delivery:** With PubSub, one `beryl.broadcast` reaches

--- a/website/src/content/docs/guides/backend-integration.md
+++ b/website/src/content/docs/guides/backend-integration.md
@@ -1,5 +1,5 @@
 ---
-title: Connect Beryl to an Existing Backend
+title: Connect beryl to an existing backend
 description: Keep authentication and database writes in your backend, then send real-time updates through Beryl.
 ---
 

--- a/website/src/content/docs/guides/channels.md
+++ b/website/src/content/docs/guides/channels.md
@@ -1,6 +1,6 @@
 ---
 title: Channels
-description: Use beryl/channel handlers, private state, typed senders, ordered actions, and lifecycle callbacks.
+description: Build topic handlers with private state, typed server messages, ordered actions, and lifecycle callbacks.
 ---
 
 `beryl/channel` is the **recommended default** for applications that serve
@@ -10,16 +10,16 @@ message, server message, and close to the correct channel.
 
 If you are not sure which layer you want, read
 [Choose an API](/choosing-an-api/) first. If you want one topic family and
-complete control over routing, use [App-Side Dispatch](/guides/dispatch/)
+complete control over routing, use [Raw Dispatch](/guides/dispatch/)
 instead. It is the core API under the channel layer.
 
-:::note[One package]
+:::note[No extra package]
 The `beryl` package includes the `beryl/channel` module. Applications need
 `beryl` and one transport. See
 [Installation](/installation/) for the dependency block.
 :::
 
-## The shape
+## Define a channel handler
 
 A channel is a **topic pattern** plus a typed `join` callback. The `join`
 callback receives one context value. It rejects the join or accepts it with
@@ -30,7 +30,7 @@ private state and callbacks.
 import beryl/channel
 import gleam/json
 
-/// This channel's private state — one value per joined topic.
+/// This channel's private state. Each joined topic has one value.
 type State {
   State(room_id: String, username: String, sent: Int)
 }
@@ -75,9 +75,9 @@ pub fn room() -> channel.Handler {
 }
 ```
 
-`State` and `Note` stay private. `channel.handler` returns a plain
-`channel.Handler`, not a generic value. Thus, unrelated channels can use one
-handler list.
+`State` and `Note` stay private. `channel.handler` returns a
+`channel.Handler`, not a generic value. Unrelated channels can therefore use
+one handler list.
 
 ## Starting a channel system
 
@@ -145,7 +145,7 @@ fn handle_http(
 `handle_http` is the HTTP fallback. `mist_transport.handler` routes WebSocket
 upgrades on the configured path to beryl. It sends all other requests to
 `handle_http`. The
-[Quick Start](/quick-start/#2-start-the-channel-system-and-wire-the-transport)
+[Quick Start](/quick-start/#2-start-beryl-and-mist)
 shows how to serve pages from this function.
 
 Both APIs use the same runtime, wire codec, presence, abuse controls, and
@@ -160,7 +160,7 @@ transports. The channel layer supplies only the `init` and `update` pair.
 | `DuplicatePattern(pattern)` | The same pattern was registered twice |
 | `InvalidConfig(beryl.ConfigError)` | The core's eager config validation failed |
 
-## Handler patterns and precedence
+## Match topics in registration order
 
 Patterns use beryl topic syntax, such as `"room:lobby"`, `"room:*"`,
 `"document:*:ops"`, and `"*"`. The layer checks patterns in
@@ -169,7 +169,7 @@ Patterns use beryl topic syntax, such as `"room:lobby"`, `"room:*"`,
 A bigger `handlers()` returns one entry per channel module:
 
 ```gleam
-// A fragment of `handlers()` — see "Starting a channel system" above.
+// A fragment of `handlers()`. See "Starting a channel system" above.
 [
   // Special-case one topic by putting it ahead of the wildcard.
   lobby_channel.lobby(),        // "room:lobby"
@@ -186,8 +186,8 @@ receive a join. It also rejects unmatched topics with
 `{"reason": "unmatched topic"}`.
 
 `InvalidPattern` contains the core
-[`topic.TopicError`](/reference/api/beryl-topic/) itself rather than a
-flattened string, so the reason stays matchable. New variants may be added
+[`topic.TopicError`](/reference/api/beryl-topic/) instead of a string, so you
+can match on the reason. New variants may be added
 in a minor release, so use a catch-all when the exact reason does not
 change your handling:
 
@@ -200,9 +200,9 @@ The same rule applies to
 `beryl.InvalidTopicPattern(pattern, reason)`, which nests the identical
 `topic.TopicError`.
 
-Validation has two phases. First, `child_spec` checks pattern syntax in
-registration order. Then it checks for duplicate strings in the same order. It
-does this before it builds the supervised subtree.
+`child_spec` first checks pattern syntax in registration order. It then checks
+for duplicate strings in the same order. Both checks happen before it builds
+the supervised child processes.
 
 ## Typed state instead of assigns
 
@@ -219,21 +219,21 @@ type State {
 channel.accept(State(room_id: context.topic, username: name, sent: 0))
 ```
 
-`channel.handler` captures the state in the callback closures. Each
-`channel.next` result rebuilds the closures with the next state. The layer does
-not erase the state to `Dynamic` or use unchecked coercion. Therefore, one
-`List(Handler)` can contain channels with unrelated state types.
+`channel.handler` keeps the state in its callbacks. Each `channel.next` result
+creates the next callbacks with the new state. The layer does not convert the
+state to `Dynamic` or use unchecked conversion. One `List(Handler)` can
+therefore contain channels with unrelated state types.
 
 The layer keeps **one instance per joined topic**. A socket joined to
 `room:general` and `room:random` has two independent `State` values, and
 the layer prunes an instance when its topic closes. You do not write
 cleanup code for the state itself.
 
-## `JoinContext` and the typed sender
+## Read `JoinContext` and use its typed sender
 
 The `join` callback receives a `channel.JoinContext(info)`:
 
-| Field | Type | What it is |
+| Field | Type | Description |
 |---|---|---|
 | `socket_id` | `String` | Unique id of the socket that is joining |
 | `seed` | `socket.ConnectSeed` | Request data the transport assembled before the upgrade: path, query, headers, and any `on_connect` metadata |
@@ -255,32 +255,31 @@ pub type Note {
   Tick(Int)
 }
 
-// Anywhere — a timer, a domain actor, an HTTP handler:
+// Call from a timer, application actor, or HTTP handler:
 channel.notify(sender, Tick(1))
 ```
 
-This mechanism does not use casts. `notify` seals the typed value in a closure.
-It creates an **envelope** with the join topic and generation. The layer
-increments the generation for each join attempt and does not reuse it. The
-envelope has no readable payload. The router compares the envelope with the
-live instance. Only the owning join can open it, during the delivery turn. The
-socket actor's mailbox does not store the typed value between turns.
+This mechanism does not use casts. `notify` keeps the value in a typed
+function and adds the join topic and a unique join generation. The router
+compares both values with the live channel instance. Only that join can read
+the value during delivery. The socket actor's mailbox does not store the typed
+value between turns.
 
-Opening the envelope uses a selective receive on the socket actor's mailbox.
-This occurs in the same turn, so one delivery costs O(mailbox depth). The cost
-is small for a short mailbox. A deep backlog makes `notify` unsuitable for a
-high-rate data path. See
-[Limitations](#limitations).
+Delivery uses a selective receive, which scans the socket actor's mailbox.
+One delivery therefore costs O(mailbox depth). The cost is small when the
+mailbox is short. Do not use `notify` for high-rate traffic when the mailbox
+can have a large backlog. See
+[When to use raw dispatch or another process](#when-to-use-raw-dispatch-or-another-process).
 
-### Stale senders
+### Senders from closed or rejoined channels
 
 A sender applies only to the join that produced it. Sending is asynchronous
 and does not report failure. The receiver determines whether the channel is
 live:
 
 - If the channel has **closed** after a client leave, `close([])`, or socket
-  teardown, the layer drops the sealed envelope.
-- If the same topic has since been **joined again**, the envelope's
+  shutdown, the layer drops the message.
+- If the same topic has since been **joined again**, the message's
   generation no longer matches the live instance, so it is dropped rather
   than handed to the new join.
 - A live match delivers exactly one `on_info` call. Sends are never
@@ -293,16 +292,17 @@ A **panic inside `on_terminate`** is an exception. For a crash during topic
 close, the core logs the crash and keeps the model from before the close. That
 model still contains the channel instance. Its sender can deliver `on_info`
 until the topic joins again or the socket ends. See
-[Crash behavior](#crash-behavior).
+[When callbacks panic](#when-callbacks-panic).
 
 Use `notify` to schedule a **later** turn, including from another process. Put
 work that must occur during the join in
-[join actions](#join-actions).
+[actions after a join](#run-actions-after-a-join).
 
-## Action builders
+## Return actions from callbacks
 
-An action is one thing to do **on this channel's own topic**. Constructors
-return one opaque action; put them in a list in wire order:
+An action is one operation **on this channel's own topic**. Constructor
+functions return one action. Put actions in a list in the order clients should
+observe them:
 
 | Action | Effect |
 |---|---|
@@ -316,14 +316,15 @@ return one opaque action; put them in a list in wire order:
 | `push_presence(event, encode)` | Presence snapshot for this topic, to this socket |
 | `broadcast_presence(event, encode)` | Presence snapshot for this topic, to every subscriber |
 
-No action names a topic: actions are always scoped to the channel that
-returned them. Cross-topic work is [a deliberate limitation](#limitations).
+No action names a topic. Each action applies to the channel that returned it.
+To send across topics, use the external APIs described in
+[When to use raw dispatch or another process](#when-to-use-raw-dispatch-or-another-process).
 
 Presence actions need a presence handle on the config
 (`beryl.with_presence_handle`); without one they are dropped with a
 warning, exactly as the equivalent core effects are.
 
-### Order is wire order
+### Clients observe action list order
 
 The runtime applies channel actions in list order. Each action maps to one core
 `socket.Effect`. An asynchronous presence effect can pause this socket while
@@ -341,7 +342,7 @@ The `encode` callbacks of `push_presence` and `broadcast_presence` run
 ]
 ```
 
-## Join actions
+## Run actions after a join
 
 `channel.with_actions` attaches ordered actions to an accepted join. They
 are emitted with the acknowledgment and applied strictly after it:
@@ -356,13 +357,13 @@ channel.accept(state)
 ])
 ```
 
-Two consequences worth designing around:
+This ordering has two consequences:
 
 - **The acknowledgment always reaches the wire first.** The socket is
   already subscribed to the topic when the join's own actions run, so a
   `push` cannot overtake its own join reply.
 - **Effect order is per socket, not a cross-socket transaction.** If an
-  action lowers to asynchronous presence work, the runtime may process other
+  action starts asynchronous presence work, the runtime may process other
   sockets while this one waits. Use application-owned synchronous state for
   an atomic capacity reservation.
 
@@ -373,9 +374,9 @@ Use join actions instead of sending `notify` to the same channel from `join`.
 `notify` schedules a later input. Join actions stay directly after the join
 acknowledgment.
 
-## Handling input
+## Handle client and server messages
 
-| Callback | Runs on | Signature |
+| Callback | Input | Signature |
 |---|---|---|
 | `on_message` | A client message on this topic | `fn(state, channel.Message) -> Next(state)` |
 | `on_info` | A `notify` addressed to this join | `fn(state, info) -> Next(state)` |
@@ -383,10 +384,10 @@ acknowledgment.
 
 `channel.accept(state)` stays joined until you add callbacks with the `on_*`
 builders. Unhandled messages and server-side notifications have no effect.
-For raw binary frames, use [App-Side Dispatch](/guides/dispatch/).
+For raw binary frames, use [Raw Dispatch](/guides/dispatch/).
 
 A `channel.Message` has `event`, the raw `payload` as `Dynamic`, and
-`reply: Option(socket.ReplyRef)` — present only when the client asked for a
+`reply: Option(socket.ReplyRef)`, which is present only when the client asked for a
 reply. Store `context.topic` in channel state when a callback needs it:
 
 ```gleam
@@ -410,7 +411,7 @@ reply. Store `context.topic` in channel state when a callback needs it:
 
 Every callback answers with a `channel.Next(state)`:
 
-| Result | Meaning |
+| Result | Behavior |
 |---|---|
 | `next(state, actions)` | Stay joined, applying the active-phase actions in order |
 | `stay(state)` | Stay joined with no actions |
@@ -419,20 +420,21 @@ Every callback answers with a `channel.Next(state)`:
 `close` applies its actions first and then closes the topic, so a
 farewell broadcast still reaches the topic's subscribers.
 
-## Termination
+## Handle channel termination
 
 `on_terminate` runs once for each accepted join. It runs after `phx_leave`,
 `close([])`, socket disconnect, heartbeat timeout, and `beryl.stop`. A rejected
 join does not create an instance, so it does not run `on_terminate`.
 
-The actions it returns are lowered inside the turn that closes the topic,
+The runtime converts the returned actions to effects during the turn that
+closes the topic,
 right after the instance has been removed. Closing-phase lists can contain
 `broadcast`, `broadcast_from`, `presence_untrack`, and
 `broadcast_presence`. Active-only pushes, replies, presence tracking, and
 presence pushes do not type-check in `on_terminate`.
 
-This is why a leave announcement and a post-leave roster belong here
-rather than in an out-of-band broadcast:
+Put a leave announcement and updated roster here instead of sending them from
+code outside the channel:
 
 ```gleam
 |> channel.on_terminate(fn(state: State, _reason) {
@@ -449,7 +451,7 @@ snapshot after it applies the untrack, so the roster is current. The runtime
 also removes presence entries when the topic closes. That removal occurs after
 `Closed`, not before your actions.
 
-## Lifecycle at a glance
+## When channel callbacks run
 
 ```mermaid
 sequenceDiagram
@@ -471,7 +473,9 @@ sequenceDiagram
   Ch-->>Router: closing-phase actions
 ```
 
-## Crash behavior
+<a id="crash-behavior"></a>
+
+## When callbacks panic
 
 An app panic does not stop the runtime. The core limits the effect based on
 where the panic occurred:
@@ -490,19 +494,18 @@ original generation. The core cannot reach it through the closed topic. Client m
 topic. A `Sender` from that join can still deliver to the retained instance. A
 rejoin replaces the entry, and socket shutdown removes it.
 
-The panic discards the model update that would remove the instance. Catching
-the callback in the layer would hide a crash that the core must log. Moving
-termination to another turn would make a termination panic close the socket.
-`crash_test` fixes this behavior. Keep code that can panic out of
-`on_terminate`. Then a closed channel is removed and its senders reach nothing.
+The panic discards the model update that would remove the instance. The core
+must log this panic, so the channel layer does not hide it. Keep code that can
+panic out of `on_terminate`. Then Beryl removes the closed channel and drops
+messages from its senders.
 
 Crash isolation stops at the socket, as it does with raw dispatch: a
 panic in `on_info` ends one socket, not the router. Another fault in that
 socket actor also loses only that socket. A router crash loses every socket on
 that `beryl.Sockets` handle. See
-[Runtime & Effect Interpreter](/architecture/runtime/).
+[Socket Processes & Restarts](/architecture/runtime/).
 
-## Supervision
+## Supervise the channel system
 
 `channel.child_spec` mirrors `beryl.child_spec` for applications
 that own their supervision tree:
@@ -531,11 +534,11 @@ pub fn start_supervised() -> beryl.Sockets {
 }
 ```
 
-It reports the same eager validation failures as
-`channel.ChildSpecError` — see the table in
+It reports the same validation errors as `channel.ChildSpecError`. See the
+table in
 [Starting a channel system](#starting-a-channel-system).
 
-The channel layer uses the core subtree, restart policy, and `beryl.stop`
+The channel layer uses the core child processes, restart policy, and `beryl.stop`
 behavior. See the [Supervision guide](/guides/supervision/). The application
 must start and supervise PubSub, presence, and group actors. Pass their handles
 to `beryl.Config`.
@@ -546,7 +549,7 @@ each join runs afresh.
 
 ## Migrating from `beryl_channels`
 
-The compiler guides the package-boundary migration:
+The compiler guides the package migration:
 
 1. Remove the `beryl_channels` dependency from `gleam.toml`.
 2. Replace imports of `beryl_channels/channel` with `beryl/channel`.
@@ -555,56 +558,55 @@ The compiler guides the package-boundary migration:
 4. Match startup errors as `channel.InvalidPattern`,
    `channel.DuplicatePattern`, and `channel.InvalidConfig`.
 
-Handler construction, closure-sealed state and server messages, action
+Handler construction, private typed state and server messages, action
 ordering, and callback behavior are unchanged. Run `gleam check` to find every
 remaining old import or qualified error name.
 
-## Limitations
+## When to use raw dispatch or another process
 
 The layer handles one topic at a time. Note these limits:
 
-- **Each action is topic-scoped.** A `room:general` channel cannot broadcast
+- **Each action applies to one topic.** A `room:general` channel cannot broadcast
   on `lobby`. Cross-topic publishing goes through the external `Sockets`
-  APIs — `beryl.broadcast`, `beryl.broadcast_from`, or a `beryl/group`
-  actor — with the handle `channel.child_spec` returned.
+  APIs, such as `beryl.broadcast`, `beryl.broadcast_from`, or a `beryl/group`
+  actor, with the handle `channel.child_spec` returned.
 - **Handlers are built before the handle is returned.** A channel cannot
   capture the `Sockets` handle directly while constructing its handler.
-  The usual pattern is a small actor that holds the handle and exposes a
-  `publish(topic, event, payload)` function — the equivalent of Phoenix's
-  `Endpoint.broadcast/3` — bound after `child_spec` returns and before the
+  One option is a small actor that holds the handle and exposes a
+  `publish(topic, event, payload)` function, like Phoenix's
+  `Endpoint.broadcast/3`. Bind it after `child_spec` returns and before the
   transport starts accepting connections.
   [`examples/showcase`](https://github.com/tylerbutler/beryl/tree/main/examples/showcase)
   does exactly this for its `lobby` room list.
 - **Channels do not share state with each other.** Anything two channels
-  both need — a document store, a presence handle, a groups actor — is a
+  both need, such as a document store, presence handle, or groups actor, is a
   dependency you capture in the handler closures when you build the
   table.
 - **The layer owns the socket-level model and message type.** Pick raw
   dispatch or the channel layer per socket endpoint; mixing hand-written
-  `update` logic into a channel system is not a supported surface.
+  `update` logic into a channel system is not supported.
 - **Raw binary frames require raw dispatch.** Binary frames decoded by the
   configured codec into normal events still reach `on_message`.
 - **`beryl/bridge` targets the core sender, not a channel's.**
   `bridge.start(to:, with:)` wants a `beryl/socket.Sender`, which a
   channel never sees. To adapt an existing actor's messages into
   `on_info`, forward them yourself from your own process by calling
-  `channel.notify(context.self, ..)` — the sealed sender is safe to hold and
+  `channel.notify(context.self, ..)`. The typed sender is safe to hold and
   is dropped after the join ends.
 - **Nothing is per-topic-process.** Like raw dispatch, all of a socket's
   channels run in its socket actor, sequentially. Long or blocking work
   belongs in your own process, which can hand results back through
   `channel.notify`.
-- **`notify` delivery costs O(mailbox depth).** Keeping the typed value
-  out of the mailbox costs a same-turn selective receive on the socket
-  actor's mailbox, which scans it. Fine at ordinary depths; not a
-  free high-rate data path on a socket with a deep backlog. Batch in your
-  own process rather than sending per item.
+- **`notify` delivery costs O(mailbox depth).** A selective receive scans the
+  socket actor's mailbox to recover the typed value. This is suitable for a
+  short mailbox, but not for high-rate traffic with a large backlog. Batch
+  messages in your own process instead of sending each item separately.
 
 ## Next steps
 
-- [Choose an API](/choosing-an-api/) — when to use this layer and when to use raw dispatch
-- [Coming from Phoenix](/guides/coming-from-phoenix/) — the callback-by-callback map
-- [App-Side Dispatch](/guides/dispatch/) — the core this layer is built on
-- [Presence](/guides/presence/) — the presence actor the presence actions need
-- [Supervision](/guides/supervision/) — subtree shape, crash, and shutdown semantics
-- [`beryl/channel`](/reference/api/beryl-channel/) — generated API reference
+- [Choose an API](/choosing-an-api/): when to use channels or raw dispatch
+- [Coming from Phoenix](/guides/coming-from-phoenix/): a callback-by-callback comparison
+- [Raw Dispatch](/guides/dispatch/): the core API under the channel handlers
+- [Presence](/guides/presence/): start the presence actor required by presence actions
+- [Supervision](/guides/supervision/): child processes, restarts, and shutdown behavior
+- [`beryl/channel`](/reference/api/beryl-channel/): generated API reference

--- a/website/src/content/docs/guides/channels.md
+++ b/website/src/content/docs/guides/channels.md
@@ -496,7 +496,7 @@ rejoin replaces the entry, and socket shutdown removes it.
 
 The panic discards the model update that would remove the instance. The core
 must log this panic, so the channel layer does not hide it. Keep code that can
-panic out of `on_terminate`. Then Beryl removes the closed channel and drops
+panic out of `on_terminate`. Then beryl removes the closed channel and drops
 messages from its senders.
 
 Crash isolation stops at the socket, as it does with raw dispatch: a

--- a/website/src/content/docs/guides/coming-from-phoenix.md
+++ b/website/src/content/docs/guides/coming-from-phoenix.md
@@ -1,6 +1,6 @@
 ---
 title: Coming from Phoenix
-description: Map Phoenix Channels processes, callbacks, assigns, and Presence to both Beryl APIs.
+description: Map Phoenix Channels processes, callbacks, assigns, and Presence to both beryl APIs.
 ---
 
 When configured with `wire.phoenix_codec()`, beryl speaks the same wire
@@ -15,7 +15,7 @@ beryl gives you two layers, and Phoenix maps onto both:
   recommended default for a Phoenix style app. Register one handler for each
   topic pattern. Each channel has callbacks and private state.
 - **`beryl`, raw dispatch:** This is the core API. Define one `init`
-  and `update` pair for the socket system. Beryl runs them separately for each
+  and `update` pair for the socket system. beryl runs them separately for each
   connected socket. Your `update` function owns topic dispatch.
 
 [Choose an API](/choosing-an-api/) compares both APIs. Both support
@@ -40,12 +40,12 @@ dispatch has no handler table: one `update` receives every event for the socket
 as `socket.Input(msg)`, and one `model` stores its state. Different socket
 actors run concurrently.
 
-Beryl provides less fault isolation between joined topics than Phoenix.
+beryl provides less fault isolation between joined topics than Phoenix.
 Different sockets have separate actors, but channels on one socket share an
 actor mailbox, execution time, and lifecycle. A slow callback delays every
 topic on that socket. A fault in the socket actor closes all its topics.
 
-Beryl catches expected callback panics with narrower behavior: a join panic
+beryl catches expected callback panics with narrower behavior: a join panic
 rejects that join, a message panic closes that topic, an `on_info` panic ends
 the socket, and a terminate panic loses that callback's actions while teardown
 continues. These rules limit known callback failures, but they do
@@ -235,9 +235,9 @@ Both beryl APIs differ from Phoenix in these ways:
 - **Server-side messages are typed.** Phoenix's `handle_info` receives any
   term. The channel layer's `on_info` receives *this channel's* own `info`
   type, delivered through the `channel.Sender(info)` in `JoinContext.self`.
-  Raw dispatch's `Info(msg)` wraps the socket's `msg` type. Beryl keeps the
+  Raw dispatch's `Info(msg)` wraps the socket's `msg` type. beryl keeps the
   value typed and records which join owns it. If that join closes or the topic
-  joins again, Beryl drops the message instead of delivering it to the wrong
+  joins again, beryl drops the message instead of delivering it to the wrong
   join.
 
 ## Assigns become a typed state value
@@ -342,6 +342,6 @@ message arrives as a typed `on_info` call. With raw dispatch, keep the
 - [Channels](/guides/channels/): build handlers with private state and callbacks
 - [Raw Dispatch](/guides/dispatch/): route socket events and order effects
 - [Choose an API](/choosing-an-api/): compare channels and raw dispatch
-- [WebSocket Transport](/guides/websocket/): connect Beryl to Mist
+- [WebSocket Transport](/guides/websocket/): connect beryl to Mist
 - [Presence](/guides/presence/): track users and synchronize nodes
 - [PubSub](/guides/pubsub/): publish to subscribers through Erlang `pg`

--- a/website/src/content/docs/guides/coming-from-phoenix.md
+++ b/website/src/content/docs/guides/coming-from-phoenix.md
@@ -57,7 +57,7 @@ in another process and return results with `channel.notify` or
 [Issue #337](https://github.com/tylerbutler/beryl/issues/337) tracks a
 Phoenix-style process-per-channel prototype.
 
-## Phoenix-to-Beryl comparison
+## Phoenix-to-beryl comparison
 
 | Phoenix | beryl channel layer (`beryl/channel`) | beryl raw dispatch (`beryl`) |
 | --- | --- | --- |

--- a/website/src/content/docs/guides/coming-from-phoenix.md
+++ b/website/src/content/docs/guides/coming-from-phoenix.md
@@ -1,6 +1,6 @@
 ---
 title: Coming from Phoenix
-description: Compare Phoenix Channels modules, callbacks, assigns, and Presence with both beryl APIs.
+description: Map Phoenix Channels processes, callbacks, assigns, and Presence to both Beryl APIs.
 ---
 
 When configured with `wire.phoenix_codec()`, beryl speaks the same wire
@@ -14,7 +14,7 @@ beryl gives you two layers, and Phoenix maps onto both:
 - **`beryl/channel`, the channel layer:** This is the closest match and the
   recommended default for a Phoenix style app. Register one handler for each
   topic pattern. Each channel has callbacks and private state.
-- **`beryl`, raw app-side dispatch:** This is the core API. Define one `init`
+- **`beryl`, raw dispatch:** This is the core API. Define one `init`
   and `update` pair for the socket system. Beryl runs them separately for each
   connected socket. Your `update` function owns topic dispatch.
 
@@ -23,7 +23,7 @@ colon-delimited topics, wildcard patterns, CRDT presence, `pg` PubSub,
 and heartbeats. Both use the Phoenix JSON array format when configured with
 `wire.phoenix_codec()`.
 
-## The core difference: processes and state
+## Compare processes and state
 
 In Phoenix, the framework owns the router and process tree. You define a
 routing table in the socket module, such as
@@ -40,29 +40,29 @@ dispatch has no handler table: one `update` receives every event for the socket
 as `socket.Input(msg)`, and one `model` stores its state. Different socket
 actors run concurrently.
 
-This gives beryl a coarser isolation boundary than Phoenix. Different sockets
-have separate actors, but channels on one socket share an actor mailbox,
-execution context, and lifecycle. A slow callback delays every topic on that
-socket. A fault in the socket actor closes all its topics.
+Beryl provides less fault isolation between joined topics than Phoenix.
+Different sockets have separate actors, but channels on one socket share an
+actor mailbox, execution time, and lifecycle. A slow callback delays every
+topic on that socket. A fault in the socket actor closes all its topics.
 
-Beryl rescues expected callback crashes with narrower behavior: a join panic
+Beryl catches expected callback panics with narrower behavior: a join panic
 rejects that join, a message panic closes that topic, an `on_info` panic ends
 the socket, and a terminate panic loses that callback's actions while teardown
-continues. These rescue boundaries limit known callback failures, but they do
+continues. These rules limit known callback failures, but they do
 not provide Phoenix's process isolation between joined topics. See
-[crash behavior](/guides/channels/#crash-behavior). Run long or blocking work
+[callback panics](/guides/channels/#when-callbacks-panic). Run long or blocking work
 in another process and return results with `channel.notify` or
 `socket.notify`.
 
 [Issue #337](https://github.com/tylerbutler/beryl/issues/337) tracks a
 Phoenix-style process-per-channel prototype.
 
-## Concept map
+## Phoenix-to-Beryl comparison
 
 | Phoenix | beryl channel layer (`beryl/channel`) | beryl raw dispatch (`beryl`) |
 | --- | --- | --- |
 | `socket "/socket", UserSocket` in the Endpoint | `beryl_mist` / `beryl_ewe` mounted on your HTTP server | same |
-| `UserSocket.connect(params, socket)` | transport `on_connect`; request data reaches `join` as `context.seed` | `init(info)` — request data in `info.seed` |
+| `UserSocket.connect(params, socket)` | transport `on_connect`; request data reaches `join` as `context.seed` | `init(info)`; request data is in `info.seed` |
 | `channel "room:*", RoomChannel` routing table | the handler list passed to `channel.child_spec` | topic pattern match in `update`, with `beryl/topic` helpers |
 | One channel process per joined topic | one socket actor per connection, with one private state value per joined topic | one socket actor and one `model` per connection, covering all its topics |
 | `socket.assigns` + `assign/3` | the channel's own `state` type, returned from each callback | your `model`, returned from each `update` |
@@ -76,7 +76,7 @@ Phoenix-style process-per-channel prototype.
 | `push(socket, event, payload)` | `channel.push(event, payload)` action | `socket.Push(topic, event, payload)` effect |
 | `broadcast!/3` | `channel.broadcast(event, payload)` action | `socket.Broadcast(topic, event, payload)` effect |
 | `broadcast_from!/3` | `channel.broadcast_from(event, payload)` action | `socket.BroadcastFrom(topic, event, payload)` effect |
-| `handle_info(msg, socket)` + `send(pid, msg)` | `channel.on_info` + `channel.notify(sender, msg)` — typed per channel | `socket.Info(msg)` + `socket.notify(sender, msg)` — typed per socket |
+| `handle_info(msg, socket)` + `send(pid, msg)` | `channel.on_info` + `channel.notify(sender, msg)`; typed per channel | `socket.Info(msg)` + `socket.notify(sender, msg)`; typed per socket |
 | `:after_join` self-send | `channel.with_actions` on the accepted join (ordered immediately after the ack) | order the effects after `AcceptJoin` in the same list |
 | `terminate/2` | `channel.on_terminate`, which returns actions | `socket.Closed(topic, reason)` event, delivered on every exit path |
 | `{:stop, reason, socket}` (ends one channel) | `channel.close(actions)` | `socket.KickTopic(topic)` |
@@ -86,9 +86,9 @@ Phoenix-style process-per-channel prototype.
 | `Phoenix.Presence.track/3` / `untrack/3` | `channel.presence_track(key, meta)` / `channel.presence_untrack(key)` actions | `socket.PresenceTrack(topic, key, meta)` / `socket.PresenceUntrack(topic, key)` effects |
 | `Phoenix.Presence.update/4` | repeat `channel.presence_track(key, meta)`; for standalone refs, `presence.update(handle, ref, meta)` | repeat `socket.PresenceTrack(topic, key, meta)`; for standalone refs, `presence.update(handle, ref, meta)` |
 | `push(socket, "presence_state", Presence.list(socket))` | `channel.push_presence("presence_state", presence_wire.encode_state)` | `socket.PushPresence(topic, "presence_state", presence_wire.encode_state)` |
-| `intercept` / `handle_out` | no equivalent — shape payloads before `broadcast`, or per-socket with `push` | no equivalent — same advice |
+| `intercept` / `handle_out` | no equivalent; create payloads before `broadcast`, or use `push` for one socket | no equivalent; use the same approach |
 
-## Side by side: a room channel
+## Compare room channel examples
 
 The same channel in all three models. Phoenix first:
 
@@ -116,9 +116,9 @@ defmodule MyAppWeb.RoomChannel do
 end
 ```
 
-The channel layer keeps the shape — one module per channel, colocated
-callbacks, per-topic state — and turns the imperative `push`/`broadcast_from!`
-calls into ordered action values:
+The channel layer follows the same structure: one module per channel,
+callbacks in that module, and per-topic state. It turns the imperative
+`push` and `broadcast_from!` calls into ordered action values:
 
 ```gleam
 import beryl/channel
@@ -166,7 +166,7 @@ pub fn room() -> channel.Handler {
 }
 ```
 
-Raw dispatch flattens the same behavior into arms of one `case`, and names the
+Raw dispatch puts the same behavior in branches of one `case` and names the
 topic on every effect:
 
 ```gleam
@@ -234,12 +234,11 @@ Both beryl APIs differ from Phoenix in these ways:
   `{"reason": "unmatched topic"}`.
 - **Server-side messages are typed.** Phoenix's `handle_info` receives any
   term. The channel layer's `on_info` receives *this channel's* own `info`
-  type, delivered through the `channel.Sender(info)` in `JoinContext.self`; raw
-  dispatch's `Info(msg)` wraps the socket's `msg` type. Nothing is coerced in
-  either direction — the layer seals the typed value in a closure and stamps
-  the envelope with the join it belongs to, so a send to a channel that has
-  closed, or to a topic that has since been rejoined, is dropped rather than
-  delivered to the wrong join.
+  type, delivered through the `channel.Sender(info)` in `JoinContext.self`.
+  Raw dispatch's `Info(msg)` wraps the socket's `msg` type. Beryl keeps the
+  value typed and records which join owns it. If that join closes or the topic
+  joins again, Beryl drops the message instead of delivering it to the wrong
+  join.
 
 ## Assigns become a typed state value
 
@@ -253,11 +252,11 @@ type State {
 
 There is no `assign/3`: a callback returns the next state directly, for example
 with `channel.next(State(..state, joined_at: now), actions)`. Because
-the state type is sealed inside the channel's closures, two channels in the
-same handler table can have states with nothing in common — and the compiler
-still checks every field access.
+the channel keeps its state type private, two channels in the same handler
+table can use unrelated state types. The compiler still checks every field
+access.
 
-## Presence and the `:after_join` dance
+## Replace the `:after_join` self-send
 
 The common Phoenix pattern sends itself a message so tracking happens after the
 join is acknowledged:
@@ -291,9 +290,8 @@ where the effects go in one list after `AcceptJoin`. Presence mutations are
 asynchronous in the runtime: this socket resumes in order after the mutation,
 while other sockets may continue in the meantime.
 
-The mirror image — Phoenix's `terminate/2` — is `channel.on_terminate`, which
-returns actions of its own, so a leave announcement and a post-leave roster
-stay inside the channel:
+Phoenix's `terminate/2` maps to `channel.on_terminate`, which returns actions.
+This keeps a leave announcement and updated roster inside the channel:
 
 ```gleam
 |> channel.on_terminate(fn(state: State, _reason) {
@@ -306,13 +304,14 @@ stay inside the channel:
 
 The closing phase allows broadcasts, presence untracking, and presence
 broadcasts; active-only pushes, replies, and presence tracking do not
-type-check there. See [Termination](/guides/channels/#termination).
+type-check there. See
+[Handle channel termination](/guides/channels/#handle-channel-termination).
 
 The wire payloads (`presence_state`, `presence_diff`) match Phoenix Presence's
 shapes. See the [Presence guide](/guides/presence/) for setup and cross-node
 replication.
 
-## Broadcasting from outside a socket
+## Broadcast from outside a socket
 
 From a controller or background job, Phoenix uses
 `MyAppWeb.Endpoint.broadcast("room:lobby", "notice", %{})`. In beryl, call
@@ -326,23 +325,23 @@ beryl.broadcast(sockets, "room:lobby", "notice", json.object([]))
 With PubSub configured, `beryl.broadcast` distributes across the cluster, the
 same way `Endpoint.broadcast` rides `Phoenix.PubSub`.
 
-This is also how a channel reaches **another** topic. Channel actions are
-scoped to the channel's own topic on purpose, and the `Sockets` handle only
-becomes available after `child_spec` returns — so an app that needs cross-topic
-publishing keeps the handle in a small actor and calls it from its callbacks.
+This is also how a channel sends to **another** topic. Channel actions apply
+only to their own topic, and the `Sockets` handle becomes available after
+`child_spec` returns. An application that sends across topics can keep the
+handle in a small actor and call it from channel callbacks.
 That actor is the layer's `Endpoint.broadcast/3`; see
-[Limitations](/guides/channels/#limitations).
+[When to use raw dispatch or another process](/guides/channels/#when-to-use-raw-dispatch-or-another-process).
 
 To message one specific channel (Phoenix: `send(channel_pid, msg)`), keep the
-`channel.Sender(info)` from `JoinContext.self` and call `channel.notify` — the
+`channel.Sender(info)` from `JoinContext.self` and call `channel.notify`. The
 message arrives as a typed `on_info` call. With raw dispatch, keep the
 `socket.Sender(msg)` from `ConnectInfo.self` and call `socket.notify`.
 
 ## Next steps
 
-- [Channels](/guides/channels/) — the full channel-layer guide
-- [App-Side Dispatch](/guides/dispatch/) — the full routing model, topic helpers, and effect ordering
-- [Choose an API](/choosing-an-api/) — which layer fits your app
-- [WebSocket Transport](/guides/websocket/) — mount beryl on Mist or Ewe, Phoenix-compatible framing
-- [Presence](/guides/presence/) — tracking, snapshots, and cross-node sync
-- [PubSub](/guides/pubsub/) — the `pg`-backed publish/subscribe layer
+- [Channels](/guides/channels/): build handlers with private state and callbacks
+- [Raw Dispatch](/guides/dispatch/): route socket events and order effects
+- [Choose an API](/choosing-an-api/): compare channels and raw dispatch
+- [WebSocket Transport](/guides/websocket/): connect Beryl to Mist
+- [Presence](/guides/presence/): track users and synchronize nodes
+- [PubSub](/guides/pubsub/): publish to subscribers through Erlang `pg`

--- a/website/src/content/docs/guides/dispatch.md
+++ b/website/src/content/docs/guides/dispatch.md
@@ -1,5 +1,5 @@
 ---
-title: Route Socket Events in One Update Function
+title: Route socket events in one update function
 description: Handle joins, messages, binary frames, closed topics, and typed server messages in one update function.
 ---
 

--- a/website/src/content/docs/guides/dispatch.md
+++ b/website/src/content/docs/guides/dispatch.md
@@ -1,19 +1,19 @@
 ---
-title: App-Side Dispatch
-description: Route joins, messages, binary frames, close events, and typed server messages in one update function.
+title: Route Socket Events in One Update Function
+description: Handle joins, messages, binary frames, closed topics, and typed server messages in one update function.
 ---
 
-Raw **app-side dispatch** is beryl's core programming model. Build one
+**Raw dispatch** is beryl's core programming model. Build one
 supervised runtime with `beryl.child_spec`. Build a per-socket model in `init`.
 Route each socket event in one `update` function. For multi-channel or
 Phoenix-style apps, use the recommended
 [`beryl/channel` layer](/guides/channels/).
 
-Your application routes `socket.Input` values and returns
-`socket.Next(model, effects)`. You do not need a registry or a per-topic module
-lifecycle.
+Your application handles `socket.Input` values and returns
+`socket.Next(model, effects)`. You do not need a registry or one module for
+each topic.
 
-## The app entry point
+## Start the runtime
 
 ```gleam
 import beryl
@@ -38,7 +38,7 @@ let assert Ok(_root) =
   - `socket.Next(model, effects)` to continue, or
   - `socket.Stop(reason)` to close the whole socket.
 
-`socket.Input(msg)` is the whole contract:
+`socket.Input(msg)` has these variants:
 
 - `socket.Join(topic, payload, ref)`
 - `socket.Message(topic, event, payload, ref)`
@@ -75,7 +75,7 @@ topic.extract_wildcards(
 
 For one namespace, match in `update`. When several namespaces share a socket,
 use [`beryl/channel`](/guides/channels/). See
-[Routing many topics from one app](#routing-many-topics-from-one-app).
+[Use channels for several topic groups](#use-channels-for-several-topic-groups).
 
 ## Single-topic example
 
@@ -197,9 +197,9 @@ A few important details:
 - Joins are explicit: return `socket.AcceptJoin(ref, reply)` or `socket.RejectJoin(ref, reason)`.
 - Message replies are explicit too: use `socket.ReplyOk` / `socket.ReplyError` when a client ref is present.
 - `socket.Closed(topic, reason)` replaces per-topic cleanup hooks. Prune topic-local state there.
-- `socket.Info(msg)` is just a typed message from your own server code.
+- `socket.Info(msg)` is a typed message from your own server code.
 
-## Routing many topics from one app
+## Use channels for several topic groups
 
 Use [`beryl/channel`](/guides/channels/). Register a list of channel handlers
 and the layer routes every socket event to the channel that owns its topic.
@@ -213,7 +213,7 @@ The `cursors` example stays on raw dispatch and matches its single
 
 ### Migrating from `beryl/socket/router`
 
-There is no replacement router API. Let the compiler expose every old import
+There is no replacement router API. Let the compiler find every old import
 and choose one of the two models:
 
 - For one topic family, match `socket.Input` directly and use
@@ -223,7 +223,7 @@ and choose one of the two models:
   with `channel.child_spec`.
 
 Delete calls to `namespace`, `accept_only`, `unknown_topic`, and `route`; do
-not rebuild the same abstraction locally. `gleam check` then points to the
+do not rebuild similar routing code. `gleam check` then points to the
 remaining `Match` and `Namespace` types that need direct topic values or
 `JoinContext.params`.
 
@@ -247,9 +247,10 @@ fn notify_socket(sender: socket.Sender(Msg), job_id: String) -> Nil {
 
 If the socket has already disconnected, `socket.notify` is ignored.
 
-For long-lived external actors that should stream updates into a socket, see `beryl/bridge`.
+For long-lived external actors that send updates to a socket, see
+`beryl/bridge`.
 
-## Effect order is observable order
+## Effects run in list order
 
 The runtime applies effects in list order during one actor turn. Therefore:
 
@@ -269,6 +270,6 @@ The same rule matters for replies:
 
 ## Next steps
 
-- [WebSocket Transport](/guides/websocket/) — connect browsers and seed `ConnectInfo.seed.metadata`
-- [Presence](/guides/presence/) — keep synchronous presence work outside the runtime's actors
-- [Runtime & Effect Interpreter](/architecture/runtime/) — runtime behavior, effect ordering, and teardown details
+- [WebSocket Transport](/guides/websocket/): connect browsers and set `ConnectInfo.seed.metadata`
+- [Presence](/guides/presence/): keep synchronous presence work outside runtime actors
+- [Socket Processes & Restarts](/architecture/runtime/): socket behavior, effect order, and shutdown details

--- a/website/src/content/docs/guides/error-handling.md
+++ b/website/src/content/docs/guides/error-handling.md
@@ -1,5 +1,5 @@
 ---
-title: Handle Errors
+title: Handle errors
 description: Reject invalid requests, understand callback panics, and return Phoenix-compatible errors.
 ---
 

--- a/website/src/content/docs/guides/error-handling.md
+++ b/website/src/content/docs/guides/error-handling.md
@@ -135,7 +135,7 @@ The client-visible effect is that the WebSocket connection is closed from the se
 
 ## When `init` or `update` panics
 
-Beryl catches panics in `init` and `update` instead of stopping the socket's
+beryl catches panics in `init` and `update` instead of stopping the socket's
 runtime actor. The result depends on where the panic occurs:
 
 | Crash site | Effect |
@@ -149,7 +149,7 @@ runtime actor. The result depends on where the panic occurs:
 Crash descriptions are depth-limited and truncated before logging so client-triggered crashes cannot bloat log metadata.
 
 This behavior applies only to the listed callbacks. A callback panic in the
-socket actor would close every topic on that socket. Beryl discards the failed
+socket actor would close every topic on that socket. beryl discards the failed
 callback result and closes only the affected join, topic, or socket when safe.
 Other faults stop that socket actor; the router closes the connection and
 removes its entries. A router fault invokes supervision and disconnects all

--- a/website/src/content/docs/guides/error-handling.md
+++ b/website/src/content/docs/guides/error-handling.md
@@ -1,9 +1,10 @@
 ---
-title: Error Handling
+title: Handle Errors
+description: Reject invalid requests, understand callback panics, and return Phoenix-compatible errors.
 ---
 
-This guide explains how beryl reports errors to your app and clients. It also
-shows how to handle them.
+This guide explains how beryl reports errors to your application and clients,
+and how your application should respond.
 
 ## Rejected joins
 
@@ -44,13 +45,13 @@ With `beryl/channel`, return `channel.reject(reason)` from the handler's
 `join` callback. A topic no handler matches is rejected automatically with
 `{"reason": "unmatched topic"}`.
 
-:::note[Unanswered joins fail closed]
+:::note[Unanswered joins are rejected]
 Answer each `Join` with `AcceptJoin` or `RejectJoin` in the same update. The
 runtime rejects and logs an unanswered join. A missing match branch cannot
 admit a client.
 :::
 
-## Connection-level authentication rejection
+## Reject a connection during authentication
 
 `on_connect` in the transport config rejects the WebSocket upgrade before any topic join occurs. Return `Error(server.ConnectRejected)` to send an HTTP 403 response:
 
@@ -69,14 +70,15 @@ let config =
 
 The client never receives a WebSocket handshake and cannot send any messages.
 
-## Malformed wire messages
+## Handle malformed messages
 
 When configured with `wire.phoenix_codec()`, beryl parses Phoenix protocol
 arrays: `[join_ref, ref, topic, event, payload]`. With any codec, it drops
 frames that the active codec cannot decode and does not send an error.
 Malformed frames are protocol violations.
 
-If you need to surface decode errors in your own payload handling, decode the `Dynamic` payload with `gleam/dynamic/decode` and return an explicit `ReplyOk` or `ReplyError`:
+To report payload decode errors to a client, decode the `Dynamic` payload with
+`gleam/dynamic/decode` and return an explicit `ReplyOk` or `ReplyError`:
 
 ```gleam
 socket.Message(_topic, "create_item", payload, option.Some(ref)) ->
@@ -96,7 +98,7 @@ socket.Message(_topic, "create_item", payload, option.Some(ref)) ->
   }
 ```
 
-:::note[Refless messages cannot be answered]
+:::note[Messages without a reply reference cannot be answered]
 `ReplyOk` and `ReplyError` need the message `ReplyRef`. It is `Some` only when
 the client expects a reply. A `Message` with `None` has no request reference.
 Use `Push` for a server message with its own event name.
@@ -108,7 +110,9 @@ If `update` does not accept a `phx_join` topic, reject it with a catch-all
 `Join` branch that returns `RejectJoin`. If `update` ignores the join, beryl's
 fail-closed default rejects it.
 
-Messages pushed to a topic the socket never joined get an automatic error reply with `response: {"reason": "unmatched topic"}` when they carry a ref, matching Phoenix; refless pushes to unjoined topics are dropped.
+Messages pushed to a topic the socket never joined get an automatic error
+reply with `response: {"reason": "unmatched topic"}` when they include a
+reference, matching Phoenix. Messages without a reference are dropped.
 
 ## Heartbeat timeouts
 
@@ -129,9 +133,10 @@ socket.Closed(topic, reason) -> {
 
 The client-visible effect is that the WebSocket connection is closed from the server side. Phoenix JS clients will attempt to reconnect automatically.
 
-## Crashes in your update function
+## When `init` or `update` panics
 
-Beryl rescues crashes in `init` and `update` rather than letting them take down the socket's runtime actor. The blast radius depends on where the crash happens:
+Beryl catches panics in `init` and `update` instead of stopping the socket's
+runtime actor. The result depends on where the panic occurs:
 
 | Crash site | Effect |
 |------------|--------|
@@ -143,16 +148,16 @@ Beryl rescues crashes in `init` and `update` rather than letting them take down 
 
 Crash descriptions are depth-limited and truncated before logging so client-triggered crashes cannot bloat log metadata.
 
-This is not a generic catch-and-continue policy. Letting a callback crash its
-socket actor would close every topic on that socket. Beryl instead discards
-the failed callback result and closes the narrowest safe scope. Faults outside
-these boundaries stop that socket actor; the router closes the connection and
-removes its entries. A router fault still invokes supervision and disconnects
-all sockets. See
-[Runtime crash containment](/architecture/runtime/#crash-containment) for the
+This behavior applies only to the listed callbacks. A callback panic in the
+socket actor would close every topic on that socket. Beryl discards the failed
+callback result and closes only the affected join, topic, or socket when safe.
+Other faults stop that socket actor; the router closes the connection and
+removes its entries. A router fault invokes supervision and disconnects all
+sockets. See
+[What closes after a callback panic](/architecture/runtime/#what-closes-after-a-callback-crash) for the
 trade-off.
 
-The channel layer maps those scopes to callbacks:
+The channel layer applies the same results to these callbacks:
 
 | Channel callback | Effect |
 |---|---|
@@ -165,17 +170,17 @@ A terminate panic also discards the router model returned by that `Closed`
 turn. The old instance therefore remains reachable through its own typed
 sender until the topic is rejoined or the socket ends, even though client
 traffic cannot reach the closed topic. Keep `on_terminate` small and
-non-panicking; see [Crash behavior](/guides/channels/#crash-behavior).
+non-panicking; see [When callbacks panic](/guides/channels/#when-callbacks-panic).
 
-## Rate limiting
+## Rate limits and dropped traffic
 
 When a client exceeds a rate limit, beryl **drops** the frame or message. It
 does not send an error. An over-rate join is the exception. It receives an
 error reply with `reason: "rate_limited"`.
 
-| Limit | Scope | Enforced | Config function |
+| Limit | Applies to | Enforced at | Config function |
 |-------|-------|----------|-----------------|
-| `frame_rate` | Per connection, every complete frame | Transport edge | `beryl.with_frame_rate` |
+| `frame_rate` | Per connection, every complete frame | Transport, before decode | `beryl.with_frame_rate` |
 | `message_rate` | Per socket, decoded non-join traffic | Runtime | `beryl.with_message_rate` |
 | `join_rate` | Per socket, joins | Runtime | `beryl.with_join_rate` |
 | `channel_rate` | Per socket+topic | Runtime | `beryl.with_channel_rate` |
@@ -203,7 +208,7 @@ bucket. If you need to inform the client that it has been rate-limited,
 implement application-level tracking in `update` and return an explicit
 `ReplyError`.
 
-## Group errors
+## Group operation errors
 
 Group operations (`create`, `delete`, `add`, `remove`, `topics`) return `Result(_, GroupError)`:
 
@@ -215,9 +220,12 @@ case group.create(groups, name) {
 }
 ```
 
-`group.broadcast` resolves the group's topics synchronously and never returns an error. If the group does not exist, the call is a no-op. Like other group operations, it panics if the groups actor is unavailable or does not reply within 5 seconds.
+`group.broadcast` resolves the group's topics synchronously and never returns
+an error. If the group does not exist, the call does nothing. Like other group
+operations, it panics if the groups actor is unavailable or does not reply
+within 5 seconds.
 
-## Startup failures
+## Startup configuration errors
 
 `beryl.child_spec` validates configuration before returning the child spec:
 
@@ -236,8 +244,8 @@ case beryl.child_spec(config, init: init, update: update) {
 }
 ```
 
-`InvalidTopicPattern` nests `beryl/topic.TopicError` rather than flattening it
-to a string. New `TopicError` variants may be added in a minor release, so
+`InvalidTopicPattern` contains `beryl/topic.TopicError` instead of a string.
+New `TopicError` variants may be added in a minor release, so
 match exact variants only when your handling differs and keep a catch-all
 otherwise.
 
@@ -247,19 +255,20 @@ otherwise.
 `beryl/topic.TopicError`; match a catch-all reason unless your code handles
 a specific variant differently.
 
-## Sender delivery is best-effort
+## Typed sender delivery is not confirmed
 
 `socket.notify` sends a typed message to socket `update` as an `Info` event. If
 the socket disconnected, beryl drops the message and returns no error:
 
 ```gleam
-// This is always Nil — no error even if the socket is gone
+// This is always Nil, even if the socket is gone.
 socket.notify(sender, MyMessage)
 ```
 
-If delivery confirmation is important, have the `Info` arm of `update` acknowledge back to the sending process.
+If you need delivery confirmation, have the `Info` branch of `update` send an
+acknowledgment to the sending process.
 
-## Client-visible error shapes
+## Client error messages
 
 With `wire.phoenix_codec()`, error responses take these shapes:
 
@@ -282,8 +291,8 @@ Terminal events repeat the topic's join ref in both reference slots. Phoenix
 client libraries handle `phx_error` and `phx_close`. The client marks the
 channel as errored or closed and can try to rejoin.
 
-## See also
+## Related guides
 
-- [Troubleshooting](/troubleshooting/) — symptom-first diagnosis for connection failures, missed messages, and auth issues
-- [WebSocket Transport guide](/guides/websocket/#authentication) — setting up `on_connect` for connection-level auth
-- [Supervision guide](/guides/supervision/) — the built-in runtime supervision and crash semantics
+- [Troubleshooting](/troubleshooting/): diagnose connection failures, missed messages, and authentication problems
+- [WebSocket Transport guide](/guides/websocket/#authenticate-before-the-upgrade): configure `on_connect` authentication
+- [Supervision guide](/guides/supervision/): understand runtime supervision and callback panics

--- a/website/src/content/docs/guides/groups.md
+++ b/website/src/content/docs/guides/groups.md
@@ -1,8 +1,9 @@
 ---
 title: Groups
+description: Name sets of topics and send one event to every topic in a set.
 ---
 
-Groups are **named topic collections on the server**. Use one group broadcast
+Groups are **named sets of topics on the server**. Use one group broadcast
 to send an event to many topics. You do not need to track subscriptions. Groups
 are similar to Socket.IO rooms and SignalR groups.
 
@@ -11,7 +12,7 @@ Only the server uses groups. Clients join individual topics with `phx_join`.
 Clients do not receive group information.
 :::
 
-## Starting the groups actor
+## Start the groups actor
 
 ```gleam
 import beryl/group
@@ -88,7 +89,7 @@ let assert Ok(Nil) = group.remove(groups, "team:engineering", "room:infra")
 
 Adding the same topic twice does nothing because the group stores a set.
 
-## Inspecting groups
+## Read groups
 
 ```gleam
 // List all topics in a group
@@ -102,12 +103,13 @@ case group.topics(groups, "team:engineering") {
 let names = group.list_groups(groups)  // ["team:engineering", "team:design"]
 ```
 
-## Broadcasting to a group
+## Send an event to every topic in a group
 
 `group.broadcast` asks the groups actor for the topic set. The calling process
-then sends the event to each topic with `beryl.broadcast`. The lookup provides
-backpressure, but the actor does not perform fan-out. The function returns
-`Nil`, not `Result`. If the group does not exist, the function does nothing.
+waits for that lookup, then sends the event to each topic with
+`beryl.broadcast`. The actor does not send the broadcasts itself. The function
+returns `Nil`, not `Result`. If the group does not exist, the function does
+nothing.
 
 ```gleam
 group.broadcast(
@@ -121,21 +123,21 @@ group.broadcast(
 
 This has the same effect as one `beryl.broadcast` call for each group topic.
 
-:::note[Missing group is a no-op]
+:::note[Missing groups do nothing]
 `group.broadcast` does not return an error. It does nothing if the group is
 missing or empty. It panics if the groups actor is unavailable or does not
 reply within 5 seconds. To check a group first, call `group.topics` and handle
 `GroupNotFound`.
 :::
 
-## Error reference
+## Group errors
 
 | Error | When |
 |-------|------|
 | `GroupAlreadyExists` | `create` called for a name already in use |
 | `GroupNotFound` | `delete`, `add`, `remove`, or `topics` called for an unknown group name |
 
-## Full example: team rooms
+## Complete example: team rooms
 
 ```gleam
 import beryl
@@ -169,7 +171,7 @@ group.broadcast(
 let assert Ok(Nil) = group.delete(groups, "team:eng")
 ```
 
-## Lifecycle
+## Restarts and node limits
 
 Start the groups actor with `group.child_spec`. Its handle uses a stable
 registered name and reaches the replacement actor after a supervised restart.

--- a/website/src/content/docs/guides/observability.md
+++ b/website/src/content/docs/guides/observability.md
@@ -3,12 +3,12 @@ title: Monitor beryl
 description: Collect telemetry events, read runtime counts, and export application metrics.
 ---
 
-Beryl provides two sources of monitoring data:
+beryl provides two sources of monitoring data:
 
 - Optional `:telemetry` events report rates, outcomes, and operation durations.
 - `beryl/stats.snapshot` reports local runtime state at one time.
 
-Beryl does not include a Prometheus or OpenTelemetry exporter. Your application
+beryl does not include a Prometheus or OpenTelemetry exporter. Your application
 must aggregate, label, and export the data.
 
 ## Enable telemetry events
@@ -119,7 +119,7 @@ detach(Id) ->
 The supervised metrics actor can convert messages for your metrics library.
 Monitor its mailbox and limit queued work. Another process avoids adding work
 to the request, but an unlimited mailbox can still overload the system. Detach
-the handler during shutdown. Beryl does not need an exporter dependency.
+the handler during shutdown. beryl does not need an exporter dependency.
 
 Useful derived signals include upgrade rejection rate by outcome, frame decode
 and rate-limit rates, join/message callback failures, connection lifetime,
@@ -162,7 +162,7 @@ per node. Cache the latest successful snapshot, add jitter, and expose the
 snapshot age. Do not convert a timeout to a zero-valued snapshot. A timeout can
 mean restart or overload, not an idle system.
 
-For a runnable JSON endpoint combining Beryl and BEAM runtime gauges, see the
+For a runnable JSON endpoint combining beryl and BEAM runtime gauges, see the
 benchmark server's [`/stats` reference](https://github.com/tylerbutler/beryl/blob/main/examples/load_test/README.md#health-and-stats)
 and
 [`http.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/load_test/src/load_test/http.gleam).

--- a/website/src/content/docs/guides/observability.md
+++ b/website/src/content/docs/guides/observability.md
@@ -1,5 +1,5 @@
 ---
-title: Monitor Beryl
+title: Monitor beryl
 description: Collect telemetry events, read runtime counts, and export application metrics.
 ---
 

--- a/website/src/content/docs/guides/observability.md
+++ b/website/src/content/docs/guides/observability.md
@@ -1,9 +1,9 @@
 ---
-title: Observability
-description: Telemetry events, runtime snapshots, and application-owned metrics export.
+title: Monitor Beryl
+description: Collect telemetry events, read runtime counts, and export application metrics.
 ---
 
-Beryl provides two types of data:
+Beryl provides two sources of monitoring data:
 
 - Optional `:telemetry` events report rates, outcomes, and operation durations.
 - `beryl/stats.snapshot` reports local runtime state at one time.
@@ -11,7 +11,7 @@ Beryl provides two types of data:
 Beryl does not include a Prometheus or OpenTelemetry exporter. Your application
 must aggregate, label, and export the data.
 
-## Enable telemetry
+## Enable telemetry events
 
 Telemetry is disabled by default:
 
@@ -24,15 +24,13 @@ let config =
 Attach handlers before traffic begins. Erlang `:telemetry` invokes handlers
 **synchronously in the process emitting the event**. A slow handler therefore
 adds latency to a WebSocket connection process, a socket's runtime actor,
-or the runtime's router.
-Perform bounded counter/histogram updates or enqueue a small message and
-return immediately; never make network calls, format logs, or run expensive
-label conversion in the handler.
+or the runtime's router. Update a fixed-size counter or histogram, or enqueue a
+small message and return. Do not make network calls, format logs, or convert
+large sets of labels in the handler.
 
-Event names and their measurement/metadata keys form Beryl's stable,
-low-cardinality telemetry taxonomy:
+These stable event names use a fixed set of measurement and metadata keys:
 
-| Event | Measurements | Metadata |
+| Event | Measurements (numeric values) | Metadata (labels) |
 |---|---|---|
 | `[:beryl, :transport, :upgrade, :stop]` | `count`, `duration` | `transport`, `outcome` |
 | `[:beryl, :transport, :frame, :stop]` | `count`, `duration`, `bytes` | `transport`, `frame_type`, `outcome` |
@@ -43,7 +41,7 @@ low-cardinality telemetry taxonomy:
 | `[:beryl, :broadcast, :stop]` | `count`, `duration`, `recipients` | `origin` |
 
 The `:channel` event-name segment is retained for telemetry compatibility
-even though app-side dispatch now owns routing. For an app `update`,
+even though raw dispatch now owns routing. For an app `update`,
 `callback_result` describes the first response-like effect (`reply`,
 `reply_error`, or `push`), `no_reply` when none is returned, and `stop` for a
 socket stop.
@@ -53,7 +51,7 @@ socket stop.
 unit) before export. It is not milliseconds. Counts and byte/recipient fields
 are integers.
 
-Metadata values are atoms from closed vocabularies. They intentionally omit
+Metadata values are atoms from fixed lists. They omit
 topics, socket IDs, payloads, and arbitrary error text, so the built-in labels
 remain bounded:
 
@@ -72,15 +70,15 @@ remain bounded:
 
 Map future unknown values to an `"unknown"` label. Do not crash the handler.
 
-## Export to Prometheus or Grafana
+## Export metrics to Prometheus or Grafana
 
-Keep the exporter at the application boundary:
+Keep the exporter in your application:
 
 1. Attach one handler with `telemetry:attach_many/4`.
 2. Map each event to an application-owned counter or histogram. Preserve only
    the bounded metadata above as labels.
-3. Convert native durations and update the in-memory aggregator synchronously,
-   or send a bounded message to a supervised metrics actor.
+3. Convert native durations and update the in-memory metrics store, or send a
+   message to a supervised metrics actor with a fixed queue limit.
 4. Expose the aggregator through your existing Prometheus HTTP endpoint,
    OpenTelemetry SDK, or hosted metrics client.
 5. Configure Prometheus to scrape that endpoint and use Grafana to query the
@@ -118,18 +116,17 @@ detach(Id) ->
     telemetry:detach(Id).
 ```
 
-The supervised aggregator can convert messages for your metrics library.
-Monitor its mailbox and use bounded aggregation or backpressure. Another
-process prevents direct request latency, but an unbounded mailbox can still
-overload the system. Detach the handler during shutdown. Beryl does not need an
-exporter dependency.
+The supervised metrics actor can convert messages for your metrics library.
+Monitor its mailbox and limit queued work. Another process avoids adding work
+to the request, but an unlimited mailbox can still overload the system. Detach
+the handler during shutdown. Beryl does not need an exporter dependency.
 
 Useful derived signals include upgrade rejection rate by outcome, frame decode
 and rate-limit rates, join/message callback failures, connection lifetime,
 broadcast recipient counts, and latency histograms. Alert on sustained rates
 and tail latency rather than individual events.
 
-## Runtime snapshots
+## Read runtime counts
 
 `beryl/stats.snapshot(channels)` requests a point-in-time view from the
 socket runtime represented by `channels`:
@@ -153,11 +150,11 @@ case stats.snapshot(channels) {
 }
 ```
 
-The snapshot describes one socket runtime on one BEAM node. It is not a cluster
-transaction or an event stream. Aggregate gauges across nodes in the monitoring
-system. `joined_socket_topic_pairs` counts memberships. One socket on two
-topics adds two. The runtime records counts when it handles the request, so
-in-flight connection changes can appear later.
+The snapshot describes one socket runtime on one BEAM node. It is not an event
+stream or a single consistent view of the whole cluster. Aggregate gauges
+across nodes in the monitoring system. `joined_socket_topic_pairs` counts
+memberships. One socket on two topics adds two. The runtime records counts when
+it handles the request, so concurrent connection changes can appear later.
 
 Poll no more than once per second. Each poll sends a request through the
 runtime. Many synchronized scrapers can add load. Use one application poller
@@ -173,7 +170,7 @@ That endpoint polls on request and is a benchmark fixture, not a bundled
 exporter. In production, prefer one application-owned poller per node and
 serve its cached snapshot through your metrics handler.
 
-## Capacity tests
+## Measure capacity
 
 Correlate telemetry and snapshots with BEAM process/port counts, memory, run
 queue, host CPU, open file descriptors, TCP statistics, and proxy/NAT

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -1,21 +1,22 @@
 ---
 title: Presence
+description: Track connected users, publish Phoenix-compatible updates, and replicate presence across nodes.
 ---
 
-beryl can track connected users and their metadata. It uses the
-`lattice_presence` conflict-free replicated data type (CRDT). The CRDT resolves
-conflicts across Erlang nodes.
+beryl can track connected users and their metadata. It uses a
+`lattice_presence` conflict-free replicated data type (CRDT), which merges
+concurrent changes from Erlang nodes without a central coordinator.
 
-## How it works
+## How Beryl tracks presence
 
 Presence uses an **add-wins observed-remove set** (AWORSet) with causal context.
 When a user joins or leaves, nodes merge their state without coordination. The
 system does not need a leader or consensus.
 
-The presence system has two layers:
+The presence API has two main parts:
 
-1. **`beryl/presence`** — OTP actor wrapping the CRDT with PubSub replication
-2. **`beryl/presence.Diff`** — An opaque notification value for `on_diff`, with accessor helpers for changed topics, joins, and leaves
+1. **`beryl/presence`**: an OTP actor that manages the CRDT and PubSub replication
+2. **`beryl/presence.Diff`**: a change value for `on_diff`, with functions that read changed topics, joins, and leaves
 
 ## Starting presence
 
@@ -60,7 +61,7 @@ let assert Ok(_root) =
 unavailable or does not reply within this timeout. Presence reads bypass the
 actor mailbox and do not use it.
 
-## Tracking presences
+## Track connected users
 
 Track a user's presence when they join a channel:
 
@@ -101,7 +102,7 @@ leaving other refs for the same key unchanged. Keep the returned ref for the
 next `update` or `untrack`; the previous ref becomes stale. An unknown, removed,
 or non-public ref returns `Error(presence.UnknownRef)`.
 
-## Untracking
+## Remove presence entries
 
 ```gleam
 // Remove a specific presence, using the ref returned by `track`
@@ -116,7 +117,7 @@ remove that entry with `untrack`. To clear all entries for a disconnected
 socket, call `untrack_all` with the session ID. The `session_id` string
 identifies the logical session, not a BEAM process.
 
-## Listing presences
+## Read presence
 
 ```gleam
 // Get all presences in a topic
@@ -132,10 +133,10 @@ let assert Ok(alice_sessions) =
 let assert Ok(online_count) = presence.count(p, "room:lobby")
 ```
 
-`list`, `get_by_key`, and `count` read an actor-owned ETS snapshot rather than
-calling through the actor mailbox, so reads remain nonblocking while the actor
-is busy. Synchronous mutations publish before replying, giving immediate
-read-after-write consistency. `count` reads a materialized count in O(1).
+`list`, `get_by_key`, and `count` read a snapshot from an ETS table owned by the
+actor. They do not wait in the actor mailbox. Synchronous changes update the
+snapshot before replying, so the next read sees the change. `count` reads a
+stored count in O(1).
 
 The table lifetime follows the actor. Before startup, after the actor stops, or
 during the brief window before a supervisor starts its replacement,
@@ -155,9 +156,9 @@ replacement actor and read model after a supervised restart. Presence entries
 and tracking refs are in-memory state and reset on restart; connected clients
 must re-track their presence.
 
-## Diff callbacks
+## Handle presence changes
 
-Use `on_diff` to receive presence changes:
+Use `on_diff` to receive presence changes.
 
 The presence actor calls the callback for local changes and remote merges. It
 calls the function before it publishes new read-model snapshots and before it
@@ -187,7 +188,7 @@ The actor calls `on_diff` after a local change or a remote merge produces a
 non-empty diff. It calls the function for each change, so rapid changes do not
 lose diffs.
 
-## Broadcasting Phoenix-compatible diffs
+## Send Phoenix-compatible `presence_diff` events
 
 Use `beryl.broadcast_presence_diff` to send a `presence_diff` event to sockets
 on the changed topic:
@@ -227,9 +228,12 @@ The payload matches Phoenix Presence's shape, with joins and leaves grouped by p
 }
 ```
 
-For lower-level integrations, `beryl/presence/wire.encode_diff(diff, topic)` returns the encoded JSON payload without broadcasting it. If channels are configured with PubSub, `broadcast_presence_diff` uses the same distributed delivery behavior as `beryl.broadcast`.
+For direct integrations, `beryl/presence/wire.encode_diff(diff, topic)`
+returns the encoded JSON payload without broadcasting it. If channels use
+PubSub, `broadcast_presence_diff` uses the same cross-node delivery as
+`beryl.broadcast`.
 
-## Cross-node replication
+## Replicate presence across nodes
 
 When you configure PubSub, the presence actor:
 
@@ -242,7 +246,7 @@ Self-delivery is prevented by `pubsub.broadcast_from`, so nodes don't process th
 
 The underlying CRDT state is intentionally internal. Applications should use PubSub replication rather than constructing or merging raw presence state values.
 
-## Integration with app-side dispatch
+## Use presence from raw dispatch
 
 Start and supervise the standalone presence actor, then attach its handle with
 `beryl.with_presence_handle`. In `update`, use presence effects rather than
@@ -271,19 +275,20 @@ shutdown handling continue while one socket waits.
 
 With `beryl/channel`, use the corresponding
 `channel.presence_track`, `presence_untrack`, `push_presence`, and
-`broadcast_presence` actions. They lower onto these same effects and keep the
-same ordering and asynchronous suspension semantics.
+`broadcast_presence` actions. They convert to the same effects, preserve the
+same order, and wait for asynchronous presence changes.
 
 The runtime owns refs created by `PresenceTrack` and automatically removes any
 remaining refs when the topic closes. Public synchronous `presence.track`
-calls remain available to application actors and other out-of-band workflows;
+calls remain available to application actors and code outside the socket runtime;
 their refs are independently addressable and are not part of runtime cleanup.
 Repeating `PresenceTrack` for the same topic and key replaces the runtime-owned
-meta atomically. Out-of-band workflows should use `presence.update` with the
+metadata atomically. Code outside the socket runtime should use
+`presence.update` with the
 ref returned by `presence.track`.
 
 ## Next steps
 
-- [PubSub guide](/guides/pubsub/) — required for cross-node presence replication; configure PubSub before passing it to presence config
-- [Reference: Client compatibility](/reference/#client-compatibility) — Phoenix JS and other clients that can handle `presence_diff` events
-- [Troubleshooting](/troubleshooting/#presence-is-stale-or-incorrect) — diagnosing stale entries, missing diffs, and cross-node sync failures
+- [PubSub guide](/guides/pubsub/): configure PubSub for cross-node presence replication
+- [Client compatibility](/reference/#client-compatibility): clients that handle `presence_diff` events
+- [Troubleshooting](/troubleshooting/#presence-is-stale-or-incorrect): diagnose stale entries, missing diffs, and cross-node synchronization failures

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -7,7 +7,7 @@ beryl can track connected users and their metadata. It uses a
 `lattice_presence` conflict-free replicated data type (CRDT), which merges
 concurrent changes from Erlang nodes without a central coordinator.
 
-## How Beryl tracks presence
+## How beryl tracks presence
 
 Presence uses an **add-wins observed-remove set** (AWORSet) with causal context.
 When a user joins or leaves, nodes merge their state without coordination. The

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -3,10 +3,10 @@ title: Prepare beryl for production
 description: Configure traffic limits, authentication, and Erlang distribution security.
 ---
 
-Beryl disables rate and connection limits by default because each deployment
+beryl disables rate and connection limits by default because each deployment
 needs different values. These defaults are suitable for development. In
 production, one hostile or faulty client can degrade a server that has no
-traffic controls. Beryl logs a startup warning when all controls are off. This
+traffic controls. beryl logs a startup warning when all controls are off. This
 guide explains which controls to configure.
 
 ## Controls enabled by default
@@ -14,7 +14,7 @@ guide explains which controls to configure.
 Even with no configuration, beryl enforces:
 
 - **Post-receipt frame size**: once the transport has assembled a complete
-  inbound WebSocket frame, Beryl closes the connection if it exceeds 1 MiB
+  inbound WebSocket frame, beryl closes the connection if it exceeds 1 MiB
   (`with_max_inbound_frame_bytes` to adjust).
 - **Topic and event lengths**: topics over 256 bytes and event names over 64
   bytes are rejected before reaching your app
@@ -27,9 +27,9 @@ Even with no configuration, beryl enforces:
   and their connections closed (60 s window by default, `with_heartbeat`).
 
 The frame-size check limits decoding and routing work. It does **not** limit
-transport memory because buffering and reassembly occur before Beryl receives
+transport memory because buffering and reassembly occur before beryl receives
 the frame. In production, set a WebSocket frame or message limit in the reverse
-proxy or load balancer. Set it at or below Beryl's limit. Also set a matching
+proxy or load balancer. Set it at or below beryl's limit. Also set a matching
 HTTP request or body limit for the upgrade.
 
 ## Configure production limits
@@ -132,7 +132,7 @@ addresses.
 
 ## Secure the Erlang cluster
 
-Beryl PubSub and presence replication use Erlang distribution. Trust every
+beryl PubSub and presence replication use Erlang distribution. Trust every
 connected peer. Erlang peers can run arbitrary code on connected nodes. A
 hostile peer can compromise the full cluster. Topic access, broadcasts,
 internal traffic, and presence state are only part of that access. Channel
@@ -147,7 +147,7 @@ They protect only WebSocket clients.
 | Erlang distribution peers | Fully trusted | Network isolation + mutually verified TLS distribution (cookies prevent accidental cross-cluster connections only) |
 
 All distributed BEAM applications need network isolation and secure
-distribution. Beryl assumes that you enforce this trust boundary.
+distribution. beryl assumes that you enforce this trust boundary.
 
 ### The Erlang cookie does not secure distribution
 

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -1,5 +1,5 @@
 ---
-title: Prepare Beryl for Production
+title: Prepare beryl for production
 description: Configure traffic limits, authentication, and Erlang distribution security.
 ---
 

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -1,14 +1,15 @@
 ---
-title: Production Hardening
+title: Prepare Beryl for Production
+description: Configure traffic limits, authentication, and Erlang distribution security.
 ---
 
-Beryl disables all rate and connection limits by default. Each deployment
-needs different limits. The defaults are suitable for development. In
-production, one hostile or faulty client can degrade a server with no abuse
-controls. Beryl logs a startup warning when all controls are off. This guide
-explains which controls to configure.
+Beryl disables rate and connection limits by default because each deployment
+needs different values. These defaults are suitable for development. In
+production, one hostile or faulty client can degrade a server that has no
+traffic controls. Beryl logs a startup warning when all controls are off. This
+guide explains which controls to configure.
 
-## What is always on
+## Controls enabled by default
 
 Even with no configuration, beryl enforces:
 
@@ -20,7 +21,7 @@ Even with no configuration, beryl enforces:
   (`with_max_topic_length`, `with_max_event_length`).
 - **Joined-topic cap**: a socket may join at most 1000 topics
   (`with_max_joined_topics_per_socket`).
-- **Protocol hygiene**: reserved `phx_*` events, reserved `beryl:*` topics,
+- **Protocol checks**: reserved `phx_*` events, reserved `beryl:*` topics,
   and messages carrying a stale `join_ref` are dropped.
 - **Heartbeat eviction**: sockets that stop sending heartbeats are evicted
   and their connections closed (60 s window by default, `with_heartbeat`).
@@ -31,12 +32,12 @@ the frame. In production, set a WebSocket frame or message limit in the reverse
 proxy or load balancer. Set it at or below Beryl's limit. Also set a matching
 HTTP request or body limit for the upgrade.
 
-## What you should configure for production
+## Configure production limits
 
 ```gleam
 let config =
   beryl.config(wire.phoenix_codec())
-  // Shed all complete frames at the transport edge before decode.
+  // Drop over-rate complete frames before decoding them.
   |> beryl.with_frame_rate(per_second: 150, burst: 300)
   // Cap messages per socket. Size to your chattiest legitimate client:
   // for most interactive apps 50-100 msg/s with 2x burst is generous.
@@ -71,11 +72,11 @@ Optionally, `with_channel_rate` adds a per-socket-per-topic limit on top of
 the global per-socket message rate, useful when a single busy topic must not
 starve others.
 
-### Per-IP rate and connection limits compose
+### Combine per-IP rate and connection limits
 
 `with_connection_rate_per_ip` caps how quickly each peer can open connections,
-which prevents reconnect churn from repeatedly refreshing per-connection frame
-and message bursts. Its token buckets live in the supervised connection
+which prevents repeated reconnects from refreshing per-connection frame and
+message bursts. Its token buckets are stored in the supervised connection
 limiter, so they survive disconnects and app runtime restarts. Idle buckets are
 removed after their allowance has fully refilled.
 
@@ -96,7 +97,7 @@ effective ceiling of roughly `max_connections × N`. Size the per-node value
 against one node's capacity, and use your load balancer's own global
 connection/rate controls when you need a cluster-wide cap.
 
-### The per-IP caveat
+### Limits behind proxies and shared IP addresses
 
 The connection limit uses the **TCP peer address**. It ignores forwarded
 headers such as `X-Forwarded-For` because clients can forge them. This has two
@@ -109,25 +110,27 @@ effects:
   the cap high enough for your worst legitimate case, or leave it off and
   rely on rate limits.
 
-### Per-connection rate limits reset on reconnect
+### Reconnects reset per-connection limits
 
 Per-socket limits are keyed by connection, so a client that hits a limit
 can reconnect for a fresh allowance. They bound the damage of any single
-connection. Configure `with_connection_rate_per_ip` to bound reconnect churn
+connection. Configure `with_connection_rate_per_ip` to limit repeated reconnects
 from one peer IP, and retain infrastructure-level controls (load balancer
 connection/request limits, WAF rules) against attackers rotating source
 addresses.
 
-## Origin checking and authentication
+## Check origins and authenticate
 
 - `with_allowed_origins` on the Mist transport rejects browser connections
   from unexpected origins before the WebSocket handshake.
-- `with_on_connect` authenticates the connection once, before upgrade —
+- `with_on_connect` authenticates the connection once, before upgrade.
   reject unauthenticated clients with a 403 rather than at join time.
 - Authorize each topic in your update's `Join` arm; clients cannot
   send events to topics they have not joined.
 
-## Erlang cluster security boundary
+<a id="erlang-cluster-security-boundary"></a>
+
+## Secure the Erlang cluster
 
 Beryl PubSub and presence replication use Erlang distribution. Trust every
 connected peer. Erlang peers can run arbitrary code on connected nodes. A
@@ -136,17 +139,17 @@ internal traffic, and presence state are only part of that access. Channel
 authorization and WebSocket controls do not apply to distribution messages.
 They protect only WebSocket clients.
 
-### Internal vs. client messages
+### Trust for client and cluster traffic
 
-| Source | Trust level | Gated by |
+| Source | Trust level | Protected by |
 |---|---|---|
 | WebSocket clients | Untrusted | `with_on_connect` authentication, `Join` authorization, and `Message` handling in `update` |
 | Erlang distribution peers | Fully trusted | Network isolation + mutually verified TLS distribution (cookies prevent accidental cross-cluster connections only) |
 
 All distributed BEAM applications need network isolation and secure
-distribution. Beryl assumes that you enforce this boundary.
+distribution. Beryl assumes that you enforce this trust boundary.
 
-### Erlang cookie
+### The Erlang cookie does not secure distribution
 
 Set a long, randomly generated cookie in `vm.args` or the
 `RELEASE_COOKIE` environment variable. Erlang
@@ -154,7 +157,7 @@ Set a long, randomly generated cookie in `vm.args` or the
 and prevent accidental cross-cluster connections; its handshake is not
 cryptographically secure authentication against an adversary. A strong cookie
 prevents accidental matches and makes offline guessing harder, but it must
-never be the security boundary. Keep distribution ports isolated and use
+never be the security control. Keep distribution ports isolated and use
 mutually verified TLS distribution.
 
 Generate a strong cookie with, for example:
@@ -163,7 +166,7 @@ Generate a strong cookie with, for example:
 openssl rand -base64 48
 ```
 
-### TLS distribution
+### Use mutually verified TLS distribution
 
 Use TLS distribution with mutual certificate verification for secure
 multi-node deployments, including traffic within private networks. See the
@@ -186,22 +189,22 @@ port to a known value for simpler rules:
 Or set `ERL_DIST_PORT` when using Elixir/Mix releases. Restrict both 4369
 and your chosen distribution port at the network layer.
 
-### Do not share clusters with untrusted tenants
+### Keep untrusted nodes outside the cluster
 
 Adding a node to a cluster lets it run arbitrary code on connected nodes. It
 can also access all `pg` groups and presence state. Do not connect beryl to
-nodes outside your trust boundary.
+nodes you do not trust.
 
 See [SECURITY.md](https://github.com/tylerbutler/beryl/blob/main/SECURITY.md)
-for the full trust-boundary and distribution-hardening reference.
+for the full distribution security reference.
 
-## Operational notes
+## Runtime capacity
 
-- The runtime uses one router actor per channels system and one actor per
-  connected socket. The transport sheds oversized frames and, when configured,
-  rate-limited traffic before routing. Extreme fan-out workloads may want
-  multiple channels systems sharded by topic space so one router does not
-  handle every subscriber.
+- The runtime uses one router actor per channel system and one actor per
+  connected socket. The transport drops oversized frames and, when configured,
+  over-rate traffic before routing. Applications that send one event to
+  many subscribers may need several channel systems divided by topic so one
+  router does not handle every subscriber.
 - The runtime always starts supervised (`child_spec` has no unsupervised
   mode); restarts are bounded at 3 per 5 seconds, after which the crash
   propagates to the process that called `child_spec`. See the

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -1,9 +1,10 @@
 ---
 title: PubSub
+description: Publish typed messages to topic subscribers on one or more connected Erlang nodes.
 ---
 
-beryl's PubSub layer uses Erlang `pg` process groups for distributed publish
-and subscribe messaging.
+beryl's PubSub API uses Erlang `pg` process groups. Publishers send messages
+to a topic, and each process subscribed to that topic receives them.
 
 ## Starting PubSub
 
@@ -21,13 +22,13 @@ The scope maps to a `pg` scope atom and identifies the PubSub instance.
 Different scopes are isolated and can use different payload types in one
 process mailbox. All handles in one scope must use the same payload type.
 
-:::danger[The scope must be a static, bounded deployment value]
+:::danger[Use a fixed scope name]
 The scope name is converted to an Erlang atom. Atoms are never
 garbage-collected; exhausting the BEAM atom table crashes the VM. The scope
-must be a static, bounded deployment or configuration value — never raw
-user-derived, per-request, per-tenant, database-derived, or otherwise
-unbounded high-cardinality runtime input. A deployment-controlled value is
-acceptable only when validated or selected from a fixed bounded set.
+must be a fixed deployment or configuration value. Never use a value from a
+request, tenant, database row, or any other source that can create unlimited
+names. A deployment-controlled value is safe only when you validate it or
+select it from a fixed set.
 :::
 
 ## Subscribing
@@ -52,9 +53,9 @@ PubSub records arrive as raw BEAM messages. `selecting` validates their types
 and matches the subscriber scope. One process can select subscribers with
 different payload types if their scopes differ.
 
-## Messages
+## Message format
 
-Subscribers receive transparent `Message(payload)` records:
+Subscribers receive typed `Message(payload)` records:
 
 ```gleam
 pub type Message(payload) {
@@ -84,7 +85,7 @@ accept old and new nodes concurrently.
 runtimes do not send the message to that socket. Thus,
 `beryl.broadcast_from` excludes the sender across cluster nodes.
 
-## Broadcasting
+## Send broadcasts
 
 ```gleam
 import gleam/json
@@ -119,7 +120,7 @@ Use `broadcast_from_socket` to send to all cluster subscribers except one
 socket. The socket can be on another node. `beryl.broadcast_from` calls this
 function.
 
-## Querying subscribers
+## List subscribers
 
 ```gleam
 // All subscribers across all nodes
@@ -129,7 +130,7 @@ let pids = pubsub.subscribers(ps, "room:lobby")
 let count = pubsub.subscriber_count(ps, "room:lobby")
 ```
 
-## Distributed operation
+## Use PubSub across Erlang nodes
 
 Erlang `pg` works across connected nodes. After your application establishes
 Erlang distribution between the nodes, `pg` merges their process groups and
@@ -141,7 +142,7 @@ on one BEAM node. [Issue #365](https://github.com/tylerbutler/beryl/issues/365)
 tracks integration coverage across separate distributed Erlang nodes for
 PubSub delivery and presence convergence.
 
-## Integration with beryl channels
+## Use PubSub with Beryl
 
 The channel system uses PubSub internally for distributed broadcasts when configured:
 
@@ -161,6 +162,6 @@ beryl.broadcast(channels, "room:lobby", "event", payload)
 
 ## Next steps
 
-- [Supervision guide](/guides/supervision/) — supervised startup and multi-node deployment checklist
-- [Architecture overview](/architecture/overview/) — how PubSub fits into the beryl layer diagram
-- [Troubleshooting](/troubleshooting/#pubsub-cluster-issues) — diagnosing cluster broadcast failures and diverging presence state
+- [Supervision guide](/guides/supervision/): supervised startup and multi-node deployment
+- [Architecture overview](/architecture/overview/): PubSub's place in Beryl
+- [Troubleshooting](/troubleshooting/#broadcasts-fail-across-erlang-nodes): diagnose cluster broadcast failures and different presence state across nodes

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -142,7 +142,7 @@ on one BEAM node. [Issue #365](https://github.com/tylerbutler/beryl/issues/365)
 tracks integration coverage across separate distributed Erlang nodes for
 PubSub delivery and presence convergence.
 
-## Use PubSub with Beryl
+## Use PubSub with beryl
 
 The channel system uses PubSub internally for distributed broadcasts when configured:
 

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -134,7 +134,7 @@ let count = pubsub.subscriber_count(ps, "room:lobby")
 
 Erlang `pg` works across connected nodes. After your application establishes
 Erlang distribution between the nodes, `pg` merges their process groups and
-sends messages to subscribers across the cluster. Beryl PubSub needs no
+sends messages to subscribers across the cluster. beryl PubSub needs no
 additional configuration, but it does not connect the nodes for you.
 
 Automated tests currently exercise distributed behavior with multiple actors
@@ -163,5 +163,5 @@ beryl.broadcast(channels, "room:lobby", "event", payload)
 ## Next steps
 
 - [Supervision guide](/guides/supervision/): supervised startup and multi-node deployment
-- [Architecture overview](/architecture/overview/): PubSub's place in Beryl
+- [Architecture overview](/architecture/overview/): PubSub's place in beryl
 - [Troubleshooting](/troubleshooting/#broadcasts-fail-across-erlang-nodes): diagnose cluster broadcast failures and different presence state across nodes

--- a/website/src/content/docs/guides/supervision.md
+++ b/website/src/content/docs/guides/supervision.md
@@ -1,5 +1,6 @@
 ---
 title: Supervision
+description: Add Beryl processes to an OTP supervisor and understand restart and shutdown behavior.
 ---
 
 Beryl has no unsupervised mode. `beryl.child_spec` returns a stable `Sockets`
@@ -8,7 +9,7 @@ OTP supervisor. The specification contains your `init` and `update` functions.
 `channel.child_spec` returns the same handle and specification shape. It first
 converts the handler table to a core `init` and `update` pair.
 
-## What child_spec supervises
+## Processes in the child specification
 
 ```text
 beryl internal supervisor (one-for-one, 3 restarts / 5 seconds)
@@ -21,7 +22,7 @@ transport connection
 
 - The **router actor** maintains the socket actor table and topic subscriber
   index. If the router crashes, the supervisor restarts it. The child
-  specification still contains the `init` and `update` closures.
+  specification still contains the `init` and `update` functions.
 - Each **socket actor** holds one model and sends events to your `update`
   function. Socket actors are not supervisor children. The transport starts
   them, and the router monitors them.
@@ -34,7 +35,7 @@ transport connection
 After **3 restarts in 5 seconds** the internal supervisor gives up and the
 failure propagates through your application's supervision tree.
 
-## What a restart means for your app
+## Runtime restarts close connections
 
 A runtime restart drops **per-socket state**: models, joined topics, and
 pending joins. Transports monitor the runtime that accepted each connection,
@@ -51,24 +52,24 @@ crashes and limits their effect:
 | `update` on `Info` | The socket is torn down |
 | `update` on `Closed` | Logged; the close completes anyway |
 
-Each socket's callbacks run in its socket actor. Letting a callback crash that
-actor would close every topic on that socket. Beryl catches a callback crash
-when it can discard the result and close a smaller safe scope. Other socket
+Each socket's callbacks run in its socket actor. A callback crash in that actor
+would close every topic on the socket. Beryl catches a callback crash when it
+can discard the result and close only the affected topic or socket. Other socket
 actor faults close only that socket, and the router removes its entries. A
 router fault reaches the supervisor and closes all connections. See
-[Runtime crash containment](/architecture/runtime/#crash-containment).
+[What closes after a callback panic](/architecture/runtime/#what-closes-after-a-callback-crash).
 
 See the [Error Handling guide](/guides/error-handling/) for details.
 
 For channel callbacks, those rows map to `join`, `on_message`, `on_info`, and
 `on_terminate`. A terminate panic loses that callback's actions but does not
 stop sibling-channel teardown; see
-[Crash behavior](/guides/channels/#crash-behavior).
+[When callbacks panic](/guides/channels/#when-callbacks-panic).
 
-## Presence and groups
+## Supervise presence and groups
 
 `presence.child_spec` and `group.child_spec` return stable handles and child
-specifications, just like the socket runtime. Add all three specifications to
+specifications, as the socket runtime does. Add all three specifications to
 your application supervisor:
 
 ```gleam
@@ -111,8 +112,8 @@ restart. Presence entries and tracking refs, and group definitions and
 memberships, are in-memory state and reset when their actor restarts.
 
 :::note[PubSub is not supervised]
-`beryl/pubsub` is backed by Erlang's `pg` module, whose lifecycle is
-managed by the BEAM runtime. Configure it with `beryl.with_pubsub`.
+`beryl/pubsub` uses Erlang's `pg` module, which the BEAM runtime manages.
+Configure it with `beryl.with_pubsub`.
 :::
 
 ## Startup errors
@@ -130,7 +131,7 @@ case beryl.child_spec(config, init: init, update: update) {
 }
 ```
 
-## Stopping
+## Stop the runtime
 
 `beryl.stop(channels)` sends a `Closed` event to each joined topic. It closes
 transport connections and stops the runtime without a restart. A second call
@@ -142,5 +143,5 @@ returns `Error(NotRunning)`. Other operations after `stop` do nothing.
 - Add application-owned presence and group child specifications alongside the
   Beryl child.
 - Configure PubSub when running more than one BEAM node.
-- Configure rate limits to protect against runaway clients — see
+- Configure rate limits to protect against faulty or hostile clients. See
   [Production Hardening](/guides/production-hardening/).

--- a/website/src/content/docs/guides/supervision.md
+++ b/website/src/content/docs/guides/supervision.md
@@ -1,9 +1,9 @@
 ---
 title: Supervision
-description: Add Beryl processes to an OTP supervisor and understand restart and shutdown behavior.
+description: Add beryl processes to an OTP supervisor and understand restart and shutdown behavior.
 ---
 
-Beryl has no unsupervised mode. `beryl.child_spec` returns a stable `Sockets`
+beryl has no unsupervised mode. `beryl.child_spec` returns a stable `Sockets`
 handle and a child specification. Add the specification to your application's
 OTP supervisor. The specification contains your `init` and `update` functions.
 `channel.child_spec` returns the same handle and specification shape. It first
@@ -41,7 +41,7 @@ A runtime restart drops **per-socket state**: models, joined topics, and
 pending joins. Transports monitor the runtime that accepted each connection,
 so those WebSockets close and clients reconnect and rejoin normally.
 
-Crashes inside `update` do **not** restart the runtime. Beryl catches callback
+Crashes inside `update` do **not** restart the runtime. beryl catches callback
 crashes and limits their effect:
 
 | Crash site | Effect |
@@ -53,7 +53,7 @@ crashes and limits their effect:
 | `update` on `Closed` | Logged; the close completes anyway |
 
 Each socket's callbacks run in its socket actor. A callback crash in that actor
-would close every topic on the socket. Beryl catches a callback crash when it
+would close every topic on the socket. beryl catches a callback crash when it
 can discard the result and close only the affected topic or socket. Other socket
 actor faults close only that socket, and the router removes its entries. A
 router fault reaches the supervisor and closes all connections. See
@@ -141,7 +141,7 @@ returns `Error(NotRunning)`. Other operations after `stop` do nothing.
 
 - Add the returned specification to your long-lived application supervisor.
 - Add application-owned presence and group child specifications alongside the
-  Beryl child.
+  beryl child.
 - Configure PubSub when running more than one BEAM node.
 - Configure rate limits to protect against faulty or hostile clients. See
   [Production Hardening](/guides/production-hardening/).

--- a/website/src/content/docs/guides/websocket.md
+++ b/website/src/content/docs/guides/websocket.md
@@ -42,7 +42,7 @@ fn handle_request(
 The `upgrade` function checks the request path. It upgrades a matching request
 and connects it to the beryl runtime.
 
-The transport works with both Beryl APIs. A handle from
+The transport works with both beryl APIs. A handle from
 `channel.child_spec` is the same `beryl.Sockets` type as one from
 `beryl.child_spec`, so the setup is identical for both.
 
@@ -184,7 +184,7 @@ Applications can pass a custom codec to `beryl.config(codec)`. The codec can
 use another text or binary message format. The transport sends each outbound
 frame as the type that the codec returns.
 
-`wire.phoenix_codec()` uses Beryl's Phoenix wire implementation and adds no
+`wire.phoenix_codec()` uses beryl's Phoenix wire implementation and adds no
 dependencies. The public `beryl/wire/codec.Codec` API and wire format are
 stable, so applications can supply a codec for another message format.
 
@@ -305,7 +305,7 @@ throttles them together. In that setup:
 - Terminate connections directly (no intermediary) if you want beryl's built-in
   per-IP limit to apply to individual clients.
 
-Beryl does not have a trusted-proxy option that reads a client IP from a
+beryl does not have a trusted-proxy option that reads a client IP from a
 forwarded header only when the immediate peer is trusted. Treat
 `X-Forwarded-For` as untrusted input.
 

--- a/website/src/content/docs/guides/websocket.md
+++ b/website/src/content/docs/guides/websocket.md
@@ -1,11 +1,12 @@
 ---
-title: WebSocket Transport
+title: Use the Mist WebSocket Transport
+description: Upgrade Mist requests to WebSockets, authenticate connections, and use the Phoenix wire protocol.
 ---
 
 beryl provides a WebSocket transport for
 [Mist](https://hexdocs.pm/mist/) browser connections.
 
-## Basic setup
+## Add WebSocket upgrades
 
 Use `mist_transport.upgrade` to add WebSocket support:
 
@@ -41,9 +42,9 @@ fn handle_request(
 The `upgrade` function checks the request path. It upgrades a matching request
 and connects it to the beryl runtime.
 
-The transport is layer-agnostic. A handle from
+The transport works with both Beryl APIs. A handle from
 `channel.child_spec` is the same `beryl.Sockets` type as one from
-`beryl.child_spec`, so this wiring is identical for both.
+`beryl.child_spec`, so the setup is identical for both.
 
 :::tip[Phoenix JS clients]
 The Phoenix JS client (`new Socket("/socket", ...)`) adds `/websocket` to the
@@ -57,7 +58,7 @@ server.default_config("/socket/websocket")
 Raw WebSocket clients connect directly to the configured path with no suffix appended.
 :::
 
-## Authentication
+## Authenticate before the upgrade
 
 Use `with_on_connect` to authenticate a connection before the upgrade. It is
 similar to Phoenix `UserSocket.connect/3`. The hook runs once for each socket
@@ -79,12 +80,12 @@ use <- mist_transport.upgrade(req, channels, ws_config)
 
 Return `Error(server.ConnectRejected)` to send HTTP 403 before the WebSocket
 upgrade. See
-[Connection-level authentication rejection](/guides/error-handling#connection-level-authentication-rejection)
+[Reject a connection during authentication](/guides/error-handling#reject-a-connection-during-authentication)
 for the client error. See
 [Authentication failures](/troubleshooting#authentication-failures) for
 diagnostic steps.
 
-### Origin validation and CSWSH
+### Block Cross-Site WebSocket Hijacking (CSWSH)
 
 Browsers include cookies on WebSocket handshakes. If your socket authentication
 uses cookies, a malicious site can open a WebSocket to your application from a
@@ -112,23 +113,22 @@ If you cannot use an origin allow-list, avoid cookie-based WebSocket
 authentication. Use a token passed explicitly to `on_connect` and reject invalid
 tokens before upgrading.
 
-### Connect-time data and the ConnectSeed
+### Read request data from `ConnectSeed`
 
 `on_connect` accepts or rejects the upgrade. The transport puts the request
 path, query parameters, and headers in a `ConnectSeed`, and your `init`
 function receives it as `ConnectInfo.seed`:
 
-| Field | Type | Contents |
+| Field | Type | Description |
 | --- | --- | --- |
 | `path` | `String` | The request path the client connected to. |
 | `query` | `List(#(String, String))` | Parsed query parameters. |
 | `headers` | `List(#(String, String))` | Request headers. |
 | `metadata` | `List(#(String, String))` | Whatever `on_connect` returned. |
 
-`on_connect` does not return a bare `Ok(Nil)` — it returns `Ok(metadata)`, a
-list of string pairs that reaches `init` as `seed.metadata`. Resolve the
-identity once during the handshake, hand the result forward, and `init` reads
-it instead of decoding the request a second time:
+`on_connect` does not return `Ok(Nil)`. It returns `Ok(metadata)`, a
+list of string pairs that reaches `init` as `seed.metadata`. Resolve the identity once during the handshake and return it as metadata.
+Then `init` can read it instead of decoding the request again:
 
 ```gleam
 let ws_config =
@@ -143,7 +143,7 @@ let ws_config =
 ```
 
 ```gleam
-// init reads what on_connect already resolved — no second decode.
+// init reads what on_connect already resolved. It does not decode again.
 beryl.child_spec(
   config,
   init: fn(info: socket.ConnectInfo(Msg)) {
@@ -166,13 +166,13 @@ than a secret.
 With the channel layer, the same seed arrives in every handler's `join`
 callback as `channel.JoinContext.seed`, metadata included; there is no
 app-level `init`. See
-[Authentication with the channel layer](/guides/authentication/#with-the-channel-layer).
+[Authentication with `beryl/channel`](/guides/authentication/#use-authentication-with-berylchannel).
 
 :::tip[Troubleshooting connections]
 If clients cannot connect, see [Clients cannot connect at all](/troubleshooting#clients-cannot-connect-at-all) for path mismatch, reverse proxy, and upgrade header checks.
 :::
 
-## Wire protocol
+## Choose the wire protocol
 
 Pass `wire.phoenix_codec()` to `beryl.config` to use the Phoenix JSON array format:
 
@@ -181,12 +181,14 @@ Pass `wire.phoenix_codec()` to `beryl.config` to use the Phoenix JSON array form
 ```
 
 Applications can pass a custom codec to `beryl.config(codec)`. The codec can
-use another text framing or binary framing. The transport sends each outbound
+use another text or binary message format. The transport sends each outbound
 frame as the type that the codec returns.
 
-`wire.phoenix_codec()` uses Beryl's native Phoenix wire implementation, which has no extra dependencies. The public `beryl/wire/codec.Codec` API and wire format are stable, so applications can supply their own codec to `beryl.config` for alternative framings.
+`wire.phoenix_codec()` uses Beryl's Phoenix wire implementation and adds no
+dependencies. The public `beryl/wire/codec.Codec` API and wire format are
+stable, so applications can supply a codec for another message format.
 
-| Field | Type | Description |
+| Field | JSON type | Description |
 |-------|------|-------------|
 | `join_ref` | `string \| null` | Reference from the join (for reply routing) |
 | `ref` | `string \| null` | Unique message reference (for reply matching) |
@@ -194,9 +196,9 @@ frame as the type that the codec returns.
 | `event` | `string` | Event name (e.g., `"phx_join"`, `"new_message"`) |
 | `payload` | `any` | JSON payload |
 
-### System events
+### Phoenix protocol events
 
-| Event | Direction | Description |
+| Event | Direction | Purpose |
 |-------|-----------|-------------|
 | `phx_join` | Client -> Server | Join a channel |
 | `phx_leave` | Client -> Server | Leave a channel |
@@ -205,7 +207,7 @@ frame as the type that the codec returns.
 | `phx_error` | Server -> Client | Error notification |
 | `phx_close` | Server -> Client | Channel closed |
 
-### Example: join flow
+### Join request and reply
 
 Client sends:
 ```json
@@ -217,14 +219,15 @@ Server replies:
 ["1", "1", "room:lobby", "phx_reply", {"status": "ok", "response": {}}]
 ```
 
-## Connection lifecycle
+## Connection steps
 
 1. Client connects via WebSocket to the configured path
-2. `on_connect` callback runs (if configured) — reject returns 403
+2. The `on_connect` callback runs, if configured. Rejection returns HTTP 403.
 3. The transport connection process builds the `ConnectSeed`, generates a
    unique socket ID, and starts a socket actor. The router admits and monitors
    that actor, which runs your `init`.
-4. Client sends `phx_join` messages to subscribe to topics — each arrives at `update` as a `Join` event
+4. The client sends `phx_join` messages to subscribe to topics. Each one
+   arrives at `update` as a `Join` event.
 5. Messages are routed through the runtime to `update` as `Message` events
 6. On disconnect, `update` receives a `Closed` event for every joined topic
 
@@ -246,7 +249,7 @@ let config =
   )
 ```
 
-## Rate limiting
+## Limit inbound traffic
 
 Protect against flood attacks with built-in rate limiting:
 
@@ -259,18 +262,18 @@ let config =
   |> beryl.with_channel_rate(per_second: 50, burst: 100)
 ```
 
-| Limiter | Scope | Enforced |
+| Limiter | Applies to | Enforced at |
 |---------|-------|----------|
-| `frame_rate` | Per connection, all complete frames | Transport edge |
+| `frame_rate` | Per connection, all complete frames | Transport, before decode |
 | `message_rate` | Per socket, decoded non-join traffic | Runtime |
 | `join_rate` | Per socket, joins | Runtime |
 | `channel_rate` | Per socket+topic | Runtime |
-| `topic_rates` | Pattern-scoped override of `channel_rate` | Runtime |
+| `topic_rates` | Topics matching a pattern; overrides `channel_rate` | Runtime |
 
 Frame and message buckets are independent. Malformed frames and joins consume
 frame tokens; joins do not consume message tokens.
 
-## Per-IP connection controls
+## Limit connections by IP address
 
 Cap both the connection-attempt rate and the number of concurrent connections
 a single client IP may hold. Both controls default to unlimited.
@@ -293,22 +296,22 @@ Both controls use the **socket peer IP**, which is the TCP address that Mist
 accepts. beryl does not trust forwarded headers such as `X-Forwarded-For`.
 Clients can forge these headers and bypass the limit.
 
-This has an important consequence when beryl runs **behind a reverse proxy or
+This affects beryl when it runs **behind a reverse proxy or
 load balancer** (nginx, HAProxy, a cloud LB, etc.): every connection arrives
 from the proxy's IP, so a per-IP limit sees all clients as one address and
-throttles them collectively. In that topology:
+throttles them together. In that setup:
 
 - Enforce per-IP limits at the proxy layer, where the real client IP is known, or
 - Terminate connections directly (no intermediary) if you want beryl's built-in
   per-IP limit to apply to individual clients.
 
-A built-in trusted-proxy opt-in (to derive the client IP from a forwarded header
-only when the immediate peer is a configured trusted proxy) may be added in a
-future release. Until then, treat `X-Forwarded-For` as untrusted input.
+Beryl does not have a trusted-proxy option that reads a client IP from a
+forwarded header only when the immediate peer is trusted. Treat
+`X-Forwarded-For` as untrusted input.
 
 ## Next steps
 
-- [Error Handling guide](/guides/error-handling/) — rejected joins, malformed frames, and client-visible error shapes
-- [Channels guide](/guides/channels/) — the same transport in front of the channel layer
-- [Supervision guide](/guides/supervision/) — the built-in runtime supervision and restart semantics
-- [Troubleshooting](/troubleshooting/) — symptom-first diagnosis for connection, join, and message delivery failures
+- [Error Handling guide](/guides/error-handling/): rejected joins, malformed frames, and client errors
+- [Channels guide](/guides/channels/): use the transport with the channel layer
+- [Supervision guide](/guides/supervision/): understand runtime restarts and shutdown
+- [Troubleshooting](/troubleshooting/): diagnose connection, join, and message delivery failures

--- a/website/src/content/docs/guides/websocket.md
+++ b/website/src/content/docs/guides/websocket.md
@@ -1,5 +1,5 @@
 ---
-title: Use the Mist WebSocket Transport
+title: Use the Mist WebSocket transport
 description: Upgrade Mist requests to WebSockets, authenticate connections, and use the Phoenix wire protocol.
 ---
 
@@ -85,7 +85,7 @@ for the client error. See
 [Authentication failures](/troubleshooting#authentication-failures) for
 diagnostic steps.
 
-### Block Cross-Site WebSocket Hijacking (CSWSH)
+### Block cross-site WebSocket hijacking (CSWSH)
 
 Browsers include cookies on WebSocket handshakes. If your socket authentication
 uses cookies, a malicious site can open a WebSocket to your application from a

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -23,7 +23,7 @@ hero:
 
 import { Aside } from '@astrojs/starlight/components';
 
-## Get started
+## Build your first beryl app
 
 <style lang="css">{`
   /* Contained surface module so the ordered path reads as a distinct block,
@@ -109,7 +109,7 @@ import { Aside } from '@astrojs/starlight/components';
 	</ol>
 </div>
 
-## Features
+## What beryl provides
 
 <style lang="css">{`
   /* Deliberately splash-only: this block ships inline with this page, so the
@@ -225,23 +225,23 @@ import { Aside } from '@astrojs/starlight/components';
 
 <div class="beryl-features">
 	<article class="beryl-feature beryl-feature--lead">
-		<h3>Channels, or your own router</h3>
+		<h3>Choose handlers or one update function</h3>
 		<p>Register one handler for each topic pattern. <code>beryl/channel</code> routes each event to the correct channel. Each channel keeps private, typed state. You can also route all events in one typed <code>update</code> function.</p>
 		<a class="beryl-feature__link" href="/choosing-an-api/">Choose an API →</a>
 	</article>
 	<article class="beryl-feature">
-		<h3>Presence tracking</h3>
-		<p>Track connected users with a CRDT. The add-wins observed-remove set resolves concurrent joins and leaves across nodes.</p>
+		<h3>Track who is connected</h3>
+		<p>Track connected users across Erlang nodes. A conflict-free replicated data type (CRDT) resolves joins and leaves that happen at the same time.</p>
 		<a class="beryl-feature__link" href="/guides/presence/">Presence guide →</a>
 	</article>
 	<article class="beryl-feature">
-		<h3>PubSub on OTP</h3>
-		<p>Erlang <code>pg</code> process groups provide distributed publish and subscribe. Connected cluster nodes need no extra message broker.</p>
+		<h3>Broadcast across Erlang nodes</h3>
+		<p>Send events between connected Erlang nodes through <code>pg</code> process groups. You do not need a separate message broker.</p>
 		<a class="beryl-feature__link" href="/guides/pubsub/">PubSub guide →</a>
 	</article>
 	<article class="beryl-feature">
-		<h3>Phoenix-compatible wire</h3>
-		<p>Configure beryl's Phoenix codec to use Phoenix client libraries and JSON array framing. Mist and Ewe provide WebSocket transports. Phoenix users can <a href="/guides/coming-from-phoenix/">compare the concepts</a>.</p>
+		<h3>Use Phoenix clients</h3>
+		<p>Use beryl's Phoenix codec with Phoenix client libraries. Mist and Ewe connect beryl to a WebSocket server. Phoenix users can <a href="/guides/coming-from-phoenix/">compare the concepts</a>.</p>
 		<a class="beryl-feature__link" href="/guides/websocket/">WebSocket guide →</a>
 	</article>
 </div>

--- a/website/src/content/docs/installation.md
+++ b/website/src/content/docs/installation.md
@@ -85,7 +85,7 @@ data did not match any variant of untagged enum Requirement
 If you see `data did not match any variant of untagged enum Requirement`,
 upgrade Gleam.
 
-## Choosing a ref
+## Pin a Git ref
 
 The example uses `main`, which matches these docs. The branch can change without
 warning. Check [GitHub Releases](https://github.com/tylerbutler/beryl/releases).
@@ -94,7 +94,7 @@ When one tag contains all required packages, replace `main` with that tag.
 Gleam resolves Git dependencies at the specified ref. Use the same ref for
 `beryl` and its transport package. Do not mix versions.
 
-## Dependencies
+## Packages installed with beryl
 
 beryl brings in these Gleam packages automatically:
 

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -12,7 +12,7 @@ beryl is a **type-safe real-time channels and presence library** for Gleam,
 for the Erlang (BEAM) runtime. It helps you add real-time features to Gleam web
 applications.
 
-## Why beryl?
+## Realtime features beryl handles
 
 Real-time features must coordinate state across many connected clients. These
 features include chat rooms, live cursors, shared editing, and presence
@@ -20,14 +20,17 @@ indicators. beryl provides:
 
 - **Channels:** Register one handler for each topic pattern. Each channel keeps
   private, typed state and a server-side message type (`beryl/channel`).
-- **App-side dispatch:** Route all socket events in one typed `update` function.
+- **Raw dispatch:** Route all socket events in one typed `update` function.
   Match topic patterns such as `"room:*"`.
-- **Presence:** Track connected users across nodes with a conflict-free CRDT.
-- **PubSub:** Publish and subscribe across nodes with Erlang `pg` process groups.
+- **Presence:** Track connected users across Erlang nodes, even when joins and
+  leaves happen at the same time.
+- **PubSub:** Broadcast events across Erlang nodes with built-in `pg` process
+  groups.
 - **Groups:** Put topics in named groups for multi-topic broadcasts.
-- **WebSocket transport:** Use Mist or Ewe with a pluggable wire codec.
+- **WebSocket servers:** Connect through Mist or Ewe and choose how beryl
+  encodes messages.
 
-## Two layers, one runtime
+## Choose handlers or one update function
 
 beryl ships one runtime and two ways to program it.
 
@@ -43,7 +46,7 @@ let assert Ok(#(sockets, spec)) =
   )
 ```
 
-**Raw app-side dispatch** (`beryl`) is the core API. Pass one `init` and
+**Raw dispatch** (`beryl`) is the core API. Pass one `init` and
 `update` pair to `beryl.child_spec`. Use this API for one topic family or for
 full control of routing and effect order:
 
@@ -56,12 +59,12 @@ let assert Ok(#(sockets, spec)) =
   )
 ```
 
-Both APIs use the same runtime, wire codec, presence, PubSub, and abuse
-controls. Add either child specification to your application's supervision
+Both APIs use the same socket processes, message format, presence, PubSub,
+connection limits, and rate limits. Add either child specification to your application's supervision
 tree. The channel layer uses only beryl's public API. See
 [Choose an API](/choosing-an-api/) for a comparison.
 
-## Design principles
+## How beryl keeps socket code safe
 
 ### Type safety first
 
@@ -100,19 +103,19 @@ fn update(model: Model, ev: socket.Input(Nil)) -> socket.Next(Model) {
 }
 ```
 
-### Built on OTP
+### One process per socket
 
 Each `beryl.Sockets` handle identifies one router actor and one actor for each
 connected socket. The socket actor owns that socket's model and runs its
 callbacks, while the router maintains the socket and topic indexes. A separate
 OTP actor manages the presence CRDT. PubSub uses Erlang `pg`.
 
-### CRDT-backed presence
+### Presence across Erlang nodes
 
-Presence uses an **add-wins observed-remove set** (AWORSet) with causal context.
-This CRDT resolves concurrent joins and leaves across Erlang nodes.
+Presence uses a conflict-free replicated data type (CRDT). It resolves joins
+and leaves that happen at the same time on different Erlang nodes.
 
-### Focused dependencies
+### Installed packages
 
 The core library depends on `gleam_stdlib`, `gleam_erlang`, `gleam_otp`,
 `gleam_json`, `gleam_crypto`, `lattice_presence`, and `palabres`. A WebSocket
@@ -120,7 +123,7 @@ transport such as `beryl_mist` adds `mist` and `gleam_http`. The core package
 includes `beryl/channel`. beryl does not require an external message broker or
 database.
 
-### Phoenix wire protocol compatibility
+### Phoenix client compatibility
 
 The built-in `wire.phoenix_codec()` uses the Phoenix Channels JSON array
 format: `[join_ref, ref, topic, event, payload]`. Existing Phoenix client
@@ -132,7 +135,7 @@ modules, callbacks, and assigns with both beryl APIs.
 
 - [Choose an API](/choosing-an-api/) — channel layer or raw dispatch
 - [Quick Start](/quick-start/) — get a working server in minutes
-- [Channels guide](/guides/channels/) — handler tables, typed state, actions, and lifecycle
+- [Channels guide](/guides/channels/) — handlers, typed state, actions, and close behavior
 - [Dispatch guide](/guides/dispatch/) — route topics, messages, and close events in one app
 - [Supervision guide](/guides/supervision/) — production startup with OTP supervision
 - [Error Handling guide](/guides/error-handling/) — rejected joins, rate limits, and more

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -1,5 +1,5 @@
 ---
-title: Quick Start
+title: Quick start
 description: Build a beryl socket app with a channel handler, WebSocket transport, and Phoenix JS client.
 ---
 
@@ -101,7 +101,7 @@ pub fn channel() -> channel.Handler {
 }
 ```
 
-<Aside type="note" title="Reply vs Push vs Broadcast">
+<Aside type="note" title="Reply vs. push vs. broadcast">
 Each action applies to the channel's topic. The runtime applies actions in list order.
 - **`channel.reply_ok` / `channel.reply_error`:** Send `phx_reply` to the calling client. The reply uses the ref from `message.reply`.
 - **`channel.push`:** Send a named event only to this socket.

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -13,7 +13,7 @@ This guide shows how to build a real-time app. You will create a Gleam server
 with the **channel layer** and connect a Phoenix JS browser client.
 
 Use the channel layer by default. For one topic family and full routing control,
-use [raw app-side dispatch](#alternative-raw-app-side-dispatch). The
+use [raw dispatch](#use-raw-dispatch-instead). The
 [Dispatch guide](/guides/dispatch/) has more information. See
 [Choose an API](/choosing-an-api/) for a comparison.
 
@@ -110,7 +110,7 @@ Each action applies to the channel's topic. The runtime applies actions in list 
 - **`channel.stay(state)`:** Continue with no outgoing frames.
 </Aside>
 
-## 2. Start the channel system and wire the transport
+## 2. Start beryl and Mist
 
 Register the handler table. Pass the returned `beryl.Sockets` handle to the
 Mist transport. `beryl.child_spec` returns the same core handle type.
@@ -239,7 +239,7 @@ channel
   });
 ```
 
-## 4. Rejecting a join
+## 4. Reject a join
 
 Return `channel.reject` when a client cannot join a topic. Put join
 authentication, capacity checks, and payload validation in the `join` callback:
@@ -260,7 +260,7 @@ A rejected join does not create a channel instance and does not run
 `on_terminate`. The layer also rejects topics that have no handler. Thus, joins
 fail closed by default.
 
-## Alternative: raw app-side dispatch
+## Use raw dispatch instead
 
 The raw dispatch version passes one `init` and `update` pair to
 `beryl.child_spec`. Your code routes each event.

--- a/website/src/content/docs/reference/api/beryl-error.md
+++ b/website/src/content/docs/reference/api/beryl-error.md
@@ -36,7 +36,7 @@ pub fn describe_start_failure(StartFailure) -> String
 
 ### `from_actor_start_error`
 
-Convert a `gleam/otp/actor.StartError` to Beryl's `StartFailure`.
+Convert a `gleam/otp/actor.StartError` to beryl's `StartFailure`.
 
 ```gleam
 pub fn from_actor_start_error(actor.StartError) -> StartFailure

--- a/website/src/content/docs/reference/api/beryl-group.md
+++ b/website/src/content/docs/reference/api/beryl-group.md
@@ -15,7 +15,7 @@ Channel Groups - Named collections of topics for multi-topic broadcasting
  Useful for scenarios like broadcasting to all channels in a "team" or
  sending a system-wide notification.
 
- Groups are independent of the Beryl runtime and run under your
+ Groups are independent of the beryl runtime and run under your
  application's supervision tree.
 
  ## Example

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -18,7 +18,7 @@ Presence - Distributed presence tracking backed by a CRDT
  - Receives remote state from PubSub and merges it internally
  - Invokes `on_diff` callback when merges produce non-empty diffs
 
- Presence is independent of the Beryl runtime and runs under your
+ Presence is independent of the beryl runtime and runs under your
  application's supervision tree.
 
  ## Read consistency
@@ -58,7 +58,7 @@ Presence - Distributed presence tracking backed by a CRDT
 Configuration for starting presence.
 
  Build configurations with `default_config` and the `with_*` functions.
- Beryl can then add options without exposing record fields as public API.
+ beryl can then add options without exposing record fields as public API.
 
 ```gleam
 pub type Config
@@ -68,7 +68,7 @@ pub type Config
 
 An opaque diff representing presence joins and leaves grouped by topic.
 
- Beryl passes this value to `Config.on_diff`.
+ beryl passes this value to `Config.on_diff`.
  `beryl.broadcast_presence_diff` also accepts it.
 
 ```gleam

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -54,7 +54,7 @@ A PubSub message delivered to subscribers.
 
  ## Frozen wire contract
 
- Beryl sends broadcasts **raw between nodes** through `pg` as a five-element
+ beryl sends broadcasts **raw between nodes** through `pg` as a five-element
  tuple. The PubSub scope atom comes first. The four message fields follow in
  order. This scope-tagged runtime shape is the frozen wire contract for each
  `payload` type. The contract also applies to `PubSubFrom`.

--- a/website/src/content/docs/reference/api/beryl-socket.md
+++ b/website/src/content/docs/reference/api/beryl-socket.md
@@ -27,7 +27,7 @@ Types for building app-side dispatch systems with `beryl.child_spec`.
 
  Most effects are applied in one actor turn. `PresenceTrack` and
  `PresenceUntrack` are the exception: they are applied by the presence
- actor. Beryl holds the rest of the list and every later input for that
+ actor. beryl holds the rest of the list and every later input for that
  socket until the mutation has been applied. It then continues exactly
  where it left off. The visible order is unchanged (a
  `PushPresence` after a `PresenceTrack` still sees the track), and the

--- a/website/src/content/docs/reference/api/beryl-stats.md
+++ b/website/src/content/docs/reference/api/beryl-stats.md
@@ -86,7 +86,7 @@ Request a snapshot from the local runtime.
  this function returns `RuntimeUnavailable` or `RequestTimedOut`. An
  overloaded runtime returns `RequestTimedOut`.
  Neither condition panics. This API reports only the node represented by
- `sockets`; aggregate multi-node statistics outside Beryl.
+ `sockets`; aggregate multi-node statistics outside beryl.
 
  Poll no more frequently than roughly once per second.
 

--- a/website/src/content/docs/reference/api/beryl-transport-origin.md
+++ b/website/src/content/docs/reference/api/beryl-transport-origin.md
@@ -99,7 +99,7 @@ pub fn allowed(
 Check a client's requested wire protocol version (the `?vsn=` query
  parameter sent by Phoenix clients) before upgrading.
 
- Beryl uses the Phoenix V2 array framing, so it accepts `vsn=2.x`. A
+ beryl uses the Phoenix V2 array framing, so it accepts `vsn=2.x`. A
  missing `vsn` (`None`) is accepted for non-Phoenix clients speaking the
  configured codec. Anything else (e.g. the V1 object framing's `vsn=1.0.0`)
  is rejected. Transports fail the handshake with `403 Forbidden` instead

--- a/website/src/content/docs/reference/api/beryl-wire-codec.md
+++ b/website/src/content/docs/reference/api/beryl-wire-codec.md
@@ -89,7 +89,7 @@ A binary frame.
 A normalized inbound message.
 
  `Inbound` is opaque: construct it with `inbound` and read it with the
- `inbound_*` accessors. The hidden record lets Beryl add fields with
+ `inbound_*` accessors. The hidden record lets beryl add fields with
  defaults without breaking custom codecs.
 
 ```gleam

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -1,6 +1,6 @@
 ---
 title: "beryl"
-description: "Beryl - Type-safe real-time communication"
+description: "beryl - Type-safe real-time communication"
 ---
 
 <!--
@@ -9,7 +9,7 @@ description: "Beryl - Type-safe real-time communication"
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
 
-Beryl - Type-safe real-time communication
+beryl - Type-safe real-time communication
 
  A standalone Gleam library for building real-time applications on the BEAM.
  Provides app-side WebSocket dispatch, distributed presence tracking,
@@ -74,7 +74,7 @@ Beryl - Type-safe real-time communication
 Configuration for an app-side socket runtime.
 
  This type is opaque. Construct it with `config` and adjust it with the
- `with_*` functions. Beryl can then add configuration options without a
+ `with_*` functions. beryl can then add configuration options without a
  breaking change.
 
 ```gleam
@@ -127,10 +127,10 @@ A per-topic-pattern rate limit used a pattern string that is not a valid
 
 ### `LoggingConfig`
 
-Logging configuration for Beryl diagnostics.
+Logging configuration for beryl diagnostics.
 
  This type is opaque. Construct it with `logging_config` and adjust it with
- the `with_*` functions. Beryl can then add logging options without a
+ the `with_*` functions. beryl can then add logging options without a
  breaking change.
 
 ```gleam
@@ -139,7 +139,7 @@ pub type LoggingConfig
 
 ### `LogLevel`
 
-Logging verbosity for Beryl's internal loggers.
+Logging verbosity for beryl's internal loggers.
 
  The variants carry a `Level` suffix so `ErrorLevel` does not shadow the
  prelude's `Result` `Error` constructor when imported unqualified.
@@ -158,7 +158,7 @@ pub type LogLevel {
 A runtime system handle.
 
  `child_spec` returns this opaque handle with the supervised subtree. Pass
- it to broadcast, group, and transport functions. Beryl hides its internals
+ it to broadcast, group, and transport functions. beryl hides its internals
  so they can change without breaking application code.
 
  The handle is non-generic. An app-side dispatch system is
@@ -172,7 +172,7 @@ pub type Sockets
 
 ### `StopError`
 
-Errors when stopping a Beryl system with [`stop`](#stop).
+Errors when stopping a beryl system with [`stop`](#stop).
 
 ```gleam
 pub type StopError {
@@ -321,7 +321,7 @@ pub fn child_spec(
 
 Build a configuration with sensible defaults.
 
- A `codec` is required. Beryl no longer provides an implicit Phoenix
+ A `codec` is required. beryl no longer provides an implicit Phoenix
  default. Pass `wire.phoenix_codec()` to keep Phoenix wire compatibility,
  or your own `Codec` for a custom framing.
 
@@ -346,7 +346,7 @@ pub fn logging_config(
 
 ### `stop`
 
-Stop a Beryl system.
+Stop a beryl system.
 
  This function drains and stops the supervised runtime. It delivers
  `Closed` to every joined topic before it closes each transport connection.
@@ -414,7 +414,7 @@ Configure a per-IP connection-attempt rate limit.
  `per_second` as the burst capacity.
 
  Unlike per-connection frame and message buckets, this allowance is keyed by
- the real socket peer IP and lives in Beryl's supervised connection limiter.
+ the real socket peer IP and lives in beryl's supervised connection limiter.
  Disconnecting or restarting the app runtime therefore does not refresh it.
  Idle IP buckets are removed once their allowance has fully refilled.
 
@@ -476,7 +476,7 @@ pub fn with_join_rate(
 
 ### `with_logging`
 
-Configure Beryl's internal logging.
+Configure beryl's internal logging.
 
 ```gleam
 pub fn with_logging(
@@ -538,11 +538,11 @@ Configure the maximum number of concurrent connections allowed per client
 
  The limit is enforced on the **real socket peer IP** as reported by the
  transport (for the Mist transport, the address of the TCP connection).
- Beryl does **not** trust or parse forwarded headers such as
+ beryl does **not** trust or parse forwarded headers such as
  `X-Forwarded-For`. A client can set these headers and spoof its address to
  bypass this limit.
 
- If Beryl runs behind a trusted reverse proxy or load balancer, every
+ If beryl runs behind a trusted reverse proxy or load balancer, every
  connection shares the proxy's address, so a per-IP limit throttles all
  clients as a single IP. In that topology you must resolve the real client
  IP yourself at the proxy layer (for example, by enforcing limits there). A
@@ -575,8 +575,8 @@ pub fn with_max_event_length(
 
 Configure the maximum allowed inbound WebSocket frame size in bytes.
 
- Beryl enforces the limit **post-assembly**. The transport (Mist or Ewe)
- buffers and assembles a complete frame first. Beryl then measures it and
+ beryl enforces the limit **post-assembly**. The transport (Mist or Ewe)
+ buffers and assembles a complete frame first. beryl then measures it and
  closes the connection if it exceeds `max_bytes`. This bounds
  per-message processing cost (decode, routing, rate-limit accounting), but
  it does **not** by itself bound transport memory. A hostile client can
@@ -586,8 +586,8 @@ Configure the maximum allowed inbound WebSocket frame size in bytes.
  node memory.
 
  For a true transport memory bound you **must** place an edge proxy or load
- balancer in front of Beryl and configure a WebSocket frame-size limit
- there (and a matching request/body size limit). Beryl's connection,
+ balancer in front of beryl and configure a WebSocket frame-size limit
+ there (and a matching request/body size limit). beryl's connection,
  frame-rate, and message-rate limits all run after frame assembly and do not
  mitigate this vector. See the README's "Security" section.
 

--- a/website/src/content/docs/reference/api/index.md
+++ b/website/src/content/docs/reference/api/index.md
@@ -1,5 +1,5 @@
 ---
-title: API Reference
+title: API reference
 description: API reference generated from Gleam docs metadata.
 ---
 
@@ -15,7 +15,7 @@ This reference uses Gleam docs metadata for `beryl`, `beryl_ewe`, and `beryl_mis
 The generator creates pages under `/reference/api/` from Gleam docs metadata. The pages include each public type, function, and constant. This is beryl's canonical API reference. Install beryl packages from GitHub. They are not on Hex.
 :::
 
-## `beryl` `0.4.1`
+## `beryl` `0.4.0`
 
 | Module | Description |
 |---|---|
@@ -36,13 +36,13 @@ The generator creates pages under `/reference/api/` from Gleam docs metadata. Th
 | [`beryl/wire`](/reference/api/beryl-wire/) | Phoenix Wire Protocol: encoding/decoding helpers and the canonical |
 | [`beryl/wire/codec`](/reference/api/beryl-wire-codec/) | Pluggable wire codec for beryl. |
 
-## `beryl_ewe` `0.2.2`
+## `beryl_ewe` `0.2.1`
 
 | Module | Description |
 |---|---|
 | [`beryl_ewe`](/reference/api/beryl_ewe/) | Ewe WebSocket Transport - Direct Ewe integration for beryl |
 
-## `beryl_mist` `0.3.2`
+## `beryl_mist` `0.3.1`
 
 | Module | Description |
 |---|---|

--- a/website/src/content/docs/reference/api/index.md
+++ b/website/src/content/docs/reference/api/index.md
@@ -15,11 +15,11 @@ This reference uses Gleam docs metadata for `beryl`, `beryl_ewe`, and `beryl_mis
 The generator creates pages under `/reference/api/` from Gleam docs metadata. The pages include each public type, function, and constant. This is beryl's canonical API reference. Install beryl packages from GitHub. They are not on Hex.
 :::
 
-## `beryl` `0.4.0`
+## `beryl` `0.4.1`
 
 | Module | Description |
 |---|---|
-| [`beryl`](/reference/api/beryl/) | Beryl - Type-safe real-time communication |
+| [`beryl`](/reference/api/beryl/) | beryl - Type-safe real-time communication |
 | [`beryl/bridge`](/reference/api/beryl-bridge/) | Bridge - Forward an external OTP actor's message stream to a socket via |
 | [`beryl/channel`](/reference/api/beryl-channel/) | The channel composition surface: a channel is a topic pattern paired |
 | [`beryl/error`](/reference/api/beryl-error/) | Shared beryl-owned error helpers. |
@@ -36,13 +36,13 @@ The generator creates pages under `/reference/api/` from Gleam docs metadata. Th
 | [`beryl/wire`](/reference/api/beryl-wire/) | Phoenix Wire Protocol: encoding/decoding helpers and the canonical |
 | [`beryl/wire/codec`](/reference/api/beryl-wire-codec/) | Pluggable wire codec for beryl. |
 
-## `beryl_ewe` `0.2.1`
+## `beryl_ewe` `0.2.2`
 
 | Module | Description |
 |---|---|
 | [`beryl_ewe`](/reference/api/beryl_ewe/) | Ewe WebSocket Transport - Direct Ewe integration for beryl |
 
-## `beryl_mist` `0.3.1`
+## `beryl_mist` `0.3.2`
 
 | Module | Description |
 |---|---|

--- a/website/src/content/docs/reference/index.md
+++ b/website/src/content/docs/reference/index.md
@@ -1,12 +1,12 @@
 ---
 title: Reference
-description: Module map, wire protocol, broadcast cheatsheet, and client compatibility for beryl.
+description: Find beryl modules, message-sending APIs, Phoenix frame formats, and compatible clients.
 ---
 
 :::note[Pre-1.0]
 beryl is not yet version 1.0. Minor releases can change the API. The library is
 not ready for production. See the
-[stability policy](#pre-10-stability-policy).
+[stability policy](#versioning-before-10).
 :::
 
 The site generates the function-level API reference from Gleam docs metadata.
@@ -15,8 +15,8 @@ Install beryl packages from GitHub. They are not on Hex:
 **[beryl](/reference/api/beryl/)** ·
 **[beryl/channel](/reference/api/beryl-channel/)**
 
-This page contains a module map, broadcast table, Phoenix wire protocol
-reference, and client compatibility notes.
+Use this page to find a module, choose how to send a message, inspect Phoenix
+frames, or select a compatible client.
 
 ---
 
@@ -24,12 +24,12 @@ reference, and client compatibility notes.
 
 | Module | What it does | When to use it |
 |---|---|---|
-| `beryl` | Top-level app-side dispatch lifecycle, config builders, and broadcast helpers | Building/stopping a Beryl socket system |
-| `beryl/channel` | Handler validation, supervised startup, typed handlers, callbacks, senders, actions, and lifecycle results | Recommended programming layer for multi-channel apps |
+| `beryl` | Start and stop raw-dispatch socket systems, configure them, and broadcast events | Building or stopping a beryl socket system |
+| `beryl/channel` | Validate handlers, start them under a supervisor, and define typed callbacks, senders, and actions | Recommended programming model for apps with several topic features |
 | `beryl/socket` | `Input`, `Next`, `Effect`, `ConnectInfo`, and `Sender` types | Writing your app's `init` and `update` functions |
 | `beryl/bridge` | Forward an external OTP actor's message stream into `socket.Info(...)` | Bridging domain actors to one socket without hand-rolled forwarders |
 | `beryl/topic` | Topic parsing, wildcard matching, segment extraction | Dynamic routing, multi-tenant patterns |
-| `beryl/pubsub` | Distributed PubSub backed by Erlang `pg`, with typed subscribers and topic joins/leaves | Multi-node fan-out, cluster broadcasts, custom background consumers |
+| `beryl/pubsub` | Distributed PubSub backed by Erlang `pg`, with typed subscribers and topic joins/leaves | Broadcasts across nodes and custom background subscribers |
 | `beryl/presence` | OTP actor wrapping the presence CRDT, plus opaque `Diff` accessors | Tracking who is online |
 | `beryl/presence/wire` | Phoenix-compatible presence state and diff encoders | Sending presence payloads to Phoenix clients |
 | `beryl/group` | Named sets of topics for bulk broadcast | Rooms with multiple sub-topics |
@@ -37,15 +37,15 @@ reference, and client compatibility notes.
 | `beryl/stats` | Local runtime snapshots | Reporting connected sockets, memberships, and active topics |
 | `beryl/wire` | Phoenix-compatible codec and Dynamic→JSON helpers | Phoenix clients, payload relays, protocol debugging |
 | `beryl/wire/codec` | Pluggable codec contract for text and binary frames | Custom wire formats |
-| `beryl/transport` | Transport SPI: socket lifecycle, inbound routing, and edge rate limiting | Writing a custom transport package |
+| `beryl/transport` | Public interface for socket setup, incoming messages, and rate limiting | Writing a custom transport package |
 | `beryl/transport/origin` | Origin and Phoenix version checks | Validating WebSocket upgrades |
-| `beryl/transport/server` | Server-agnostic connection and frame pipeline | Implementing a WebSocket transport |
+| `beryl/transport/server` | Shared connection and frame handling for any WebSocket server | Implementing a WebSocket transport |
 | `beryl_mist` | Mist WebSocket upgrade and request handler integration (separate `beryl_mist` package) | Wiring beryl to a Mist HTTP server |
 | `beryl_ewe` | Ewe WebSocket transport integration (separate `beryl_ewe` package) | Wiring beryl to an Ewe HTTP server |
 
 ---
 
-## Broadcast / push / send cheatsheet
+## Choose how to send a message
 
 | Goal | API | Notes |
 |---|---|---|
@@ -66,7 +66,7 @@ the same core effects.
 
 ---
 
-## Phoenix wire protocol reference
+## Phoenix frame format
 
 With `wire.phoenix_codec()`, beryl uses the Phoenix Channels JSON array format.
 Each frame has five elements:
@@ -94,7 +94,7 @@ Each frame has five elements:
 | `phx_close` | server → client | Channel closed by server |
 | `heartbeat` | client → server | Keep-alive ping (topic `"phoenix"`) |
 
-### Reply shape (`phx_reply`)
+### Reply frame (`phx_reply`)
 
 The server sends this frame in response to a client message. `socket.ReplyOk`
 and `socket.ReplyError` use `phx_reply` with the original ref.
@@ -109,7 +109,7 @@ A join reply uses the `join_ref` as both `join_ref` and `ref`:
 ["1", "1", "room:lobby", "phx_reply", {"status": "ok", "response": {}}]
 ```
 
-### Heartbeat shape
+### Heartbeat frames
 
 The client sends heartbeats on the `"phoenix"` topic; beryl replies immediately:
 
@@ -121,7 +121,7 @@ The client sends heartbeats on the `"phoenix"` topic; beryl replies immediately:
 [null, "ref", "phoenix", "phx_reply", {"status": "ok", "response": {}}]
 ```
 
-### Presence diff shape
+### Presence update
 
 The payload uses the Phoenix presence diff format. The `joins` and `leaves`
 objects use the presence key, usually the user ID. Each value has a `metas`
@@ -162,7 +162,7 @@ handler at `"/socket/websocket"`. See the
 
 ---
 
-## Pre-1.0 stability policy
+## Versioning before 1.0
 
 beryl follows [Semantic Versioning](https://semver.org/) but is **not yet 1.0**. Until the 1.0 release:
 

--- a/website/src/content/docs/reference/index.md
+++ b/website/src/content/docs/reference/index.md
@@ -33,7 +33,7 @@ frames, or select a compatible client.
 | `beryl/presence` | OTP actor wrapping the presence CRDT, plus opaque `Diff` accessors | Tracking who is online |
 | `beryl/presence/wire` | Phoenix-compatible presence state and diff encoders | Sending presence payloads to Phoenix clients |
 | `beryl/group` | Named sets of topics for bulk broadcast | Rooms with multiple sub-topics |
-| `beryl/error` | Shared opaque error helpers | Handling Beryl-owned startup errors |
+| `beryl/error` | Shared opaque error helpers | Handling beryl-owned startup errors |
 | `beryl/stats` | Local runtime snapshots | Reporting connected sockets, memberships, and active topics |
 | `beryl/wire` | Phoenix-compatible codec and Dynamic→JSON helpers | Phoenix clients, payload relays, protocol debugging |
 | `beryl/wire/codec` | Pluggable codec contract for text and binary frames | Custom wire formats |

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -88,7 +88,7 @@ receive a reply or push.
 
 ---
 
-## Channel-layer symptoms
+## Channel handler problems
 
 ### `child_spec` returns a handler error
 
@@ -100,9 +100,10 @@ receive a reply or push.
 
 ### `channel.notify` never reaches `on_info`
 
-The sender is generation-scoped. Mail for a closed or rejoined channel is
-dropped still sealed, and `notify` never reports liveness. Capture
-`context.self` from each new join and install `channel.on_info`.
+The sender belongs to one accepted channel join. Messages for a channel that
+closed or joined again are dropped, and `notify` does not report whether the
+channel is still open. Capture `context.self` from each new join and install
+`channel.on_info`.
 
 ### A termination action does not compile
 
@@ -122,7 +123,7 @@ one topic, and `on_info` tears down the whole socket. See
 
 ---
 
-## Enable Beryl debug diagnostics
+## Turn on debug logs
 
 Beryl uses [palabres](https://hexdocs.pm/palabres/) loggers under the `beryl.*`
 namespaces. Enable debug logs when you diagnose integration problems:
@@ -230,7 +231,7 @@ recent joins or leaves.
 
 ---
 
-## PubSub cluster issues
+## Broadcasts fail across Erlang nodes
 
 **Symptoms:** Broadcasts do not reach other Erlang nodes. Presence state differs
 between nodes.
@@ -286,7 +287,7 @@ This prevents proxy idle disconnects.
 
 ---
 
-## Runtime crash / no messages processed
+## All socket messages stop
 
 **Symptoms:** All WebSocket operations stop. The runtime does not respond.
 

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -125,7 +125,7 @@ one topic, and `on_info` tears down the whole socket. See
 
 ## Turn on debug logs
 
-Beryl uses [palabres](https://hexdocs.pm/palabres/) loggers under the `beryl.*`
+beryl uses [palabres](https://hexdocs.pm/palabres/) loggers under the `beryl.*`
 namespaces. Enable debug logs when you diagnose integration problems:
 
 ```gleam
@@ -297,7 +297,7 @@ This prevents proxy idle disconnects.
    After 3 restarts in 5 seconds, the supervisor stops and sends the failure to
    the process that called `child_spec`. Check the logs for the first crash.
 
-2. **Check the failure scope.** Beryl catches crashes in `init` and `update`
+2. **Check the failure scope.** beryl catches crashes in `init` and `update`
    and limits them to one socket or topic. A fault elsewhere in a socket actor
    closes only that socket. If every connection closes, inspect the router and
    supervisor logs for the first fault.

--- a/website/src/content/docs/tutorial/composition-raw-dispatch-and-channels.md
+++ b/website/src/content/docs/tutorial/composition-raw-dispatch-and-channels.md
@@ -8,7 +8,7 @@ stores each child model. The parent message type has one variant for each child
 message type. The parent update function looks at the message and sends it to
 the correct child.
 
-Raw Beryl works the same way. One update function sees every topic on a socket.
+Raw beryl works the same way. One update function sees every topic on a socket.
 This is type-safe, and it gives you full control. But the work grows with each
 new topic family you add. `beryl/channel` does that routing for you. It runs on
 the same core runtime.
@@ -94,7 +94,7 @@ different state type and a different info type. Both still fit in one
 ## A handler creates one channel for each join
 
 A handler has two parts: a topic pattern and a join function. When a client
-joins a topic that matches the pattern, Beryl calls the join function with a
+joins a topic that matches the pattern, beryl calls the join function with a
 `channel.JoinContext`. The join function returns the new channel.
 
 ```gleam
@@ -169,7 +169,7 @@ store the state and callbacks inside more closures. Each `channel.next` does
 the same with the new state. The types stay concrete inside those closures.
 From the outside, every handler has the same type.
 
-Beryl does not turn your state or info messages into `Dynamic`. Only the
+beryl does not turn your state or info messages into `Dynamic`. Only the
 client payload is `Dynamic`, because it comes from the wire. That is true for
 both APIs.
 
@@ -257,7 +257,7 @@ The channel layer turns each action into one core `socket.Effect`. It keeps the
 order. The same runtime runs them, so the reply goes out before the broadcast.
 
 A join can also return actions. Use `channel.with_actions` on an accepted join.
-Beryl sends the join acknowledgment first, then those actions. A push can never
+beryl sends the join acknowledgment first, then those actions. A push can never
 arrive before its own join acknowledgment.
 
 ## Pick one API for each endpoint
@@ -279,8 +279,8 @@ the Elm analogy stops.
 
 - [Lustre for Elm developers](https://lustre.hexdocs.pm/cheatsheets/elm.html)
 - [`beryl/channel` source](https://github.com/tylerbutler/beryl/blob/main/packages/beryl/src/beryl/channel.gleam)
-- [Beryl channels guide](/guides/channels/)
-- [Choose a Beryl API](/choosing-an-api/)
+- [beryl channels guide](/guides/channels/)
+- [Choose a beryl API](/choosing-an-api/)
 - [ADR 0002: app-side dispatch](https://github.com/tylerbutler/beryl/blob/main/docs/adr/0002-app-side-dispatch.md)
 - [ADR 0003: layered channel API](https://github.com/tylerbutler/beryl/blob/main/docs/adr/0003-layered-channel-api.md)
 

--- a/website/src/content/docs/tutorial/composition-raw-dispatch-and-channels.md
+++ b/website/src/content/docs/tutorial/composition-raw-dispatch-and-channels.md
@@ -281,8 +281,6 @@ the Elm analogy stops.
 - [`beryl/channel` source](https://github.com/tylerbutler/beryl/blob/main/packages/beryl/src/beryl/channel.gleam)
 - [beryl channels guide](/guides/channels/)
 - [Choose a beryl API](/choosing-an-api/)
-- [ADR 0002: app-side dispatch](https://github.com/tylerbutler/beryl/blob/main/docs/adr/0002-app-side-dispatch.md)
-- [ADR 0003: layered channel API](https://github.com/tylerbutler/beryl/blob/main/docs/adr/0003-layered-channel-api.md)
 
 ## Runnable checkpoint: step 04
 

--- a/website/src/content/docs/tutorial/composition-raw-dispatch-and-channels.md
+++ b/website/src/content/docs/tutorial/composition-raw-dispatch-and-channels.md
@@ -1,5 +1,5 @@
 ---
-title: "Composition: Raw Dispatch and beryl/channel"
+title: "Move From Raw Dispatch to Channel Handlers"
 description: Move from one socket-wide update function to channel handlers that each keep their own state and message type.
 ---
 
@@ -13,7 +13,7 @@ This is type-safe, and it gives you full control. But the work grows with each
 new topic family you add. `beryl/channel` does that routing for you. It runs on
 the same core runtime.
 
-## Raw dispatch: your update function is the router
+## Raw dispatch makes your update function route topics
 
 Imagine one socket that serves polls, document cursors, and account alerts. In
 raw dispatch, your `Model` must hold state for all three. Your `Message` type
@@ -56,7 +56,7 @@ branches.
 This is not a type-safety problem. It is the price you pay when your app owns
 the full socket router.
 
-## The channel layer is the router
+## Channel handlers route topics for you
 
 For apps with many topic families, or apps shaped like Phoenix Channels, use
 `beryl/channel`. Step 4 of the example starts it like this:
@@ -91,7 +91,7 @@ One handler owns the `poll:*` topics. The other owns `guide`. Each one uses a
 different state type and a different info type. Both still fit in one
 `List(channel.Handler)`. The next sections show how.
 
-## A handler makes one channel for each join
+## A handler creates one channel for each join
 
 A handler has two parts: a topic pattern and a join function. When a client
 joins a topic that matches the pattern, Beryl calls the join function with a
@@ -158,7 +158,7 @@ Read it from the top:
 The state type is `String`. The info type is `PollInfo`. Neither type appears
 in a socket-wide `Model` or `Message`. They belong to this handler only.
 
-## How different handlers fit in one list
+## Keep different state types in one handler list
 
 `channel.Handler` has no type parameters. This is what lets the poll handler
 and the guide handler share one list.
@@ -176,7 +176,7 @@ both APIs.
 The channel layer is built on the public core API. It gives `beryl.child_spec`
 its own raw `init` and `update` pair. It does not go around the runtime.
 
-## The second handler
+## Add a handler with different types
 
 The guide handler uses different types from the poll handler:
 
@@ -214,7 +214,7 @@ The browser joins `guide` after it joins its poll topic. The `Ready` message
 becomes a `tip` push. The client stores the tip as the `title` of its status
 element.
 
-## Actions belong to one channel
+## Actions apply to one channel
 
 A raw effect names its topic:
 
@@ -241,7 +241,7 @@ can reply, push, broadcast, track presence, or close. In `on_terminate`, the
 channel is closing. A reply, push, or presence track makes no sense there, and
 the compiler rejects them. Broadcast and presence cleanup still work.
 
-## Actions become effects, in order
+## Beryl runs actions in list order
 
 The vote branch returns:
 

--- a/website/src/content/docs/tutorial/composition-raw-dispatch-and-channels.md
+++ b/website/src/content/docs/tutorial/composition-raw-dispatch-and-channels.md
@@ -1,5 +1,5 @@
 ---
-title: "Move From Raw Dispatch to Channel Handlers"
+title: "Move from raw dispatch to channel handlers"
 description: Move from one socket-wide update function to channel handlers that each keep their own state and message type.
 ---
 
@@ -241,7 +241,7 @@ can reply, push, broadcast, track presence, or close. In `on_terminate`, the
 channel is closing. A reply, push, or presence track makes no sense there, and
 the compiler rejects them. Broadcast and presence cleanup still work.
 
-## Beryl runs actions in list order
+## beryl runs actions in list order
 
 The vote branch returns:
 

--- a/website/src/content/docs/tutorial/index.md
+++ b/website/src/content/docs/tutorial/index.md
@@ -3,11 +3,11 @@ title: Build a live poll
 description: Build a live poll with raw dispatch, channel handlers, typed messages, and supervised processes.
 ---
 
-This tutorial teaches Beryl by building one app: a live poll. If you want a
+This tutorial teaches beryl by building one app: a live poll. If you want a
 shorter path, start with the [Quick Start](/quick-start/). All prose and code
 excerpts come from the runnable
 [`examples/live_poll/`](https://github.com/tylerbutler/beryl/tree/main/examples/live_poll)
-project. Beryl is pre-1.0. Expect the API to change.
+project. beryl is pre-1.0. Expect the API to change.
 
 ## Chapters
 
@@ -16,7 +16,7 @@ project. Beryl is pre-1.0. Expect the API to change.
 3. [Typed messages from the rest of your Gleam system](/tutorial/typed-messages-from-your-gleam-system/)
 4. [Composition: raw dispatch and `beryl/channel`](/tutorial/composition-raw-dispatch-and-channels/)
 5. [Where the analogy ends](/tutorial/where-the-analogy-ends/)
-6. [Supervising Beryl](/tutorial/supervising-beryl/)
+6. [Supervising beryl](/tutorial/supervising-beryl/)
 
 You can read each chapter on its own. The checkpoints build on each other. They
 start with a read-only poll and end with a supervised channel system.
@@ -36,7 +36,7 @@ Run each command from the repository root:
 
 Stop a checkpoint with Ctrl-C before you start the next one. The browser client
 loads Phoenix JavaScript 1.7.20 from unpkg, so the first page load needs
-internet access. The Gleam server and the Beryl runtime run on your machine.
+internet access. The Gleam server and the beryl runtime run on your machine.
 
 ## Files used by every chapter
 
@@ -50,7 +50,7 @@ configuration and starts the shared modules:
   poll commands.
 - `store.gleam` keeps poll state in a Gleam OTP actor.
 - `timer.gleam` runs delayed callbacks from its own actor.
-- `server.gleam` starts the Beryl child specification and the Mist transport,
+- `server.gleam` starts the beryl child specification and the Mist transport,
   serves the browser client, and can serve `/healthz`.
 - `test/live_poll_test.gleam` tests the poll types and the protocol decoder.
 
@@ -61,7 +61,7 @@ behavior is on. It does not repeat the runtime, poll, or browser code.
 
 The tutorial uses these terms, and keeps them separate:
 
-- A **socket** is one client connection that the Beryl runtime knows about.
+- A **socket** is one client connection that the beryl runtime knows about.
 - A **topic** is a string that a socket subscribes to, such as `poll:demo`.
 - **Raw dispatch** is the core API. Your app defines a **Model** and an update
   function. The update function receives a `socket.Input`, and returns a
@@ -76,14 +76,14 @@ The tutorial uses these terms, and keeps them separate:
   The socket actor holds the model and runs effects. The router keeps the
   socket index and sends broadcasts to subscribers.
 - A Gleam OTP `process.Subject` is a typed address for a process mailbox. A
-  Beryl `socket.Sender` is narrower. It delivers typed `Info` only to the
+  beryl `socket.Sender` is narrower. It delivers typed `Info` only to the
   socket that owns it. After the socket disconnects, the runtime drops the
   message.
 
 Do not use `Subject`, `Sender`, `socket`, `topic`, `channel`, or `handler` in
 place of one another. Each term names a different part of the system.
 
-Raw dispatch is Beryl's core, and the clearest way to learn it. For apps with
+Raw dispatch is beryl's core, and the clearest way to learn it. For apps with
 many channels, or apps shaped like Phoenix, use `beryl/channel`.
 
 ## Related Gleam concepts

--- a/website/src/content/docs/tutorial/index.md
+++ b/website/src/content/docs/tutorial/index.md
@@ -1,6 +1,6 @@
 ---
 title: Build a Live Poll
-description: Learn Beryl by building a live poll from raw dispatch through channels, runtime boundaries, and supervision.
+description: Build a live poll with raw dispatch, channel handlers, typed messages, and supervised processes.
 ---
 
 This tutorial teaches Beryl by building one app: a live poll. If you want a
@@ -9,7 +9,7 @@ excerpts come from the runnable
 [`examples/live_poll/`](https://github.com/tylerbutler/beryl/tree/main/examples/live_poll)
 project. Beryl is pre-1.0. Expect the API to change.
 
-## Sequence
+## Chapters
 
 1. [The Elm architecture, without a DOM](/tutorial/the-elm-architecture-without-a-dom/)
 2. [One update function, many socket events](/tutorial/one-update-function-many-socket-events/)
@@ -38,7 +38,7 @@ Stop a checkpoint with Ctrl-C before you start the next one. The browser client
 loads Phoenix JavaScript 1.7.20 from unpkg, so the first page load needs
 internet access. The Gleam server and the Beryl runtime run on your machine.
 
-## Example layout
+## Files used by every chapter
 
 The five `step_0N.gleam` files are short entry modules. Each one picks a
 configuration and starts the shared modules:
@@ -57,7 +57,7 @@ configuration and starts the shared modules:
 Read each step module together with the shared files. A step file shows which
 behavior is on. It does not repeat the runtime, poll, or browser code.
 
-## Terminology
+## Terms used in this tutorial
 
 The tutorial uses these terms, and keeps them separate:
 
@@ -74,19 +74,19 @@ The tutorial uses these terms, and keeps them separate:
   callback's own topic.
 - The **runtime** has one router actor and one actor for each connected socket.
   The socket actor holds the model and runs effects. The router keeps the
-  socket index and fans out broadcasts.
+  socket index and sends broadcasts to subscribers.
 - A Gleam OTP `process.Subject` is a typed address for a process mailbox. A
   Beryl `socket.Sender` is narrower. It delivers typed `Info` only to the
   socket that owns it. After the socket disconnects, the runtime drops the
   message.
 
 Do not use `Subject`, `Sender`, `socket`, `topic`, `channel`, or `handler` in
-place of one another. Each one names a different boundary.
+place of one another. Each term names a different part of the system.
 
 Raw dispatch is Beryl's core, and the clearest way to learn it. For apps with
 many channels, or apps shaped like Phoenix, use `beryl/channel`.
 
-## Official comparison material
+## Related Gleam concepts
 
 - [Lustre](https://lustre.hexdocs.pm/index.html)
 - [Lustre for Elm developers](https://lustre.hexdocs.pm/cheatsheets/elm.html)

--- a/website/src/content/docs/tutorial/index.md
+++ b/website/src/content/docs/tutorial/index.md
@@ -1,5 +1,5 @@
 ---
-title: Build a Live Poll
+title: Build a live poll
 description: Build a live poll with raw dispatch, channel handlers, typed messages, and supervised processes.
 ---
 

--- a/website/src/content/docs/tutorial/one-update-function-many-socket-events.md
+++ b/website/src/content/docs/tutorial/one-update-function-many-socket-events.md
@@ -43,7 +43,7 @@ A socket is one client connection. A topic is one subscription string inside
 that socket, such as `poll:demo`. Raw dispatch has no channel object. Your
 `Model` and update function route topic strings themselves.
 
-## A join ref is a one-time token
+## Answer each join with its one-time reference
 
 `Join(topic, payload, ref)` gives you a `socket.JoinRef`. You cannot make one
 yourself, and you cannot read its contents. You can only pass it back. Return
@@ -81,7 +81,7 @@ Beryl also protects you when you forget a case. If your update turn does not
 return `AcceptJoin(ref, ...)` or `RejectJoin(ref, ...)` for the waiting ref,
 the runtime rejects the join. A missing branch cannot leave a join half open.
 
-## Reply refs live longer
+## Reply references can outlive one update
 
 `Message` includes `Option(socket.ReplyRef)`. A client can send a frame with no
 message ref. Then the client does not expect a reply. When the ref is present,
@@ -112,7 +112,7 @@ example has a small local helper. It returns `ReplyError` only when the ref is
 Treat both ref types as tokens. Do not compare them. Do not build them from
 Phoenix fields. Pass the value back to Beryl while it is still valid.
 
-## `Dynamic` stops at the wire
+## Decode client data before using it
 
 Client JSON arrives in `Join` and `Message` as `Dynamic`. `Dynamic` is Gleam's
 type for data of unknown shape. This is on purpose. The remote client chooses
@@ -187,7 +187,7 @@ presence changes. The runtime can pause the rest of one socket's list while
 that actor works. Other sockets keep going. When the presence actor is done,
 the paused socket runs its remaining effects in order.
 
-## `Binary`, `Closed`, and unknown messages still need a branch
+## Handle binary data, closed topics, and unknown messages
 
 The example does not use binary frames. Its update function still matches
 every variant. The `Closed` branch also releases the shared poll after the last
@@ -230,7 +230,7 @@ The runtime already sends client messages only for joined topics. The model
 check makes the app's own routing state visible. It also shows why `Closed`
 must clean up.
 
-## Two tabs show the difference
+## Compare replies and broadcasts with two tabs
 
 With one tab, a reply and a broadcast look the same. With two tabs in the same
 room, they do not. The tab that voted gets its reply. The other tab gets
@@ -248,8 +248,8 @@ socket-scoped `Sender` with a general OTP `Subject`.
 ## Sources and further reading
 
 - [`beryl/socket` source](https://github.com/tylerbutler/beryl/blob/main/packages/beryl/src/beryl/socket.gleam)
-- [Beryl message lifecycle](/architecture/message-lifecycle/)
-- [Beryl app-side dispatch guide](/guides/dispatch/)
+- [How beryl handles a message](/architecture/message-lifecycle/)
+- [Beryl raw dispatch guide](/guides/dispatch/)
 - [Gleam dynamic decoding](https://hexdocs.pm/gleam_stdlib/gleam/dynamic/decode.html)
 
 ## Runnable checkpoint: step 02

--- a/website/src/content/docs/tutorial/one-update-function-many-socket-events.md
+++ b/website/src/content/docs/tutorial/one-update-function-many-socket-events.md
@@ -6,7 +6,7 @@ description: Handle joins, messages, binary frames, closes, replies, and ordered
 A WebSocket connection does more than carry app commands. A client joins
 topics. It sends text events and binary frames. It leaves, or it disconnects.
 It expects a reply to some of the frames it sent. Your server processes also
-need a typed way to send messages into the same socket logic. Raw Beryl puts
+need a typed way to send messages into the same socket logic. Raw beryl puts
 all of these cases in one `socket.Input` type. Your update function matches
 every variant.
 
@@ -77,7 +77,7 @@ It is valid only for the one join that is waiting for an answer. Suppose a
 client joins a topic, then joins the same topic again. A late answer for the
 first join cannot accept the second one.
 
-Beryl also protects you when you forget a case. If your update turn does not
+beryl also protects you when you forget a case. If your update turn does not
 return `AcceptJoin(ref, ...)` or `RejectJoin(ref, ...)` for the waiting ref,
 the runtime rejects the join. A missing branch cannot leave a join half open.
 
@@ -110,7 +110,7 @@ example has a small local helper. It returns `ReplyError` only when the ref is
 `Some(ref)`.
 
 Treat both ref types as tokens. Do not compare them. Do not build them from
-Phoenix fields. Pass the value back to Beryl while it is still valid.
+Phoenix fields. Pass the value back to beryl while it is still valid.
 
 ## Decode client data before using it
 
@@ -147,7 +147,7 @@ After this function, `handle_command` matches on `poll.GetState`,
 reaches the store actor. The wire payload is `Dynamic`. The domain command is
 not.
 
-This does not mean Beryl loses your types. The core runtime is generic over
+This does not mean beryl loses your types. The core runtime is generic over
 your `model` and `message` types. `beryl.child_spec` keeps your typed
 functions inside closures. The transport handle it returns has no type
 parameters. Only data from the wire is `Dynamic`.
@@ -167,14 +167,14 @@ Ok(state) ->
   )
 ```
 
-This exact excerpt comes from `raw.gleam`. When `reply` is present, Beryl
+This exact excerpt comes from `raw.gleam`. When `reply` is present, beryl
 runs the list as:
 
 1. send `ReplyOk` to the browser that voted;
 2. broadcast `poll_state` to every other socket on the topic.
 
 The socket actor runs the effects in list order and writes the frames in the
-same order. For one socket, list order is wire order. This is a Beryl
+same order. For one socket, list order is wire order. This is a beryl
 guarantee. Lustre makes no such promise for its effects.
 
 The same rule applies to a join. If one update returns
@@ -213,7 +213,7 @@ up forever. In the `Closed` turn, the runtime drops pushes to the closing
 topic. Broadcasts still reach the other subscribers.
 
 The example ignores `Binary` on purpose. A codec with a binary decoder can
-turn binary frames into protocol messages. Without one, Beryl delivers the raw
+turn binary frames into protocol messages. Without one, beryl delivers the raw
 bytes for joined topics. The empty branch documents what this poll supports.
 
 The `Message` branch also checks that the model knows the topic:
@@ -249,7 +249,7 @@ socket-scoped `Sender` with a general OTP `Subject`.
 
 - [`beryl/socket` source](https://github.com/tylerbutler/beryl/blob/main/packages/beryl/src/beryl/socket.gleam)
 - [How beryl handles a message](/architecture/message-lifecycle/)
-- [Beryl raw dispatch guide](/guides/dispatch/)
+- [beryl raw dispatch guide](/guides/dispatch/)
 - [Gleam dynamic decoding](https://hexdocs.pm/gleam_stdlib/gleam/dynamic/decode.html)
 
 ## Runnable checkpoint: step 02

--- a/website/src/content/docs/tutorial/one-update-function-many-socket-events.md
+++ b/website/src/content/docs/tutorial/one-update-function-many-socket-events.md
@@ -1,5 +1,5 @@
 ---
-title: One Update Function, Many Socket Events
+title: One update function, many socket events
 description: Handle joins, messages, binary frames, closes, replies, and ordered effects in one typed update function.
 ---
 

--- a/website/src/content/docs/tutorial/supervising-beryl.md
+++ b/website/src/content/docs/tutorial/supervising-beryl.md
@@ -1,6 +1,6 @@
 ---
 title: Supervising beryl
-description: Start Beryl under an OTP supervisor and control restarts, shutdown, and process ownership.
+description: Start beryl under an OTP supervisor and control restarts, shutdown, and process ownership.
 ---
 
 `beryl.child_spec` does not start anything. It returns two values. The first is
@@ -16,7 +16,7 @@ configuration the supervisor needs to build that system again.
 
 ## Put the child specification in your application tree
 
-The live-poll example starts Beryl under a root supervisor. Then it starts the
+The live-poll example starts beryl under a root supervisor. Then it starts the
 Mist listener:
 
 ```gleam
@@ -39,7 +39,7 @@ The supervisor code comes from
 The server then passes `sockets` to `mist_transport.upgrade`.
 
 The order matters. You get the handle when `child_spec` returns. But no runtime
-process exists until a supervisor starts `spec`. Before that, Beryl refuses new
+process exists until a supervisor starts `spec`. Before that, beryl refuses new
 connections. Calls through the handle that do not wait for a reply, such as a
 broadcast, do nothing. They do not crash because the process is missing.
 
@@ -48,11 +48,11 @@ broadcast, do nothing. They do not crash because the process is missing.
 
 ## Processes started by beryl
 
-The child specification adds a Beryl subtree to your application:
+The child specification adds a beryl subtree to your application:
 
 ```text
 application supervisor
-└── Beryl subtree (Transient)
+└── beryl subtree (Transient)
     ├── router actor (Transient, significant)
     └── connection limiter (optional)
 
@@ -60,7 +60,7 @@ transport connection
 └── socket actor (one per connection, monitored by the router)
 ```
 
-The Beryl subtree has its own supervisor. That supervisor uses `OneForOne`. It
+The beryl subtree has its own supervisor. That supervisor uses `OneForOne`. It
 allows 3 restarts in 5 seconds. The router actor keeps the list of socket
 actors and the set of subscribers for each topic. Each socket actor keeps one
 model, its channel instances, its joined topics, and its pending reply
@@ -69,7 +69,7 @@ connection starts each one, and the router monitors it. If you enable
 connection limits, the limiter runs next to the router.
 
 The router is marked as *significant*. When
-the router stops normally, the Beryl supervisor stops the rest of the subtree,
+the router stops normally, the beryl supervisor stops the rest of the subtree,
 including the limiter. Your application supervisor and its other children keep
 running.
 
@@ -97,7 +97,7 @@ WebSockets. Clients must reconnect and join again. The new router then gets
 fresh socket actors, models, and channel state. Phoenix clients already know
 how to reconnect and rejoin.
 
-If state must survive a restart, keep it outside the Beryl runtime. The live
+If state must survive a restart, keep it outside the beryl runtime. The live
 poll keeps room totals in `store.Store`, an actor your application owns. A
 database or another supervised process works the same way.
 
@@ -121,8 +121,8 @@ If you enable connection limits, the limiter survives a normal router restart.
 
 ## Repeated router failures stop the beryl subtree
 
-The Beryl supervisor allows 3 router restarts in 5 seconds. A fourth failure in
-that window uses up the budget. The whole Beryl subtree then exits with an
+The beryl supervisor allows 3 router restarts in 5 seconds. A fourth failure in
+that window uses up the budget. The whole beryl subtree then exits with an
 error. Your application supervisor decides what to do next. It may restart the
 subtree, or it may give up.
 
@@ -130,13 +130,13 @@ If the parent restarts the subtree, the router and the optional limiter both get
 new processes. The original `Sockets` handle still works. The subtree registers
 the same names again.
 
-This rule stops the Beryl supervisor from retrying the same fault forever. Your
+This rule stops the beryl supervisor from retrying the same fault forever. Your
 own supervision strategy gets a say. To find the cause, read the logs from the
 first router failure.
 
 ## A callback crash usually does not reach the supervisor
 
-Chapter 5 described how Beryl catches panics in callbacks. A panic in raw
+Chapter 5 described how beryl catches panics in callbacks. A panic in raw
 `update` or in a channel callback has a small effect. It rejects the join, or
 it closes the topic or socket that caused it. The socket actor keeps running
 when the scope allows. A fault outside that catch stops the socket actor, and
@@ -148,13 +148,13 @@ failures in logs and in client behavior.
 
 ## Graceful shutdown drains the runtime
 
-Use `beryl.stop(sockets)` when your application must stop only Beryl:
+Use `beryl.stop(sockets)` when your application must stop only beryl:
 
 ```gleam
 case beryl.stop(sockets) {
   Ok(Nil) -> Nil
   Error(beryl.NotRunning) -> Nil
-  Error(beryl.StopTimeout) -> panic as "Beryl did not stop in time"
+  Error(beryl.StopTimeout) -> panic as "beryl did not stop in time"
 }
 ```
 
@@ -169,31 +169,31 @@ handle, the system already stopped, or the call happened during a restart
 window. `StopTimeout` means the router did not confirm the drain, or the
 subtree did not end before the deadline.
 
-Beryl does not stop processes your application owns. The poll store, the timer,
+beryl does not stop processes your application owns. The poll store, the timer,
 the presence actor, and the group actor all belong to the process or supervisor
-that started them. When your root supervisor shuts down, it stops Beryl with the
+that started them. When your root supervisor shuts down, it stops beryl with the
 rest of the tree.
 
 ## Start processes before the WebSocket listener
 
 A production startup path makes four decisions, in this order:
 
-1. Build Beryl's handle and child specification.
+1. Build beryl's handle and child specification.
 2. Start your domain actors from a long-lived application process, or under
    their own supervisor.
-3. Add Beryl's specification to your application supervisor and start it.
+3. Add beryl's specification to your application supervisor and start it.
 4. Start the HTTP/WebSocket listener with the running `Sockets` handle.
 
-Each part then has a clear recovery path. Beryl's supervisor restores the
+Each part then has a clear recovery path. beryl's supervisor restores the
 router. Clients restore socket actors and subscriptions when they reconnect.
 Your own processes or storage keep the domain state. Graceful shutdown drains
 socket callbacks without stopping unrelated services.
 
 ## Sources and further reading
 
-- [Beryl supervision guide](/guides/supervision/)
+- [beryl supervision guide](/guides/supervision/)
 - [`beryl.child_spec` and `beryl.stop`](https://github.com/tylerbutler/beryl/blob/main/packages/beryl/src/beryl.gleam)
-- [Beryl runtime architecture](/architecture/runtime/)
+- [beryl runtime architecture](/architecture/runtime/)
 - [Error handling](/guides/error-handling/)
 
 ## Runnable checkpoint: step 05

--- a/website/src/content/docs/tutorial/supervising-beryl.md
+++ b/website/src/content/docs/tutorial/supervising-beryl.md
@@ -1,6 +1,6 @@
 ---
 title: Supervising Beryl
-description: Place Beryl in an OTP supervision tree and understand restart, shutdown, and ownership boundaries.
+description: Start Beryl under an OTP supervisor and control restarts, shutdown, and process ownership.
 ---
 
 `beryl.child_spec` does not start anything. It returns two values. The first is
@@ -9,7 +9,7 @@ specification tells an OTP supervisor how to start and restart a process. Your
 application adds it to its own supervisor. `channel.child_spec` returns the same
 two values. It builds the raw router from your handlers first.
 
-This split decides three things: what starts first, what happens after a crash,
+This split controls three things: what starts first, what happens after a crash,
 and what happens at shutdown. The handle names one socket system. It stays valid
 when the runtime restarts. The child specification holds the code and
 configuration the supervisor needs to build that system again.
@@ -46,7 +46,7 @@ broadcast, do nothing. They do not crash because the process is missing.
 `child_spec` checks the configuration and the handler list before it returns
 `spec`. If it returns an error, there is nothing to add to the supervisor.
 
-## Beryl owns a small tree of its own
+## Processes started by beryl
 
 The child specification adds a Beryl subtree to your application:
 
@@ -68,7 +68,7 @@ capabilities. Socket actors are not children of the supervisor. The transport
 connection starts each one, and the router monitors it. If you enable
 connection limits, the limiter runs next to the router.
 
-The router is marked as *significant*. This gives shutdown a clear edge. When
+The router is marked as *significant*. When
 the router stops normally, the Beryl supervisor stops the rest of the subtree,
 including the limiter. Your application supervisor and its other children keep
 running.
@@ -101,7 +101,7 @@ If state must survive a restart, keep it outside the Beryl runtime. The live
 poll keeps room totals in `store.Store`, an actor your application owns. A
 database or another supervised process works the same way.
 
-## A restart window is an unavailable window
+## Calls can fail while the router restarts
 
 The stable handle means you never hold a dead process id. It does not make a
 restart invisible. Between the old runtime exiting and the new one registering:
@@ -119,7 +119,7 @@ broadcast is not a durable message.
 If you enable connection limits, the limiter survives a normal router restart.
 `OneForOne` restarts only the router. The new router uses the same limiter.
 
-## Repeated failures move up the tree
+## Repeated router failures stop the beryl subtree
 
 The Beryl supervisor allows 3 router restarts in 5 seconds. A fourth failure in
 that window uses up the budget. The whole Beryl subtree then exits with an
@@ -174,7 +174,7 @@ the presence actor, and the group actor all belong to the process or supervisor
 that started them. When your root supervisor shuts down, it stops Beryl with the
 rest of the tree.
 
-## Decide who owns what before you open the listener
+## Start processes before the WebSocket listener
 
 A production startup path makes four decisions, in this order:
 

--- a/website/src/content/docs/tutorial/supervising-beryl.md
+++ b/website/src/content/docs/tutorial/supervising-beryl.md
@@ -1,5 +1,5 @@
 ---
-title: Supervising Beryl
+title: Supervising beryl
 description: Start Beryl under an OTP supervisor and control restarts, shutdown, and process ownership.
 ---
 

--- a/website/src/content/docs/tutorial/the-elm-architecture-without-a-dom.md
+++ b/website/src/content/docs/tutorial/the-elm-architecture-without-a-dom.md
@@ -18,7 +18,7 @@ We start with Beryl's core API. It keeps state, inputs, and effects in plain
 view. First we compare the Lustre and OTP forms. Then we show the Beryl API
 and map its terms onto the same model.
 
-## What we are building
+## Build a live poll
 
 We will build a live poll with rooms. A browser joins a topic such as
 `poll:demo`. It reads the current totals, votes for Gleam or Erlang, and sees
@@ -44,7 +44,7 @@ This chapter ends with the smallest useful checkpoint. The server accepts a
 `poll:*` join and returns the current poll state. Voting, broadcasts, timers,
 and channels come later, after the core loop is clear.
 
-## One model, different domains
+## The shared model-update pattern
 
 The shared model has four parts:
 
@@ -163,11 +163,11 @@ is a typed address for the actor's mailbox.
 Now we can carry the same model into Beryl and give each part a socket
 meaning.
 
-## Beryl applies the loop to sockets
+## Apply the loop to sockets
 
 Beryl gives you two ways to program a socket endpoint. The channel layer is
 the recommended one. It routes each event to a handler based on the topic.
-Under it sits the raw app-side dispatch API. Raw dispatch gives every event on
+Under it sits the raw dispatch API. Raw dispatch gives every event on
 a socket to one `update` function that you write.
 
 "Raw dispatch" means your application does the routing. Your code receives
@@ -288,7 +288,7 @@ in the update closure. Each browser socket gets its own raw `Model`. All
 sockets send poll operations to the same store. Per-socket state and shared
 domain state stay apart.
 
-## The first mismatch is useful
+## Where beryl differs from a frontend
 
 The Elm architecture gives us words for pure state transitions. But Beryl is
 not a frontend framework:
@@ -313,7 +313,7 @@ protocol.
 - [Gleam OTP actor module](https://gleam-otp.hexdocs.pm/gleam/otp/actor.html)
 - [Gleam Erlang process module](https://gleam-erlang.hexdocs.pm/gleam/erlang/process.html)
 - [`beryl/socket` source](https://github.com/tylerbutler/beryl/blob/main/packages/beryl/src/beryl/socket.gleam)
-- [Beryl app-side dispatch guide](/guides/dispatch/)
+- [Beryl raw dispatch guide](/guides/dispatch/)
 
 ## Runnable checkpoint: step 01
 

--- a/website/src/content/docs/tutorial/the-elm-architecture-without-a-dom.md
+++ b/website/src/content/docs/tutorial/the-elm-architecture-without-a-dom.md
@@ -1,5 +1,5 @@
 ---
-title: The Elm Architecture, Without a DOM
+title: The Elm Architecture, without a DOM
 description: Learn Beryl's model-update architecture by building the first read-only stage of a live poll.
 ---
 

--- a/website/src/content/docs/tutorial/the-elm-architecture-without-a-dom.md
+++ b/website/src/content/docs/tutorial/the-elm-architecture-without-a-dom.md
@@ -1,21 +1,21 @@
 ---
 title: The Elm Architecture, without a DOM
-description: Learn Beryl's model-update architecture by building the first read-only stage of a live poll.
+description: Learn beryl's model-update architecture by building the first read-only stage of a live poll.
 ---
 
 Lustre and Gleam OTP actors use the same programming model. Each one starts
 with some state. Each one receives a typed message. Each one runs one function
 that returns the next state and any work to do. Lustre uses this model to run
-a user interface. An OTP actor uses it to run a concurrent process. Beryl uses
+a user interface. An OTP actor uses it to run a concurrent process. beryl uses
 it to handle realtime socket traffic.
 
 The last step is different in each case. Lustre renders a view. An actor keeps
-its next state or stops. Beryl returns protocol effects. An effect can accept a
-join, send a reply, or broadcast a message. Beryl also creates state once for
+its next state or stops. beryl returns protocol effects. An effect can accept a
+join, send a reply, or broadcast a message. beryl also creates state once for
 each connected socket, not once for the whole application.
 
-We start with Beryl's core API. It keeps state, inputs, and effects in plain
-view. First we compare the Lustre and OTP forms. Then we show the Beryl API
+We start with beryl's core API. It keeps state, inputs, and effects in plain
+view. First we compare the Lustre and OTP forms. Then we show the beryl API
 and map its terms onto the same model.
 
 ## Build a live poll
@@ -27,10 +27,10 @@ of subscription.
 
 A **topic** is a string. It names one subscription inside a WebSocket
 connection. In `poll:demo`, `poll` is the kind of subscription and `demo` is
-the room. One socket can join many topics. Beryl uses the topic string to route
+the room. One socket can join many topics. beryl uses the topic string to route
 messages and broadcasts.
 
-Beryl does not call this subscription a channel. In Beryl, a **channel** is a
+beryl does not call this subscription a channel. In beryl, a **channel** is a
 separate API built on top of topics. A later chapter introduces that API. For
 now, the browser joins a topic, and your application routes it by its string.
 
@@ -53,7 +53,7 @@ The shared model has four parts:
 3. handle one input against the current state;
 4. return the next state and say what happens next.
 
-Lustre, OTP actors, and Beryl use different names for the fourth part. They
+Lustre, OTP actors, and beryl use different names for the fourth part. They
 also do different things with it. Parts one to three look the same in all
 three.
 
@@ -160,12 +160,12 @@ runtime uses `actor.Next` to continue or stop the process.
 To send a message to an actor, you use a `process.Subject(message)`. A subject
 is a typed address for the actor's mailbox.
 
-Now we can carry the same model into Beryl and give each part a socket
+Now we can carry the same model into beryl and give each part a socket
 meaning.
 
 ## Apply the loop to sockets
 
-Beryl gives you two ways to program a socket endpoint. The channel layer is
+beryl gives you two ways to program a socket endpoint. The channel layer is
 the recommended one. It routes each event to a handler based on the topic.
 Under it sits the raw dispatch API. Raw dispatch gives every event on
 a socket to one `update` function that you write.
@@ -173,7 +173,7 @@ a socket to one `update` function that you write.
 "Raw dispatch" means your application does the routing. Your code receives
 joins, client messages, binary frames, close events, and typed server messages.
 Each one arrives as a `socket.Input` value. Your code decides how each input
-changes the socket's model. Beryl still owns the WebSocket transport, wire
+changes the socket's model. beryl still owns the WebSocket transport, wire
 decoding, protocol checks, and effect execution.
 
 We start with raw dispatch because it shows the full loop. A later chapter
@@ -182,14 +182,14 @@ moves out of your code.
 
 The three domains now line up:
 
-| Role | Lustre | Gleam OTP actor | Beryl raw dispatch |
+| Role | Lustre | Gleam OTP actor | beryl raw dispatch |
 |---|---|---|---|
 | state | application model | actor state | one app-defined `Model` per socket |
 | input | `Message` | actor message | `socket.Input(Message)` |
 | transition | `update` | `on_message` handler | `update` |
 | next step | model and optional effect | `actor.Next` | `socket.Next(model, effects)` |
 
-Beryl asks your application for `init` and `update`. This exact excerpt comes
+beryl asks your application for `init` and `update`. This exact excerpt comes
 from `step_01.gleam`:
 
 ```gleam
@@ -204,7 +204,7 @@ You can see it in
 [`step_01.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/live_poll/src/live_poll/step_01.gleam).
 `beryl.child_spec` returns two values. The first is a `beryl.Sockets` handle.
 The second is a child specification for your supervisor. Your model and message
-types stay inside the closures you pass in. Beryl never converts them to
+types stay inside the closures you pass in. beryl never converts them to
 `Dynamic`.
 
 The live-poll example defines these raw types:
@@ -231,20 +231,20 @@ Each name has one meaning:
 - `Message` is your own type for server-side events. The poll defines
   `ClosePoll` because a timer must tell a socket that one of its polls has
   ended. Another application would define its own variants.
-- `socket.Effect` describes work for Beryl to do after `init` or `update`.
+- `socket.Effect` describes work for beryl to do after `init` or `update`.
 - `socket.ConnectInfo.self` is a sender for this socket only. It is not a
   general process `Subject`.
 
 The type parameter links the server-message path together.
 `ConnectInfo(Message)` gives you a `Sender(Message)`. When you send a value
-through that sender, Beryl delivers it to `update` as `Info(Message)`. Client
+through that sender, beryl delivers it to `update` as `Info(Message)`. Client
 frames take a different path. They arrive as the `Join`, `Message`, and
 `Binary` variants of `socket.Input`. Your `Message` type never holds decoded
 client data.
 
 The `update` function has the type
 `fn(Model, socket.Input(Message)) -> socket.Next(Model)`. It matches every
-input variant. Beryl uses `socket.Input(Message)` where Lustre uses `Message`
+input variant. beryl uses `socket.Input(Message)` where Lustre uses `Message`
 and an actor uses its mailbox message. Some input variants carry client data.
 `Info(Message)` carries your typed server-side data. `socket.Next(model,
 effects)` continues with the next model. `socket.Stop(reason)` stops the whole
@@ -252,7 +252,7 @@ socket.
 
 ## There is no view
 
-We have mapped state and input. The last difference is output. Beryl does not
+We have mapped state and input. The last difference is output. beryl does not
 render the model. Instead, your application returns an ordered list of
 `socket.Effect` values. This exact excerpt comes from `raw.gleam`:
 
@@ -276,7 +276,7 @@ topics this socket has joined is one example.
 ## Initialization belongs to the socket
 
 Lustre creates one application model. An OTP actor usually creates one state
-value. Beryl calls raw `init` once for every socket that connects. One socket
+value. beryl calls raw `init` once for every socket that connects. One socket
 actor stores that socket's `Model` and runs its updates. A separate router
 actor keeps the list of sockets and routes frames and broadcasts. This split
 matters for blocking work and crashes. Chapter 5 covers both.
@@ -290,7 +290,7 @@ domain state stay apart.
 
 ## Where beryl differs from a frontend
 
-The Elm architecture gives us words for pure state transitions. But Beryl is
+The Elm architecture gives us words for pure state transitions. But beryl is
 not a frontend framework:
 
 - there is no `view` function;
@@ -299,7 +299,7 @@ not a frontend framework:
 - output is an explicit list of `socket.Effect` values;
 - one socket actor stores each socket's model and runs its updates.
 
-Raw dispatch shows these facts with little extra code. It is Beryl's core. It
+Raw dispatch shows these facts with little extra code. It is beryl's core. It
 is the clearest place to learn joins, replies, close events, and effect order.
 When an application has several channel families, you will usually move to
 `beryl/channel`. That is the recommended default for multi-channel and
@@ -313,7 +313,7 @@ protocol.
 - [Gleam OTP actor module](https://gleam-otp.hexdocs.pm/gleam/otp/actor.html)
 - [Gleam Erlang process module](https://gleam-erlang.hexdocs.pm/gleam/erlang/process.html)
 - [`beryl/socket` source](https://github.com/tylerbutler/beryl/blob/main/packages/beryl/src/beryl/socket.gleam)
-- [Beryl raw dispatch guide](/guides/dispatch/)
+- [beryl raw dispatch guide](/guides/dispatch/)
 
 ## Runnable checkpoint: step 01
 

--- a/website/src/content/docs/tutorial/typed-messages-from-your-gleam-system.md
+++ b/website/src/content/docs/tutorial/typed-messages-from-your-gleam-system.md
@@ -12,7 +12,7 @@ calls these server-side events. It routes them through a
 This looks like a typed OTP send. But a Beryl sender can do less than a
 `process.Subject`. This chapter shows the difference.
 
-## The OTP baseline
+## Start with an OTP actor
 
 A Gleam OTP actor is a process with a mailbox. It receives typed messages
 through a `process.Subject`. The example's store keeps its subject inside an
@@ -192,7 +192,7 @@ the socket is still connected. If the browser closed during that minute, Beryl
 drops the message. The timer actor does not need to watch the socket or clean
 up after it.
 
-## Domain state stays in the store actor
+## Keep shared poll state in the store actor
 
 The raw `Model` holds the sender and the set of joined topics. It does not hold
 vote counts. Both client events and timer events call the shared
@@ -233,7 +233,7 @@ the caller not to broadcast again. Each socket join sets its own timer. Two
 tabs on the same room set two timers. Only the first `ClosePoll` changes the
 store.
 
-## Close now uses the same state change
+## Reuse the same close operation
 
 In the timed stage, a client can send `close_poll`. The raw handler calls the
 same `store.close` function. It returns effects in order:
@@ -264,7 +264,7 @@ broadcast.
 This order guarantee is a Beryl rule. Lustre effects and OTP sends have their
 own rules. Do not assume they order work the same way.
 
-## `Info` is not scoped to a topic
+## Include the topic in each `Info` message
 
 An `Info(Message)` does not carry a topic. Your message must carry the routing
 data it needs. The example defines `ClosePoll(topic: String)` because one raw
@@ -280,7 +280,7 @@ server-side events, you must put them all in one `Message` type. Your update
 function must route each variant. `beryl/channel` removes this shared type.
 Each channel gets its own private info type.
 
-## Choose the boundary
+## Keep slow work outside socket callbacks
 
 Keep slow work in your own processes. Keep work that needs its own supervisor
 there too. Send a small typed result into Beryl when the socket must decide on

--- a/website/src/content/docs/tutorial/typed-messages-from-your-gleam-system.md
+++ b/website/src/content/docs/tutorial/typed-messages-from-your-gleam-system.md
@@ -1,5 +1,5 @@
 ---
-title: Typed Messages From Your Gleam System
+title: Typed messages from your Gleam system
 description: Send typed server-side events from actors and timers into the socket update loop.
 ---
 

--- a/website/src/content/docs/tutorial/typed-messages-from-your-gleam-system.md
+++ b/website/src/content/docs/tutorial/typed-messages-from-your-gleam-system.md
@@ -4,12 +4,12 @@ description: Send typed server-side events from actors and timers into the socke
 ---
 
 Client frames are not the only source of socket work. A database worker can
-finish. A timer can expire. An actor in your app can publish an event. Beryl
+finish. A timer can expire. An actor in your app can publish an event. beryl
 calls these server-side events. It routes them through a
 `socket.Sender(Message)`. The socket's update function receives them as
 `socket.Info(Message)`.
 
-This looks like a typed OTP send. But a Beryl sender can do less than a
+This looks like a typed OTP send. But a beryl sender can do less than a
 `process.Subject`. This chapter shows the difference.
 
 ## Start with an OTP actor
@@ -64,11 +64,11 @@ Vote(room, choice, reply) -> {
 ```
 
 A subject can carry any message type the actor accepts. It knows nothing about
-Beryl sockets or when they close.
+beryl sockets or when they close.
 
 ## A socket sender has one destination
 
-When a socket connects, Beryl calls your raw `init` with a
+When a socket connects, beryl calls your raw `init` with a
 `socket.ConnectInfo(Message)`. Its `self` field is a `socket.Sender(Message)`:
 
 ```gleam
@@ -96,7 +96,7 @@ input variant that holds a decoded client event. Your own `Message` holds
 events from your actors and workers. A chat app might define `NewChatMessage`
 or `UserBanned` here.
 
-The example stores `info.self` in the socket's `Model`. Beryl makes the sender
+The example stores `info.self` in the socket's `Model`. beryl makes the sender
 when the socket connects. It knows which socket actor it belongs to. If that
 socket has closed, the sender drops the message. You never see the subject
 inside it.
@@ -111,7 +111,7 @@ socket.Input(Message)
 socket.Info(ClosePoll(topic))
 ```
 
-To send an event, call `socket.notify(sender, ClosePoll(topic))`. Beryl
+To send an event, call `socket.notify(sender, ClosePoll(topic))`. beryl
 delivers it to the socket's update function as `Info(ClosePoll(topic))`.
 
 The update function handles it like this:
@@ -140,7 +140,7 @@ A sender can do less than a `process.Subject`:
 
 - It accepts only values of your `Message` type.
 - It sends only to the socket that made it.
-- Beryl wraps each value as `socket.Info(Message)`.
+- beryl wraps each value as `socket.Info(Message)`.
 - It drops the value if the socket has disconnected.
 - It has no request/reply protocol and no mailbox selection.
 
@@ -184,11 +184,11 @@ case stage {
 ```
 
 `step_03` sets `duration_ms` to `60_000`. After 60 seconds, the timer actor
-runs the callback. The callback calls `socket.notify`. Beryl then calls the
+runs the callback. The callback calls `socket.notify`. beryl then calls the
 socket's update function with `Info(ClosePoll(topic))`.
 
 `socket.notify` is fire-and-forget. It returns `Nil`. It does not tell you if
-the socket is still connected. If the browser closed during that minute, Beryl
+the socket is still connected. If the browser closed during that minute, beryl
 drops the message. The timer actor does not need to watch the socket or clean
 up after it.
 
@@ -256,12 +256,12 @@ Timed -> {
 }
 ```
 
-The reply comes before the broadcast in the list. Beryl runs effects in list
+The reply comes before the broadcast in the list. beryl runs effects in list
 order. The wire sees them in that order too. The timer can still send a later
 `Info`. But `store.close` is safe to call twice, so there is no second
 broadcast.
 
-This order guarantee is a Beryl rule. Lustre effects and OTP sends have their
+This order guarantee is a beryl rule. Lustre effects and OTP sends have their
 own rules. Do not assume they order work the same way.
 
 ## Include the topic in each `Info` message
@@ -271,8 +271,8 @@ data it needs. The example defines `ClosePoll(topic: String)` because one raw
 socket can join several poll topics.
 
 This has one effect on crashes. When a `Message` or `Binary` callback crashes,
-Beryl knows the topic. It closes only that topic. When an `Info` callback
-crashes, Beryl has no topic. It closes the whole socket. Chapter 5 explains the
+beryl knows the topic. It closes only that topic. When an `Info` callback
+crashes, beryl has no topic. It closes the whole socket. Chapter 5 explains the
 full crash behavior.
 
 It also has a cost when you compose. If several topic families need different
@@ -283,12 +283,12 @@ Each channel gets its own private info type.
 ## Keep slow work outside socket callbacks
 
 Keep slow work in your own processes. Keep work that needs its own supervisor
-there too. Send a small typed result into Beryl when the socket must decide on
+there too. Send a small typed result into beryl when the socket must decide on
 new state or effects. Each socket actor runs its update callbacks one at a
 time. If `update` sleeps, blocks on I/O, or does long work, that socket's
 messages, effects, and heartbeat checks wait. Other sockets are not affected.
 
-`socket.Sender` gives you a typed way back into the socket. Beryl does not
+`socket.Sender` gives you a typed way back into the socket. beryl does not
 become the owner of your job, store, or timer. Your app still decides how to
 supervise those processes.
 
@@ -300,7 +300,7 @@ handlers. Each handler keeps its own state and info types.
 - [Gleam OTP actor module](https://gleam-otp.hexdocs.pm/gleam/otp/actor.html)
 - [Gleam Erlang process module](https://gleam-erlang.hexdocs.pm/gleam/erlang/process.html)
 - [`beryl/socket` source](https://github.com/tylerbutler/beryl/blob/main/packages/beryl/src/beryl/socket.gleam)
-- [Beryl runtime architecture](/architecture/runtime/)
+- [beryl runtime architecture](/architecture/runtime/)
 
 ## Runnable checkpoint: step 03
 
@@ -311,6 +311,6 @@ cd examples/live_poll && gleam run -m live_poll/step_03
 Open `http://localhost:8103`, join `demo`, and vote. Select **Close poll now**
 to close the poll at once, or wait 60 seconds. In both cases, the client
 receives the closed state and voting stops. If you close the browser before
-the timer fires, Beryl drops the later `socket.notify` message.
+the timer fires, beryl drops the later `socket.notify` message.
 
 Next: [Composition: raw dispatch and `beryl/channel`](/tutorial/composition-raw-dispatch-and-channels/).

--- a/website/src/content/docs/tutorial/where-the-analogy-ends.md
+++ b/website/src/content/docs/tutorial/where-the-analogy-ends.md
@@ -1,5 +1,5 @@
 ---
-title: Where the Analogy Ends
+title: Where the analogy ends
 description: Follow a frame through Beryl and learn where frontend model-update ideas stop matching runtime behavior.
 ---
 

--- a/website/src/content/docs/tutorial/where-the-analogy-ends.md
+++ b/website/src/content/docs/tutorial/where-the-analogy-ends.md
@@ -1,12 +1,12 @@
 ---
 title: Where the analogy ends
-description: Follow a frame through Beryl and learn where frontend model-update ideas stop matching runtime behavior.
+description: Follow a frame through beryl and learn where frontend model-update ideas stop matching runtime behavior.
 ---
 
 The model-update words from the last chapters help you organize your code.
-But they can give you the wrong idea about how Beryl runs that code. Beryl
+But they can give you the wrong idea about how beryl runs that code. beryl
 gives each socket its own actor. An actor is a process with a mailbox that
-handles one message at a time. But Beryl does not draw a view from your model.
+handles one message at a time. But beryl does not draw a view from your model.
 It does not bring your socket state back after a crash. One router actor keeps
 the list of sockets and sends broadcasts to them. Each socket actor calls your
 update function and runs the effects it returns, in order.
@@ -20,7 +20,7 @@ A frame is one WebSocket message. For a text frame, the path is:
 ```text
 transport connection
   -> configured wire codec
-  -> Beryl router actor
+  -> beryl router actor
   -> socket actor
   -> app update or channel callback
   -> returned effects or actions
@@ -62,7 +62,7 @@ The live-poll example follows that rule:
 
 - `store.Store` keeps the shared poll state in its own actor;
 - `timer.Timer` waits and runs delayed callbacks in its own actor;
-- Beryl callbacks make short calls, pick the next state, and return effects.
+- beryl callbacks make short calls, pick the next state, and return effects.
 
 If some work takes a long time, do not run it in a callback. Run it under your
 own supervision. Then send a typed result back through `socket.Sender` or
@@ -71,8 +71,8 @@ own supervision. Then send a typed result back through `socket.Sender` or
 ## A callback crash closes the smallest affected part
 
 In Erlang, "let it crash" means: let a process die and let its supervisor
-restart it. If Beryl did that here, one bad callback would close every topic on
-its socket. Instead, Beryl catches the crash. What happens next depends on
+restart it. If beryl did that here, one bad callback would close every topic on
+its socket. Instead, beryl catches the crash. What happens next depends on
 which input failed:
 
 | Callback or raw input | Runtime behavior |
@@ -85,11 +85,11 @@ which input failed:
 
 Other socket actors keep running. If a socket actor crashes somewhere else,
 only that actor stops. The router sees this, closes the connection, and removes
-the socket from its list. Beryl cuts long crash descriptions before it logs
+the socket from its list. beryl cuts long crash descriptions before it logs
 them.
 
 The `on_terminate` case has one special behavior in the channel layer. If the
-callback panics, Beryl drops the router update and the actions it returned.
+callback panics, beryl drops the router update and the actions it returned.
 The channel's sender can still reach the old channel until the client joins the
 topic again or the socket ends. Client traffic cannot reach it, because the
 topic is closed. Keep `on_terminate` small. Do not do half-finished work there.
@@ -113,12 +113,12 @@ restart windows, restart intensity, and graceful shutdown.
 ## Heartbeats test that a connection is alive
 
 Phoenix clients send a heartbeat frame on the `phoenix` topic at a regular
-interval. Beryl handles heartbeats inside each socket actor. Your update
+interval. beryl handles heartbeats inside each socket actor. Your update
 function does not see them. Each actor records the time of the last heartbeat
 and runs its own timer to check it. There is no global check across all
 sockets.
 
-If a socket misses its heartbeat, Beryl closes the transport. It then delivers
+If a socket misses its heartbeat, beryl closes the transport. It then delivers
 `Closed(topic, HeartbeatTimeout)` for every joined topic. Raw dispatch can
 remove the topic from its model. The channel layer calls `on_terminate` for
 each channel.
@@ -197,7 +197,7 @@ normal app code.
 The earlier chapters started with a familiar update loop. In production, keep
 these differences in view:
 
-- Beryl has no `view`.
+- beryl has no `view`.
 - Raw `init` runs once per socket.
 - One actor stores each socket model. A separate router stores the socket list
   and the subscribers.
@@ -206,7 +206,7 @@ these differences in view:
 - The order of your effect list is the order on the wire.
 - Raw effects can work across topics. Channel actions apply to one topic, and
   the close phase allows fewer of them.
-- Beryl catches callback crashes. The size of the cleanup depends on the input.
+- beryl catches callback crashes. The size of the cleanup depends on the input.
 - A supervisor restart brings dispatch back. It does not bring live socket
   state back.
 
@@ -218,9 +218,9 @@ subscriptions when they reconnect.
 
 ## Sources and further reading
 
-- [Beryl runtime architecture](/architecture/runtime/)
+- [beryl runtime architecture](/architecture/runtime/)
 - [How beryl handles a message](/architecture/message-lifecycle/)
-- [Choose a Beryl API](/choosing-an-api/)
+- [Choose a beryl API](/choosing-an-api/)
 - [`beryl` source](https://github.com/tylerbutler/beryl/blob/main/packages/beryl/src/beryl.gleam)
 - [`beryl/socket` source](https://github.com/tylerbutler/beryl/blob/main/packages/beryl/src/beryl/socket.gleam)
 - [`beryl/channel` source](https://github.com/tylerbutler/beryl/blob/main/packages/beryl/src/beryl/channel.gleam)
@@ -236,4 +236,4 @@ poll now or wait 60 seconds. The behavior matches step 04, but the runtime now
 uses the heartbeat and abuse-control settings shown above. In another shell,
 run `curl http://localhost:8105/healthz`. The expected response is `ok`.
 
-Next: [Supervising Beryl](/tutorial/supervising-beryl/).
+Next: [Supervising beryl](/tutorial/supervising-beryl/).

--- a/website/src/content/docs/tutorial/where-the-analogy-ends.md
+++ b/website/src/content/docs/tutorial/where-the-analogy-ends.md
@@ -23,8 +23,8 @@ transport connection
   -> Beryl router actor
   -> socket actor
   -> app update or channel callback
-  -> effect/action interpreter
-  -> encoded wire frame or broadcast fan-out
+  -> returned effects or actions
+  -> encoded WebSocket frame or broadcast to subscribers
 ```
 
 The transport owns the WebSocket connection. It does the first checks: is the
@@ -68,7 +68,7 @@ If some work takes a long time, do not run it in a callback. Run it under your
 own supervision. Then send a typed result back through `socket.Sender` or
 `channel.Sender`.
 
-## Beryl catches callback crashes, and the effect depends on the input
+## A callback crash closes the smallest affected part
 
 In Erlang, "let it crash" means: let a process die and let its supervisor
 restart it. If Beryl did that here, one bad callback would close every topic on
@@ -88,7 +88,7 @@ only that actor stops. The router sees this, closes the connection, and removes
 the socket from its list. Beryl cuts long crash descriptions before it logs
 them.
 
-The `on_terminate` case has one small edge in the channel layer. If the
+The `on_terminate` case has one special behavior in the channel layer. If the
 callback panics, Beryl drops the router update and the actions it returned.
 The channel's sender can still reach the old channel until the client joins the
 topic again or the socket ends. Client traffic cannot reach it, because the
@@ -97,7 +97,7 @@ topic is closed. Keep `on_terminate` small. Do not do half-finished work there.
 This policy contains crashes in your callbacks. It does not pretend that every
 crash has the same size.
 
-## Supervision restores dispatch, not sessions
+## A restart restores the service, not socket state
 
 `beryl.child_spec` and `channel.child_spec` return a child specification. You
 put it in your application's supervisor. If the router dies, the supervisor
@@ -143,7 +143,7 @@ These values make the example look like a production app. They are not correct
 for every app. Choose your limits from the traffic you expect and the capacity
 you have.
 
-## PubSub and presence sit outside the MVU analogy
+## PubSub and presence follow different rules
 
 PubSub sends broadcasts between BEAM nodes. It uses Erlang `pg`, the built-in
 process group library. A remote payload and its subscribers are a distributed
@@ -157,8 +157,7 @@ for one socket while the presence actor applies the change. Other sockets,
 heartbeats, broadcasts, and shutdown keep going. When the change is done, the
 socket runs the rest of its list in the original order.
 
-PubSub and presence are not hidden fields in your socket `Model`. Each one has
-its own lifecycle and its own distributed rules. Design them on their own:
+PubSub and presence are not hidden fields in your socket `Model`. Each one starts, stops, and communicates across nodes in its own way:
 
 - configure PubSub when broadcasts must cross nodes;
 - start and supervise presence when clients need a shared member list;
@@ -193,7 +192,7 @@ Channel actions apply only to the current topic, and only some actions are
 allowed during close. Raw effects can name any topic, so work across topics is
 normal app code.
 
-## The boundaries to remember
+## Rules to remember
 
 The earlier chapters started with a familiar update loop. In production, keep
 these differences in view:
@@ -212,15 +211,15 @@ these differences in view:
   state back.
 
 These rules tell you where to put state and work. Keep facts about one
-connection in raw models or channel state. Keep shared domain state in
-processes your app owns. Decode at the wire boundary. Return short, ordered
+connection in raw models or channel state. Keep shared app state in
+processes your app owns. Decode client data after beryl reads the frame. Return short, ordered
 effect lists. Let supervision restore services. Let clients restore their
 subscriptions when they reconnect.
 
 ## Sources and further reading
 
 - [Beryl runtime architecture](/architecture/runtime/)
-- [Beryl message lifecycle](/architecture/message-lifecycle/)
+- [How beryl handles a message](/architecture/message-lifecycle/)
 - [Choose a Beryl API](/choosing-an-api/)
 - [`beryl` source](https://github.com/tylerbutler/beryl/blob/main/packages/beryl/src/beryl.gleam)
 - [`beryl/socket` source](https://github.com/tylerbutler/beryl/blob/main/packages/beryl/src/beryl/socket.gleam)


### PR DESCRIPTION
## Summary

- rewrite authored website copy and headings with direct, reader-focused language
- standardize on “raw dispatch” and explain required technical terms
- remove Netlify’s ignore rule so every deploy builds the website

## Checks

- 144 Gleam documentation snippets type-check
- reference generator tests pass
- Astro check passes
- production website build and internal-link validation pass