### PR TITLE
feat(runtime): supervise sockets with an actor factory

### DIFF
--- a/docs/adr/0005-socket-actor-supervision.md
+++ b/docs/adr/0005-socket-actor-supervision.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed (2026-08-28).
+Accepted (2026-08-28).
 
 This ADR follows
 [ADR 0004](0004-channel-process-fault-boundaries.md). ADR 0004 assigns one
@@ -282,6 +282,13 @@ application `init`. Phase two will use the existing admission token and
 owner check. The router will monitor and index the actor before it forwards
 `AdmitSocket`. The actor will run application `init` and answer the transport.
 
+The `Booting` phase will be bounded. A cancelled admission stops the actor
+through the existing `StopSocketActor` cast. An actor whose transport process
+dies before it reaches the router receives no such cast, so the actor also
+stops itself at a boot deadline. This keeps a never-admitted child from
+accumulating under the factory. The deadline is read between turns only, so it
+never interrupts a slow application `init`.
+
 Socket actors will remain `Temporary`. The supervisor will not restart socket
 or topic state without a new client handshake. If a socket actor stops, the
 router monitor will still remove routing and presence state. If the router
@@ -294,6 +301,20 @@ it closes the WebSocket when the admitting router generation stops.
 Graceful `beryl.stop` must drain socket actors before the internal supervisor
 stops the socket factory. The factory shutdown timeout is a final safeguard
 for actors that do not finish the drain.
+
+### Factory failure
+
+The factory owns and links every socket actor it starts. If the factory
+fails, all of its socket actors stop with it, in both the `Booting` and the
+`Active` phase. The router monitors each admitted actor, so it sweeps their
+topic index entries and presence data and calls their transport closers. The
+clients see closed connections and reconnect.
+
+The factory is a `Permanent` child, so the nested beryl supervisor restarts it
+under the same registered name. The router is not restarted by that failure
+and keeps its generation. Transports reach the replacement factory through its
+name rather than a captured PID, so new connections are admitted as soon as
+the replacement is registered.
 
 ## Consequences
 
@@ -308,7 +329,8 @@ for actors that do not finish the drain.
 - The factory and router both retain per-socket process metadata.
 - Admission gains explicit `Booting`, `Active`, and `Closing` phases.
 - Shutdown must preserve drain-before-factory-stop order.
-- A factory failure can affect the ownership of all active socket actors.
+- A factory failure closes every connection the factory owned. The router
+  sweep and the `Permanent` restart restore service without a router restart.
 
 The new factory improves OTP ownership and inspection. It does not replace
 protocol-level monitors or client reconnect and rejoin recovery.
@@ -356,6 +378,33 @@ admission latency for unrelated sockets. Burst-start throughput must not
 regress by more than 10 percent at the expected deployment scale. The pull
 request must report the test scale, Erlang version, scheduler count, and raw
 results.
+
+### Results
+
+The implementation was compared with the direct-start design on Erlang
+27.2.1 with 12 schedulers. Both variants used the Mist transport and the k6
+`connection-rate` profile at 2,000 connections per second for 30 seconds.
+Each variant ran three times after a protocol warm-up and a 65-second
+cool-down between runs.
+
+| Design and run | Starts per second | p50 | p95 | p99 | Dropped | Errors |
+|---|---:|---:|---:|---:|---:|---:|
+| Direct 1 | 1,999.86 | 1 ms | 4 ms | 9 ms | 0 | 0 |
+| Direct 2 | 1,999.70 | 1 ms | 4 ms | 10 ms | 0 | 0 |
+| Direct 3 | 1,999.29 | 1 ms | 2 ms | 7 ms | 0 | 0 |
+| Factory 1 | 1,998.11 | 1 ms | 15 ms | 56 ms | 0 | 0 |
+| Factory 2 | 1,999.90 | 1 ms | 2 ms | 4 ms | 0 | 0 |
+| Factory 3 | 1,999.90 | 0 ms | 2 ms | 5 ms | 0 | 0 |
+
+Median throughput was 1,999.70 starts per second for direct startup and
+1,999.90 for factory startup. Factory throughput was 100.01 percent of the
+direct-start result, so it passed the 90 percent acceptance threshold. The
+factory medians were 1 ms at p50, 2 ms at p95, and 5 ms at p99, with no
+dropped iterations or unexpected errors.
+
+A higher-rate probe was excluded because other processes loaded the shared
+host during one variant. Capacity above 2,000 starts per second requires a
+separate comparison on an isolated host.
 
 ## Sources
 

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -612,6 +612,9 @@ pub type AppHandle {
     /// Current pid of the supervised runtime, if running (used by tests
     /// and PubSub sender attribution).
     runtime_owner: fn() -> Result(process.Pid, Nil),
+    /// Current pid of the supervised socket factory, if running (used by
+    /// tests).
+    socket_factory_owner: fn() -> Result(process.Pid, Nil),
     stats: fn() -> Result(runtime.StatsSnapshot, StatsError),
   )
 }
@@ -928,6 +931,7 @@ fn build_app_subtree(
 
   let runtime_name = process.new_name("beryl_runtime")
   let supervisor_name = process.new_name("beryl_app_supervisor")
+  let factory_name = process.new_name("beryl_socket_factory")
   let limiter_name = case
     connection_limit.enabled(
       config.max_connections_per_ip,
@@ -946,13 +950,10 @@ fn build_app_subtree(
       app: app_handle(
         process.named_subject(runtime_name),
         process.named_subject(supervisor_name),
+        process.named_subject(factory_name),
         fn(runtime_pid) {
-          runtime.start_socket_actor(
-            config: to_runtime_config(config),
-            init: init,
-            update: update,
-            open_worker: open_worker,
-            router: process.named_subject(runtime_name),
+          runtime.start_socket_child(
+            factory: factory_name,
             router_pid: runtime_pid,
           )
         },
@@ -964,21 +965,53 @@ fn build_app_subtree(
       supervisor_name,
       stop_runtime(process.named_subject(runtime_name), _),
       fn() {
-        child_spec_supervisor(config, runtime_name, limiter_name, init, update)
+        child_spec_supervisor(
+          config,
+          runtime_name,
+          factory_name,
+          limiter_name,
+          init,
+          update,
+          open_worker,
+        )
       },
     )
   })
 }
 
-/// Start the nested beryl subtree: a one-for-one supervisor owning the runtime
-/// as a transient child, with the optional connection limiter as a sibling.
+/// Start the nested beryl subtree: a one-for-one supervisor owning the socket
+/// factory and the runtime, with the optional connection limiter as a sibling.
+///
+/// The socket factory is added first, so the runtime is asked to shut down
+/// before it (children terminate in reverse start order). A graceful
+/// `beryl.stop` therefore drains every socket actor through the router before
+/// the factory tears the survivors down.
 fn child_spec_supervisor(
   config: Config,
   runtime_name: process.Name(runtime.Msg(msg)),
+  factory_name: process.Name(runtime.SocketFactoryMessage(msg)),
   limiter_name: Option(process.Name(connection_limit.Message)),
   init: fn(socket.ConnectInfo(msg)) -> #(model, List(socket.Effect)),
   update: fn(model, socket.Input(msg)) -> socket.Next(model),
+  open_worker: Option(fn(socket.WorkerContext) -> socket.WorkerOutcome),
 ) -> Result(actor.Started(static_supervisor.Supervisor), actor.StartError) {
+  // Socket actors are `Temporary` children of this factory: it owns their
+  // process lifetime and forced shutdown, but never reconstructs the
+  // connection state a stopped socket owned. A factory crash therefore takes
+  // its whole socket population with it; the router's monitors sweep the
+  // routing and presence state and close the transports, and the `Permanent`
+  // factory restarts under the same name to accept new connections.
+  let factory_child =
+    runtime.socket_factory_child(
+      config: to_runtime_config(config),
+      init: init,
+      update: update,
+      open_worker: open_worker,
+      router: process.named_subject(runtime_name),
+      name: factory_name,
+    )
+    |> supervision.restart(supervision.Permanent)
+
   let runtime_child =
     supervision.worker(fn() {
       runtime.start_named(
@@ -1000,6 +1033,7 @@ fn child_spec_supervisor(
     static_supervisor.new(static_supervisor.OneForOne)
     |> static_supervisor.restart_tolerance(intensity: 3, period: 5)
     |> static_supervisor.auto_shutdown(static_supervisor.AnySignificant)
+    |> static_supervisor.add(factory_child)
     |> static_supervisor.add(runtime_child)
 
   let builder = case limiter_name {
@@ -1041,6 +1075,7 @@ fn await_admission(
 fn app_handle(
   subject: Subject(runtime.Msg(msg)),
   supervisor: Subject(app_supervisor.Message),
+  factory: Subject(runtime.SocketFactoryMessage(msg)),
   start_socket_actor: fn(process.Pid) ->
     Result(actor.Started(Subject(runtime.Msg(msg))), actor.StartError),
 ) -> AppHandle {
@@ -1056,17 +1091,15 @@ fn app_handle(
     ) {
       case process.subject_owner(subject) {
         Ok(current_owner) if current_owner == owner -> {
-          // The socket's actor is started here, in the transport's
-          // connection process, so connection setup never serialises
-          // through the runtime; the runtime's admission turn is an O(1)
-          // atomic admit-and-forward, and the actor answers `reply`
-          // itself once the app `init` has run.
+          // Phase one of admission: the socket factory starts the actor, so
+          // it is an owned supervision-tree child before registration
+          // begins. Only that start is serialised through the factory —
+          // the app `init` runs later, in the actor itself, so the
+          // runtime's admission turn stays an O(1) atomic
+          // admit-and-forward and connection setup stays parallel.
           case start_socket_actor(owner) {
             Error(_) -> False
             Ok(started) -> {
-              // `actor.start` linked the actor to this transport process;
-              // its lifecycle belongs to the runtime instead.
-              process.unlink(started.pid)
               let reply = process.new_subject()
               let admission = runtime.new_admission_token()
               process.send(
@@ -1124,6 +1157,7 @@ fn app_handle(
     },
     stop: fn() { request_runtime_stop(supervisor) },
     runtime_owner: fn() { process.subject_owner(subject) },
+    socket_factory_owner: fn() { process.subject_owner(factory) },
     stats: fn() {
       case process.subject_owner(subject) {
         Error(Nil) -> Error(StatsRuntimeUnavailable)
@@ -1206,6 +1240,12 @@ pub fn app_runtime_pid(channels: Sockets) -> Result(process.Pid, Nil) {
 @internal
 pub fn app_limiter_pid(channels: Sockets) -> Result(process.Pid, Nil) {
   app_limiter_owner(channels.connection_limiter)
+}
+
+/// The pid of the app subtree's socket factory supervisor, if running.
+@internal
+pub fn app_socket_factory_pid(channels: Sockets) -> Result(process.Pid, Nil) {
+  channels.app.socket_factory_owner()
 }
 
 fn to_runtime_config(config: Config) -> runtime.Config {

--- a/packages/beryl/src/beryl/runtime.gleam
+++ b/packages/beryl/src/beryl/runtime.gleam
@@ -187,6 +187,12 @@ pub type Msg(msg) {
   WorkerDown(down: process.Down)
   /// A closing topic's worker did not report its termination in time.
   WorkerTerminateTimedOut(socket_id: String, worker: Pid)
+  /// A socket actor was still `Booting` when its boot deadline expired: the
+  /// admission that started it was cancelled, or the transport process died
+  /// before it reached the router. The actor stops so the socket factory
+  /// cannot accumulate never-admitted children. Ignored once the actor is
+  /// `Active` or `Closing`.
+  BootTimedOut
 }
 
 /// What a topic worker sends its socket actor.
@@ -286,6 +292,8 @@ type RuntimeRole(msg) {
   )
   SocketActorRole(
     router: Subject(Msg(msg)),
+    /// Where this actor sits in the two-phase admission of ADR 0005.
+    phase: SocketPhase,
     /// The supervisor that starts topic workers for a socket actor.
     ///
     /// `beryl/channel` uses this supervisor for one process per accepted
@@ -295,6 +303,19 @@ type RuntimeRole(msg) {
     /// sockets do not wait for each other.
     workers: Option(factory_supervisor.Supervisor(WorkerSpawn, WorkerStarted)),
   )
+}
+
+/// The admission phase of a socket actor (ADR 0005).
+///
+/// Phase one of admission starts the actor under the socket factory and
+/// returns before any application callback runs, so the actor is `Booting`.
+/// Phase two runs the application `init` from the router's `AdmitSocket`
+/// and moves the actor to `Active`. `Closing` covers teardown, where no
+/// admission may still be accepted.
+type SocketPhase {
+  Booting
+  Active
+  Closing
 }
 
 /// One topic worker a socket owns.
@@ -650,6 +671,74 @@ pub fn start_named(
   |> actor.start
 }
 
+/// The socket factory's message type, used only as the payload of its
+/// registered name. The per-connection start argument is the router pid the
+/// transport captured before admission.
+pub type SocketFactoryMessage(msg) =
+  factory_supervisor.Message(process.Pid, Subject(Msg(msg)))
+
+/// Build the socket factory child of the nested beryl supervisor (ADR 0005).
+///
+/// The factory is one `simple_one_for_one` supervisor for the whole system.
+/// Its child template captures the runtime configuration, the application
+/// `init` and `update`, and the optional topic-worker opener, so the only
+/// per-connection argument is the captured router pid. Socket actors are
+/// `Temporary`: a socket owns connection state that no supervisor can
+/// reconstruct, so a stopped socket is recovered by a client reconnect.
+///
+/// The template runs no application callback. It starts the actor, which
+/// runs `init` later, from the router's `AdmitSocket`.
+pub fn socket_factory_child(
+  config config: Config,
+  init init: fn(ConnectInfo(msg)) -> #(model, List(Effect)),
+  update update: fn(model, Input(msg)) -> Next(model),
+  open_worker open_worker: Option(fn(WorkerContext) -> WorkerOutcome),
+  router router: Subject(Msg(msg)),
+  name name: process.Name(SocketFactoryMessage(msg)),
+) -> supervision.ChildSpecification(
+  factory_supervisor.Supervisor(process.Pid, Subject(Msg(msg))),
+) {
+  factory_supervisor.worker_child(fn(router_pid) {
+    start_socket_actor(
+      config:,
+      init:,
+      update:,
+      open_worker:,
+      router:,
+      router_pid:,
+    )
+  })
+  |> factory_supervisor.restart_strategy(supervision.Temporary)
+  |> factory_supervisor.named(name)
+  |> factory_supervisor.supervised
+}
+
+/// Start one socket actor as a `Temporary` child of the named socket factory.
+///
+/// Called from the transport's connection process (through `beryl`'s
+/// admission closure), so connection setup stays parallel and the router's
+/// admission turn stays O(1). The factory is reached through its registered
+/// name rather than a captured pid, so a restarted factory is used without
+/// the caller holding a stale reference. If no factory is registered — before
+/// startup, during a factory restart window, or after shutdown — this reports
+/// the failure instead of crashing the transport process.
+pub fn start_socket_child(
+  factory factory: process.Name(SocketFactoryMessage(msg)),
+  router_pid router_pid: process.Pid,
+) -> Result(actor.Started(Subject(Msg(msg))), actor.StartError) {
+  case
+    internal.rescue(fn() {
+      factory_supervisor.start_child(
+        factory_supervisor.get_by_name(factory),
+        router_pid,
+      )
+    })
+  {
+    Ok(result) -> result
+    Error(crash) -> Error(actor.InitFailed(crash))
+  }
+}
+
 /// Start one actor to own one socket.
 ///
 /// It runs the same `handle_message` on the same `State` as the router —
@@ -657,11 +746,10 @@ pub fn start_named(
 /// topic index beyond its own memberships, no PubSub subscriber, and
 /// `router` set. That is the whole lift of `dispatch_socket_msg`.
 ///
-/// Called from the transport's connection process (via `beryl`'s admission
-/// closure), not from the router, so connection setup stays parallel and
-/// the router's admission turn stays O(1). The caller is expected to
-/// unlink the started actor and hand it to the router with `AdmitSocket`.
-pub fn start_socket_actor(
+/// This is phase one of admission: it starts the actor and its per-socket
+/// topic-worker factory and returns. It runs no application callback, so a
+/// slow `init` never holds the socket factory's start turn.
+fn start_socket_actor(
   config config: Config,
   init init: fn(ConnectInfo(msg)) -> #(model, List(Effect)),
   update update: fn(model, Input(msg)) -> Next(model),
@@ -705,13 +793,15 @@ pub fn start_socket_actor(
         queued: dict.new(),
         unacked_tracks: dict.new(),
         stopping: False,
-        role: SocketActorRole(router:, workers:),
+        role: SocketActorRole(router:, phase: Booting, workers:),
       )
     // Router death must take its socket actors with it: each actor
-    // monitors the router and stops on its `Down`, while staying unlinked
-    // so a socket crash cannot travel the other way.
+    // monitors the router and stops on its `Down`, while a socket crash
+    // reaches the router through the router's own monitor instead of a
+    // link.
     let monitor = process.monitor(router_pid)
     schedule_heartbeat_check(subject, config)
+    schedule_boot_check(subject)
     // Match the router monitor before the general monitor handler. Each other
     // `Down` message belongs to a topic worker for this socket.
     process.new_selector()
@@ -735,6 +825,20 @@ fn schedule_heartbeat_check(subject: Subject(Msg(msg)), config: Config) -> Nil {
       config.heartbeat_timeout_ms / 2,
       CheckHeartbeats,
     )
+  Nil
+}
+
+/// How long a socket actor may stay in `Booting` before it gives up.
+///
+/// The transport waits one second for admission and then cancels it, so an
+/// actor that is still unadmitted well past that has lost its transport: the
+/// connection process died before it reached the router, or its cancellation
+/// never arrived. The deadline is only read between turns, so it never cuts a
+/// slow application `init` short.
+const socket_boot_timeout_ms = 5000
+
+fn schedule_boot_check(subject: Subject(Msg(msg))) -> Nil {
+  let _timer = process.send_after(subject, socket_boot_timeout_ms, BootTimedOut)
   Nil
 }
 
@@ -939,6 +1043,17 @@ fn handle_message(
           handle_router_socket_actor_down(state, down, socket_actors)
       }
     RouterDown -> actor.stop()
+    BootTimedOut ->
+      case state.role {
+        SocketActorRole(phase: Booting, ..) -> {
+          state.logger
+          |> log.warn("Socket actor stopping: never admitted", [])
+          actor.stop()
+        }
+        SocketActorRole(phase: Active, ..)
+        | SocketActorRole(phase: Closing, ..)
+        | RouterRole(..) -> actor.continue(state)
+      }
   }
 }
 
@@ -1129,7 +1244,8 @@ fn dispatch_socket_msg(
     | IndexLeave(..)
     | SocketClosed(..)
     | SocketActorDown(..)
-    | RouterDown -> state
+    | RouterDown
+    | BootTimedOut -> state
   }
 }
 
@@ -1215,10 +1331,10 @@ fn handle_admit_socket(
   actor_pid: process.Pid,
 ) -> actor.Next(State(model, msg), Msg(msg)) {
   case state.role {
-    // In a socket actor: the router has already admitted this socket
-    // atomically in its own turn; this actor runs the app `init` and
-    // answers the transport directly.
-    SocketActorRole(router:, ..) -> {
+    // Phase two of admission (ADR 0005). The router has already admitted
+    // this socket atomically in its own turn; this actor runs the app
+    // `init` and answers the transport directly.
+    SocketActorRole(router:, phase: Booting, workers:) -> {
       let #(state, admitted) =
         register_socket(
           state,
@@ -1232,7 +1348,13 @@ fn handle_admit_socket(
         )
       process.send(reply, admitted)
       case admitted {
-        True -> actor.continue(state)
+        True ->
+          actor.continue(
+            State(
+              ..state,
+              role: SocketActorRole(router:, phase: Active, workers:),
+            ),
+          )
         // Refused: the app `init` crashed, or the transport's wait timed
         // out and cancelled the token. The router already indexed this
         // actor, so unwind that entry on the way out.
@@ -1241,6 +1363,13 @@ fn handle_admit_socket(
           actor.stop()
         }
       }
+    }
+    // A second admission for an actor that is already admitted or already
+    // tearing down. Only one socket may ever register per actor, so this
+    // is refused without running `init` again.
+    SocketActorRole(phase: Active, ..) | SocketActorRole(phase: Closing, ..) -> {
+      process.send(reply, False)
+      actor.continue(state)
     }
     // The router's whole admission turn: the checks that must be atomic
     // with each other, one monitor-free insert, and a forward. It never
@@ -1475,6 +1604,13 @@ fn finalize_for_stop(state: State(model, msg)) -> State(model, msg) {
   // From here on there is no runtime left to receive an acknowledgement,
   // so presence mutations are sent fire-and-forget and never suspend.
   let state = State(..state, stopping: True)
+  // A socket actor is closing from here on, so a late `AdmitSocket` must
+  // not run the application `init` behind the teardown.
+  let state = case state.role {
+    RouterRole(..) -> state
+    SocketActorRole(router:, workers:, ..) ->
+      State(..state, role: SocketActorRole(router:, phase: Closing, workers:))
+  }
   let state =
     dict.keys(state.suspended)
     |> list.fold(state, finalize_suspension)

--- a/packages/beryl/test/app_supervision_test.gleam
+++ b/packages/beryl/test/app_supervision_test.gleam
@@ -10,15 +10,18 @@
 import app_test_helpers as h
 import beryl
 import beryl/socket.{AcceptJoin, Broadcast, Join, Next}
+import beryl/stats
 import beryl/transport
 import beryl/wire
 import gleam/erlang/process
 import gleam/json
+import gleam/list
 import gleam/option.{None}
 import gleam/otp/actor
 import gleam/otp/static_supervisor
 import gleam/otp/supervision
 import gleam/result
+import gleam/string
 import gleeunit/should
 import test_helpers
 
@@ -32,6 +35,9 @@ fn wait_for_gate(gate: Gate) -> Nil
 
 @external(erlang, "beryl_supervisor_test_ffi", "gate_release")
 fn release_gate(gate: Gate) -> Nil
+
+@external(erlang, "beryl_supervisor_test_ffi", "active_child_count")
+fn active_child_count(supervisor: process.Pid) -> Int
 
 // ── A trivial named sibling worker used to prove parent/sibling survival ────
 
@@ -786,4 +792,347 @@ pub fn stop_leaves_no_registered_name_or_process_test() {
   beryl.app_limiter_pid(sockets) |> should.be_error
   // The system is fully gone: a fresh connection cannot be admitted.
   transport.acquire_connection_slot(sockets, "1.2.3.4") |> should.be_error
+}
+
+// ── the socket factory owns the socket actors (ADR 0005) ────────────────────
+
+fn socket_factory_pid(sockets: beryl.Sockets) -> process.Pid {
+  let assert Ok(pid) = beryl.app_socket_factory_pid(sockets)
+  pid
+}
+
+fn connected_sockets(sockets: beryl.Sockets) -> Int {
+  case stats.snapshot(sockets) {
+    Ok(snapshot) -> stats.connected_sockets(snapshot)
+    Error(_) -> -1
+  }
+}
+
+pub fn socket_factory_crash_closes_sockets_and_recovers_test() {
+  let assert Ok(sockets) =
+    h.start_app(
+      beryl.config(wire.phoenix_codec()),
+      init: h.accepting_init,
+      update: h.accepting_update,
+    )
+
+  let closed = process.new_subject()
+  let runtime = h.runtime_pid(sockets)
+  admit(sockets, runtime, "factory-a", fn() {
+    process.send(closed, "factory-a")
+  })
+  |> should.equal(Ok(Nil))
+  admit(sockets, runtime, "factory-b", fn() {
+    process.send(closed, "factory-b")
+  })
+  |> should.equal(Ok(Nil))
+
+  // Both socket actors are owned children of the shared factory.
+  let factory = socket_factory_pid(sockets)
+  active_child_count(factory) |> should.equal(2)
+
+  process.kill(factory)
+
+  // The factory took its whole socket population with it, and the router
+  // swept both actors through its monitors and closed their transports.
+  let assert Ok(first) = process.receive(closed, 2000)
+  let assert Ok(second) = process.receive(closed, 2000)
+  [first, second]
+  |> list.sort(string.compare)
+  |> should.equal(["factory-a", "factory-b"])
+  test_helpers.wait_until(fn() { connected_sockets(sockets) == 0 }, 2000, 10)
+  connected_sockets(sockets) |> should.equal(0)
+
+  // Only the factory restarted: the permanent child comes back under the same
+  // name while the router keeps running.
+  test_helpers.wait_until(
+    fn() {
+      case beryl.app_socket_factory_pid(sockets) {
+        Ok(pid) -> pid != factory && process.is_alive(pid)
+        Error(Nil) -> False
+      }
+    },
+    2000,
+    10,
+  )
+  let recovered = socket_factory_pid(sockets)
+  recovered |> should.not_equal(factory)
+  beryl.app_runtime_pid(sockets) |> should.equal(Ok(runtime))
+  active_child_count(recovered) |> should.equal(0)
+
+  // New connections are accepted, and are children of the replacement.
+  admit(sockets, runtime, "after-factory-crash", fn() { Nil })
+  |> should.equal(Ok(Nil))
+  active_child_count(recovered) |> should.equal(1)
+  connected_sockets(sockets) |> should.equal(1)
+
+  beryl.stop(sockets) |> should.equal(Ok(Nil))
+}
+
+pub fn cancelled_admission_leaves_no_booting_factory_child_test() {
+  let gate = new_gate()
+  let init_entered = process.new_subject()
+  let assert Ok(sockets) =
+    h.start_app(
+      beryl.config(wire.phoenix_codec()),
+      init: fn(_info: socket.ConnectInfo(Nil)) {
+        process.send(init_entered, Nil)
+        wait_for_gate(gate)
+        #(Nil, [])
+      },
+      update: h.accepting_update,
+    )
+
+  let factory = socket_factory_pid(sockets)
+  let admission_result = process.new_subject()
+  let connection_closed = process.new_subject()
+  let _connection =
+    process.spawn(fn() {
+      let assert Ok(owner) = transport.runtime_pid(sockets)
+      process.send(
+        admission_result,
+        transport.admit_socket(
+          sockets: sockets,
+          owner: owner,
+          socket_id: "cancelled",
+          send: fn(_message) { Ok(Nil) },
+          send_binary: fn(_data) { Ok(Nil) },
+          codec: None,
+          seed: socket.empty_seed(),
+          close: fn() { process.send(connection_closed, Nil) },
+        ),
+      )
+    })
+
+  // Phase one is done: the actor exists as a factory child while it is still
+  // booting, before the application `init` has registered anything.
+  process.receive(init_entered, 1000) |> should.equal(Ok(Nil))
+  active_child_count(factory) |> should.equal(1)
+
+  // The transport's admission wait expires and cancels the token.
+  process.receive(admission_result, 2000) |> should.equal(Ok(Error(Nil)))
+  process.receive(connection_closed, 1000) |> should.equal(Ok(Nil))
+
+  // The booting actor finds its admission cancelled and stops instead of
+  // leaking as a never-admitted child of the factory.
+  release_gate(gate)
+  test_helpers.wait_until(fn() { active_child_count(factory) == 0 }, 2000, 10)
+  active_child_count(factory) |> should.equal(0)
+  test_helpers.wait_until(fn() { connected_sockets(sockets) == 0 }, 2000, 10)
+  connected_sockets(sockets) |> should.equal(0)
+
+  beryl.stop(sockets) |> should.equal(Ok(Nil))
+}
+
+pub fn stop_drains_socket_actors_before_stopping_the_factory_test() {
+  let closes = process.new_subject()
+  let assert Ok(sockets) =
+    h.start_app(
+      beryl.config(wire.phoenix_codec()),
+      init: h.accepting_init,
+      update: fn(model, input) {
+        case input {
+          socket.Closed(topic, reason) -> {
+            process.send(closes, #(topic, reason))
+            Next(model, [])
+          }
+          Join(_, _, ref) -> Next(model, [AcceptJoin(ref, None)])
+          _ -> Next(model, [])
+        }
+      },
+    )
+
+  let transport_closed = process.new_subject()
+  let frames =
+    h.connect_with_close(sockets, "drained", fn() {
+      process.send(transport_closed, Nil)
+    })
+  h.join_ok(sockets, frames, "drained", "room:a", "jr-1", "r-1")
+  let factory = socket_factory_pid(sockets)
+  active_child_count(factory) |> should.equal(1)
+
+  beryl.stop(sockets) |> should.equal(Ok(Nil))
+
+  // The socket actor ran its shutdown teardown before the factory was
+  // stopped: a factory shutdown that preceded the drain would have killed the
+  // actor without ever delivering `Closed`.
+  process.receive(closes, 1000)
+  |> should.equal(Ok(#("room:a", socket.Shutdown)))
+  process.receive(transport_closed, 1000) |> should.equal(Ok(Nil))
+
+  // The factory is then torn down with the rest of the subtree.
+  test_helpers.wait_until(fn() { !process.is_alive(factory) }, 2000, 10)
+  process.is_alive(factory) |> should.be_false
+  beryl.app_socket_factory_pid(sockets) |> should.be_error
+}
+
+// ── transport close during `Booting` discards init effects (ADR 0005) ──────
+
+pub fn cancelled_admission_during_booting_discards_init_effects_test() {
+  let gate = new_gate()
+  let init_entered = process.new_subject()
+  let assert Ok(sockets) =
+    h.start_app(
+      beryl.config(wire.phoenix_codec()),
+      init: fn(info: socket.ConnectInfo(Nil)) {
+        case info.socket_id {
+          "cancelled-with-effects" -> {
+            process.send(init_entered, Nil)
+            wait_for_gate(gate)
+            #(Nil, [Broadcast("room:a", "leak", json.string("leaked"))])
+          }
+          _ -> #(Nil, [])
+        }
+      },
+      update: h.accepting_update,
+    )
+
+  // A bystander already joined to the topic the cancelled init would
+  // broadcast to: if the cancelled `init`'s effects ever leaked into the
+  // runtime, this socket would see the broadcast frame.
+  let frames = h.connect(sockets, "bystander")
+  h.join_ok(sockets, frames, "bystander", "room:a", "jr-0", "r-0")
+
+  let factory = socket_factory_pid(sockets)
+  active_child_count(factory) |> should.equal(1)
+
+  let admission_result = process.new_subject()
+  let connection_closed = process.new_subject()
+  let _connection =
+    process.spawn(fn() {
+      let assert Ok(owner) = transport.runtime_pid(sockets)
+      process.send(
+        admission_result,
+        transport.admit_socket(
+          sockets: sockets,
+          owner: owner,
+          socket_id: "cancelled-with-effects",
+          send: fn(_message) { Ok(Nil) },
+          send_binary: fn(_data) { Ok(Nil) },
+          codec: None,
+          seed: socket.empty_seed(),
+          close: fn() { process.send(connection_closed, Nil) },
+        ),
+      )
+    })
+
+  // Phase one is done: the actor exists as a factory child while `init` is
+  // still running, before it has registered anything.
+  process.receive(init_entered, 1000) |> should.equal(Ok(Nil))
+  active_child_count(factory) |> should.equal(2)
+
+  // The transport's admission wait expires and closes the connection while
+  // `init` is still running -- a transport close/disconnect during
+  // `Booting`.
+  process.receive(admission_result, 2000) |> should.equal(Ok(Error(Nil)))
+  process.receive(connection_closed, 1000) |> should.equal(Ok(Nil))
+
+  release_gate(gate)
+
+  // The cancelled actor stops instead of leaking as a factory child, and its
+  // `init` effects -- queued behind the cancellation check -- never apply:
+  // the bystander never sees the broadcast.
+  test_helpers.wait_until(fn() { active_child_count(factory) == 1 }, 2000, 10)
+  active_child_count(factory) |> should.equal(1)
+  h.recv_none(frames)
+
+  beryl.stop(sockets) |> should.equal(Ok(Nil))
+}
+
+// ── graceful stop drains a `Booting` socket alongside an `Active` one ──────
+// (ADR 0005)
+
+pub fn stop_drains_active_and_booting_socket_actors_test() {
+  let gate = new_gate()
+  let init_entered = process.new_subject()
+  let closes = process.new_subject()
+  let assert Ok(sockets) =
+    h.start_app(
+      beryl.config(wire.phoenix_codec()),
+      init: fn(info: socket.ConnectInfo(Nil)) {
+        case info.socket_id {
+          "booting" -> {
+            process.send(init_entered, Nil)
+            wait_for_gate(gate)
+            Nil
+          }
+          _ -> Nil
+        }
+        #(Nil, [])
+      },
+      update: fn(model, input) {
+        case input {
+          socket.Closed(topic, reason) -> {
+            process.send(closes, #(topic, reason))
+            Next(model, [])
+          }
+          Join(_, _, ref) -> Next(model, [AcceptJoin(ref, None)])
+          _ -> Next(model, [])
+        }
+      },
+    )
+
+  let transport_closed = process.new_subject()
+  let frames =
+    h.connect_with_close(sockets, "active", fn() {
+      process.send(transport_closed, Nil)
+    })
+  h.join_ok(sockets, frames, "active", "room:a", "jr-1", "r-1")
+
+  let factory = socket_factory_pid(sockets)
+  active_child_count(factory) |> should.equal(1)
+
+  // A second connection whose `init` is gated: it stays `Booting`.
+  let admission_result = process.new_subject()
+  let booting_closed = process.new_subject()
+  let _connection =
+    process.spawn(fn() {
+      let assert Ok(owner) = transport.runtime_pid(sockets)
+      process.send(
+        admission_result,
+        transport.admit_socket(
+          sockets: sockets,
+          owner: owner,
+          socket_id: "booting",
+          send: fn(_message) { Ok(Nil) },
+          send_binary: fn(_data) { Ok(Nil) },
+          codec: None,
+          seed: socket.empty_seed(),
+          close: fn() { process.send(booting_closed, Nil) },
+        ),
+      )
+    })
+  process.receive(init_entered, 1000) |> should.equal(Ok(Nil))
+  active_child_count(factory) |> should.equal(2)
+
+  // `stop` blocks until the whole subtree drains, so it runs in its own
+  // process.
+  let stop_result = process.new_subject()
+  process.spawn(fn() { process.send(stop_result, beryl.stop(sockets)) })
+
+  // The drain waits for every socket actor to finish shutdown phase one
+  // before it tears any of them down: the already-`Active` socket's
+  // `Closed` and transport close have not fired while its sibling is still
+  // `Booting`.
+  process.receive(closes, 150) |> should.be_error
+  process.receive(transport_closed, 150) |> should.be_error
+
+  release_gate(gate)
+
+  // The booting socket finishes `init`, registers, and immediately reports
+  // its own shutdown phase one; only then does the drain proceed for both
+  // sockets.
+  process.receive(admission_result, 2000) |> should.equal(Ok(Ok(Nil)))
+  process.receive(booting_closed, 1000) |> should.equal(Ok(Nil))
+  process.receive(closes, 1000)
+  |> should.equal(Ok(#("room:a", socket.Shutdown)))
+  process.receive(transport_closed, 1000) |> should.equal(Ok(Nil))
+
+  // `stop` completes with its documented result once the drain finishes.
+  process.receive(stop_result, 2000) |> should.equal(Ok(Ok(Nil)))
+
+  // No booting factory child is left behind; the whole subtree is gone.
+  test_helpers.wait_until(fn() { !process.is_alive(factory) }, 2000, 10)
+  process.is_alive(factory) |> should.be_false
+  beryl.app_socket_factory_pid(sockets) |> should.be_error
 }

--- a/packages/beryl/test/beryl_supervisor_test_ffi.erl
+++ b/packages/beryl/test/beryl_supervisor_test_ffi.erl
@@ -1,5 +1,5 @@
 -module(beryl_supervisor_test_ffi).
--export([get_subject_pid/1, crash_reason/0,
+-export([get_subject_pid/1, crash_reason/0, active_child_count/1,
          gate_new/0, gate_wait/1, gate_release/1]).
 
 %% Extract the process that will receive messages for a subject.
@@ -20,6 +20,15 @@ get_subject_pid(Subject) ->
 %% Return an atom that serves as an abnormal exit reason
 crash_reason() ->
     test_crash.
+
+%% Number of children a supervisor currently owns. A dead supervisor owns
+%% none, so a stopped socket factory reports zero rather than crashing.
+active_child_count(Pid) ->
+    try supervisor:count_children(Pid) of
+        Counts -> proplists:get_value(active, Counts, 0)
+    catch
+        _:_ -> 0
+    end.
 
 gate_new() ->
     Gate = atomics:new(1, [{signed, false}]),


### PR DESCRIPTION
## Summary

- Add a permanent, named socket factory to the beryl supervision tree and start each socket actor as a temporary child.
- Split socket admission into `Booting`, `Active`, and `Closing` phases so application `init` stays parallel and late or duplicate admissions cannot run during teardown.
- Stop cancelled or orphaned booting actors, drain socket actors before factory shutdown, and recover from factory crashes without restarting the router.
- Accept ADR 0005 and record the socket-start benchmark results.

## Coverage

- Add tests for factory crash cleanup and restart, cancelled admissions, discarded init effects, and graceful shutdown of active and booting sockets.
- Factory startup sustained a median 1,999.90 socket starts per second versus 1,999.70 for direct startup, with no dropped iterations or unexpected errors.
