### PR TITLE
docs(website): improve API reference layout

### DIFF
--- a/.changes/unreleased/beryl-improve-the-generated-api.toml
+++ b/.changes/unreleased/beryl-improve-the-generated-api.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Changed"
+body = "Improve the generated API reference layout with symbol indexes, signature-first entries, and responsive module lists."

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-08-22T01:35:24Z",
+  "generatedAt": "2026-08-28T21:24:04Z",
   "title": "Design System: beryl",
   "extensions": {
     "colorMeta": {
@@ -121,6 +121,7 @@
       {"name": "reduced-motion", "value": "0.001ms", "purpose": "Site-wide non-motion fallback."}
     ],
     "breakpoints": [
+      {"name": "compact-reference", "value": "38rem"},
       {"name": "content-grid", "value": "50rem"},
       {"name": "desktop-hero", "value": "68rem"}
     ]
@@ -179,6 +180,20 @@
       "description": "Compact reference data with restrained row separation.",
       "html": "<table class=\"ds-table\"><thead><tr><th>Event</th><th>Effect</th></tr></thead><tbody><tr><td>Join</td><td>AcceptJoin</td></tr><tr><td>Message</td><td>Reply</td></tr></tbody></table>",
       "css": ".ds-table { width: 100%; border: 1px solid var(--beryl-hairline); border-spacing: 0; border-radius: 12px; overflow: hidden; color: var(--sl-color-gray-2); font: 0.95rem/1.5 var(--sl-font); } .ds-table th, .ds-table td { padding: 0.6rem 0.9rem; text-align: left; border-bottom: 1px solid color-mix(in oklch, var(--beryl-hairline) 55%, transparent); } .ds-table th { background: var(--beryl-surface); color: var(--sl-color-white); font-weight: 650; } .ds-table tr:last-child td { border-bottom: 0; } .ds-table tbody tr { transition: background 0.15s ease-out; } .ds-table tbody tr:hover { background: var(--beryl-magenta-soft); }"
+    },
+    {
+      "name": "API Module Ledger",
+      "kind": "nav",
+      "description": "A responsive, border-only module directory for generated package reference pages.",
+      "html": "<ul class=\"ds-api-modules\"><li><a href=\"#\"><code>beryl/channel</code></a><p>Typed channel handlers with private state.</p></li><li><a href=\"#\"><code>beryl/presence</code></a><p>Distributed presence tracking backed by a CRDT.</p></li></ul>",
+      "css": ".ds-api-modules { display: grid; gap: 0; margin: 0; padding: 0; border-block: 1px solid var(--beryl-hairline); color: var(--sl-color-white); font-family: var(--sl-font); list-style: none; } .ds-api-modules li { display: grid; grid-template-columns: minmax(11rem, 0.7fr) minmax(0, 1.3fr); gap: 1rem 2rem; align-items: baseline; padding: 1rem 0.25rem; border-bottom: 1px solid var(--beryl-hairline); } .ds-api-modules li:last-child { border-bottom: 0; } .ds-api-modules a { color: var(--sl-color-accent-high); font-weight: 700; text-underline-offset: 0.25em; } .ds-api-modules p { max-width: 68ch; margin: 0; color: var(--sl-color-gray-2); } @media (max-width: 38rem) { .ds-api-modules li { grid-template-columns: 1fr; gap: 0.45rem; } }"
+    },
+    {
+      "name": "API Symbol Index",
+      "kind": "nav",
+      "description": "A compact map of generated types and functions that keeps long API pages scannable.",
+      "html": "<nav class=\"ds-api-index\" aria-label=\"Module contents\"><section><a class=\"ds-api-index-section\" href=\"#\">Types</a><ul><li><a href=\"#\"><code>Config</code></a></li><li><a href=\"#\"><code>Sockets</code></a></li></ul></section><section><a class=\"ds-api-index-section\" href=\"#\">Functions</a><ul><li><a href=\"#\"><code>child_spec</code></a></li><li><a href=\"#\"><code>broadcast</code></a></li><li><a href=\"#\"><code>stop</code></a></li></ul></section></nav>",
+      "css": ".ds-api-index { display: grid; gap: 1.5rem; padding-block: 1.25rem; border-block: 1px solid var(--beryl-hairline); color: var(--sl-color-white); font-family: var(--sl-font); } .ds-api-index section { display: grid; grid-template-columns: minmax(7rem, 0.22fr) minmax(0, 1fr); gap: 0.75rem 1.5rem; align-items: start; } .ds-api-index-section { color: var(--sl-color-white); font-weight: 700; text-underline-offset: 0.25em; } .ds-api-index ul { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 9rem), 1fr)); gap: 0.4rem 1rem; margin: 0; padding: 0; list-style: none; } .ds-api-index a { color: var(--sl-color-accent-high); } @media (max-width: 38rem) { .ds-api-index section { grid-template-columns: 1fr; gap: 0.45rem; } .ds-api-index ul { grid-template-columns: repeat(2, minmax(0, 1fr)); } }"
     }
   ],
   "narrative": {

--- a/website/scripts/generate-reference.mjs
+++ b/website/scripts/generate-reference.mjs
@@ -154,8 +154,12 @@ function moduleSlug(moduleName) {
 
 function descriptionFromDocs(documentation, fallback) {
 	const text = normalizeDoc(documentation);
-	const firstLine = text.split("\n").find((line) => line.trim().length > 0);
-	return firstLine ? firstLine.trim() : fallback;
+	const firstParagraph = text
+		.split(/\n\s*\n/)
+		.find((paragraph) => paragraph.trim().length > 0);
+	return firstParagraph
+		? firstParagraph.replaceAll(/\s+/g, " ").trim()
+		: fallback;
 }
 
 // Frontmatter values are arbitrary prose lifted from module docs, so they
@@ -165,10 +169,23 @@ function yamlString(value) {
 	return `"${String(value).replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
 }
 
-// Markdown tables are cell-delimited by `|`, so any pipe inside prose has
-// to be escaped or it splits the row.
-function tableCell(value) {
-	return String(value).replaceAll("|", "\\|");
+function html(value) {
+	return String(value)
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;");
+}
+
+function htmlInlineCode(value) {
+	return String(value)
+		.split(/(`[^`]+`)/g)
+		.map((part) =>
+			part.startsWith("`") && part.endsWith("`")
+				? `<code>${html(part.slice(1, -1))}</code>`
+				: html(part),
+		)
+		.join("");
 }
 
 function normalizeDoc(documentation) {
@@ -181,6 +198,30 @@ function normalizeDoc(documentation) {
 		return "";
 	}
 	return rewriteDocLinks(text);
+}
+
+function normalizeNestedDoc(documentation, parentLevel) {
+	const text = normalizeDoc(documentation);
+	let fence = null;
+	return text
+		.split("\n")
+		.map((line) => {
+			const fenceMatch = line.match(/^\s{0,3}(`{3,}|~{3,})/);
+			if (fenceMatch) {
+				const marker = fenceMatch[1][0];
+				fence = fence === marker ? null : fence ?? marker;
+				return line;
+			}
+			if (fence) {
+				return line;
+			}
+			return line.replace(
+				/^(\s{0,3})(#{1,6})(\s+)/,
+				(_match, indent, hashes, spacing) =>
+					`${indent}${"#".repeat(Math.min(6, hashes.length + parentLevel - 1))}${spacing}`,
+			);
+		})
+		.join("\n");
 }
 
 // Gleam docs use HexDocs HTML paths and case-preserving type fragments.
@@ -327,14 +368,17 @@ function renderIndex(packages) {
 						moduleInterface.documentation,
 						`Reference for ${moduleName}.`,
 					);
-					return `| [${code(moduleName)}](${referenceBasePath}/${moduleSlug(moduleName)}/) | ${tableCell(description)} |`;
+					return `<li class="api-module-list__item">
+  <a class="api-module-list__name" href="${referenceBasePath}/${moduleSlug(moduleName)}/"><code>${html(moduleName)}</code></a>
+  <p>${htmlInlineCode(description)}</p>
+</li>`;
 				})
 				.join("\n");
 			return `## ${code(packageInterface.name)} ${code(packageInterface.version)}
 
-| Module | Description |
-|---|---|
-${moduleRows}`;
+<ul class="api-module-list">
+${moduleRows}
+</ul>`;
 		})
 		.join("\n\n");
 
@@ -349,6 +393,8 @@ description: API reference generated from Gleam docs metadata.
 
 ${GENERATED_MARKER}
 
+<div class="api-reference-marker" aria-hidden="true"></div>
+
 This reference uses Gleam docs metadata for ${packageList}.
 
 :::note[Generated content]
@@ -357,6 +403,58 @@ The generator creates pages under \`${referenceBasePath}/\` from Gleam docs meta
 
 ${packageSections}
 `;
+}
+
+function symbolSlug(name) {
+	return name.toLowerCase().replaceAll(/\s+/g, "-");
+}
+
+function entryId(kind, name) {
+	return `api-${kind}-${symbolSlug(name)}`;
+}
+
+function entryAnchor(kind, name) {
+	return `<div class="api-entry-anchor" id="${entryId(kind, name)}" aria-hidden="true"></div>`;
+}
+
+function renderSymbolIndex(moduleInterface) {
+	const groups = [
+		["Types", "type", moduleInterface.types],
+		["Type aliases", "type-alias", moduleInterface["type-aliases"]],
+		["Constants", "constant", moduleInterface.constants],
+		["Functions", "function", moduleInterface.functions],
+	]
+		.map(([label, kind, entries]) => [
+			label,
+			kind,
+			Object.keys(entries || {}).sort((left, right) => left.localeCompare(right)),
+		])
+		.filter(([, , names]) => names.length > 0);
+
+	if (groups.length === 0) {
+		return "";
+	}
+
+	const contents = groups
+		.map(([label, kind, names]) => {
+			const links = names
+				.map(
+					(name) =>
+						`<li><a href="#${entryId(kind, name)}"><code>${html(name)}</code></a></li>`,
+				)
+				.join("\n");
+			return `<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#${symbolSlug(label)}">${html(label)}</a>
+  <ul>
+${links}
+  </ul>
+</section>`;
+		})
+		.join("\n");
+
+	return `<nav class="api-symbol-index" aria-label="Module contents">
+${contents}
+</nav>`;
 }
 
 function renderModulePage(moduleName, moduleInterface) {
@@ -374,11 +472,18 @@ function renderModulePage(moduleName, moduleInterface) {
 	return `---
 title: ${yamlString(moduleName)}
 description: ${yamlString(description)}
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 ${GENERATED_MARKER}
 
+<div class="api-reference-marker" aria-hidden="true"></div>
+
 ${normalizeDoc(moduleInterface.documentation) || description}
+
+${renderSymbolIndex(moduleInterface)}
 
 ${sections.join("\n\n")}
 `;
@@ -393,7 +498,13 @@ function renderConstructorsSection(typeInterface, moduleName) {
 	}
 
 	const items = constructors
-		.map((c) => `##### ${code(renderConstructor(c, moduleName))}\n\n${normalizeDoc(c.documentation)}`)
+		.map((c) => `##### ${code(c.name)}
+
+\`\`\`gleam
+${renderConstructor(c, moduleName)}
+\`\`\`
+
+${normalizeNestedDoc(c.documentation, 5)}`)
 		.join("\n\n");
 	return `#### Constructors\n\n${items}`;
 }
@@ -409,16 +520,20 @@ function renderTypes(types, moduleName) {
 	return [
 		"## Types",
 		...entries.map(([name, typeInterface]) => {
-			const docs = normalizeDoc(typeInterface.documentation);
+			const docs = normalizeNestedDoc(typeInterface.documentation, 3);
 			const deprecation = deprecationBlock(typeInterface.deprecation);
 			const definition = renderTypeDefinition(name, typeInterface, moduleName);
 			const constructors = renderConstructorsSection(typeInterface, moduleName);
 			const sections = [
-				docs ? `${docs}${deprecation}` : deprecation.replace(/^\n\n/, ""),
 				`\`\`\`gleam\n${definition}\n\`\`\``,
+				docs ? `${docs}${deprecation}` : deprecation.replace(/^\n\n/, ""),
 				constructors,
 			].filter((section) => section && section.length > 0);
-			return `### ${code(name)}\n\n${sections.join("\n\n")}`;
+			return `${entryAnchor("type", name)}
+
+### ${code(name)}
+
+${sections.join("\n\n")}`;
 		}),
 	].join("\n\n");
 }
@@ -442,13 +557,15 @@ function renderTypeAliases(typeAliases, moduleName) {
 
 	return [
 		"## Type aliases",
-		...entries.map(([name, alias]) => `### ${code(name)}
+		...entries.map(([name, alias]) => `${entryAnchor("type-alias", name)}
 
-${normalizeDoc(alias.documentation)}${deprecationBlock(alias.deprecation)}
+### ${code(name)}
 
 \`\`\`gleam
 ${renderAliasDefinition(name, alias, moduleName)}
-\`\`\``),
+\`\`\`
+
+${normalizeNestedDoc(alias.documentation, 3)}${deprecationBlock(alias.deprecation)}`),
 	].join("\n\n");
 }
 
@@ -462,13 +579,15 @@ function renderConstants(constants, moduleName) {
 
 	return [
 		"## Constants",
-		...entries.map(([name, constant]) => `### ${code(name)}
+		...entries.map(([name, constant]) => `${entryAnchor("constant", name)}
 
-${normalizeDoc(constant.documentation)}${deprecationBlock(constant.deprecation)}
+### ${code(name)}
 
 \`\`\`gleam
 ${renderConstantDefinition(name, constant, moduleName)}
-\`\`\``),
+\`\`\`
+
+${normalizeNestedDoc(constant.documentation, 3)}${deprecationBlock(constant.deprecation)}`),
 	].join("\n\n");
 }
 
@@ -489,13 +608,15 @@ function renderFunctions(functions, moduleName) {
 				functionInterface.return,
 				moduleName,
 			);
-			return `### ${code(name)}
+			return `${entryAnchor("function", name)}
 
-${normalizeDoc(functionInterface.documentation)}${deprecationBlock(functionInterface.deprecation)}
+### ${code(name)}
 
 \`\`\`gleam
 ${signature}
-\`\`\``;
+\`\`\`
+
+${normalizeNestedDoc(functionInterface.documentation, 3)}${deprecationBlock(functionInterface.deprecation)}`;
 		}),
 	].join("\n\n");
 }

--- a/website/scripts/generate-reference.test.mjs
+++ b/website/scripts/generate-reference.test.mjs
@@ -130,6 +130,7 @@ test("generates an index and one page per module", async () => {
 		const index = await readFile(path.join(outputDir, "index.md"), "utf8");
 		assert.match(index, /title: API reference/);
 		assert.match(index, /`beryl` `9\.9\.9`/);
+		assert.match(index, /class="api-module-list"/);
 		// Modules are sorted alphabetically: beryl before beryl/channel.
 		assert.ok(index.indexOf("/reference/api/beryl/") < index.indexOf("/reference/api/beryl-channel/"));
 	});
@@ -161,6 +162,29 @@ test("renders types, aliases, constants, and functions", async () => {
 		assert.match(page, /coords: #\(Int, Int\)/);
 		assert.match(page, /callback: fn\(String\) -> Nil/);
 		assert.match(page, /-> HandleResult\(a\)/);
+		assert.ok(
+			page.indexOf("pub fn handle(") <
+				page.indexOf("Handle an inbound message."),
+		);
+		assert.match(page, /class="api-symbol-index"/);
+		assert.match(page, /href="#api-function-handle"/);
+		assert.match(page, /id="api-function-handle"/);
+		assert.match(page, /maxHeadingLevel: 2/);
+	});
+});
+
+test("keeps nested documentation headings below their API symbol", async () => {
+	const nestedFixture = structuredClone(fixture);
+	nestedFixture.modules["beryl/channel"].functions.handle.documentation =
+		"Handle an inbound message.\n\n## Example\n\nUse `handle`.";
+
+	await withFixture(async ({ jsonPath, outputDir }) => {
+		await writeFile(jsonPath, JSON.stringify(nestedFixture));
+		await generateReference({ docsJsonPath: jsonPath, outputDir });
+		const page = await readFile(path.join(outputDir, "beryl-channel.md"), "utf8");
+
+		assert.match(page, /#### Example/);
+		assert.doesNotMatch(page, /\n## Example/);
 	});
 });
 
@@ -205,8 +229,8 @@ test("quotes frontmatter so prose punctuation cannot break the YAML", async () =
 				version: "0.2.0",
 				modules: {
 					"beryl/channel": {
-						// A colon in the first line is bare-YAML poison, and a pipe
-						// would split the module table row on the index page.
+						// A colon in the first line is bare-YAML poison, and HTML-sensitive
+						// characters must stay literal in the generated module ledger.
 						documentation: [
 							'The channel surface: a "pattern" | a callback.',
 							"",
@@ -232,18 +256,17 @@ test("quotes frontmatter so prose punctuation cannot break the YAML", async () =
 			frontmatter,
 			/description: "The channel surface: a \\"pattern\\" \| a callback\."/,
 		);
-		// Every frontmatter value is a quoted scalar, so no bare `:` or `#`
-		// can be reinterpreted as YAML structure.
-		for (const line of frontmatter.trim().split("\n")) {
+		// Prose-bearing frontmatter values are quoted scalars, so no bare `:`
+		// or `#` can be reinterpreted as YAML structure.
+		for (const line of frontmatter.trim().split("\n").slice(0, 2)) {
 			assert.match(line, /^[a-z]+: ".*"$/);
 		}
 
 		const index = await readFile(path.join(outputDir, "index.md"), "utf8");
-		const row = index
-			.split("\n")
-			.find((line) => line.includes("/reference/api/beryl-channel/"));
-		// Escaped pipe keeps the row at exactly two cells.
-		assert.equal(row.split(/(?<!\\)\|/).length - 2, 2);
+		assert.match(
+			index,
+			/The channel surface: a &quot;pattern&quot; \| a callback\./,
+		);
 	} finally {
 		await rm(dir, { force: true, recursive: true });
 	}

--- a/website/src/content/docs/reference/api/beryl-bridge.md
+++ b/website/src/content/docs/reference/api/beryl-bridge.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/bridge"
-description: "Bridge - Forward an external OTP actor's message stream to a socket via"
+description: "Bridge - Forward an external OTP actor's message stream to a socket via its `Sender`."
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "Bridge - Forward an external OTP actor's message stream to a socke
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 Bridge - Forward an external OTP actor's message stream to a socket via
  its `Sender`.
@@ -61,9 +66,34 @@ Bridge - Forward an external OTP actor's message stream to a socket via
  bridge.stop(model.bridge)
  ```
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#types">Types</a>
+  <ul>
+<li><a href="#api-type-bridge"><code>Bridge</code></a></li>
+<li><a href="#api-type-starterror"><code>StartError</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-pid"><code>pid</code></a></li>
+<li><a href="#api-function-start"><code>start</code></a></li>
+<li><a href="#api-function-stop"><code>stop</code></a></li>
+<li><a href="#api-function-subject"><code>subject</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Types
 
+<div class="api-entry-anchor" id="api-type-bridge" aria-hidden="true"></div>
+
 ### `Bridge`
+
+```gleam
+pub type Bridge(a)
+```
 
 A handle to a running bridge forwarder.
 
@@ -71,13 +101,9 @@ A handle to a running bridge forwarder.
  `Subject`. Get the subject with `subject`. Call `stop` to stop the
  forwarder.
 
-```gleam
-pub type Bridge(a)
-```
+<div class="api-entry-anchor" id="api-type-starterror" aria-hidden="true"></div>
 
 ### `StartError`
-
-Why a bridge failed to start.
 
 ```gleam
 pub type StartError {
@@ -85,27 +111,44 @@ pub type StartError {
 }
 ```
 
+Why a bridge failed to start.
+
 #### Constructors
 
 ##### `ForwarderUnavailable`
+
+```gleam
+ForwarderUnavailable
+```
 
 The forwarder did not report its subjects within
  `handshake_timeout_ms`. It failed to spawn or start.
 
 ## Functions
 
+<div class="api-entry-anchor" id="api-function-pid" aria-hidden="true"></div>
+
 ### `pid`
+
+```gleam
+pub fn pid(Bridge(a)) -> process.Pid
+```
 
 Return the forwarder process ID.
 
  Use this value for diagnostics and supervision. Most callers need only
  `subject` and `stop`.
 
-```gleam
-pub fn pid(Bridge(a)) -> process.Pid
-```
+<div class="api-entry-anchor" id="api-function-start" aria-hidden="true"></div>
 
 ### `start`
+
+```gleam
+pub fn start(
+  to: socket.Sender(a),
+  with: fn(b) -> a
+) -> Result(Bridge(b), StartError)
+```
 
 Start a bridge from an external `Subject` to a socket's `update` function.
 
@@ -123,31 +166,28 @@ Start a bridge from an external `Subject` to a socket's `update` function.
  the owner dies without calling `stop`, but it does not track topic
  lifecycles.
 
-```gleam
-pub fn start(
-  to: socket.Sender(a),
-  with: fn(b) -> a
-) -> Result(Bridge(b), StartError)
-```
+<div class="api-entry-anchor" id="api-function-stop" aria-hidden="true"></div>
 
 ### `stop`
+
+```gleam
+pub fn stop(Bridge(a)) -> Nil
+```
 
 Stop the bridge's forwarder.
 
  Call this when the owning socket or topic ends. It is safe to call more
  than once and after the forwarder has already exited.
 
-```gleam
-pub fn stop(Bridge(a)) -> Nil
-```
+<div class="api-entry-anchor" id="api-function-subject" aria-hidden="true"></div>
 
 ### `subject`
+
+```gleam
+pub fn subject(Bridge(a)) -> process.Subject(a)
+```
 
 Return the `Subject` that receives the external actor's stream.
 
  Give this subject to the domain actor, for example as its subscriber.
  Each value is then sent to the bridged socket.
-
-```gleam
-pub fn subject(Bridge(a)) -> process.Subject(a)
-```

--- a/website/src/content/docs/reference/api/beryl-channel.md
+++ b/website/src/content/docs/reference/api/beryl-channel.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/channel"
-description: "The channel composition surface: a channel is a topic pattern paired"
+description: "The channel composition surface: a channel is a topic pattern paired with a typed `join` callback and callbacks over private state."
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "The channel composition surface: a channel is a topic pattern pair
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 The channel composition surface: a channel is a topic pattern paired
  with a typed `join` callback and callbacks over private state.
@@ -80,35 +85,79 @@ The channel composition surface: a channel is a topic pattern paired
  closes the topic, after the channel instance is gone. Its closing-phase
  action type permits only operations that remain meaningful then.
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#types">Types</a>
+  <ul>
+<li><a href="#api-type-action"><code>Action</code></a></li>
+<li><a href="#api-type-active"><code>Active</code></a></li>
+<li><a href="#api-type-childspecerror"><code>ChildSpecError</code></a></li>
+<li><a href="#api-type-closing"><code>Closing</code></a></li>
+<li><a href="#api-type-handler"><code>Handler</code></a></li>
+<li><a href="#api-type-joincontext"><code>JoinContext</code></a></li>
+<li><a href="#api-type-joinresult"><code>JoinResult</code></a></li>
+<li><a href="#api-type-message"><code>Message</code></a></li>
+<li><a href="#api-type-next"><code>Next</code></a></li>
+<li><a href="#api-type-sender"><code>Sender</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-accept"><code>accept</code></a></li>
+<li><a href="#api-function-broadcast"><code>broadcast</code></a></li>
+<li><a href="#api-function-broadcast_from"><code>broadcast_from</code></a></li>
+<li><a href="#api-function-broadcast_presence"><code>broadcast_presence</code></a></li>
+<li><a href="#api-function-child_spec"><code>child_spec</code></a></li>
+<li><a href="#api-function-close"><code>close</code></a></li>
+<li><a href="#api-function-handler"><code>handler</code></a></li>
+<li><a href="#api-function-next"><code>next</code></a></li>
+<li><a href="#api-function-notify"><code>notify</code></a></li>
+<li><a href="#api-function-on_info"><code>on_info</code></a></li>
+<li><a href="#api-function-on_message"><code>on_message</code></a></li>
+<li><a href="#api-function-on_terminate"><code>on_terminate</code></a></li>
+<li><a href="#api-function-presence_track"><code>presence_track</code></a></li>
+<li><a href="#api-function-presence_untrack"><code>presence_untrack</code></a></li>
+<li><a href="#api-function-push"><code>push</code></a></li>
+<li><a href="#api-function-push_presence"><code>push_presence</code></a></li>
+<li><a href="#api-function-reject"><code>reject</code></a></li>
+<li><a href="#api-function-reply_error"><code>reply_error</code></a></li>
+<li><a href="#api-function-reply_ok"><code>reply_ok</code></a></li>
+<li><a href="#api-function-stay"><code>stay</code></a></li>
+<li><a href="#api-function-with_actions"><code>with_actions</code></a></li>
+<li><a href="#api-function-with_reply"><code>with_reply</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Types
 
+<div class="api-entry-anchor" id="api-type-action" aria-hidden="true"></div>
+
 ### `Action`
+
+```gleam
+pub type Action(a)
+```
 
 One operation on the channel's own topic.
 
  The phase parameter prevents [`on_terminate`](#on_terminate) from returning
  active-only operations. Put actions in a list in wire order.
 
-```gleam
-pub type Action(a)
-```
+<div class="api-entry-anchor" id="api-type-active" aria-hidden="true"></div>
 
 ### `Active`
-
-Marker for actions valid while a channel is active.
 
 ```gleam
 pub type Active
 ```
 
+Marker for actions valid while a channel is active.
+
+<div class="api-entry-anchor" id="api-type-childspecerror" aria-hidden="true"></div>
+
 ### `ChildSpecError`
-
-Why building a channel-system child specification failed.
-
- The function validates handler patterns before the core configuration. It
- checks each pattern's syntax in registration order. It then checks for
- exact duplicates in the same order. Overlapping patterns are allowed when
- they are not identical because routing uses the first match.
 
 ```gleam
 pub type ChildSpecError {
@@ -121,32 +170,59 @@ pub type ChildSpecError {
 }
 ```
 
+Why building a channel-system child specification failed.
+
+ The function validates handler patterns before the core configuration. It
+ checks each pattern's syntax in registration order. It then checks for
+ exact duplicates in the same order. Overlapping patterns are allowed when
+ they are not identical because routing uses the first match.
+
 #### Constructors
 
-##### `InvalidPattern(
+##### `InvalidPattern`
+
+```gleam
+InvalidPattern(
   pattern: String,
   reason: topic.TopicError
-)`
+)
+```
 
 A handler used an invalid topic pattern.
 
-##### `DuplicatePattern(pattern: String)`
+##### `DuplicatePattern`
+
+```gleam
+DuplicatePattern(pattern: String)
+```
 
 Two handlers registered the same pattern string.
 
-##### `InvalidConfig(reason: beryl.ConfigError)`
+##### `InvalidConfig`
+
+```gleam
+InvalidConfig(reason: beryl.ConfigError)
+```
 
 The core `beryl.Config` failed eager validation.
 
-### `Closing`
+<div class="api-entry-anchor" id="api-type-closing" aria-hidden="true"></div>
 
-Marker for actions valid while a channel is closing.
+### `Closing`
 
 ```gleam
 pub type Closing
 ```
 
+Marker for actions valid while a channel is closing.
+
+<div class="api-entry-anchor" id="api-type-handler" aria-hidden="true"></div>
+
 ### `Handler`
+
+```gleam
+pub type Handler
+```
 
 A registered channel: a topic pattern plus its sealed `join` callback.
 
@@ -154,17 +230,9 @@ A registered channel: a topic pattern plus its sealed `join` callback.
  and `info` types. A single `List(Handler)` can therefore hold channels
  with unrelated types.
 
-```gleam
-pub type Handler
-```
+<div class="api-entry-anchor" id="api-type-joincontext" aria-hidden="true"></div>
 
 ### `JoinContext`
-
-Information about one join attempt.
-
- `params` contains wildcard captures in pattern order and is empty for
- exact patterns. `self` is this channel's generation-scoped
- [`Sender`](#sender), for scheduling a later turn.
 
 ```gleam
 pub type JoinContext(a) {
@@ -179,7 +247,19 @@ pub type JoinContext(a) {
 }
 ```
 
+Information about one join attempt.
+
+ `params` contains wildcard captures in pattern order and is empty for
+ exact patterns. `self` is this channel's generation-scoped
+ [`Sender`](#sender), for scheduling a later turn.
+
+<div class="api-entry-anchor" id="api-type-joinresult" aria-hidden="true"></div>
+
 ### `JoinResult`
+
+```gleam
+pub type JoinResult(a, b)
+```
 
 A `join` callback's answer: join this channel, or refuse.
 
@@ -188,16 +268,9 @@ A `join` callback's answer: join this channel, or refuse.
  inputs keep the channel joined and produce no actions. [`handler`](#handler)
  seals the private `state` and `info` types.
 
-```gleam
-pub type JoinResult(a, b)
-```
+<div class="api-entry-anchor" id="api-type-message" aria-hidden="true"></div>
 
 ### `Message`
-
-A client message delivered to a joined channel's `on_message` callback.
-
- `reply` is present only when the client asked for a reply; pass it to
- [`reply_ok`](#reply_ok) or [`reply_error`](#reply_error).
 
 ```gleam
 pub type Message {
@@ -209,18 +282,31 @@ pub type Message {
 }
 ```
 
+A client message delivered to a joined channel's `on_message` callback.
+
+ `reply` is present only when the client asked for a reply; pass it to
+ [`reply_ok`](#reply_ok) or [`reply_error`](#reply_error).
+
+<div class="api-entry-anchor" id="api-type-next" aria-hidden="true"></div>
+
 ### `Next`
+
+```gleam
+pub type Next(a)
+```
 
 What a channel callback decided to do next.
 
  Build one with [`next`](#next) or [`close`](#close). Use [`stay`](#stay)
  when the state does not change and there are no actions.
 
-```gleam
-pub type Next(a)
-```
+<div class="api-entry-anchor" id="api-type-sender" aria-hidden="true"></div>
 
 ### `Sender`
+
+```gleam
+pub type Sender(a)
+```
 
 A typed handle for sending server-side messages to one joined channel.
 
@@ -243,7 +329,7 @@ A typed handle for sending server-side messages to one joined channel.
  another join in that window. It is the *same* instance, outliving its own
  termination.
 
- ## Cost
+ #### Cost
 
  Delivery is cast-free but not free. Each message is carried to the
  socket's runtime actor as a sealed thunk, and unsealing it does a
@@ -253,27 +339,24 @@ A typed handle for sending server-side messages to one joined channel.
  non-issue at ordinary depths; it is worth knowing before using
  `notify` as a high-rate data path.
 
-```gleam
-pub type Sender(a)
-```
-
 ## Functions
 
+<div class="api-entry-anchor" id="api-function-accept" aria-hidden="true"></div>
+
 ### `accept`
+
+```gleam
+pub fn accept(a) -> JoinResult(a, b)
+```
 
 Accept the join with an empty acknowledgment.
 
  Pipe the result through `on_message`, `on_info`, and `on_terminate` to
  register the callbacks that the channel needs.
 
-```gleam
-pub fn accept(a) -> JoinResult(a, b)
-```
+<div class="api-entry-anchor" id="api-function-broadcast" aria-hidden="true"></div>
 
 ### `broadcast`
-
-Broadcast to every subscriber of this channel's topic, including this
- socket.
 
 ```gleam
 pub fn broadcast(
@@ -282,10 +365,12 @@ pub fn broadcast(
 ) -> Action(a)
 ```
 
-### `broadcast_from`
-
-Broadcast to every subscriber of this channel's topic except this
+Broadcast to every subscriber of this channel's topic, including this
  socket.
+
+<div class="api-entry-anchor" id="api-function-broadcast_from" aria-hidden="true"></div>
+
+### `broadcast_from`
 
 ```gleam
 pub fn broadcast_from(
@@ -294,11 +379,12 @@ pub fn broadcast_from(
 ) -> Action(a)
 ```
 
-### `broadcast_presence`
+Broadcast to every subscriber of this channel's topic except this
+ socket.
 
-Broadcast a presence snapshot for this channel's topic to every
- subscriber, with the same apply-time `encode` semantics as
- [`push_presence`](#push_presence).
+<div class="api-entry-anchor" id="api-function-broadcast_presence" aria-hidden="true"></div>
+
+### `broadcast_presence`
 
 ```gleam
 pub fn broadcast_presence(
@@ -307,7 +393,20 @@ pub fn broadcast_presence(
 ) -> Action(a)
 ```
 
+Broadcast a presence snapshot for this channel's topic to every
+ subscriber, with the same apply-time `encode` semantics as
+ [`push_presence`](#push_presence).
+
+<div class="api-entry-anchor" id="api-function-child_spec" aria-hidden="true"></div>
+
 ### `child_spec`
+
+```gleam
+pub fn child_spec(
+  beryl.Config,
+  handlers: List(Handler)
+) -> Result(#(beryl.Sockets, supervision.ChildSpecification(static_supervisor.Supervisor)), ChildSpecError)
+```
 
 Build a channel system's supervision child specification for embedding
  in an application's supervision tree.
@@ -317,7 +416,7 @@ Build a channel system's supervision child specification for embedding
  then validates `beryl.Config`. You can use the returned `beryl.Sockets`
  after the owning tree starts.
 
- ## Example
+ #### Example
 
  ```gleam
  let assert Ok(#(sockets, child_specification)) =
@@ -332,25 +431,29 @@ Build a channel system's supervision child specification for embedding
    |> static_supervisor.start()
  ```
 
-```gleam
-pub fn child_spec(
-  beryl.Config,
-  handlers: List(Handler)
-) -> Result(#(beryl.Sockets, supervision.ChildSpecification(static_supervisor.Supervisor)), ChildSpecError)
-```
+<div class="api-entry-anchor" id="api-function-close" aria-hidden="true"></div>
 
 ### `close`
+
+```gleam
+pub fn close(List(Action(Active))) -> Next(a)
+```
 
 Leave this channel after applying `actions` in order.
 
  The socket stays connected. Its other channels do not change. This
  channel's [`on_terminate`](#on_terminate) callback still runs.
 
-```gleam
-pub fn close(List(Action(Active))) -> Next(a)
-```
+<div class="api-entry-anchor" id="api-function-handler" aria-hidden="true"></div>
 
 ### `handler`
+
+```gleam
+pub fn handler(
+  String,
+  fn(JoinContext(a)) -> JoinResult(b, a)
+) -> Handler
+```
 
 Register a channel for every topic matching `pattern`.
 
@@ -361,16 +464,9 @@ Register a channel for every topic matching `pattern`.
  `join` receives one [`JoinContext`](#joincontext) containing connection
  data, the concrete topic, wildcard captures, and the payload.
 
-```gleam
-pub fn handler(
-  String,
-  fn(JoinContext(a)) -> JoinResult(b, a)
-) -> Handler
-```
+<div class="api-entry-anchor" id="api-function-next" aria-hidden="true"></div>
 
 ### `next`
-
-Stay joined with the given state, applying `actions` in order.
 
 ```gleam
 pub fn next(
@@ -379,7 +475,18 @@ pub fn next(
 ) -> Next(a)
 ```
 
+Stay joined with the given state, applying `actions` in order.
+
+<div class="api-entry-anchor" id="api-function-notify" aria-hidden="true"></div>
+
 ### `notify`
+
+```gleam
+pub fn notify(
+  Sender(a),
+  a
+) -> Nil
+```
 
 Send a typed server-side message to the channel that owns `sender`.
 
@@ -392,17 +499,9 @@ Send a typed server-side message to the channel that owns `sender`.
  for a channel that has ended. See [`Sender`](#sender) for delivery cost and
  the one case in which an ended channel can still receive a message.
 
-```gleam
-pub fn notify(
-  Sender(a),
-  a
-) -> Nil
-```
+<div class="api-entry-anchor" id="api-function-on_info" aria-hidden="true"></div>
 
 ### `on_info`
-
-Handle typed server-side messages sent through this channel's
- [`Sender`](#sender).
 
 ```gleam
 pub fn on_info(
@@ -411,9 +510,12 @@ pub fn on_info(
 ) -> JoinResult(a, b)
 ```
 
-### `on_message`
+Handle typed server-side messages sent through this channel's
+ [`Sender`](#sender).
 
-Handle client messages on this channel's topic.
+<div class="api-entry-anchor" id="api-function-on_message" aria-hidden="true"></div>
+
+### `on_message`
 
 ```gleam
 pub fn on_message(
@@ -422,7 +524,18 @@ pub fn on_message(
 ) -> JoinResult(a, b)
 ```
 
+Handle client messages on this channel's topic.
+
+<div class="api-entry-anchor" id="api-function-on_terminate" aria-hidden="true"></div>
+
 ### `on_terminate`
+
+```gleam
+pub fn on_terminate(
+  JoinResult(a, b),
+  fn(a, socket.StopReason) -> List(Action(Closing))
+) -> JoinResult(a, b)
+```
 
 Run cleanup when the channel ends for any reason: client leave, a
  [`close`](#close) result, a socket teardown, or a disconnect.
@@ -437,19 +550,9 @@ Run cleanup when the channel ends for any reason: client leave, a
  [`Sender`](#sender) can reach it until the topic is rejoined or the socket
  ends.
 
-```gleam
-pub fn on_terminate(
-  JoinResult(a, b),
-  fn(a, socket.StopReason) -> List(Action(Closing))
-) -> JoinResult(a, b)
-```
+<div class="api-entry-anchor" id="api-function-presence_track" aria-hidden="true"></div>
 
 ### `presence_track`
-
-Track this socket's presence under `key` on this channel's topic and
- broadcast the matching `presence_diff` join.
-
- Requires a presence handle on the `Config` (`beryl.with_presence_handle`).
 
 ```gleam
 pub fn presence_track(
@@ -458,19 +561,26 @@ pub fn presence_track(
 ) -> Action(Active)
 ```
 
-### `presence_untrack`
+Track this socket's presence under `key` on this channel's topic and
+ broadcast the matching `presence_diff` join.
 
-Untrack a presence previously tracked with
- [`presence_track`](#presence_track) and broadcast the matching
- `presence_diff` leave.
+ Requires a presence handle on the `Config` (`beryl.with_presence_handle`).
+
+<div class="api-entry-anchor" id="api-function-presence_untrack" aria-hidden="true"></div>
+
+### `presence_untrack`
 
 ```gleam
 pub fn presence_untrack(String) -> Action(a)
 ```
 
-### `push`
+Untrack a presence previously tracked with
+ [`presence_track`](#presence_track) and broadcast the matching
+ `presence_diff` leave.
 
-Push a server-initiated message to this socket on this channel's topic.
+<div class="api-entry-anchor" id="api-function-push" aria-hidden="true"></div>
+
+### `push`
 
 ```gleam
 pub fn push(
@@ -479,13 +589,11 @@ pub fn push(
 ) -> Action(Active)
 ```
 
+Push a server-initiated message to this socket on this channel's topic.
+
+<div class="api-entry-anchor" id="api-function-push_presence" aria-hidden="true"></div>
+
 ### `push_presence`
-
-Push a presence snapshot for this channel's topic to this socket.
-
- `encode` runs when the action is applied, so it already sees any
- earlier [`presence_track`](#presence_track) or
- [`presence_untrack`](#presence_untrack) in the same list.
 
 ```gleam
 pub fn push_presence(
@@ -494,20 +602,25 @@ pub fn push_presence(
 ) -> Action(Active)
 ```
 
-### `reject`
+Push a presence snapshot for this channel's topic to this socket.
 
-Refuse the join, returning `reason` to the client.
+ `encode` runs when the action is applied, so it already sees any
+ earlier [`presence_track`](#presence_track) or
+ [`presence_untrack`](#presence_untrack) in the same list.
+
+<div class="api-entry-anchor" id="api-function-reject" aria-hidden="true"></div>
+
+### `reject`
 
 ```gleam
 pub fn reject(json.Json) -> JoinResult(a, b)
 ```
 
+Refuse the join, returning `reason` to the client.
+
+<div class="api-entry-anchor" id="api-function-reply_error" aria-hidden="true"></div>
+
 ### `reply_error`
-
-Reply with an error when a client message supplied a reply handle.
-
- [`option.None`](https://hexdocs.pm/gleam_stdlib/gleam/option.html#Option)
- produces no effect.
 
 ```gleam
 pub fn reply_error(
@@ -516,12 +629,14 @@ pub fn reply_error(
 ) -> Action(Active)
 ```
 
-### `reply_ok`
-
-Reply successfully when a client message supplied a reply handle.
+Reply with an error when a client message supplied a reply handle.
 
  [`option.None`](https://hexdocs.pm/gleam_stdlib/gleam/option.html#Option)
  produces no effect.
+
+<div class="api-entry-anchor" id="api-function-reply_ok" aria-hidden="true"></div>
+
+### `reply_ok`
 
 ```gleam
 pub fn reply_ok(
@@ -530,15 +645,31 @@ pub fn reply_ok(
 ) -> Action(Active)
 ```
 
-### `stay`
+Reply successfully when a client message supplied a reply handle.
 
-Stay joined with the given state and no actions.
+ [`option.None`](https://hexdocs.pm/gleam_stdlib/gleam/option.html#Option)
+ produces no effect.
+
+<div class="api-entry-anchor" id="api-function-stay" aria-hidden="true"></div>
+
+### `stay`
 
 ```gleam
 pub fn stay(a) -> Next(a)
 ```
 
+Stay joined with the given state and no actions.
+
+<div class="api-entry-anchor" id="api-function-with_actions" aria-hidden="true"></div>
+
 ### `with_actions`
+
+```gleam
+pub fn with_actions(
+  JoinResult(a, b),
+  List(Action(Active))
+) -> JoinResult(a, b)
+```
 
 Add ordered actions to an accepted join.
 
@@ -557,18 +688,9 @@ Add ordered actions to an accepted join.
  Existing actions stay before the actions added here. A refused join has no
  topic, so this function returns [`reject`](#reject) results unchanged.
 
-```gleam
-pub fn with_actions(
-  JoinResult(a, b),
-  List(Action(Active))
-) -> JoinResult(a, b)
-```
+<div class="api-entry-anchor" id="api-function-with_reply" aria-hidden="true"></div>
 
 ### `with_reply`
-
-Add a payload to an accepted join's acknowledgment.
-
- A rejected join remains rejected.
 
 ```gleam
 pub fn with_reply(
@@ -576,3 +698,7 @@ pub fn with_reply(
   json.Json
 ) -> JoinResult(a, b)
 ```
+
+Add a payload to an accepted join's acknowledgment.
+
+ A rejected join remains rejected.

--- a/website/src/content/docs/reference/api/beryl-error.md
+++ b/website/src/content/docs/reference/api/beryl-error.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/error"
 description: "Shared beryl-owned error helpers."
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -9,35 +12,59 @@ description: "Shared beryl-owned error helpers."
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
 
+<div class="api-reference-marker" aria-hidden="true"></div>
+
 Shared beryl-owned error helpers.
+
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#types">Types</a>
+  <ul>
+<li><a href="#api-type-startfailure"><code>StartFailure</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-describe_start_failure"><code>describe_start_failure</code></a></li>
+<li><a href="#api-function-from_actor_start_error"><code>from_actor_start_error</code></a></li>
+  </ul>
+</section>
+</nav>
 
 ## Types
 
+<div class="api-entry-anchor" id="api-type-startfailure" aria-hidden="true"></div>
+
 ### `StartFailure`
+
+```gleam
+pub type StartFailure
+```
 
 A stable description of an internal beryl actor startup failure.
 
  This type hides OTP's `actor.StartError` so public APIs do not expose
  dependency-specific error constructors.
 
-```gleam
-pub type StartFailure
-```
-
 ## Functions
 
-### `describe_start_failure`
+<div class="api-entry-anchor" id="api-function-describe_start_failure" aria-hidden="true"></div>
 
-Return a human-readable description of a startup failure.
+### `describe_start_failure`
 
 ```gleam
 pub fn describe_start_failure(StartFailure) -> String
 ```
 
-### `from_actor_start_error`
+Return a human-readable description of a startup failure.
 
-Convert a `gleam/otp/actor.StartError` to beryl's `StartFailure`.
+<div class="api-entry-anchor" id="api-function-from_actor_start_error" aria-hidden="true"></div>
+
+### `from_actor_start_error`
 
 ```gleam
 pub fn from_actor_start_error(actor.StartError) -> StartFailure
 ```
+
+Convert a `gleam/otp/actor.StartError` to beryl's `StartFailure`.

--- a/website/src/content/docs/reference/api/beryl-group.md
+++ b/website/src/content/docs/reference/api/beryl-group.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/group"
 description: "Channel Groups - Named collections of topics for multi-topic broadcasting"
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "Channel Groups - Named collections of topics for multi-topic broad
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 Channel Groups - Named collections of topics for multi-topic broadcasting
 
@@ -32,21 +37,51 @@ Channel Groups - Named collections of topics for multi-topic broadcasting
  group.broadcast(groups, channels, "team:engineering", "announce", payload)
  ```
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#types">Types</a>
+  <ul>
+<li><a href="#api-type-config"><code>Config</code></a></li>
+<li><a href="#api-type-grouperror"><code>GroupError</code></a></li>
+<li><a href="#api-type-groups"><code>Groups</code></a></li>
+<li><a href="#api-type-message"><code>Message</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-add"><code>add</code></a></li>
+<li><a href="#api-function-broadcast"><code>broadcast</code></a></li>
+<li><a href="#api-function-child_spec"><code>child_spec</code></a></li>
+<li><a href="#api-function-child_spec_with_config"><code>child_spec_with_config</code></a></li>
+<li><a href="#api-function-create"><code>create</code></a></li>
+<li><a href="#api-function-default_config"><code>default_config</code></a></li>
+<li><a href="#api-function-delete"><code>delete</code></a></li>
+<li><a href="#api-function-list_groups"><code>list_groups</code></a></li>
+<li><a href="#api-function-remove"><code>remove</code></a></li>
+<li><a href="#api-function-topics"><code>topics</code></a></li>
+<li><a href="#api-function-with_call_timeout"><code>with_call_timeout</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Types
 
+<div class="api-entry-anchor" id="api-type-config" aria-hidden="true"></div>
+
 ### `Config`
-
-Configuration for starting a groups actor.
-
- Build configs with `default_config` and the `with_*` functions.
 
 ```gleam
 pub type Config
 ```
 
-### `GroupError`
+Configuration for starting a groups actor.
 
-Errors from group operations.
+ Build configs with `default_config` and the `with_*` functions.
+
+<div class="api-entry-anchor" id="api-type-grouperror" aria-hidden="true"></div>
+
+### `GroupError`
 
 ```gleam
 pub type GroupError {
@@ -55,50 +90,61 @@ pub type GroupError {
 }
 ```
 
+Errors from group operations.
+
 #### Constructors
 
 ##### `GroupAlreadyExists`
+
+```gleam
+GroupAlreadyExists
+```
 
 The group already exists.
 
 ##### `GroupNotFound`
 
+```gleam
+GroupNotFound
+```
+
 The group was not found.
 
+<div class="api-entry-anchor" id="api-type-groups" aria-hidden="true"></div>
+
 ### `Groups`
+
+```gleam
+pub type Groups
+```
 
 A running groups instance.
 
  This handle is opaque. Callers cannot forge the actor subject or depend
  on its runtime representation.
 
- ## Node affinity
+ #### Node affinity
 
  The stable registered subject is resolved on the caller's node. Keep a
  `Groups` handle on the node where its child specification runs. Calls from
  another BEAM node cannot reach the owning actor; synchronous operations
  panic as unavailable, and fire-and-forget broadcasts are not delivered.
 
-```gleam
-pub type Groups
-```
+<div class="api-entry-anchor" id="api-type-message" aria-hidden="true"></div>
 
 ### `Message`
-
-Messages that the groups actor handles.
 
 ```gleam
 pub type Message
 ```
 
+Messages that the groups actor handles.
+
 ## Functions
 
+<div class="api-entry-anchor" id="api-function-add" aria-hidden="true"></div>
+
 ### `add`
-
-Add a topic to a group.
-
- Panics if the groups actor is unavailable or does not reply within the
- configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn add(
@@ -108,16 +154,14 @@ pub fn add(
 ) -> Result(Nil, GroupError)
 ```
 
-### `broadcast`
-
-Broadcast a message to all topics in a group.
-
- This function sends the message to each topic through `beryl.broadcast`.
- The groups actor performs the topic lookup. The caller performs the
- fan-out. If the group does not exist, this function does nothing.
+Add a topic to a group.
 
  Panics if the groups actor is unavailable or does not reply within the
- configured call timeout.
+ configured call timeout (5 seconds by default).
+
+<div class="api-entry-anchor" id="api-function-broadcast" aria-hidden="true"></div>
+
+### `broadcast`
 
 ```gleam
 pub fn broadcast(
@@ -129,7 +173,22 @@ pub fn broadcast(
 ) -> Nil
 ```
 
+Broadcast a message to all topics in a group.
+
+ This function sends the message to each topic through `beryl.broadcast`.
+ The groups actor performs the topic lookup. The caller performs the
+ fan-out. If the group does not exist, this function does nothing.
+
+ Panics if the groups actor is unavailable or does not reply within the
+ configured call timeout.
+
+<div class="api-entry-anchor" id="api-function-child_spec" aria-hidden="true"></div>
+
 ### `child_spec`
+
+```gleam
+pub fn child_spec() -> #(Groups, supervision.ChildSpecification(process.Subject(Message)))
+```
 
 Build the supervised groups actor with the default configuration.
 
@@ -138,24 +197,19 @@ Build the supervised groups actor with the default configuration.
  after a supervised restart. Group definitions are in-memory state and are
  reset by a restart.
 
-```gleam
-pub fn child_spec() -> #(Groups, supervision.ChildSpecification(process.Subject(Message)))
-```
+<div class="api-entry-anchor" id="api-function-child_spec_with_config" aria-hidden="true"></div>
 
 ### `child_spec_with_config`
-
-Build the supervised groups actor with a custom configuration.
 
 ```gleam
 pub fn child_spec_with_config(Config) -> #(Groups, supervision.ChildSpecification(process.Subject(Message)))
 ```
 
+Build the supervised groups actor with a custom configuration.
+
+<div class="api-entry-anchor" id="api-function-create" aria-hidden="true"></div>
+
 ### `create`
-
-Create a named group.
-
- Panics if the groups actor is unavailable or does not reply within the
- configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn create(
@@ -164,20 +218,24 @@ pub fn create(
 ) -> Result(Nil, GroupError)
 ```
 
-### `default_config`
+Create a named group.
 
-Build a groups configuration with a 5-second actor call timeout.
+ Panics if the groups actor is unavailable or does not reply within the
+ configured call timeout (5 seconds by default).
+
+<div class="api-entry-anchor" id="api-function-default_config" aria-hidden="true"></div>
+
+### `default_config`
 
 ```gleam
 pub fn default_config() -> Config
 ```
 
+Build a groups configuration with a 5-second actor call timeout.
+
+<div class="api-entry-anchor" id="api-function-delete" aria-hidden="true"></div>
+
 ### `delete`
-
-Delete a group.
-
- Panics if the groups actor is unavailable or does not reply within the
- configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn delete(
@@ -186,23 +244,27 @@ pub fn delete(
 ) -> Result(Nil, GroupError)
 ```
 
+Delete a group.
+
+ Panics if the groups actor is unavailable or does not reply within the
+ configured call timeout (5 seconds by default).
+
+<div class="api-entry-anchor" id="api-function-list_groups" aria-hidden="true"></div>
+
 ### `list_groups`
+
+```gleam
+pub fn list_groups(Groups) -> List(String)
+```
 
 Return all group names.
 
  Panics if the groups actor is unavailable or does not reply within the
  configured call timeout (5 seconds by default).
 
-```gleam
-pub fn list_groups(Groups) -> List(String)
-```
+<div class="api-entry-anchor" id="api-function-remove" aria-hidden="true"></div>
 
 ### `remove`
-
-Remove a topic from a group.
-
- Panics if the groups actor is unavailable or does not reply within the
- configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn remove(
@@ -212,12 +274,14 @@ pub fn remove(
 ) -> Result(Nil, GroupError)
 ```
 
-### `topics`
-
-Return all topics in a group.
+Remove a topic from a group.
 
  Panics if the groups actor is unavailable or does not reply within the
  configured call timeout (5 seconds by default).
+
+<div class="api-entry-anchor" id="api-function-topics" aria-hidden="true"></div>
+
+### `topics`
 
 ```gleam
 pub fn topics(
@@ -226,13 +290,14 @@ pub fn topics(
 ) -> Result(set.Set(String), GroupError)
 ```
 
+Return all topics in a group.
+
+ Panics if the groups actor is unavailable or does not reply within the
+ configured call timeout (5 seconds by default).
+
+<div class="api-entry-anchor" id="api-function-with_call_timeout" aria-hidden="true"></div>
+
 ### `with_call_timeout`
-
-Set the timeout for synchronous group operations, in milliseconds.
-
- This applies to `create`, `delete`, `add`, `remove`, `topics`, and
- `list_groups`. These functions panic if the actor does not reply within
- this timeout.
 
 ```gleam
 pub fn with_call_timeout(
@@ -240,3 +305,9 @@ pub fn with_call_timeout(
   Int
 ) -> Config
 ```
+
+Set the timeout for synchronous group operations, in milliseconds.
+
+ This applies to `create`, `delete`, `add`, `remove`, `topics`, and
+ `list_groups`. These functions panic if the actor does not reply within
+ this timeout.

--- a/website/src/content/docs/reference/api/beryl-presence-wire.md
+++ b/website/src/content/docs/reference/api/beryl-presence-wire.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/presence/wire"
 description: "Phoenix-compatible wire encoding for presence diffs."
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -9,11 +12,32 @@ description: "Phoenix-compatible wire encoding for presence diffs."
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
 
+<div class="api-reference-marker" aria-hidden="true"></div>
+
 Phoenix-compatible wire encoding for presence diffs.
+
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-encode_diff"><code>encode_diff</code></a></li>
+<li><a href="#api-function-encode_state"><code>encode_state</code></a></li>
+  </ul>
+</section>
+</nav>
 
 ## Functions
 
+<div class="api-entry-anchor" id="api-function-encode_diff" aria-hidden="true"></div>
+
 ### `encode_diff`
+
+```gleam
+pub fn encode_diff(
+  presence.Diff,
+  String
+) -> json.Json
+```
 
 Encode a presence diff for one topic as a Phoenix-compatible payload.
 
@@ -27,14 +51,13 @@ Encode a presence diff for one topic as a Phoenix-compatible payload.
  }
  ```
 
-```gleam
-pub fn encode_diff(
-  presence.Diff,
-  String
-) -> json.Json
-```
+<div class="api-entry-anchor" id="api-function-encode_state" aria-hidden="true"></div>
 
 ### `encode_state`
+
+```gleam
+pub fn encode_state(List(presence.PresenceEntry)) -> json.Json
+```
 
 Encode a topic's full presence list as a Phoenix-compatible
  `presence_state` payload.
@@ -50,7 +73,3 @@ Encode a topic's full presence list as a Phoenix-compatible
  Phoenix clients expect a `presence_state` event with this payload after
  they join a presence-enabled topic. Incremental `presence_diff` events
  follow it. Build the entry list with `presence.list`.
-
-```gleam
-pub fn encode_state(List(presence.PresenceEntry)) -> json.Json
-```

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/presence"
 description: "Presence - Distributed presence tracking backed by a CRDT"
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "Presence - Distributed presence tracking backed by a CRDT"
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 Presence - Distributed presence tracking backed by a CRDT
 
@@ -58,39 +63,87 @@ Presence - Distributed presence tracking backed by a CRDT
  let assert Ok(entries) = presence.list(presence_handle, "room:lobby")
  ```
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#types">Types</a>
+  <ul>
+<li><a href="#api-type-config"><code>Config</code></a></li>
+<li><a href="#api-type-diff"><code>Diff</code></a></li>
+<li><a href="#api-type-message"><code>Message</code></a></li>
+<li><a href="#api-type-presence"><code>Presence</code></a></li>
+<li><a href="#api-type-presenceentry"><code>PresenceEntry</code></a></li>
+<li><a href="#api-type-presenceupdateerror"><code>PresenceUpdateError</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-child_spec"><code>child_spec</code></a></li>
+<li><a href="#api-function-count"><code>count</code></a></li>
+<li><a href="#api-function-default_config"><code>default_config</code></a></li>
+<li><a href="#api-function-diff"><code>diff</code></a></li>
+<li><a href="#api-function-diff_joins"><code>diff_joins</code></a></li>
+<li><a href="#api-function-diff_leaves"><code>diff_leaves</code></a></li>
+<li><a href="#api-function-diff_topics"><code>diff_topics</code></a></li>
+<li><a href="#api-function-get_by_key"><code>get_by_key</code></a></li>
+<li><a href="#api-function-list"><code>list</code></a></li>
+<li><a href="#api-function-track"><code>track</code></a></li>
+<li><a href="#api-function-untrack"><code>untrack</code></a></li>
+<li><a href="#api-function-untrack_all"><code>untrack_all</code></a></li>
+<li><a href="#api-function-update"><code>update</code></a></li>
+<li><a href="#api-function-with_broadcast_interval"><code>with_broadcast_interval</code></a></li>
+<li><a href="#api-function-with_call_timeout"><code>with_call_timeout</code></a></li>
+<li><a href="#api-function-with_on_diff"><code>with_on_diff</code></a></li>
+<li><a href="#api-function-with_pubsub"><code>with_pubsub</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Types
 
+<div class="api-entry-anchor" id="api-type-config" aria-hidden="true"></div>
+
 ### `Config`
+
+```gleam
+pub type Config
+```
 
 Configuration for starting presence.
 
  Build configurations with `default_config` and the `with_*` functions.
  beryl can then add options without exposing record fields as public API.
 
-```gleam
-pub type Config
-```
+<div class="api-entry-anchor" id="api-type-diff" aria-hidden="true"></div>
 
 ### `Diff`
+
+```gleam
+pub type Diff
+```
 
 An opaque diff representing presence joins and leaves grouped by topic.
 
  beryl passes this value to `Config.on_diff`.
  `beryl.broadcast_presence_diff` also accepts it.
 
-```gleam
-pub type Diff
-```
+<div class="api-entry-anchor" id="api-type-message" aria-hidden="true"></div>
 
 ### `Message`
-
-Messages that the presence actor handles.
 
 ```gleam
 pub type Message
 ```
 
+Messages that the presence actor handles.
+
+<div class="api-entry-anchor" id="api-type-presence" aria-hidden="true"></div>
+
 ### `Presence`
+
+```gleam
+pub type Presence
+```
 
 A running Presence instance.
 
@@ -98,7 +151,7 @@ A running Presence instance.
  the runtime representation. It contains the actor's stable registered
  subject and the name of its actor-owned ETS read model.
 
- ## Node affinity
+ #### Node affinity
 
  The stable registered subject and ETS read model are resolved on the
  caller's node. Keep a `Presence` handle on the node where its child
@@ -109,16 +162,9 @@ A running Presence instance.
  replication (`with_pubsub`) to share presence state across nodes instead of
  moving the handle itself.
 
-```gleam
-pub type Presence
-```
+<div class="api-entry-anchor" id="api-type-presenceentry" aria-hidden="true"></div>
 
 ### `PresenceEntry`
-
-A presence entry returned from queries and diff accessors.
-
- This type is transparent. Callers can inspect query results and construct
- entries for `diff`.
 
 ```gleam
 pub type PresenceEntry {
@@ -130,9 +176,14 @@ pub type PresenceEntry {
 }
 ```
 
-### `PresenceUpdateError`
+A presence entry returned from queries and diff accessors.
 
-Errors from an update to a tracked presence.
+ This type is transparent. Callers can inspect query results and construct
+ entries for `diff`.
+
+<div class="api-entry-anchor" id="api-type-presenceupdateerror" aria-hidden="true"></div>
+
+### `PresenceUpdateError`
 
 ```gleam
 pub type PresenceUpdateError {
@@ -140,15 +191,27 @@ pub type PresenceUpdateError {
 }
 ```
 
+Errors from an update to a tracked presence.
+
 #### Constructors
 
 ##### `UnknownRef`
+
+```gleam
+UnknownRef
+```
 
 The ref is unknown, already removed, or was not returned by `track`.
 
 ## Functions
 
+<div class="api-entry-anchor" id="api-function-child_spec" aria-hidden="true"></div>
+
 ### `child_spec`
+
+```gleam
+pub fn child_spec(Config) -> #(Presence, supervision.ChildSpecification(process.Subject(Message)))
+```
 
 Build the supervised presence actor.
 
@@ -156,11 +219,16 @@ Build the supervised presence actor.
  The returned handle is name-backed and works again after a supervised
  restart. A restart resets the in-memory presence entries and tracking refs.
 
-```gleam
-pub fn child_spec(Config) -> #(Presence, supervision.ChildSpecification(process.Subject(Message)))
-```
+<div class="api-entry-anchor" id="api-function-count" aria-hidden="true"></div>
 
 ### `count`
+
+```gleam
+pub fn count(
+  Presence,
+  String
+) -> Result(Int, Nil)
+```
 
 Count presences in a topic.
 
@@ -179,14 +247,13 @@ Count presences in a topic.
  from a process on another BEAM node than the one it was started on (see
  the node affinity note on `Presence`).
 
-```gleam
-pub fn count(
-  Presence,
-  String
-) -> Result(Int, Nil)
-```
+<div class="api-entry-anchor" id="api-function-default_config" aria-hidden="true"></div>
 
 ### `default_config`
+
+```gleam
+pub fn default_config(String) -> Config
+```
 
 Default configuration (no PubSub).
 
@@ -195,16 +262,9 @@ Default configuration (no PubSub).
  the interval is unused. Use `with_broadcast_interval(0)` to disable
  periodic broadcasts and control replication manually.
 
-```gleam
-pub fn default_config(String) -> Config
-```
+<div class="api-entry-anchor" id="api-function-diff" aria-hidden="true"></div>
 
 ### `diff`
-
-Build a presence diff from topic-grouped joins and leaves.
-
- Most applications receive diffs from `Config.on_diff`. Use this function
- to construct a diff for `beryl.broadcast_presence_diff`.
 
 ```gleam
 pub fn diff(
@@ -213,9 +273,14 @@ pub fn diff(
 ) -> Diff
 ```
 
-### `diff_joins`
+Build a presence diff from topic-grouped joins and leaves.
 
-Return presence joins for a topic in this diff.
+ Most applications receive diffs from `Config.on_diff`. Use this function
+ to construct a diff for `beryl.broadcast_presence_diff`.
+
+<div class="api-entry-anchor" id="api-function-diff_joins" aria-hidden="true"></div>
+
+### `diff_joins`
 
 ```gleam
 pub fn diff_joins(
@@ -224,9 +289,11 @@ pub fn diff_joins(
 ) -> List(PresenceEntry)
 ```
 
-### `diff_leaves`
+Return presence joins for a topic in this diff.
 
-Return presence leaves for a topic in this diff.
+<div class="api-entry-anchor" id="api-function-diff_leaves" aria-hidden="true"></div>
+
+### `diff_leaves`
 
 ```gleam
 pub fn diff_leaves(
@@ -235,15 +302,29 @@ pub fn diff_leaves(
 ) -> List(PresenceEntry)
 ```
 
-### `diff_topics`
+Return presence leaves for a topic in this diff.
 
-List topics touched by this diff.
+<div class="api-entry-anchor" id="api-function-diff_topics" aria-hidden="true"></div>
+
+### `diff_topics`
 
 ```gleam
 pub fn diff_topics(Diff) -> List(String)
 ```
 
+List topics touched by this diff.
+
+<div class="api-entry-anchor" id="api-function-get_by_key" aria-hidden="true"></div>
+
 ### `get_by_key`
+
+```gleam
+pub fn get_by_key(
+  Presence,
+  String,
+  String
+) -> Result(List(#(String, json.Json)), Nil)
+```
 
 Get presences for a specific key within a topic.
 
@@ -257,15 +338,16 @@ Get presences for a specific key within a topic.
  from a process on another BEAM node than the one it was started on (see
  the node affinity note on `Presence`).
 
-```gleam
-pub fn get_by_key(
-  Presence,
-  String,
-  String
-) -> Result(List(#(String, json.Json)), Nil)
-```
+<div class="api-entry-anchor" id="api-function-list" aria-hidden="true"></div>
 
 ### `list`
+
+```gleam
+pub fn list(
+  Presence,
+  String
+) -> Result(List(PresenceEntry), Nil)
+```
 
 List all presences for a topic.
 
@@ -279,14 +361,19 @@ List all presences for a topic.
  from a process on another BEAM node than the one it was started on (see
  the node affinity note on `Presence`).
 
-```gleam
-pub fn list(
-  Presence,
-  String
-) -> Result(List(PresenceEntry), Nil)
-```
+<div class="api-entry-anchor" id="api-function-track" aria-hidden="true"></div>
 
 ### `track`
+
+```gleam
+pub fn track(
+  Presence,
+  String,
+  String,
+  String,
+  json.Json
+) -> String
+```
 
 Track a presence in a topic.
 
@@ -302,24 +389,9 @@ Track a presence in a topic.
  Panics if the presence actor is unavailable or does not reply within the
  configured call timeout (5 seconds by default).
 
-```gleam
-pub fn track(
-  Presence,
-  String,
-  String,
-  String,
-  json.Json
-) -> String
-```
+<div class="api-entry-anchor" id="api-function-untrack" aria-hidden="true"></div>
 
 ### `untrack`
-
-Untrack a specific presence using the ref returned by `track`.
-
- Removing an unknown or already-removed ref is a harmless no-op.
-
- Panics if the presence actor is unavailable or does not reply within the
- configured call timeout (5 seconds by default).
 
 ```gleam
 pub fn untrack(
@@ -328,12 +400,16 @@ pub fn untrack(
 ) -> Nil
 ```
 
-### `untrack_all`
+Untrack a specific presence using the ref returned by `track`.
 
-Untrack all presences for a session, such as when a socket disconnects.
+ Removing an unknown or already-removed ref is a harmless no-op.
 
  Panics if the presence actor is unavailable or does not reply within the
  configured call timeout (5 seconds by default).
+
+<div class="api-entry-anchor" id="api-function-untrack_all" aria-hidden="true"></div>
+
+### `untrack_all`
 
 ```gleam
 pub fn untrack_all(
@@ -342,7 +418,22 @@ pub fn untrack_all(
 ) -> Nil
 ```
 
+Untrack all presences for a session, such as when a socket disconnects.
+
+ Panics if the presence actor is unavailable or does not reply within the
+ configured call timeout (5 seconds by default).
+
+<div class="api-entry-anchor" id="api-function-update" aria-hidden="true"></div>
+
 ### `update`
+
+```gleam
+pub fn update(
+  Presence,
+  String,
+  json.Json
+) -> Result(String, PresenceUpdateError)
+```
 
 Replace the meta of a presence created by `track`.
 
@@ -357,19 +448,9 @@ Replace the meta of a presence created by `track`.
  Panics if the presence actor is unavailable or does not reply within the
  configured call timeout (5 seconds by default).
 
-```gleam
-pub fn update(
-  Presence,
-  String,
-  json.Json
-) -> Result(String, PresenceUpdateError)
-```
+<div class="api-entry-anchor" id="api-function-with_broadcast_interval" aria-hidden="true"></div>
 
 ### `with_broadcast_interval`
-
-Set how often presence state is broadcast for replication.
-
- Use `0` to disable periodic broadcasts.
 
 ```gleam
 pub fn with_broadcast_interval(
@@ -378,13 +459,13 @@ pub fn with_broadcast_interval(
 ) -> Config
 ```
 
+Set how often presence state is broadcast for replication.
+
+ Use `0` to disable periodic broadcasts.
+
+<div class="api-entry-anchor" id="api-function-with_call_timeout" aria-hidden="true"></div>
+
 ### `with_call_timeout`
-
-Set the timeout for synchronous presence mutations, in milliseconds.
-
- This timeout applies to `track`, `update`, `untrack`, and `untrack_all`. These
- functions panic if the actor does not reply before the timeout. The default
- is 5000 ms.
 
 ```gleam
 pub fn with_call_timeout(
@@ -393,7 +474,22 @@ pub fn with_call_timeout(
 ) -> Config
 ```
 
+Set the timeout for synchronous presence mutations, in milliseconds.
+
+ This timeout applies to `track`, `update`, `untrack`, and `untrack_all`. These
+ functions panic if the actor does not reply before the timeout. The default
+ is 5000 ms.
+
+<div class="api-entry-anchor" id="api-function-with_on_diff" aria-hidden="true"></div>
+
 ### `with_on_diff`
+
+```gleam
+pub fn with_on_diff(
+  Config,
+  fn(Diff) -> Nil
+) -> Config
+```
 
 Set the callback for diffs from local changes or remote merges.
 
@@ -420,16 +516,9 @@ Set the callback for diffs from local changes or remote merges.
  mailbox and are not delayed. Only the socket with an active presence
  effect waits for the callback.
 
-```gleam
-pub fn with_on_diff(
-  Config,
-  fn(Diff) -> Nil
-) -> Config
-```
+<div class="api-entry-anchor" id="api-function-with_pubsub" aria-hidden="true"></div>
 
 ### `with_pubsub`
-
-Enable PubSub replication for presence.
 
 ```gleam
 pub fn with_pubsub(
@@ -437,3 +526,5 @@ pub fn with_pubsub(
   pubsub.PubSub(SyncPayload)
 ) -> Config
 ```
+
+Enable PubSub replication for presence.

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/pubsub"
 description: "PubSub - Distributed publish/subscribe using Erlang pg"
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "PubSub - Distributed publish/subscribe using Erlang pg"
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 PubSub - Distributed publish/subscribe using Erlang pg
 
@@ -43,16 +48,60 @@ PubSub - Distributed publish/subscribe using Erlang pg
    |> pubsub.selecting(subscriber, RemoteBroadcast)
  ```
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#types">Types</a>
+  <ul>
+<li><a href="#api-type-message"><code>Message</code></a></li>
+<li><a href="#api-type-pubsub"><code>PubSub</code></a></li>
+<li><a href="#api-type-pubsubconfig"><code>PubSubConfig</code></a></li>
+<li><a href="#api-type-pubsubfrom"><code>PubSubFrom</code></a></li>
+<li><a href="#api-type-subscriber"><code>Subscriber</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-broadcast"><code>broadcast</code></a></li>
+<li><a href="#api-function-broadcast_from"><code>broadcast_from</code></a></li>
+<li><a href="#api-function-broadcast_from_socket"><code>broadcast_from_socket</code></a></li>
+<li><a href="#api-function-config_with_scope"><code>config_with_scope</code></a></li>
+<li><a href="#api-function-default_config"><code>default_config</code></a></li>
+<li><a href="#api-function-join"><code>join</code></a></li>
+<li><a href="#api-function-leave"><code>leave</code></a></li>
+<li><a href="#api-function-local_broadcast"><code>local_broadcast</code></a></li>
+<li><a href="#api-function-selecting"><code>selecting</code></a></li>
+<li><a href="#api-function-start"><code>start</code></a></li>
+<li><a href="#api-function-subscriber"><code>subscriber</code></a></li>
+<li><a href="#api-function-subscriber_count"><code>subscriber_count</code></a></li>
+<li><a href="#api-function-subscribers"><code>subscribers</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Types
 
+<div class="api-entry-anchor" id="api-type-message" aria-hidden="true"></div>
+
 ### `Message`
+
+```gleam
+pub type Message(a) {
+  Message(
+    topic: String,
+    event: String,
+    payload: a,
+    from: PubSubFrom
+  )
+}
+```
 
 A PubSub message delivered to subscribers.
 
  This type is transparent. Subscribers can inspect the topic, event,
  payload, and sender metadata in their process mailbox.
 
- ## Frozen wire contract
+ #### Frozen wire contract
 
  beryl sends broadcasts **raw between nodes** through `pg` as a five-element
  tuple. The PubSub scope atom comes first. The four message fields follow in
@@ -66,18 +115,13 @@ A PubSub message delivered to subscribers.
  `selecting`. It safely adds the subscriber's raw mailbox messages to a
  typed `Selector`. Do not match the raw process message yourself.
 
-```gleam
-pub type Message(a) {
-  Message(
-    topic: String,
-    event: String,
-    payload: a,
-    from: PubSubFrom
-  )
-}
-```
+<div class="api-entry-anchor" id="api-type-pubsub" aria-hidden="true"></div>
 
 ### `PubSub`
+
+```gleam
+pub type PubSub(a)
+```
 
 A running PubSub instance.
 
@@ -86,26 +130,22 @@ A running PubSub instance.
  sent through this instance. The scope identifies the runtime instance.
  All handles for one scope must use the same payload type.
 
-```gleam
-pub type PubSub(a)
-```
+<div class="api-entry-anchor" id="api-type-pubsubconfig" aria-hidden="true"></div>
 
 ### `PubSubConfig`
+
+```gleam
+pub type PubSubConfig
+```
 
 PubSub configuration.
 
  Build with `default_config` or `config_with_scope` so the underlying pg
  scope representation can evolve without exposing record fields.
 
-```gleam
-pub type PubSubConfig
-```
+<div class="api-entry-anchor" id="api-type-pubsubfrom" aria-hidden="true"></div>
 
 ### `PubSubFrom`
-
-Identifies the sender of a broadcast.
-
- Part of the frozen wire contract described on `Message`.
 
 ```gleam
 pub type PubSubFrom {
@@ -118,24 +158,46 @@ pub type PubSubFrom {
 }
 ```
 
+Identifies the sender of a broadcast.
+
+ Part of the frozen wire contract described on `Message`.
+
 #### Constructors
 
 ##### `System`
 
+```gleam
+System
+```
+
 The broadcast came from the system and has no sender PID.
 
-##### `FromPid(process.Pid)`
+##### `FromPid`
+
+```gleam
+FromPid(process.Pid)
+```
 
 The broadcast came from a specific process.
 
-##### `FromSocket(
+##### `FromSocket`
+
+```gleam
+FromSocket(
   process.Pid,
   String
-)`
+)
+```
 
 The broadcast came from a process and must exclude a socket ID.
 
+<div class="api-entry-anchor" id="api-type-subscriber" aria-hidden="true"></div>
+
 ### `Subscriber`
+
+```gleam
+pub type Subscriber(a)
+```
 
 A typed subscription handle owned by a single process.
 
@@ -147,15 +209,11 @@ A typed subscription handle owned by a single process.
  Create it in the receiving process, such as an actor's initializer.
  A `Subject` delivers messages only to its owner.
 
-```gleam
-pub type Subscriber(a)
-```
-
 ## Functions
 
-### `broadcast`
+<div class="api-entry-anchor" id="api-function-broadcast" aria-hidden="true"></div>
 
-Broadcast a message to all topic subscribers on all nodes.
+### `broadcast`
 
 ```gleam
 pub fn broadcast(
@@ -166,9 +224,11 @@ pub fn broadcast(
 ) -> Nil
 ```
 
-### `broadcast_from`
+Broadcast a message to all topic subscribers on all nodes.
 
-Broadcast a message to all subscribers except a specific PID.
+<div class="api-entry-anchor" id="api-function-broadcast_from" aria-hidden="true"></div>
+
+### `broadcast_from`
 
 ```gleam
 pub fn broadcast_from(
@@ -180,11 +240,11 @@ pub fn broadcast_from(
 ) -> Nil
 ```
 
+Broadcast a message to all subscribers except a specific PID.
+
+<div class="api-entry-anchor" id="api-function-broadcast_from_socket" aria-hidden="true"></div>
+
 ### `broadcast_from_socket`
-
-Broadcast a message to all subscribers except a process.
-
- Preserve a socket ID that receiving runtimes must exclude locally.
 
 ```gleam
 pub fn broadcast_from_socket(
@@ -197,7 +257,17 @@ pub fn broadcast_from_socket(
 ) -> Nil
 ```
 
+Broadcast a message to all subscribers except a process.
+
+ Preserve a socket ID that receiving runtimes must exclude locally.
+
+<div class="api-entry-anchor" id="api-function-config_with_scope" aria-hidden="true"></div>
+
 ### `config_with_scope`
+
+```gleam
+pub fn config_with_scope(String) -> PubSubConfig
+```
 
 Create a PubSub configuration with a custom scope name.
 
@@ -222,24 +292,19 @@ Create a PubSub configuration with a custom scope name.
  // pubsub.config_with_scope(database_row.name)
  ```
 
-```gleam
-pub fn config_with_scope(String) -> PubSubConfig
-```
+<div class="api-entry-anchor" id="api-function-default_config" aria-hidden="true"></div>
 
 ### `default_config`
-
-Create a default PubSub configuration with scope `beryl_pubsub`.
 
 ```gleam
 pub fn default_config() -> PubSubConfig
 ```
 
+Create a default PubSub configuration with scope `beryl_pubsub`.
+
+<div class="api-entry-anchor" id="api-function-join" aria-hidden="true"></div>
+
 ### `join`
-
-Join a topic so this subscriber receives broadcasts sent to it.
-
- A subscriber can join many topics. All topics deliver through its one
- subject. Joining a topic is idempotent.
 
 ```gleam
 pub fn join(
@@ -248,9 +313,14 @@ pub fn join(
 ) -> Nil
 ```
 
-### `leave`
+Join a topic so this subscriber receives broadcasts sent to it.
 
-Leave a topic previously joined with `join`.
+ A subscriber can join many topics. All topics deliver through its one
+ subject. Joining a topic is idempotent.
+
+<div class="api-entry-anchor" id="api-function-leave" aria-hidden="true"></div>
+
+### `leave`
 
 ```gleam
 pub fn leave(
@@ -259,9 +329,11 @@ pub fn leave(
 ) -> Nil
 ```
 
-### `local_broadcast`
+Leave a topic previously joined with `join`.
 
-Broadcast a message only to subscribers on the current node.
+<div class="api-entry-anchor" id="api-function-local_broadcast" aria-hidden="true"></div>
+
+### `local_broadcast`
 
 ```gleam
 pub fn local_broadcast(
@@ -272,7 +344,19 @@ pub fn local_broadcast(
 ) -> Nil
 ```
 
+Broadcast a message only to subscribers on the current node.
+
+<div class="api-entry-anchor" id="api-function-selecting" aria-hidden="true"></div>
+
 ### `selecting`
+
+```gleam
+pub fn selecting(
+  process.Selector(a),
+  Subscriber(b),
+  fn(Message(b)) -> a
+) -> process.Selector(a)
+```
 
 Add a subscriber's PubSub message delivery to a `Selector`, alongside a
  process's own subjects.
@@ -295,15 +379,13 @@ Add a subscriber's PubSub message delivery to a `Selector`, alongside a
    |> pubsub.selecting(subscriber, RemoteBroadcast)
  ```
 
-```gleam
-pub fn selecting(
-  process.Selector(a),
-  Subscriber(b),
-  fn(Message(b)) -> a
-) -> process.Selector(a)
-```
+<div class="api-entry-anchor" id="api-function-start" aria-hidden="true"></div>
 
 ### `start`
+
+```gleam
+pub fn start(PubSubConfig) -> PubSub(a)
+```
 
 Start a PubSub instance.
 
@@ -315,11 +397,13 @@ Start a PubSub instance.
  Starting the same scope again returns another handle to the same runtime
  instance, so every use of that scope must choose the same payload type.
 
-```gleam
-pub fn start(PubSubConfig) -> PubSub(a)
-```
+<div class="api-entry-anchor" id="api-function-subscriber" aria-hidden="true"></div>
 
 ### `subscriber`
+
+```gleam
+pub fn subscriber(PubSub(a)) -> Subscriber(a)
+```
 
 Create a subscription handle owned by the current process.
 
@@ -331,13 +415,9 @@ Create a subscription handle owned by the current process.
  `selecting` uses each subscriber's scope to keep their raw mailbox messages
  separate.
 
-```gleam
-pub fn subscriber(PubSub(a)) -> Subscriber(a)
-```
+<div class="api-entry-anchor" id="api-function-subscriber_count" aria-hidden="true"></div>
 
 ### `subscriber_count`
-
-Return the number of topic subscribers on all nodes.
 
 ```gleam
 pub fn subscriber_count(
@@ -346,9 +426,11 @@ pub fn subscriber_count(
 ) -> Int
 ```
 
-### `subscribers`
+Return the number of topic subscribers on all nodes.
 
-Return all topic subscribers on all nodes.
+<div class="api-entry-anchor" id="api-function-subscribers" aria-hidden="true"></div>
+
+### `subscribers`
 
 ```gleam
 pub fn subscribers(
@@ -356,3 +438,5 @@ pub fn subscribers(
   String
 ) -> List(process.Pid)
 ```
+
+Return all topic subscribers on all nodes.

--- a/website/src/content/docs/reference/api/beryl-socket.md
+++ b/website/src/content/docs/reference/api/beryl-socket.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/socket"
 description: "Types for building app-side dispatch systems with `beryl.child_spec`."
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "Types for building app-side dispatch systems with `beryl.child_spe
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 Types for building app-side dispatch systems with `beryl.child_spec`.
 
@@ -36,11 +41,36 @@ Types for building app-side dispatch systems with `beryl.child_spec`.
  continue, so a broadcast from elsewhere may arrive between two effects
  from this socket.
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#types">Types</a>
+  <ul>
+<li><a href="#api-type-connectinfo"><code>ConnectInfo</code></a></li>
+<li><a href="#api-type-connectseed"><code>ConnectSeed</code></a></li>
+<li><a href="#api-type-effect"><code>Effect</code></a></li>
+<li><a href="#api-type-input"><code>Input</code></a></li>
+<li><a href="#api-type-joinref"><code>JoinRef</code></a></li>
+<li><a href="#api-type-next"><code>Next</code></a></li>
+<li><a href="#api-type-replyref"><code>ReplyRef</code></a></li>
+<li><a href="#api-type-sender"><code>Sender</code></a></li>
+<li><a href="#api-type-stopreason"><code>StopReason</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-empty_seed"><code>empty_seed</code></a></li>
+<li><a href="#api-function-notify"><code>notify</code></a></li>
+<li><a href="#api-function-reply_ok"><code>reply_ok</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Types
 
-### `ConnectInfo`
+<div class="api-entry-anchor" id="api-type-connectinfo" aria-hidden="true"></div>
 
-Everything the app's `init` receives when a socket connects.
+### `ConnectInfo`
 
 ```gleam
 pub type ConnectInfo(a) {
@@ -52,12 +82,11 @@ pub type ConnectInfo(a) {
 }
 ```
 
+Everything the app's `init` receives when a socket connects.
+
+<div class="api-entry-anchor" id="api-type-connectseed" aria-hidden="true"></div>
+
 ### `ConnectSeed`
-
-Connection metadata that the transport builds before the WebSocket
- upgrade.
-
- The app's `init` function receives it through `ConnectInfo`.
 
 ```gleam
 pub type ConnectSeed {
@@ -70,10 +99,14 @@ pub type ConnectSeed {
 }
 ```
 
-### `Effect`
+Connection metadata that the transport builds before the WebSocket
+ upgrade.
 
-One update may return several effects, applied strictly in list order
- (see the module docs for the ordering guarantee).
+ The app's `init` function receives it through `ConnectInfo`.
+
+<div class="api-entry-anchor" id="api-type-effect" aria-hidden="true"></div>
+
+### `Effect`
 
 ```gleam
 pub type Effect {
@@ -131,70 +164,105 @@ pub type Effect {
 }
 ```
 
+One update may return several effects, applied strictly in list order
+ (see the module docs for the ordering guarantee).
+
 #### Constructors
 
-##### `AcceptJoin(
+##### `AcceptJoin`
+
+```gleam
+AcceptJoin(
   ref: JoinRef,
   reply: option.Option(json.Json)
-)`
+)
+```
 
 Accept a pending join. This subscribes the socket to the topic and sends
  the join acknowledgment with an optional reply payload. The effect is
  valid only while the `Join` input's ref is pending.
 
-##### `RejectJoin(
+##### `RejectJoin`
+
+```gleam
+RejectJoin(
   ref: JoinRef,
   reason: json.Json
-)`
+)
+```
 
 Reject a pending join with an error payload.
 
-##### `ReplyOk(
+##### `ReplyOk`
+
+```gleam
+ReplyOk(
   ref: ReplyRef,
   payload: json.Json
-)`
+)
+```
 
 Reply successfully to a client message ref.
 
-##### `ReplyError(
+##### `ReplyError`
+
+```gleam
+ReplyError(
   ref: ReplyRef,
   payload: json.Json
-)`
+)
+```
 
 Reply with an error to a client message ref.
 
-##### `Push(
+##### `Push`
+
+```gleam
+Push(
   topic: String,
   event: String,
   payload: json.Json
-)`
+)
+```
 
 Push a server-initiated message to this socket on a joined topic.
  The runtime drops pushes to topics that this socket has not joined and
  logs a warning. Put a `Push` after its topic's `AcceptJoin`.
 
-##### `Broadcast(
+##### `Broadcast`
+
+```gleam
+Broadcast(
   topic: String,
   event: String,
   payload: json.Json
-)`
+)
+```
 
 Broadcast to every subscriber of a topic (including this socket, when
  joined). Distributed via PubSub when configured.
 
-##### `BroadcastFrom(
+##### `BroadcastFrom`
+
+```gleam
+BroadcastFrom(
   topic: String,
   event: String,
   payload: json.Json
-)`
+)
+```
 
 Broadcast to every subscriber of a topic except this socket.
 
-##### `PresenceTrack(
+##### `PresenceTrack`
+
+```gleam
+PresenceTrack(
   topic: String,
   key: String,
   meta: json.Json
-)`
+)
+```
 
 Track this socket's presence under a key in a topic and broadcast the
  corresponding `presence_diff` join. This effect requires a presence
@@ -206,10 +274,14 @@ Track this socket's presence under a key in a topic and broadcast the
  both the leave and the join. Later effects wait for the mutation, as
  described in the module documentation. Other sockets do not wait.
 
-##### `PresenceUntrack(
+##### `PresenceUntrack`
+
+```gleam
+PresenceUntrack(
   topic: String,
   key: String
-)`
+)
+```
 
 Untrack a presence previously tracked with `PresenceTrack` and
  broadcast the corresponding `presence_diff` leave. When the topic
@@ -219,11 +291,15 @@ Untrack a presence previously tracked with `PresenceTrack` and
  This effect requires a presence handle (`beryl.with_presence_handle`).
  Without a handle, the runtime drops the effect and logs a warning.
 
-##### `PushPresence(
+##### `PushPresence`
+
+```gleam
+PushPresence(
   topic: String,
   event: String,
   encode: fn(List(presence.PresenceEntry)) -> json.Json
-)`
+)
+```
 
 Push a presence snapshot for a topic to this socket. A payload built
  inside `update` sees presence from *before* this effects list. In
@@ -234,11 +310,15 @@ Push a presence snapshot for a topic to this socket. A payload built
  Without a handle, the runtime drops the effect and logs a warning.
  Like `Push`, the runtime drops it if the topic is not joined.
 
-##### `BroadcastPresence(
+##### `BroadcastPresence`
+
+```gleam
+BroadcastPresence(
   topic: String,
   event: String,
   encode: fn(List(presence.PresenceEntry)) -> json.Json
-)`
+)
+```
 
 Broadcast a presence snapshot for a topic to all its subscribers,
  with the same apply-time `encode` semantics as `PushPresence`.
@@ -247,14 +327,18 @@ Broadcast a presence snapshot for a topic to all its subscribers,
  (`beryl.with_presence_handle`). Without a handle, the runtime drops the
  effect and logs a warning.
 
-##### `KickTopic(topic: String)`
+##### `KickTopic`
+
+```gleam
+KickTopic(topic: String)
+```
 
 Close this socket's subscription to a topic. The topic receives a
  `Closed(topic, Shutdown)` input and the client a terminal frame.
 
-### `Input`
+<div class="api-entry-anchor" id="api-type-input" aria-hidden="true"></div>
 
-Everything the runtime delivers to the app's `update` function.
+### `Input`
 
 ```gleam
 pub type Input(a) {
@@ -281,52 +365,80 @@ pub type Input(a) {
 }
 ```
 
+Everything the runtime delivers to the app's `update` function.
+
 #### Constructors
 
-##### `Join(
+##### `Join`
+
+```gleam
+Join(
   topic: String,
   payload: dynamic.Dynamic,
   ref: JoinRef
-)`
+)
+```
 
 A client asked to join a topic. Return an `AcceptJoin` or `RejectJoin`
  effect. The runtime rejects a `Join` that is unanswered at the end of
  the update turn.
 
-##### `Message(
+##### `Message`
+
+```gleam
+Message(
   topic: String,
   event: String,
   payload: dynamic.Dynamic,
   ref: option.Option(ReplyRef)
-)`
+)
+```
 
 A client message on a joined topic. `ref` is present for messages
  that expect a reply.
 
-##### `Binary(
+##### `Binary`
+
+```gleam
+Binary(
   topic: String,
   data: BitArray
-)`
+)
+```
 
 A binary frame on a joined topic (codecs without a binary decoder
  deliver the raw frame once per joined topic).
 
-##### `Closed(
+##### `Closed`
+
+```gleam
+Closed(
   topic: String,
   reason: StopReason
-)`
+)
+```
 
 A joined topic ended because of a client leave, kick, crash, or socket
  close. The runtime sends this input on every exit path. Use it to remove
  per-topic state from the model. Frames pushed to the closing topic are
  dropped; broadcasts still reach the topic's remaining subscribers.
 
-##### `Info(a)`
+##### `Info`
+
+```gleam
+Info(a)
+```
 
 A typed server-side message, sent via the socket's `Sender` (see
  `ConnectInfo.self` and `notify`).
 
+<div class="api-entry-anchor" id="api-type-joinref" aria-hidden="true"></div>
+
 ### `JoinRef`
+
+```gleam
+pub type JoinRef
+```
 
 A pending join correlation handle.
 
@@ -334,16 +446,9 @@ A pending join correlation handle.
  its pending join. It carries a unique runtime token. A delayed completion
  for an older same-topic join cannot answer a replacement or retry.
 
-```gleam
-pub type JoinRef
-```
+<div class="api-entry-anchor" id="api-type-next" aria-hidden="true"></div>
 
 ### `Next`
-
-The result of one `update` call.
-
- It contains the next model and effects, or an instruction to stop the
- socket.
 
 ```gleam
 pub type Next(a) {
@@ -355,21 +460,40 @@ pub type Next(a) {
 }
 ```
 
+The result of one `update` call.
+
+ It contains the next model and effects, or an instruction to stop the
+ socket.
+
 #### Constructors
 
-##### `Next(
+##### `Next`
+
+```gleam
+Next(
   model: a,
   effects: List(Effect)
-)`
+)
+```
 
 Continue with the given model, applying the effects in order.
 
-##### `Stop(reason: StopReason)`
+##### `Stop`
+
+```gleam
+Stop(reason: StopReason)
+```
 
 Tear down the socket: every joined topic receives a `Closed` input,
  terminal frames are sent, and the transport connection is closed.
 
+<div class="api-entry-anchor" id="api-type-replyref" aria-hidden="true"></div>
+
 ### `ReplyRef`
+
+```gleam
+pub type ReplyRef
+```
 
 A client message reply correlation handle.
 
@@ -378,11 +502,13 @@ A client message reply correlation handle.
  asynchronous lookup. They are single-use. They remain valid only while
  the topic instance that received the message stays open.
 
-```gleam
-pub type ReplyRef
-```
+<div class="api-entry-anchor" id="api-type-sender" aria-hidden="true"></div>
 
 ### `Sender`
+
+```gleam
+pub type Sender(a)
+```
 
 A typed handle for sending server-side messages to one socket.
 
@@ -390,16 +516,9 @@ A typed handle for sending server-side messages to one socket.
  `notify` with it. The socket's `update` function receives the message as
  an `Info` event. This typed send does not erase the message type.
 
-```gleam
-pub type Sender(a)
-```
+<div class="api-entry-anchor" id="api-type-stopreason" aria-hidden="true"></div>
 
 ### `StopReason`
-
-Why a socket or topic is stopping.
-
- The runtime delivers this reason in `Closed` inputs, and `Stop` accepts it.
- Match with a catch-all (`_`) arm. Minor releases can add stop reasons.
 
 ```gleam
 pub type StopReason {
@@ -410,21 +529,42 @@ pub type StopReason {
 }
 ```
 
+Why a socket or topic is stopping.
+
+ The runtime delivers this reason in `Closed` inputs, and `Stop` accepts it.
+ Match with a catch-all (`_`) arm. Minor releases can add stop reasons.
+
 #### Constructors
 
 ##### `Normal`
+
+```gleam
+Normal
+```
 
 Normal shutdown (client left or disconnected cleanly).
 
 ##### `Shutdown`
 
+```gleam
+Shutdown
+```
+
 Server-initiated shutdown (system stop, `KickTopic`).
 
 ##### `HeartbeatTimeout`
 
+```gleam
+HeartbeatTimeout
+```
+
 The client failed to send a heartbeat within the configured timeout.
 
-##### `Errored(String)`
+##### `Errored`
+
+```gleam
+Errored(String)
+```
 
 An error stopped the socket or topic. The name `Errored` prevents an
  unqualified import from shadowing the prelude's `Result` `Error`
@@ -432,20 +572,19 @@ An error stopped the socket or topic. The name `Errored` prevents an
 
 ## Functions
 
-### `empty_seed`
+<div class="api-entry-anchor" id="api-function-empty_seed" aria-hidden="true"></div>
 
-Return an empty connect seed for tests and transports with no request data.
+### `empty_seed`
 
 ```gleam
 pub fn empty_seed() -> ConnectSeed
 ```
 
+Return an empty connect seed for tests and transports with no request data.
+
+<div class="api-entry-anchor" id="api-function-notify" aria-hidden="true"></div>
+
 ### `notify`
-
-Send a typed server-side message to a socket.
-
- The socket's `update` function receives `Info(message)`. The runtime
- ignores the message if the socket has disconnected.
 
 ```gleam
 pub fn notify(
@@ -454,14 +593,14 @@ pub fn notify(
 ) -> Nil
 ```
 
+Send a typed server-side message to a socket.
+
+ The socket's `update` function receives `Info(message)`. The runtime
+ ignores the message if the socket has disconnected.
+
+<div class="api-entry-anchor" id="api-function-reply_ok" aria-hidden="true"></div>
+
 ### `reply_ok`
-
-Return a `ReplyOk` effect when the client supplied a ref.
-
- `Message` inputs carry `Option(ReplyRef)` (refless messages expect no
- reply) while the `ReplyOk` effect demands a `ReplyRef`, so every handler
- that replies conditionally needs this check. This function returns no
- effects when the client did not supply a ref.
 
 ```gleam
 pub fn reply_ok(
@@ -469,3 +608,10 @@ pub fn reply_ok(
   json.Json
 ) -> List(Effect)
 ```
+
+Return a `ReplyOk` effect when the client supplied a ref.
+
+ `Message` inputs carry `Option(ReplyRef)` (refless messages expect no
+ reply) while the `ReplyOk` effect demands a `ReplyRef`, so every handler
+ that replies conditionally needs this check. This function returns no
+ effects when the client did not supply a ref.

--- a/website/src/content/docs/reference/api/beryl-stats.md
+++ b/website/src/content/docs/reference/api/beryl-stats.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/stats"
 description: "Local runtime statistics."
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "Local runtime statistics."
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 Local runtime statistics.
 
@@ -19,19 +24,40 @@ Local runtime statistics.
  more frequently than roughly once per second so observation does not add
  meaningful runtime load.
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#types">Types</a>
+  <ul>
+<li><a href="#api-type-snapshot"><code>Snapshot</code></a></li>
+<li><a href="#api-type-snapshoterror"><code>SnapshotError</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-active_topics"><code>active_topics</code></a></li>
+<li><a href="#api-function-connected_sockets"><code>connected_sockets</code></a></li>
+<li><a href="#api-function-joined_socket_topic_pairs"><code>joined_socket_topic_pairs</code></a></li>
+<li><a href="#api-function-snapshot"><code>snapshot</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Types
 
-### `Snapshot`
+<div class="api-entry-anchor" id="api-type-snapshot" aria-hidden="true"></div>
 
-A point-in-time snapshot of local runtime state.
+### `Snapshot`
 
 ```gleam
 pub type Snapshot
 ```
 
-### `SnapshotError`
+A point-in-time snapshot of local runtime state.
 
-Errors from a runtime snapshot request.
+<div class="api-entry-anchor" id="api-type-snapshoterror" aria-hidden="true"></div>
+
+### `SnapshotError`
 
 ```gleam
 pub type SnapshotError {
@@ -40,45 +66,67 @@ pub type SnapshotError {
 }
 ```
 
+Errors from a runtime snapshot request.
+
 #### Constructors
 
 ##### `RuntimeUnavailable`
+
+```gleam
+RuntimeUnavailable
+```
 
 The local socket runtime is not running.
 
 ##### `RequestTimedOut`
 
+```gleam
+RequestTimedOut
+```
+
 The runtime did not process the request before the timeout.
 
 ## Functions
 
-### `active_topics`
+<div class="api-entry-anchor" id="api-function-active_topics" aria-hidden="true"></div>
 
-Return the number of topics with at least one local joined socket.
+### `active_topics`
 
 ```gleam
 pub fn active_topics(Snapshot) -> Int
 ```
 
-### `connected_sockets`
+Return the number of topics with at least one local joined socket.
 
-Return the number of sockets connected to the local runtime.
+<div class="api-entry-anchor" id="api-function-connected_sockets" aria-hidden="true"></div>
+
+### `connected_sockets`
 
 ```gleam
 pub fn connected_sockets(Snapshot) -> Int
 ```
 
+Return the number of sockets connected to the local runtime.
+
+<div class="api-entry-anchor" id="api-function-joined_socket_topic_pairs" aria-hidden="true"></div>
+
 ### `joined_socket_topic_pairs`
-
-Return the number of joined socket/topic pairs.
-
- One socket joined to two topics contributes two pairs.
 
 ```gleam
 pub fn joined_socket_topic_pairs(Snapshot) -> Int
 ```
 
+Return the number of joined socket/topic pairs.
+
+ One socket joined to two topics contributes two pairs.
+
+<div class="api-entry-anchor" id="api-function-snapshot" aria-hidden="true"></div>
+
 ### `snapshot`
+
+```gleam
+pub fn snapshot(beryl.Sockets) -> Result(Snapshot, SnapshotError)
+```
 
 Request a snapshot from the local runtime.
 
@@ -89,7 +137,3 @@ Request a snapshot from the local runtime.
  `sockets`; aggregate multi-node statistics outside beryl.
 
  Poll no more frequently than roughly once per second.
-
-```gleam
-pub fn snapshot(beryl.Sockets) -> Result(Snapshot, SnapshotError)
-```

--- a/website/src/content/docs/reference/api/beryl-topic.md
+++ b/website/src/content/docs/reference/api/beryl-topic.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/topic"
 description: "Pattern matching for topic routing."
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "Pattern matching for topic routing."
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 Pattern matching for topic routing.
 
@@ -17,11 +22,37 @@ Pattern matching for topic routing.
  segment-aware wildcards where "*" occupies a complete colon-delimited
  segment.
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#types">Types</a>
+  <ul>
+<li><a href="#api-type-extracterror"><code>ExtractError</code></a></li>
+<li><a href="#api-type-topicerror"><code>TopicError</code></a></li>
+<li><a href="#api-type-topicpattern"><code>TopicPattern</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-extract_id"><code>extract_id</code></a></li>
+<li><a href="#api-function-extract_wildcards"><code>extract_wildcards</code></a></li>
+<li><a href="#api-function-from_segments"><code>from_segments</code></a></li>
+<li><a href="#api-function-matches"><code>matches</code></a></li>
+<li><a href="#api-function-namespace"><code>namespace</code></a></li>
+<li><a href="#api-function-parse_pattern"><code>parse_pattern</code></a></li>
+<li><a href="#api-function-segments"><code>segments</code></a></li>
+<li><a href="#api-function-validate"><code>validate</code></a></li>
+<li><a href="#api-function-validate_event"><code>validate_event</code></a></li>
+<li><a href="#api-function-validate_pattern"><code>validate_pattern</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Types
 
-### `ExtractError`
+<div class="api-entry-anchor" id="api-type-extracterror" aria-hidden="true"></div>
 
-Errors from extracting wildcard values from a topic pattern.
+### `ExtractError`
 
 ```gleam
 pub type ExtractError {
@@ -32,32 +63,45 @@ pub type ExtractError {
 }
 ```
 
+Errors from extracting wildcard values from a topic pattern.
+
 #### Constructors
 
 ##### `NoWildcard`
+
+```gleam
+NoWildcard
+```
 
 The pattern has no wildcard to extract.
 
 ##### `TopicMismatch`
 
+```gleam
+TopicMismatch
+```
+
 The topic does not match the pattern.
 
-##### `ExpectedOneWildcard(Int)`
+##### `ExpectedOneWildcard`
+
+```gleam
+ExpectedOneWildcard(Int)
+```
 
 `extract_id` expected exactly one wildcard value but found this many.
 
 ##### `EmptyNamespace`
 
+```gleam
+EmptyNamespace
+```
+
 `namespace` was called with an empty topic.
 
+<div class="api-entry-anchor" id="api-type-topicerror" aria-hidden="true"></div>
+
 ### `TopicError`
-
-Errors returned when validating a topic or topic pattern.
-
- A minor release can add variants as validation gets stricter. Do not treat
- this type as closed for exhaustive matching. Match exact variants only
- when you handle them differently. Otherwise, use a catch-all arm
- (`_ -> ...`) so new variants do not break your code.
 
 ```gleam
 pub type TopicError {
@@ -66,20 +110,35 @@ pub type TopicError {
 }
 ```
 
+Errors returned when validating a topic or topic pattern.
+
+ A minor release can add variants as validation gets stricter. Do not treat
+ this type as closed for exhaustive matching. Match exact variants only
+ when you handle them differently. Otherwise, use a catch-all arm
+ (`_ -> ...`) so new variants do not break your code.
+
 #### Constructors
 
 ##### `EmptyTopic`
 
+```gleam
+EmptyTopic
+```
+
 The topic or pattern was an empty string.
 
-##### `InvalidFormat(String)`
+##### `InvalidFormat`
+
+```gleam
+InvalidFormat(String)
+```
 
 The topic, pattern, or event was malformed; the wrapped `String`
  describes the problem (e.g. leading/trailing `:` or control characters).
 
-### `TopicPattern`
+<div class="api-entry-anchor" id="api-type-topicpattern" aria-hidden="true"></div>
 
-A topic pattern for routing.
+### `TopicPattern`
 
 ```gleam
 pub type TopicPattern {
@@ -89,36 +148,41 @@ pub type TopicPattern {
 }
 ```
 
+A topic pattern for routing.
+
 #### Constructors
 
-##### `Exact(String)`
+##### `Exact`
+
+```gleam
+Exact(String)
+```
 
 Exact match. `"room:lobby"` matches only `"room:lobby"`.
 
-##### `Wildcard(prefix: String)`
+##### `Wildcard`
+
+```gleam
+Wildcard(prefix: String)
+```
 
 Wildcard suffix. `"room:*"` matches `"room:lobby"`, `"room:123"`,
  and other values with the same prefix.
 
-##### `SegmentWildcard(segments: List(String))`
+##### `SegmentWildcard`
+
+```gleam
+SegmentWildcard(segments: List(String))
+```
 
 Segment wildcard. `"document:*:ops"` matches topics with the same
  number of `":"` segments. `"*"` occupies one complete segment.
 
 ## Functions
 
+<div class="api-entry-anchor" id="api-function-extract_id" aria-hidden="true"></div>
+
 ### `extract_id`
-
-Extract the wildcard part of a topic.
-
- ## Examples
-
- ```gleam
- extract_id(Wildcard("room:"), "room:lobby") // -> Ok("lobby")
- extract_id(Wildcard("doc:"), "doc:abc:123") // -> Ok("abc:123")
- extract_id(SegmentWildcard(["doc", "*", "ops"]), "doc:abc:ops") // -> Ok("abc")
- extract_id(Exact("room:lobby"), "room:lobby") // -> Error(NoWildcard)
- ```
 
 ```gleam
 pub fn extract_id(
@@ -127,20 +191,20 @@ pub fn extract_id(
 ) -> Result(String, ExtractError)
 ```
 
-### `extract_wildcards`
+Extract the wildcard part of a topic.
 
-Extract values captured by wildcard segments.
-
- For legacy prefix wildcards, this function returns the suffix as one
- value. For segment wildcards, it returns each topic segment matched by
- `"*"`.
-
- ## Examples
+ #### Examples
 
  ```gleam
- extract_wildcards(parse_pattern("document:*:*"), "document:tenant-a:doc-42")
- // -> Ok(["tenant-a", "doc-42"])
+ extract_id(Wildcard("room:"), "room:lobby") // -> Ok("lobby")
+ extract_id(Wildcard("doc:"), "doc:abc:123") // -> Ok("abc:123")
+ extract_id(SegmentWildcard(["doc", "*", "ops"]), "doc:abc:ops") // -> Ok("abc")
+ extract_id(Exact("room:lobby"), "room:lobby") // -> Error(NoWildcard)
  ```
+
+<div class="api-entry-anchor" id="api-function-extract_wildcards" aria-hidden="true"></div>
+
+### `extract_wildcards`
 
 ```gleam
 pub fn extract_wildcards(
@@ -149,26 +213,50 @@ pub fn extract_wildcards(
 ) -> Result(List(String), ExtractError)
 ```
 
+Extract values captured by wildcard segments.
+
+ For legacy prefix wildcards, this function returns the suffix as one
+ value. For segment wildcards, it returns each topic segment matched by
+ `"*"`.
+
+ #### Examples
+
+ ```gleam
+ extract_wildcards(parse_pattern("document:*:*"), "document:tenant-a:doc-42")
+ // -> Ok(["tenant-a", "doc-42"])
+ ```
+
+<div class="api-entry-anchor" id="api-function-from_segments" aria-hidden="true"></div>
+
 ### `from_segments`
+
+```gleam
+pub fn from_segments(List(String)) -> String
+```
 
 Build a topic from segments.
 
- ## Examples
+ #### Examples
 
  ```gleam
  from_segments(["room", "lobby"]) // -> "room:lobby"
  from_segments(["doc", "tenant", "123"]) // -> "doc:tenant:123"
  ```
 
-```gleam
-pub fn from_segments(List(String)) -> String
-```
+<div class="api-entry-anchor" id="api-function-matches" aria-hidden="true"></div>
 
 ### `matches`
 
+```gleam
+pub fn matches(
+  TopicPattern,
+  String
+) -> Bool
+```
+
 Return whether a topic matches a pattern.
 
- ## Examples
+ #### Examples
 
  ```gleam
  matches(Wildcard("room:"), "room:lobby") // -> True
@@ -179,33 +267,34 @@ Return whether a topic matches a pattern.
  matches(parse_pattern("document:*:ops"), "document:tenant-a:view") // -> False
  ```
 
-```gleam
-pub fn matches(
-  TopicPattern,
-  String
-) -> Bool
-```
+<div class="api-entry-anchor" id="api-function-namespace" aria-hidden="true"></div>
 
 ### `namespace`
 
+```gleam
+pub fn namespace(String) -> Result(String, ExtractError)
+```
+
 Return the first segment (namespace) of a topic.
 
- ## Examples
+ #### Examples
 
  ```gleam
  namespace("room:lobby") // -> Ok("room")
  namespace("") // -> Error(EmptyNamespace)
  ```
 
-```gleam
-pub fn namespace(String) -> Result(String, ExtractError)
-```
+<div class="api-entry-anchor" id="api-function-parse_pattern" aria-hidden="true"></div>
 
 ### `parse_pattern`
 
+```gleam
+pub fn parse_pattern(String) -> TopicPattern
+```
+
 Parse a pattern string into `TopicPattern`.
 
- ## Examples
+ #### Examples
 
  ```gleam
  parse_pattern("room:*") // -> Wildcard("room:")
@@ -215,26 +304,30 @@ Parse a pattern string into `TopicPattern`.
  parse_pattern("document:tenant-a:*") // -> Wildcard("document:tenant-a:")
  ```
 
-```gleam
-pub fn parse_pattern(String) -> TopicPattern
-```
+<div class="api-entry-anchor" id="api-function-segments" aria-hidden="true"></div>
 
 ### `segments`
 
+```gleam
+pub fn segments(String) -> List(String)
+```
+
 Split a topic into segments at each `":"`.
 
- ## Examples
+ #### Examples
 
  ```gleam
  segments("room:lobby") // -> ["room", "lobby"]
  segments("doc:tenant:123:ops") // -> ["doc", "tenant", "123", "ops"]
  ```
 
-```gleam
-pub fn segments(String) -> List(String)
-```
+<div class="api-entry-anchor" id="api-function-validate" aria-hidden="true"></div>
 
 ### `validate`
+
+```gleam
+pub fn validate(String) -> Result(String, TopicError)
+```
 
 Validate a topic string.
 
@@ -243,11 +336,13 @@ Validate a topic string.
  - not contain control characters (codepoints 0–31 or 127); and
  - not start or end with `":"`.
 
-```gleam
-pub fn validate(String) -> Result(String, TopicError)
-```
+<div class="api-entry-anchor" id="api-function-validate_event" aria-hidden="true"></div>
 
 ### `validate_event`
+
+```gleam
+pub fn validate_event(String) -> Result(String, TopicError)
+```
 
 Validate an event name.
 
@@ -255,11 +350,13 @@ Validate an event name.
  - not be empty; and
  - not contain control characters (codepoints 0–31 or 127).
 
-```gleam
-pub fn validate_event(String) -> Result(String, TopicError)
-```
+<div class="api-entry-anchor" id="api-function-validate_pattern" aria-hidden="true"></div>
 
 ### `validate_pattern`
+
+```gleam
+pub fn validate_pattern(String) -> Result(String, TopicError)
+```
 
 Validate a topic pattern string.
 
@@ -269,7 +366,3 @@ Validate a topic pattern string.
 
  The bare pattern `"*"` is valid: it parses to a catch-all wildcard that
  matches every topic.
-
-```gleam
-pub fn validate_pattern(String) -> Result(String, TopicError)
-```

--- a/website/src/content/docs/reference/api/beryl-transport-origin.md
+++ b/website/src/content/docs/reference/api/beryl-transport-origin.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/transport/origin"
 description: "Origin and handshake-version checks for WebSocket upgrades."
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -9,6 +12,8 @@ description: "Origin and handshake-version checks for WebSocket upgrades."
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
 
+<div class="api-reference-marker" aria-hidden="true"></div>
+
 Origin and handshake-version checks for WebSocket upgrades.
 
  Pure string-level checks shared by beryl's WebSocket transports. They
@@ -16,9 +21,35 @@ Origin and handshake-version checks for WebSocket upgrades.
  types; `beryl/transport/server` applies them to `gleam/http` requests as
  part of the shared upgrade pipeline.
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#types">Types</a>
+  <ul>
+<li><a href="#api-type-originpolicy"><code>OriginPolicy</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-allowed"><code>allowed</code></a></li>
+<li><a href="#api-function-vsn_supported"><code>vsn_supported</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Types
 
+<div class="api-entry-anchor" id="api-type-originpolicy" aria-hidden="true"></div>
+
 ### `OriginPolicy`
+
+```gleam
+pub type OriginPolicy {
+  SameOrigin
+  AllowList(List(String))
+  AllowAll
+}
+```
 
 Policy for validating the browser `Origin` header before a WebSocket
  upgrade completes.
@@ -36,17 +67,13 @@ Policy for validating the browser `Origin` header before a WebSocket
  not apply to these clients. [`AllowList`](#originpolicy) is the exception.
  It requires a matching `Origin` and rejects an absent header.
 
-```gleam
-pub type OriginPolicy {
-  SameOrigin
-  AllowList(List(String))
-  AllowAll
-}
-```
-
 #### Constructors
 
 ##### `SameOrigin`
+
+```gleam
+SameOrigin
+```
 
 Allow an upgrade only when the request `Origin` authority (host plus any
  port, with the scheme stripped) matches the request `Host` authority.
@@ -62,7 +89,11 @@ Allow an upgrade only when the request `Origin` authority (host plus any
  headers such as `X-Forwarded-Host` are not trusted, because clients can
  spoof them.
 
-##### `AllowList(List(String))`
+##### `AllowList`
+
+```gleam
+AllowList(List(String))
+```
 
 Allow an upgrade only when the request `Origin` header matches one of the
  listed values exactly (including scheme, host, and any port), such as
@@ -71,20 +102,19 @@ Allow an upgrade only when the request `Origin` header matches one of the
 
 ##### `AllowAll`
 
+```gleam
+AllowAll
+```
+
 Allow every upgrade regardless of `Origin`. This disables CSWSH
  protection. Use it only for sockets that do not rely on ambient
  browser credentials (or that authenticate every message independently).
 
 ## Functions
 
+<div class="api-entry-anchor" id="api-function-allowed" aria-hidden="true"></div>
+
 ### `allowed`
-
-Decide whether an upgrade is allowed under the configured origin policy.
-
- `origin` and `host` are the request's `Origin` and `Host` header values.
- Use `None` when a header is absent. `SameOrigin` and `AllowAll` admit a
- request without an `Origin` header because non-browser clients omit it.
- `AllowList` rejects the request because it requires an explicit match.
 
 ```gleam
 pub fn allowed(
@@ -94,7 +124,20 @@ pub fn allowed(
 ) -> Bool
 ```
 
+Decide whether an upgrade is allowed under the configured origin policy.
+
+ `origin` and `host` are the request's `Origin` and `Host` header values.
+ Use `None` when a header is absent. `SameOrigin` and `AllowAll` admit a
+ request without an `Origin` header because non-browser clients omit it.
+ `AllowList` rejects the request because it requires an explicit match.
+
+<div class="api-entry-anchor" id="api-function-vsn_supported" aria-hidden="true"></div>
+
 ### `vsn_supported`
+
+```gleam
+pub fn vsn_supported(vsn: option.Option(String)) -> Bool
+```
 
 Check a client's requested wire protocol version (the `?vsn=` query
  parameter sent by Phoenix clients) before upgrading.
@@ -104,7 +147,3 @@ Check a client's requested wire protocol version (the `?vsn=` query
  configured codec. Anything else (e.g. the V1 object framing's `vsn=1.0.0`)
  is rejected. Transports fail the handshake with `403 Forbidden` instead
  of accepting a connection with frames that cannot be decoded.
-
-```gleam
-pub fn vsn_supported(vsn: option.Option(String)) -> Bool
-```

--- a/website/src/content/docs/reference/api/beryl-transport-server.md
+++ b/website/src/content/docs/reference/api/beryl-transport-server.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/transport/server"
 description: "Server-agnostic WebSocket transport infrastructure."
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "Server-agnostic WebSocket transport infrastructure."
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 Server-agnostic WebSocket transport infrastructure.
 
@@ -24,11 +29,41 @@ Server-agnostic WebSocket transport infrastructure.
  request body type, so one config value works with any transport whose
  server exposes `gleam/http` requests.
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#types">Types</a>
+  <ul>
+<li><a href="#api-type-connecterror"><code>ConnectError</code></a></li>
+<li><a href="#api-type-connectionstate"><code>ConnectionState</code></a></li>
+<li><a href="#api-type-framedisposition"><code>FrameDisposition</code></a></li>
+<li><a href="#api-type-sendrequest"><code>SendRequest</code></a></li>
+<li><a href="#api-type-transportconfig"><code>TransportConfig</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-close_connection"><code>close_connection</code></a></li>
+<li><a href="#api-function-connect_seed"><code>connect_seed</code></a></li>
+<li><a href="#api-function-default_config"><code>default_config</code></a></li>
+<li><a href="#api-function-handle_binary_frame"><code>handle_binary_frame</code></a></li>
+<li><a href="#api-function-handle_text_frame"><code>handle_text_frame</code></a></li>
+<li><a href="#api-function-handler"><code>handler</code></a></li>
+<li><a href="#api-function-init_connection"><code>init_connection</code></a></li>
+<li><a href="#api-function-is_websocket_request"><code>is_websocket_request</code></a></li>
+<li><a href="#api-function-upgrade"><code>upgrade</code></a></li>
+<li><a href="#api-function-with_allow_all_origins"><code>with_allow_all_origins</code></a></li>
+<li><a href="#api-function-with_allowed_origins"><code>with_allowed_origins</code></a></li>
+<li><a href="#api-function-with_on_connect"><code>with_on_connect</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Types
 
-### `ConnectError`
+<div class="api-entry-anchor" id="api-type-connecterror" aria-hidden="true"></div>
 
-Errors returned from a transport `on_connect` callback.
+### `ConnectError`
 
 ```gleam
 pub type ConnectError {
@@ -36,23 +71,31 @@ pub type ConnectError {
 }
 ```
 
+Errors returned from a transport `on_connect` callback.
+
 #### Constructors
 
 ##### `ConnectRejected`
 
+```gleam
+ConnectRejected
+```
+
 Reject the WebSocket upgrade with `403 Forbidden`.
 
-### `ConnectionState`
+<div class="api-entry-anchor" id="api-type-connectionstate" aria-hidden="true"></div>
 
-State maintained per WebSocket connection.
+### `ConnectionState`
 
 ```gleam
 pub type ConnectionState
 ```
 
-### `FrameDisposition`
+State maintained per WebSocket connection.
 
-What a transport must do after it handles an inbound frame.
+<div class="api-entry-anchor" id="api-type-framedisposition" aria-hidden="true"></div>
+
+### `FrameDisposition`
 
 ```gleam
 pub type FrameDisposition {
@@ -61,22 +104,29 @@ pub type FrameDisposition {
 }
 ```
 
+What a transport must do after it handles an inbound frame.
+
 #### Constructors
 
-##### `Continue(ConnectionState)`
+##### `Continue`
+
+```gleam
+Continue(ConnectionState)
+```
 
 Keep the connection open with the updated state.
 
 ##### `Stop`
 
+```gleam
+Stop
+```
+
 Close the connection (the frame exceeded the configured size cap).
 
+<div class="api-entry-anchor" id="api-type-sendrequest" aria-hidden="true"></div>
+
 ### `SendRequest`
-
-Outbound requests from the runtime to a connection process.
-
- Transports receive these as custom or user WebSocket messages. They send
- the frame or close the connection.
 
 ```gleam
 pub type SendRequest {
@@ -86,36 +136,58 @@ pub type SendRequest {
 }
 ```
 
+Outbound requests from the runtime to a connection process.
+
+ Transports receive these as custom or user WebSocket messages. They send
+ the frame or close the connection.
+
 #### Constructors
 
 ##### `Close`
 
+```gleam
+Close
+```
+
 Runtime-initiated close (e.g. heartbeat eviction).
 
+<div class="api-entry-anchor" id="api-type-transportconfig" aria-hidden="true"></div>
+
 ### `TransportConfig`
+
+```gleam
+pub type TransportConfig(a)
+```
 
 Configuration for a WebSocket transport.
 
  The `body` parameter is the server's request body type. The same
  configuration works with any transport built on `gleam/http` requests.
 
-```gleam
-pub type TransportConfig(a)
-```
-
 ## Functions
 
+<div class="api-entry-anchor" id="api-function-close_connection" aria-hidden="true"></div>
+
 ### `close_connection`
-
-Clean up a closed connection.
-
- Release the held connection slot and report the disconnect to the runtime.
 
 ```gleam
 pub fn close_connection(ConnectionState) -> Nil
 ```
 
+Clean up a closed connection.
+
+ Release the held connection slot and report the disconnect to the runtime.
+
+<div class="api-entry-anchor" id="api-function-connect_seed" aria-hidden="true"></div>
+
 ### `connect_seed`
+
+```gleam
+pub fn connect_seed(
+  request.Request(a),
+  List(#(String, String))
+) -> socket.ConnectSeed
+```
 
 Build the connection seed for an app-dispatch system's `init` function.
 
@@ -127,14 +199,13 @@ Build the connection seed for an app-dispatch system's `init` function.
  callback returns no metadata. This function preserves order and duplicate
  keys.
 
-```gleam
-pub fn connect_seed(
-  request.Request(a),
-  List(#(String, String))
-) -> socket.ConnectSeed
-```
+<div class="api-entry-anchor" id="api-function-default_config" aria-hidden="true"></div>
 
 ### `default_config`
+
+```gleam
+pub fn default_config(String) -> TransportConfig(a)
+```
 
 Create a default transport config with no connect hook.
 
@@ -148,15 +219,9 @@ Create a default transport config with no connect hook.
  metadata. Use `with_allowed_origins` to set an explicit allow-list. Use
  `with_allow_all_origins` to opt out of origin checking entirely.
 
-```gleam
-pub fn default_config(String) -> TransportConfig(a)
-```
+<div class="api-entry-anchor" id="api-function-handle_binary_frame" aria-hidden="true"></div>
 
 ### `handle_binary_frame`
-
-Check the size and rate of an inbound binary frame, then decode it in the
- connection process. A codec without a binary decoder keeps the raw
- `transport.route_binary` fan-out through the runtime.
 
 ```gleam
 pub fn handle_binary_frame(
@@ -165,7 +230,20 @@ pub fn handle_binary_frame(
 ) -> FrameDisposition
 ```
 
+Check the size and rate of an inbound binary frame, then decode it in the
+ connection process. A codec without a binary decoder keeps the raw
+ `transport.route_binary` fan-out through the runtime.
+
+<div class="api-entry-anchor" id="api-function-handle_text_frame" aria-hidden="true"></div>
+
 ### `handle_text_frame`
+
+```gleam
+pub fn handle_text_frame(
+  ConnectionState,
+  String
+) -> FrameDisposition
+```
 
 Size-check, rate-check, and decode an inbound text frame in the
  connection process, so parse cost stays there and only valid,
@@ -175,19 +253,9 @@ Size-check, rate-check, and decode an inbound text frame in the
  silently drops over-rate frames. It logs and drops frames that it cannot
  decode.
 
-```gleam
-pub fn handle_text_frame(
-  ConnectionState,
-  String
-) -> FrameDisposition
-```
+<div class="api-entry-anchor" id="api-function-handler" aria-hidden="true"></div>
 
 ### `handler`
-
-Build a request handler for WebSocket upgrades and other HTTP requests.
-
- The handler sends upgrade requests to the transport-specific `upgrade`
- function. It sends all other requests to HTTP.
 
 ```gleam
 pub fn handler(
@@ -196,7 +264,26 @@ pub fn handler(
 ) -> fn(request.Request(a)) -> response.Response(b)
 ```
 
+Build a request handler for WebSocket upgrades and other HTTP requests.
+
+ The handler sends upgrade requests to the transport-specific `upgrade`
+ function. It sends all other requests to HTTP.
+
+<div class="api-entry-anchor" id="api-function-init_connection" aria-hidden="true"></div>
+
 ### `init_connection`
+
+```gleam
+pub fn init_connection(
+  sockets: beryl.Sockets,
+  seed: socket.ConnectSeed,
+  connection_permit: transport.ConnectionPermit,
+  base_selector: process.Selector(SendRequest),
+  logger_name: String,
+  telemetry: transport.Telemetry,
+  codec: option.Option(codec.Codec)
+) -> #(ConnectionState, process.Selector(SendRequest))
+```
 
 Initialize a new WebSocket connection in its connection process.
 
@@ -214,19 +301,13 @@ Initialize a new WebSocket connection in its connection process.
  warnings (e.g. `"beryl_mist"`). `codec` is the codec negotiated for this
  socket; `None` inherits the app-wide codec.
 
-```gleam
-pub fn init_connection(
-  sockets: beryl.Sockets,
-  seed: socket.ConnectSeed,
-  connection_permit: transport.ConnectionPermit,
-  base_selector: process.Selector(SendRequest),
-  logger_name: String,
-  telemetry: transport.Telemetry,
-  codec: option.Option(codec.Codec)
-) -> #(ConnectionState, process.Selector(SendRequest))
-```
+<div class="api-entry-anchor" id="api-function-is_websocket_request" aria-hidden="true"></div>
 
 ### `is_websocket_request`
+
+```gleam
+pub fn is_websocket_request(request.Request(a)) -> Bool
+```
 
 Determine whether a request is a WebSocket upgrade request.
 
@@ -234,11 +315,22 @@ Determine whether a request is a WebSocket upgrade request.
  regard to case. Use it to distinguish WebSocket handshakes from regular
  HTTP traffic on the same listener.
 
-```gleam
-pub fn is_websocket_request(request.Request(a)) -> Bool
-```
+<div class="api-entry-anchor" id="api-function-upgrade" aria-hidden="true"></div>
 
 ### `upgrade`
+
+```gleam
+pub fn upgrade(
+  request: request.Request(a),
+  sockets: beryl.Sockets,
+  config: TransportConfig(a),
+  telemetry: transport.Telemetry,
+  request_ip: fn(request.Request(a)) -> Result(String, Nil),
+  reject: fn(Int) -> response.Response(b),
+  accept: fn(List(#(String, String)), transport.ConnectionPermit) -> response.Response(b),
+  next: fn() -> response.Response(b)
+) -> response.Response(b)
+```
 
 Run the shared upgrade admission pipeline for a request.
 
@@ -254,12 +346,12 @@ Run the shared upgrade admission pipeline for a request.
 
  Non-matching paths fall through to `next`.
 
- ## Path matching
+ #### Path matching
 
  Request and configured paths are normalized without trailing or doubled
  slashes before an exact comparison.
 
- ## Connection limits
+ #### Connection limits
 
  When `beryl.with_max_connections_per_ip` is configured, the limit is
  enforced before completing the handshake, returning `reject(429)` once the
@@ -287,20 +379,13 @@ Run the shared upgrade admission pipeline for a request.
  scales with the node count. Use the load balancer's controls for a
  cluster-wide cap.
 
-```gleam
-pub fn upgrade(
-  request: request.Request(a),
-  sockets: beryl.Sockets,
-  config: TransportConfig(a),
-  telemetry: transport.Telemetry,
-  request_ip: fn(request.Request(a)) -> Result(String, Nil),
-  reject: fn(Int) -> response.Response(b),
-  accept: fn(List(#(String, String)), transport.ConnectionPermit) -> response.Response(b),
-  next: fn() -> response.Response(b)
-) -> response.Response(b)
-```
+<div class="api-entry-anchor" id="api-function-with_allow_all_origins" aria-hidden="true"></div>
 
 ### `with_allow_all_origins`
+
+```gleam
+pub fn with_allow_all_origins(TransportConfig(a)) -> TransportConfig(a)
+```
 
 Disable `Origin` checking, allowing WebSocket upgrades from any origin.
 
@@ -310,11 +395,16 @@ Disable `Origin` checking, allowing WebSocket upgrades from any origin.
  independently. For cookie/session-authenticated apps, prefer the default
  `SameOrigin` policy or `with_allowed_origins`.
 
-```gleam
-pub fn with_allow_all_origins(TransportConfig(a)) -> TransportConfig(a)
-```
+<div class="api-entry-anchor" id="api-function-with_allowed_origins" aria-hidden="true"></div>
 
 ### `with_allowed_origins`
+
+```gleam
+pub fn with_allowed_origins(
+  TransportConfig(a),
+  List(String)
+) -> TransportConfig(a)
+```
 
 Restrict WebSocket upgrades to requests whose `Origin` header exactly
  matches one of the given values.
@@ -329,14 +419,16 @@ Restrict WebSocket upgrades to requests whose `Origin` header exactly
  that should be allowed (e.g. behind a reverse proxy that rewrites the
  `Host` header, where `SameOrigin` cannot see the public host).
 
-```gleam
-pub fn with_allowed_origins(
-  TransportConfig(a),
-  List(String)
-) -> TransportConfig(a)
-```
+<div class="api-entry-anchor" id="api-function-with_on_connect" aria-hidden="true"></div>
 
 ### `with_on_connect`
+
+```gleam
+pub fn with_on_connect(
+  TransportConfig(a),
+  fn(request.Request(a)) -> Result(List(#(String, String)), ConnectError)
+) -> TransportConfig(a)
+```
 
 Set a socket-level connect/authentication callback on the transport config.
 
@@ -349,10 +441,3 @@ Set a socket-level connect/authentication callback on the transport config.
 
  `ConnectSeed.metadata` preserves callback order and duplicate keys.
  Transports never log metadata values.
-
-```gleam
-pub fn with_on_connect(
-  TransportConfig(a),
-  fn(request.Request(a)) -> Result(List(#(String, String)), ConnectError)
-) -> TransportConfig(a)
-```

--- a/website/src/content/docs/reference/api/beryl-transport.md
+++ b/website/src/content/docs/reference/api/beryl-transport.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/transport"
-description: "Transport SPI: the contract between beryl core and WebSocket transport"
+description: "Transport SPI: the contract between beryl core and WebSocket transport implementations such as the `beryl_mist` and `beryl_ewe` packages."
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "Transport SPI: the contract between beryl core and WebSocket trans
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 Transport SPI: the contract between beryl core and WebSocket transport
  implementations such as the `beryl_mist` and `beryl_ewe` packages.
@@ -18,9 +23,55 @@ Transport SPI: the contract between beryl core and WebSocket transport
  atomic admission, disconnect, text/binary routing, the configured codec,
  and transport telemetry.
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#types">Types</a>
+  <ul>
+<li><a href="#api-type-connectionpermit"><code>ConnectionPermit</code></a></li>
+<li><a href="#api-type-framekind"><code>FrameKind</code></a></li>
+<li><a href="#api-type-frameoutcome"><code>FrameOutcome</code></a></li>
+<li><a href="#api-type-telemetry"><code>Telemetry</code></a></li>
+<li><a href="#api-type-telemetrytransport"><code>TelemetryTransport</code></a></li>
+<li><a href="#api-type-upgradeoutcome"><code>UpgradeOutcome</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#type-aliases">Type aliases</a>
+  <ul>
+<li><a href="#api-type-alias-sockets"><code>Sockets</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-acquire_connection_slot"><code>acquire_connection_slot</code></a></li>
+<li><a href="#api-function-active_codec"><code>active_codec</code></a></li>
+<li><a href="#api-function-admit_socket"><code>admit_socket</code></a></li>
+<li><a href="#api-function-bind_connection_slot"><code>bind_connection_slot</code></a></li>
+<li><a href="#api-function-max_inbound_frame_bytes"><code>max_inbound_frame_bytes</code></a></li>
+<li><a href="#api-function-release_connection_slot"><code>release_connection_slot</code></a></li>
+<li><a href="#api-function-route_binary"><code>route_binary</code></a></li>
+<li><a href="#api-function-route_decoded"><code>route_decoded</code></a></li>
+<li><a href="#api-function-route_decoded_binary"><code>route_decoded_binary</code></a></li>
+<li><a href="#api-function-runtime_pid"><code>runtime_pid</code></a></li>
+<li><a href="#api-function-socket_disconnected"><code>socket_disconnected</code></a></li>
+<li><a href="#api-function-telemetry"><code>telemetry</code></a></li>
+<li><a href="#api-function-telemetry_frame_stop"><code>telemetry_frame_stop</code></a></li>
+<li><a href="#api-function-telemetry_start"><code>telemetry_start</code></a></li>
+<li><a href="#api-function-telemetry_upgrade_stop"><code>telemetry_upgrade_stop</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Types
 
+<div class="api-entry-anchor" id="api-type-connectionpermit" aria-hidden="true"></div>
+
 ### `ConnectionPermit`
+
+```gleam
+pub type ConnectionPermit
+```
 
 A held connection slot returned by `acquire_connection_slot`.
 
@@ -29,13 +80,9 @@ A held connection slot returned by `acquire_connection_slot`.
  limit is configured, the permit allows all connections. Releasing it does
  nothing.
 
-```gleam
-pub type ConnectionPermit
-```
+<div class="api-entry-anchor" id="api-type-framekind" aria-hidden="true"></div>
 
 ### `FrameKind`
-
-WebSocket data frame kinds.
 
 ```gleam
 pub type FrameKind {
@@ -44,9 +91,11 @@ pub type FrameKind {
 }
 ```
 
-### `FrameOutcome`
+WebSocket data frame kinds.
 
-Closed terminal outcomes for inbound frame processing.
+<div class="api-entry-anchor" id="api-type-frameoutcome" aria-hidden="true"></div>
+
+### `FrameOutcome`
 
 ```gleam
 pub type FrameOutcome {
@@ -57,20 +106,24 @@ pub type FrameOutcome {
 }
 ```
 
+Closed terminal outcomes for inbound frame processing.
+
+<div class="api-entry-anchor" id="api-type-telemetry" aria-hidden="true"></div>
+
 ### `Telemetry`
+
+```gleam
+pub type Telemetry
+```
 
 A low-cost transport telemetry context.
 
  When telemetry is disabled, operations avoid VM clock calls and event
  construction.
 
-```gleam
-pub type Telemetry
-```
+<div class="api-entry-anchor" id="api-type-telemetrytransport" aria-hidden="true"></div>
 
 ### `TelemetryTransport`
-
-WebSocket transport implementations in beryl's telemetry schema.
 
 ```gleam
 pub type TelemetryTransport {
@@ -79,9 +132,11 @@ pub type TelemetryTransport {
 }
 ```
 
-### `UpgradeOutcome`
+WebSocket transport implementations in beryl's telemetry schema.
 
-Closed terminal outcomes for a matched WebSocket upgrade.
+<div class="api-entry-anchor" id="api-type-upgradeoutcome" aria-hidden="true"></div>
+
+### `UpgradeOutcome`
 
 ```gleam
 pub type UpgradeOutcome {
@@ -94,25 +149,25 @@ pub type UpgradeOutcome {
 }
 ```
 
+Closed terminal outcomes for a matched WebSocket upgrade.
+
 ## Type aliases
 
-### `Sockets`
+<div class="api-entry-anchor" id="api-type-alias-sockets" aria-hidden="true"></div>
 
-A runtime handle for transport implementations.
+### `Sockets`
 
 ```gleam
 pub type Sockets = beryl.Sockets
 ```
 
+A runtime handle for transport implementations.
+
 ## Functions
 
+<div class="api-entry-anchor" id="api-function-acquire_connection_slot" aria-hidden="true"></div>
+
 ### `acquire_connection_slot`
-
-Try to acquire a configured connection slot for a transport.
-
- Pass the real socket peer IP. Do not pass a client-supplied address such as
- `X-Forwarded-For`. Return `Error(Nil)` when the configured per-IP or
- node-wide limit is already reached.
 
 ```gleam
 pub fn acquire_connection_slot(
@@ -121,24 +176,27 @@ pub fn acquire_connection_slot(
 ) -> Result(ConnectionPermit, Nil)
 ```
 
+Try to acquire a configured connection slot for a transport.
+
+ Pass the real socket peer IP. Do not pass a client-supplied address such as
+ `X-Forwarded-For`. Return `Error(Nil)` when the configured per-IP or
+ node-wide limit is already reached.
+
+<div class="api-entry-anchor" id="api-function-active_codec" aria-hidden="true"></div>
+
 ### `active_codec`
-
-Return the wire codec configured for these sockets.
-
- Transports use it to decode inbound frames in the connection process.
 
 ```gleam
 pub fn active_codec(beryl.Sockets) -> codec.Codec
 ```
 
+Return the wire codec configured for these sockets.
+
+ Transports use it to decode inbound frames in the connection process.
+
+<div class="api-entry-anchor" id="api-function-admit_socket" aria-hidden="true"></div>
+
 ### `admit_socket`
-
-Register a socket and its closer against the captured connection owner.
-
- Install a monitor for `owner` before calling this function. Admission
- succeeds only if that runtime instance processes the registration. A
- restart cannot redirect it to the next runtime. On `Error`, this function
- closes the connection so its bound permit can be released.
 
 ```gleam
 pub fn admit_socket(
@@ -153,38 +211,49 @@ pub fn admit_socket(
 ) -> Result(Nil, Nil)
 ```
 
+Register a socket and its closer against the captured connection owner.
+
+ Install a monitor for `owner` before calling this function. Admission
+ succeeds only if that runtime instance processes the registration. A
+ restart cannot redirect it to the next runtime. On `Error`, this function
+ closes the connection so its bound permit can be released.
+
+<div class="api-entry-anchor" id="api-function-bind_connection_slot" aria-hidden="true"></div>
+
 ### `bind_connection_slot`
+
+```gleam
+pub fn bind_connection_slot(ConnectionPermit) -> Nil
+```
 
 Bind an acquired connection slot to the calling connection process.
 
  The limiter monitors the caller. It reclaims the slot if the process dies
  without running its close path.
 
-```gleam
-pub fn bind_connection_slot(ConnectionPermit) -> Nil
-```
+<div class="api-entry-anchor" id="api-function-max_inbound_frame_bytes" aria-hidden="true"></div>
 
 ### `max_inbound_frame_bytes`
-
-Return the configured inbound frame size cap for transports.
 
 ```gleam
 pub fn max_inbound_frame_bytes(beryl.Sockets) -> Int
 ```
 
-### `release_connection_slot`
+Return the configured inbound frame size cap for transports.
 
-Release a connection slot acquired by a transport.
+<div class="api-entry-anchor" id="api-function-release_connection_slot" aria-hidden="true"></div>
+
+### `release_connection_slot`
 
 ```gleam
 pub fn release_connection_slot(ConnectionPermit) -> Nil
 ```
 
+Release a connection slot acquired by a transport.
+
+<div class="api-entry-anchor" id="api-function-route_binary" aria-hidden="true"></div>
+
 ### `route_binary`
-
-Route a raw binary frame for a codec without a binary decoder.
-
- The runtime sends a `Binary` event to `update` for each joined topic.
 
 ```gleam
 pub fn route_binary(
@@ -194,7 +263,21 @@ pub fn route_binary(
 ) -> Nil
 ```
 
+Route a raw binary frame for a codec without a binary decoder.
+
+ The runtime sends a `Binary` event to `update` for each joined topic.
+
+<div class="api-entry-anchor" id="api-function-route_decoded" aria-hidden="true"></div>
+
 ### `route_decoded`
+
+```gleam
+pub fn route_decoded(
+  sockets: beryl.Sockets,
+  socket_id: String,
+  message: codec.Inbound
+) -> Nil
+```
 
 Route a transport-decoded inbound message to the runtime. Decode in
  the connection process (see `active_codec`) so parse cost and malformed
@@ -205,21 +288,9 @@ Route a transport-decoded inbound message to the runtime. Decode in
  over-rate traffic therefore leads to heartbeat eviction and a call to the
  closer registered by `admit_socket`.
 
-```gleam
-pub fn route_decoded(
-  sockets: beryl.Sockets,
-  socket_id: String,
-  message: codec.Inbound
-) -> Nil
-```
+<div class="api-entry-anchor" id="api-function-route_decoded_binary" aria-hidden="true"></div>
 
 ### `route_decoded_binary`
-
-Route a transport-decoded binary message while preserving its binary
- frame classification for runtime telemetry and rate accounting.
-
- This function supplements `route_decoded`. The text semantics of
- `route_decoded` remain unchanged for third-party transport compatibility.
 
 ```gleam
 pub fn route_decoded_binary(
@@ -229,7 +300,19 @@ pub fn route_decoded_binary(
 ) -> Nil
 ```
 
+Route a transport-decoded binary message while preserving its binary
+ frame classification for runtime telemetry and rate accounting.
+
+ This function supplements `route_decoded`. The text semantics of
+ `route_decoded` remain unchanged for third-party transport compatibility.
+
+<div class="api-entry-anchor" id="api-function-runtime_pid" aria-hidden="true"></div>
+
 ### `runtime_pid`
+
+```gleam
+pub fn runtime_pid(beryl.Sockets) -> Result(process.Pid, Nil)
+```
 
 Return the pid of the runtime that owns transport connections.
 
@@ -237,13 +320,9 @@ Return the pid of the runtime that owns transport connections.
  connection on its `Down`. `Error(Nil)` means the runtime is unavailable
  (pre-start or a restart window), so the connection must be refused.
 
-```gleam
-pub fn runtime_pid(beryl.Sockets) -> Result(process.Pid, Nil)
-```
+<div class="api-entry-anchor" id="api-function-socket_disconnected" aria-hidden="true"></div>
 
 ### `socket_disconnected`
-
-Announce that a socket's connection has closed.
 
 ```gleam
 pub fn socket_disconnected(
@@ -252,9 +331,11 @@ pub fn socket_disconnected(
 ) -> Nil
 ```
 
-### `telemetry`
+Announce that a socket's connection has closed.
 
-Create a telemetry context from the channels configuration.
+<div class="api-entry-anchor" id="api-function-telemetry" aria-hidden="true"></div>
+
+### `telemetry`
 
 ```gleam
 pub fn telemetry(
@@ -263,9 +344,11 @@ pub fn telemetry(
 ) -> Telemetry
 ```
 
-### `telemetry_frame_stop`
+Create a telemetry context from the channels configuration.
 
-Emit exactly one terminal inbound-frame event.
+<div class="api-entry-anchor" id="api-function-telemetry_frame_stop" aria-hidden="true"></div>
+
+### `telemetry_frame_stop`
 
 ```gleam
 pub fn telemetry_frame_stop(
@@ -277,19 +360,23 @@ pub fn telemetry_frame_stop(
 ) -> Nil
 ```
 
+Emit exactly one terminal inbound-frame event.
+
+<div class="api-entry-anchor" id="api-function-telemetry_start" aria-hidden="true"></div>
+
 ### `telemetry_start`
-
-Start a timed transport operation.
-
- Returns zero when telemetry is disabled.
 
 ```gleam
 pub fn telemetry_start(Telemetry) -> Int
 ```
 
-### `telemetry_upgrade_stop`
+Start a timed transport operation.
 
-Emit exactly one terminal matched-upgrade event.
+ Returns zero when telemetry is disabled.
+
+<div class="api-entry-anchor" id="api-function-telemetry_upgrade_stop" aria-hidden="true"></div>
+
+### `telemetry_upgrade_stop`
 
 ```gleam
 pub fn telemetry_upgrade_stop(
@@ -298,3 +385,5 @@ pub fn telemetry_upgrade_stop(
   UpgradeOutcome
 ) -> Nil
 ```
+
+Emit exactly one terminal matched-upgrade event.

--- a/website/src/content/docs/reference/api/beryl-wire-codec.md
+++ b/website/src/content/docs/reference/api/beryl-wire-codec.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/wire/codec"
 description: "Pluggable wire codec for beryl."
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "Pluggable wire codec for beryl."
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 Pluggable wire codec for beryl.
 
@@ -23,22 +28,63 @@ Pluggable wire codec for beryl.
  All codecs must normalise inbound traffic to the `Inbound` shape so
  the runtime can stay framing-agnostic.
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#types">Types</a>
+  <ul>
+<li><a href="#api-type-codec"><code>Codec</code></a></li>
+<li><a href="#api-type-decodeerror"><code>DecodeError</code></a></li>
+<li><a href="#api-type-frame"><code>Frame</code></a></li>
+<li><a href="#api-type-inbound"><code>Inbound</code></a></li>
+<li><a href="#api-type-inboundkind"><code>InboundKind</code></a></li>
+<li><a href="#api-type-replystatus"><code>ReplyStatus</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-apply_decode_binary"><code>apply_decode_binary</code></a></li>
+<li><a href="#api-function-apply_decode_text"><code>apply_decode_text</code></a></li>
+<li><a href="#api-function-apply_encode_close"><code>apply_encode_close</code></a></li>
+<li><a href="#api-function-apply_encode_error"><code>apply_encode_error</code></a></li>
+<li><a href="#api-function-apply_encode_heartbeat_reply"><code>apply_encode_heartbeat_reply</code></a></li>
+<li><a href="#api-function-apply_encode_push"><code>apply_encode_push</code></a></li>
+<li><a href="#api-function-apply_encode_reply"><code>apply_encode_reply</code></a></li>
+<li><a href="#api-function-format_decode_error"><code>format_decode_error</code></a></li>
+<li><a href="#api-function-inbound"><code>inbound</code></a></li>
+<li><a href="#api-function-inbound_join_ref"><code>inbound_join_ref</code></a></li>
+<li><a href="#api-function-inbound_kind"><code>inbound_kind</code></a></li>
+<li><a href="#api-function-inbound_payload"><code>inbound_payload</code></a></li>
+<li><a href="#api-function-inbound_ref"><code>inbound_ref</code></a></li>
+<li><a href="#api-function-inbound_topic"><code>inbound_topic</code></a></li>
+<li><a href="#api-function-new"><code>new</code></a></li>
+<li><a href="#api-function-uses_topicless_events"><code>uses_topicless_events</code></a></li>
+<li><a href="#api-function-with_binary_decoder"><code>with_binary_decoder</code></a></li>
+<li><a href="#api-function-with_close_encoder"><code>with_close_encoder</code></a></li>
+<li><a href="#api-function-with_error_encoder"><code>with_error_encoder</code></a></li>
+<li><a href="#api-function-with_topicless_events"><code>with_topicless_events</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Types
 
+<div class="api-entry-anchor" id="api-type-codec" aria-hidden="true"></div>
+
 ### `Codec`
+
+```gleam
+pub type Codec
+```
 
 A wire codec.
 
  `Codec` is opaque. Build one with `new`. For binary support, add
  `with_binary_decoder`.
 
-```gleam
-pub type Codec
-```
+<div class="api-entry-anchor" id="api-type-decodeerror" aria-hidden="true"></div>
 
 ### `DecodeError`
-
-Errors a codec may emit when decoding inbound bytes.
 
 ```gleam
 pub type DecodeError {
@@ -48,24 +94,38 @@ pub type DecodeError {
 }
 ```
 
+Errors a codec may emit when decoding inbound bytes.
+
 #### Constructors
 
-##### `InvalidJson(reason: String)`
+##### `InvalidJson`
+
+```gleam
+InvalidJson(reason: String)
+```
 
 The bytes were not valid JSON; `reason` describes the parse error.
 
-##### `InvalidFormat(reason: String)`
+##### `InvalidFormat`
+
+```gleam
+InvalidFormat(reason: String)
+```
 
 The message was valid JSON but did not match the expected framing;
  `reason` describes the mismatch.
 
-##### `MissingField(name: String)`
+##### `MissingField`
+
+```gleam
+MissingField(name: String)
+```
 
 A required field was absent; `name` is the missing field.
 
-### `Frame`
+<div class="api-entry-anchor" id="api-type-frame" aria-hidden="true"></div>
 
-Encoded WebSocket frame returned by a codec.
+### `Frame`
 
 ```gleam
 pub type Frame {
@@ -74,17 +134,33 @@ pub type Frame {
 }
 ```
 
+Encoded WebSocket frame returned by a codec.
+
 #### Constructors
 
-##### `TextFrame(String)`
+##### `TextFrame`
+
+```gleam
+TextFrame(String)
+```
 
 A UTF-8 text frame.
 
-##### `BinaryFrame(BitArray)`
+##### `BinaryFrame`
+
+```gleam
+BinaryFrame(BitArray)
+```
 
 A binary frame.
 
+<div class="api-entry-anchor" id="api-type-inbound" aria-hidden="true"></div>
+
 ### `Inbound`
+
+```gleam
+pub type Inbound
+```
 
 A normalized inbound message.
 
@@ -92,13 +168,9 @@ A normalized inbound message.
  `inbound_*` accessors. The hidden record lets beryl add fields with
  defaults without breaking custom codecs.
 
-```gleam
-pub type Inbound
-```
+<div class="api-entry-anchor" id="api-type-inboundkind" aria-hidden="true"></div>
 
 ### `InboundKind`
-
-Structural inbound message kind used for protocol dispatch.
 
 ```gleam
 pub type InboundKind {
@@ -109,27 +181,45 @@ pub type InboundKind {
 }
 ```
 
+Structural inbound message kind used for protocol dispatch.
+
 #### Constructors
 
 ##### `Join`
+
+```gleam
+Join
+```
 
 A client joining a topic.
 
 ##### `Leave`
 
+```gleam
+Leave
+```
+
 A client leaving a topic.
 
 ##### `Heartbeat`
 
+```gleam
+Heartbeat
+```
+
 A heartbeat/keep-alive message.
 
-##### `Event(String)`
+##### `Event`
+
+```gleam
+Event(String)
+```
 
 A user-defined event; the wrapped `String` is the event name.
 
-### `ReplyStatus`
+<div class="api-entry-anchor" id="api-type-replystatus" aria-hidden="true"></div>
 
-Status of a reply produced by the app.
+### `ReplyStatus`
 
 ```gleam
 pub type ReplyStatus {
@@ -138,24 +228,31 @@ pub type ReplyStatus {
 }
 ```
 
+Status of a reply produced by the app.
+
 #### Constructors
 
 ##### `StatusOk`
+
+```gleam
+StatusOk
+```
 
 The handler succeeded (`"ok"` in Phoenix framing).
 
 ##### `StatusError`
 
+```gleam
+StatusError
+```
+
 The handler failed (`"error"` in Phoenix framing).
 
 ## Functions
 
+<div class="api-entry-anchor" id="api-function-apply_decode_binary" aria-hidden="true"></div>
+
 ### `apply_decode_binary`
-
-Decode a binary frame with a codec, if it has a binary decoder.
-
- Returns `None` when the codec has no decoder configured with
- `with_binary_decoder`.
 
 ```gleam
 pub fn apply_decode_binary(
@@ -164,11 +261,14 @@ pub fn apply_decode_binary(
 ) -> option.Option(Result(Inbound, DecodeError))
 ```
 
+Decode a binary frame with a codec, if it has a binary decoder.
+
+ Returns `None` when the codec has no decoder configured with
+ `with_binary_decoder`.
+
+<div class="api-entry-anchor" id="api-function-apply_decode_text" aria-hidden="true"></div>
+
 ### `apply_decode_text`
-
-Decode a text frame with a codec.
-
- Codec authors can use this to test the decoder supplied to `new`.
 
 ```gleam
 pub fn apply_decode_text(
@@ -177,12 +277,13 @@ pub fn apply_decode_text(
 ) -> Result(Inbound, DecodeError)
 ```
 
+Decode a text frame with a codec.
+
+ Codec authors can use this to test the decoder supplied to `new`.
+
+<div class="api-entry-anchor" id="api-function-apply_encode_close" aria-hidden="true"></div>
+
 ### `apply_encode_close`
-
-Encode a graceful topic close with a codec, if it has a close encoder.
-
- Returns `None` when the codec has no encoder configured with
- `with_close_encoder`.
 
 ```gleam
 pub fn apply_encode_close(
@@ -192,13 +293,14 @@ pub fn apply_encode_close(
 ) -> option.Option(Frame)
 ```
 
-### `apply_encode_error`
-
-Encode an abnormal topic termination with a codec, if it has an error
- encoder.
+Encode a graceful topic close with a codec, if it has a close encoder.
 
  Returns `None` when the codec has no encoder configured with
- `with_error_encoder`.
+ `with_close_encoder`.
+
+<div class="api-entry-anchor" id="api-function-apply_encode_error" aria-hidden="true"></div>
+
+### `apply_encode_error`
 
 ```gleam
 pub fn apply_encode_error(
@@ -208,9 +310,15 @@ pub fn apply_encode_error(
 ) -> option.Option(Frame)
 ```
 
-### `apply_encode_heartbeat_reply`
+Encode an abnormal topic termination with a codec, if it has an error
+ encoder.
 
-Encode a heartbeat reply with a codec.
+ Returns `None` when the codec has no encoder configured with
+ `with_error_encoder`.
+
+<div class="api-entry-anchor" id="api-function-apply_encode_heartbeat_reply" aria-hidden="true"></div>
+
+### `apply_encode_heartbeat_reply`
 
 ```gleam
 pub fn apply_encode_heartbeat_reply(
@@ -219,9 +327,11 @@ pub fn apply_encode_heartbeat_reply(
 ) -> Frame
 ```
 
-### `apply_encode_push`
+Encode a heartbeat reply with a codec.
 
-Encode a server-initiated push with a codec.
+<div class="api-entry-anchor" id="api-function-apply_encode_push" aria-hidden="true"></div>
+
+### `apply_encode_push`
 
 ```gleam
 pub fn apply_encode_push(
@@ -232,9 +342,11 @@ pub fn apply_encode_push(
 ) -> Frame
 ```
 
-### `apply_encode_reply`
+Encode a server-initiated push with a codec.
 
-Encode a reply with a codec.
+<div class="api-entry-anchor" id="api-function-apply_encode_reply" aria-hidden="true"></div>
+
+### `apply_encode_reply`
 
 ```gleam
 pub fn apply_encode_reply(
@@ -247,27 +359,23 @@ pub fn apply_encode_reply(
 ) -> Frame
 ```
 
+Encode a reply with a codec.
+
+<div class="api-entry-anchor" id="api-function-format_decode_error" aria-hidden="true"></div>
+
 ### `format_decode_error`
-
-Format a `DecodeError` as human-readable text.
-
- The runtime log messages and `wire.format_decode_error` use this text.
 
 ```gleam
 pub fn format_decode_error(DecodeError) -> String
 ```
 
+Format a `DecodeError` as human-readable text.
+
+ The runtime log messages and `wire.format_decode_error` use this text.
+
+<div class="api-entry-anchor" id="api-function-inbound" aria-hidden="true"></div>
+
 ### `inbound`
-
-Construct a normalized inbound message.
-
- - `join_ref`: optional client-side reference assigned at join time
-   (used by some Phoenix replies; codecs without this concept should
-   pass `None`)
- - `ref`: optional per-message reference for reply correlation
- - `topic`: subscription topic (e.g. `"room:lobby"`, `"doc:abc"`)
- - `kind`: structural protocol event or user event
- - `payload`: message body as a `Dynamic` for the app to decode
 
 ```gleam
 pub fn inbound(
@@ -279,47 +387,78 @@ pub fn inbound(
 ) -> Inbound
 ```
 
-### `inbound_join_ref`
+Construct a normalized inbound message.
 
-Return the inbound message's join-time client reference, if any.
+ - `join_ref`: optional client-side reference assigned at join time
+   (used by some Phoenix replies; codecs without this concept should
+   pass `None`)
+ - `ref`: optional per-message reference for reply correlation
+ - `topic`: subscription topic (e.g. `"room:lobby"`, `"doc:abc"`)
+ - `kind`: structural protocol event or user event
+ - `payload`: message body as a `Dynamic` for the app to decode
+
+<div class="api-entry-anchor" id="api-function-inbound_join_ref" aria-hidden="true"></div>
+
+### `inbound_join_ref`
 
 ```gleam
 pub fn inbound_join_ref(Inbound) -> option.Option(String)
 ```
 
-### `inbound_kind`
+Return the inbound message's join-time client reference, if any.
 
-Return the inbound message's structural kind.
+<div class="api-entry-anchor" id="api-function-inbound_kind" aria-hidden="true"></div>
+
+### `inbound_kind`
 
 ```gleam
 pub fn inbound_kind(Inbound) -> InboundKind
 ```
 
-### `inbound_payload`
+Return the inbound message's structural kind.
 
-Return the inbound message body for the app to decode.
+<div class="api-entry-anchor" id="api-function-inbound_payload" aria-hidden="true"></div>
+
+### `inbound_payload`
 
 ```gleam
 pub fn inbound_payload(Inbound) -> dynamic.Dynamic
 ```
 
-### `inbound_ref`
+Return the inbound message body for the app to decode.
 
-Return the inbound message's per-message reply reference, if any.
+<div class="api-entry-anchor" id="api-function-inbound_ref" aria-hidden="true"></div>
+
+### `inbound_ref`
 
 ```gleam
 pub fn inbound_ref(Inbound) -> option.Option(String)
 ```
 
-### `inbound_topic`
+Return the inbound message's per-message reply reference, if any.
 
-Return the inbound message's subscription topic.
+<div class="api-entry-anchor" id="api-function-inbound_topic" aria-hidden="true"></div>
+
+### `inbound_topic`
 
 ```gleam
 pub fn inbound_topic(Inbound) -> String
 ```
 
+Return the inbound message's subscription topic.
+
+<div class="api-entry-anchor" id="api-function-new" aria-hidden="true"></div>
+
 ### `new`
+
+```gleam
+pub fn new(
+  decode_text: fn(String) -> Result(Inbound, DecodeError),
+  encode_reply: fn(option.Option(String), option.Option(String), String, ReplyStatus, json.Json) -> Frame,
+  encode_push: fn(String, String, json.Json) -> Frame,
+  encode_heartbeat_reply: fn(option.Option(String)) -> Frame
+) -> Codec
+```
 
 Build a text-only wire codec.
 
@@ -333,32 +472,21 @@ Build a text-only wire codec.
  delivered to the app's `update` as a raw `Binary` event. Add a binary
  decoder with `with_binary_decoder`.
 
-```gleam
-pub fn new(
-  decode_text: fn(String) -> Result(Inbound, DecodeError),
-  encode_reply: fn(option.Option(String), option.Option(String), String, ReplyStatus, json.Json) -> Frame,
-  encode_push: fn(String, String, json.Json) -> Frame,
-  encode_heartbeat_reply: fn(option.Option(String)) -> Frame
-) -> Codec
-```
+<div class="api-entry-anchor" id="api-function-uses_topicless_events" aria-hidden="true"></div>
 
 ### `uses_topicless_events`
-
-Whether the codec routes events without an explicit topic.
-
- Codec authors can use this to test `with_topicless_events`.
 
 ```gleam
 pub fn uses_topicless_events(Codec) -> Bool
 ```
 
+Whether the codec routes events without an explicit topic.
+
+ Codec authors can use this to test `with_topicless_events`.
+
+<div class="api-entry-anchor" id="api-function-with_binary_decoder" aria-hidden="true"></div>
+
 ### `with_binary_decoder`
-
-Add a binary decoder to a codec.
-
- When set, the decoder converts binary WebSocket frames to a normalized
- `Inbound` via `decode_binary`. The app's `update` function does not receive
- a raw `Binary` event.
 
 ```gleam
 pub fn with_binary_decoder(
@@ -367,14 +495,15 @@ pub fn with_binary_decoder(
 ) -> Codec
 ```
 
+Add a binary decoder to a codec.
+
+ When set, the decoder converts binary WebSocket frames to a normalized
+ `Inbound` via `decode_binary`. The app's `update` function does not receive
+ a raw `Binary` event.
+
+<div class="api-entry-anchor" id="api-function-with_close_encoder" aria-hidden="true"></div>
+
 ### `with_close_encoder`
-
-Add a topic-close encoder to a codec.
-
- When set, the runtime sends this frame when one of the client's topics
- terminates gracefully (leave, server shutdown, heartbeat
- eviction): `(join_ref, topic)`. Phoenix clients rely on `phx_close` to
- leave the joined state instead of waiting out push timeouts.
 
 ```gleam
 pub fn with_close_encoder(
@@ -383,14 +512,16 @@ pub fn with_close_encoder(
 ) -> Codec
 ```
 
-### `with_error_encoder`
-
-Add a topic-error encoder to a codec.
+Add a topic-close encoder to a codec.
 
  When set, the runtime sends this frame when one of the client's topics
- terminates abnormally (crashed or stopped with an error):
- `(join_ref, topic)`. Phoenix clients rely on `phx_error` to schedule an
- automatic rejoin.
+ terminates gracefully (leave, server shutdown, heartbeat
+ eviction): `(join_ref, topic)`. Phoenix clients rely on `phx_close` to
+ leave the joined state instead of waiting out push timeouts.
+
+<div class="api-entry-anchor" id="api-function-with_error_encoder" aria-hidden="true"></div>
+
+### `with_error_encoder`
 
 ```gleam
 pub fn with_error_encoder(
@@ -399,7 +530,20 @@ pub fn with_error_encoder(
 ) -> Codec
 ```
 
+Add a topic-error encoder to a codec.
+
+ When set, the runtime sends this frame when one of the client's topics
+ terminates abnormally (crashed or stopped with an error):
+ `(join_ref, topic)`. Phoenix clients rely on `phx_error` to schedule an
+ automatic rejoin.
+
+<div class="api-entry-anchor" id="api-function-with_topicless_events" aria-hidden="true"></div>
+
 ### `with_topicless_events`
+
+```gleam
+pub fn with_topicless_events(Codec) -> Codec
+```
 
 Mark a codec's events as topicless.
 
@@ -409,7 +553,3 @@ Mark a codec's events as topicless.
  zero or multiple joins.
  Topic-carrying codecs (like the Phoenix codec) must leave this off so
  the runtime rejects empty-topic frames instead of inferring a topic.
-
-```gleam
-pub fn with_topicless_events(Codec) -> Codec
-```

--- a/website/src/content/docs/reference/api/beryl-wire.md
+++ b/website/src/content/docs/reference/api/beryl-wire.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl/wire"
-description: "Phoenix Wire Protocol: encoding/decoding helpers and the canonical"
+description: "Phoenix Wire Protocol: encoding/decoding helpers and the canonical `phoenix_codec()` for `beryl/wire/codec`."
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "Phoenix Wire Protocol: encoding/decoding helpers and the canonical
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 Phoenix Wire Protocol: encoding/decoding helpers and the canonical
  `phoenix_codec()` for `beryl/wire/codec`.
@@ -22,14 +27,33 @@ Phoenix Wire Protocol: encoding/decoding helpers and the canonical
  beryl.config(wire.phoenix_codec())
  ```
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-binary_broadcast"><code>binary_broadcast</code></a></li>
+<li><a href="#api-function-binary_push"><code>binary_push</code></a></li>
+<li><a href="#api-function-binary_reply"><code>binary_reply</code></a></li>
+<li><a href="#api-function-channel_close"><code>channel_close</code></a></li>
+<li><a href="#api-function-channel_error"><code>channel_error</code></a></li>
+<li><a href="#api-function-decode_binary_message"><code>decode_binary_message</code></a></li>
+<li><a href="#api-function-decode_message"><code>decode_message</code></a></li>
+<li><a href="#api-function-dynamic_to_json"><code>dynamic_to_json</code></a></li>
+<li><a href="#api-function-encode"><code>encode</code></a></li>
+<li><a href="#api-function-format_decode_error"><code>format_decode_error</code></a></li>
+<li><a href="#api-function-heartbeat_reply"><code>heartbeat_reply</code></a></li>
+<li><a href="#api-function-phoenix_codec"><code>phoenix_codec</code></a></li>
+<li><a href="#api-function-push"><code>push</code></a></li>
+<li><a href="#api-function-reply_json"><code>reply_json</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Functions
 
+<div class="api-entry-anchor" id="api-function-binary_broadcast" aria-hidden="true"></div>
+
 ### `binary_broadcast`
-
-Encode a Phoenix V2 binary broadcast: `(topic, event, payload)`.
-
- Returns `Error(Nil)` when a metadata component exceeds the framing's
- 255-byte limit.
 
 ```gleam
 pub fn binary_broadcast(
@@ -39,12 +63,14 @@ pub fn binary_broadcast(
 ) -> Result(codec.Frame, Nil)
 ```
 
-### `binary_push`
-
-Encode a Phoenix V2 binary server push: `(join_ref, topic, event, payload)`.
+Encode a Phoenix V2 binary broadcast: `(topic, event, payload)`.
 
  Returns `Error(Nil)` when a metadata component exceeds the framing's
  255-byte limit.
+
+<div class="api-entry-anchor" id="api-function-binary_push" aria-hidden="true"></div>
+
+### `binary_push`
 
 ```gleam
 pub fn binary_push(
@@ -55,12 +81,14 @@ pub fn binary_push(
 ) -> Result(codec.Frame, Nil)
 ```
 
-### `binary_reply`
-
-Encode a Phoenix V2 binary reply: `(join_ref, ref, topic, status, payload)`.
+Encode a Phoenix V2 binary server push: `(join_ref, topic, event, payload)`.
 
  Returns `Error(Nil)` when a metadata component exceeds the framing's
  255-byte limit.
+
+<div class="api-entry-anchor" id="api-function-binary_reply" aria-hidden="true"></div>
+
+### `binary_reply`
 
 ```gleam
 pub fn binary_reply(
@@ -72,11 +100,14 @@ pub fn binary_reply(
 ) -> Result(codec.Frame, Nil)
 ```
 
+Encode a Phoenix V2 binary reply: `(join_ref, ref, topic, status, payload)`.
+
+ Returns `Error(Nil)` when a metadata component exceeds the framing's
+ 255-byte limit.
+
+<div class="api-entry-anchor" id="api-function-channel_close" aria-hidden="true"></div>
+
 ### `channel_close`
-
-Create a Phoenix `phx_close` frame for a normal channel termination.
-
- Phoenix copies the channel's `join_ref` to the `ref` slot.
 
 ```gleam
 pub fn channel_close(
@@ -85,11 +116,13 @@ pub fn channel_close(
 ) -> codec.Frame
 ```
 
+Create a Phoenix `phx_close` frame for a normal channel termination.
+
+ Phoenix copies the channel's `join_ref` to the `ref` slot.
+
+<div class="api-entry-anchor" id="api-function-channel_error" aria-hidden="true"></div>
+
 ### `channel_error`
-
-Create a Phoenix `phx_error` frame for an abnormal channel termination.
-
- Phoenix clients respond by scheduling an automatic rejoin.
 
 ```gleam
 pub fn channel_error(
@@ -98,7 +131,17 @@ pub fn channel_error(
 ) -> codec.Frame
 ```
 
+Create a Phoenix `phx_error` frame for an abnormal channel termination.
+
+ Phoenix clients respond by scheduling an automatic rejoin.
+
+<div class="api-entry-anchor" id="api-function-decode_binary_message" aria-hidden="true"></div>
+
 ### `decode_binary_message`
+
+```gleam
+pub fn decode_binary_message(BitArray) -> Result(codec.Inbound, codec.DecodeError)
+```
 
 Decode a Phoenix V2 binary push frame from a client into an `Inbound`.
 
@@ -109,57 +152,69 @@ Decode a Phoenix V2 binary push frame from a client into an `Inbound`.
  `ref` components decode as `None`. Reserved protocol events use the same
  classification as text frames.
 
-```gleam
-pub fn decode_binary_message(BitArray) -> Result(codec.Inbound, codec.DecodeError)
-```
+<div class="api-entry-anchor" id="api-function-decode_message" aria-hidden="true"></div>
 
 ### `decode_message`
+
+```gleam
+pub fn decode_message(String) -> Result(codec.Inbound, codec.DecodeError)
+```
 
 Parse a JSON string into an `Inbound`.
 
  Expected format: `[join_ref, ref, topic, event, payload]` where
  The `join_ref` and `ref` values can be `null`.
 
-```gleam
-pub fn decode_message(String) -> Result(codec.Inbound, codec.DecodeError)
-```
+<div class="api-entry-anchor" id="api-function-dynamic_to_json" aria-hidden="true"></div>
 
 ### `dynamic_to_json`
+
+```gleam
+pub fn dynamic_to_json(dynamic.Dynamic) -> Result(json.Json, Nil)
+```
 
 Convert a `Dynamic` value decoded from JSON back to `json.Json`.
 
  Returns `Error(Nil)` when the value exceeds the wire protocol's maximum
  JSON depth or contains a value that JSON cannot represent.
 
-```gleam
-pub fn dynamic_to_json(dynamic.Dynamic) -> Result(json.Json, Nil)
-```
+<div class="api-entry-anchor" id="api-function-encode" aria-hidden="true"></div>
 
 ### `encode`
-
-Encode an `Inbound` back to a Phoenix wire JSON string.
 
 ```gleam
 pub fn encode(codec.Inbound) -> String
 ```
 
-### `format_decode_error`
+Encode an `Inbound` back to a Phoenix wire JSON string.
 
-Format a `DecodeError` as a human-readable string.
+<div class="api-entry-anchor" id="api-function-format_decode_error" aria-hidden="true"></div>
+
+### `format_decode_error`
 
 ```gleam
 pub fn format_decode_error(codec.DecodeError) -> String
 ```
 
-### `heartbeat_reply`
+Format a `DecodeError` as a human-readable string.
 
-Create a Phoenix heartbeat reply.
+<div class="api-entry-anchor" id="api-function-heartbeat_reply" aria-hidden="true"></div>
+
+### `heartbeat_reply`
 
 ```gleam
 pub fn heartbeat_reply(option.Option(String)) -> codec.Frame
 ```
 
+Create a Phoenix heartbeat reply.
+
+<div class="api-entry-anchor" id="api-function-phoenix_codec" aria-hidden="true"></div>
+
 ### `phoenix_codec`
+
+```gleam
+pub fn phoenix_codec() -> codec.Codec
+```
 
 Return the canonical Phoenix wire codec.
 
@@ -172,13 +227,9 @@ Return the canonical Phoenix wire codec.
  `Binary` event only for an undecoded frame from a codec without a binary
  decoder.
 
-```gleam
-pub fn phoenix_codec() -> codec.Codec
-```
+<div class="api-entry-anchor" id="api-function-push" aria-hidden="true"></div>
 
 ### `push`
-
-Create a server-initiated push message.
 
 ```gleam
 pub fn push(
@@ -188,9 +239,11 @@ pub fn push(
 ) -> codec.Frame
 ```
 
-### `reply_json`
+Create a server-initiated push message.
 
-Create a Phoenix `phx_reply` JSON string.
+<div class="api-entry-anchor" id="api-function-reply_json" aria-hidden="true"></div>
+
+### `reply_json`
 
 ```gleam
 pub fn reply_json(
@@ -201,3 +254,5 @@ pub fn reply_json(
   json.Json
 ) -> codec.Frame
 ```
+
+Create a Phoenix `phx_reply` JSON string.

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl"
 description: "beryl - Type-safe real-time communication"
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "beryl - Type-safe real-time communication"
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 beryl - Type-safe real-time communication
 
@@ -72,9 +77,61 @@ beryl - Type-safe real-time communication
  }
  ```
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#types">Types</a>
+  <ul>
+<li><a href="#api-type-config"><code>Config</code></a></li>
+<li><a href="#api-type-configerror"><code>ConfigError</code></a></li>
+<li><a href="#api-type-loggingconfig"><code>LoggingConfig</code></a></li>
+<li><a href="#api-type-loglevel"><code>LogLevel</code></a></li>
+<li><a href="#api-type-sockets"><code>Sockets</code></a></li>
+<li><a href="#api-type-stoperror"><code>StopError</code></a></li>
+  </ul>
+</section>
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-broadcast"><code>broadcast</code></a></li>
+<li><a href="#api-function-broadcast_from"><code>broadcast_from</code></a></li>
+<li><a href="#api-function-broadcast_presence_diff"><code>broadcast_presence_diff</code></a></li>
+<li><a href="#api-function-child_spec"><code>child_spec</code></a></li>
+<li><a href="#api-function-config"><code>config</code></a></li>
+<li><a href="#api-function-logging_config"><code>logging_config</code></a></li>
+<li><a href="#api-function-stop"><code>stop</code></a></li>
+<li><a href="#api-function-validate_config"><code>validate_config</code></a></li>
+<li><a href="#api-function-with_channel_rate"><code>with_channel_rate</code></a></li>
+<li><a href="#api-function-with_channel_rate_max_keys_per_socket"><code>with_channel_rate_max_keys_per_socket</code></a></li>
+<li><a href="#api-function-with_connection_rate_per_ip"><code>with_connection_rate_per_ip</code></a></li>
+<li><a href="#api-function-with_frame_rate"><code>with_frame_rate</code></a></li>
+<li><a href="#api-function-with_heartbeat"><code>with_heartbeat</code></a></li>
+<li><a href="#api-function-with_join_rate"><code>with_join_rate</code></a></li>
+<li><a href="#api-function-with_logging"><code>with_logging</code></a></li>
+<li><a href="#api-function-with_max_connections"><code>with_max_connections</code></a></li>
+<li><a href="#api-function-with_max_connections_per_ip"><code>with_max_connections_per_ip</code></a></li>
+<li><a href="#api-function-with_max_event_length"><code>with_max_event_length</code></a></li>
+<li><a href="#api-function-with_max_inbound_frame_bytes"><code>with_max_inbound_frame_bytes</code></a></li>
+<li><a href="#api-function-with_max_joined_topics_per_socket"><code>with_max_joined_topics_per_socket</code></a></li>
+<li><a href="#api-function-with_max_topic_length"><code>with_max_topic_length</code></a></li>
+<li><a href="#api-function-with_message_rate"><code>with_message_rate</code></a></li>
+<li><a href="#api-function-with_payload_preview_bytes"><code>with_payload_preview_bytes</code></a></li>
+<li><a href="#api-function-with_presence_handle"><code>with_presence_handle</code></a></li>
+<li><a href="#api-function-with_pubsub"><code>with_pubsub</code></a></li>
+<li><a href="#api-function-with_telemetry"><code>with_telemetry</code></a></li>
+<li><a href="#api-function-with_topic_rate"><code>with_topic_rate</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Types
 
+<div class="api-entry-anchor" id="api-type-config" aria-hidden="true"></div>
+
 ### `Config`
+
+```gleam
+pub type Config
+```
 
 Configuration for an app-side socket runtime.
 
@@ -82,17 +139,9 @@ Configuration for an app-side socket runtime.
  `with_*` functions. beryl can then add configuration options without a
  breaking change.
 
-```gleam
-pub type Config
-```
+<div class="api-entry-anchor" id="api-type-configerror" aria-hidden="true"></div>
 
 ### `ConfigError`
-
-Why an eagerly validated `Config` was rejected before any process started.
-
- `child_spec` validates the configuration before it allocates names or
- starts the runtime. It returns an invalid configuration instead of
- crashing a supervised child during initialization.
 
 ```gleam
 pub type ConfigError {
@@ -104,9 +153,19 @@ pub type ConfigError {
 }
 ```
 
+Why an eagerly validated `Config` was rejected before any process started.
+
+ `child_spec` validates the configuration before it allocates names or
+ starts the runtime. It returns an invalid configuration instead of
+ crashing a supervised child during initialization.
+
 #### Constructors
 
-##### `HeartbeatTimeoutTooLow(minimum: Int)`
+##### `HeartbeatTimeoutTooLow`
+
+```gleam
+HeartbeatTimeoutTooLow(minimum: Int)
+```
 
 `heartbeat_timeout_ms` was below the minimum. The server derives its
  staleness check interval as `heartbeat_timeout_ms / 2` (integer
@@ -114,10 +173,14 @@ pub type ConfigError {
  disable heartbeat eviction. The wrapped `Int` is the
  smallest accepted timeout.
 
-##### `InvalidTopicPattern(
+##### `InvalidTopicPattern`
+
+```gleam
+InvalidTopicPattern(
   pattern: String,
   reason: topic.TopicError
-)`
+)
+```
 
 A per-topic-pattern rate limit used a pattern string that is not a valid
  topic pattern. `pattern` is the offending pattern and `reason` is the
@@ -130,7 +193,13 @@ A per-topic-pattern rate limit used a pattern string that is not a valid
  when you act on them differently, and otherwise keep a catch-all arm
  such as `InvalidTopicPattern(pattern, _)`.
 
+<div class="api-entry-anchor" id="api-type-loggingconfig" aria-hidden="true"></div>
+
 ### `LoggingConfig`
+
+```gleam
+pub type LoggingConfig
+```
 
 Logging configuration for beryl diagnostics.
 
@@ -138,16 +207,9 @@ Logging configuration for beryl diagnostics.
  the `with_*` functions. beryl can then add logging options without a
  breaking change.
 
-```gleam
-pub type LoggingConfig
-```
+<div class="api-entry-anchor" id="api-type-loglevel" aria-hidden="true"></div>
 
 ### `LogLevel`
-
-Logging verbosity for beryl's internal loggers.
-
- The variants carry a `Level` suffix so `ErrorLevel` does not shadow the
- prelude's `Result` `Error` constructor when imported unqualified.
 
 ```gleam
 pub type LogLevel {
@@ -158,7 +220,18 @@ pub type LogLevel {
 }
 ```
 
+Logging verbosity for beryl's internal loggers.
+
+ The variants carry a `Level` suffix so `ErrorLevel` does not shadow the
+ prelude's `Result` `Error` constructor when imported unqualified.
+
+<div class="api-entry-anchor" id="api-type-sockets" aria-hidden="true"></div>
+
 ### `Sockets`
+
+```gleam
+pub type Sockets
+```
 
 A runtime system handle.
 
@@ -171,13 +244,9 @@ A runtime system handle.
  inside monomorphic closures at construction time. They
  never appear in this handle or in any transport signature.
 
-```gleam
-pub type Sockets
-```
+<div class="api-entry-anchor" id="api-type-stoperror" aria-hidden="true"></div>
 
 ### `StopError`
-
-Errors when stopping a beryl system with [`stop`](#stop).
 
 ```gleam
 pub type StopError {
@@ -186,9 +255,15 @@ pub type StopError {
 }
 ```
 
+Errors when stopping a beryl system with [`stop`](#stop).
+
 #### Constructors
 
 ##### `NotRunning`
+
+```gleam
+NotRunning
+```
 
 The handle referred to a system that was not running: it was never
  started (for example, a `child_spec` handle whose supervisor was never
@@ -197,29 +272,18 @@ The handle referred to a system that was not running: it was never
 
 ##### `StopTimeout`
 
+```gleam
+StopTimeout
+```
+
 The runtime did not acknowledge the stop request within the shutdown
  window. The system may still be terminating.
 
 ## Functions
 
+<div class="api-entry-anchor" id="api-function-broadcast" aria-hidden="true"></div>
+
 ### `broadcast`
-
-Broadcast a message to all subscribers of a topic.
-
- This function sends the message to all sockets subscribed to the topic.
- When the system was started with PubSub, it also sends the broadcast to
- subscribers on other nodes.
-
- ## Example
-
- ```gleam
- beryl.broadcast(
-   sockets,
-   "room:lobby",
-   "new_message",
-   json.object([#("text", json.string("Hello!"))]),
- )
- ```
 
 ```gleam
 pub fn broadcast(
@@ -230,26 +294,26 @@ pub fn broadcast(
 ) -> Nil
 ```
 
-### `broadcast_from`
+Broadcast a message to all subscribers of a topic.
 
-Broadcast a message to all subscribers except one socket.
+ This function sends the message to all sockets subscribed to the topic.
+ When the system was started with PubSub, it also sends the broadcast to
+ subscribers on other nodes.
 
- Useful for broadcasting a message to everyone except the sender.
- When PubSub is configured, the excluded socket ID is preserved across
- nodes so clustered deployments do not echo the event back to that
- socket on another node.
-
- ## Example
+ #### Example
 
  ```gleam
- beryl.broadcast_from(
+ beryl.broadcast(
    sockets,
-   socket_id,
    "room:lobby",
-   "user_typing",
-   json.object([#("user", json.string("alice"))]),
+   "new_message",
+   json.object([#("text", json.string("Hello!"))]),
  )
  ```
+
+<div class="api-entry-anchor" id="api-function-broadcast_from" aria-hidden="true"></div>
+
+### `broadcast_from`
 
 ```gleam
 pub fn broadcast_from(
@@ -261,7 +325,36 @@ pub fn broadcast_from(
 ) -> Nil
 ```
 
+Broadcast a message to all subscribers except one socket.
+
+ Useful for broadcasting a message to everyone except the sender.
+ When PubSub is configured, the excluded socket ID is preserved across
+ nodes so clustered deployments do not echo the event back to that
+ socket on another node.
+
+ #### Example
+
+ ```gleam
+ beryl.broadcast_from(
+   sockets,
+   socket_id,
+   "room:lobby",
+   "user_typing",
+   json.object([#("user", json.string("alice"))]),
+ )
+ ```
+
+<div class="api-entry-anchor" id="api-function-broadcast_presence_diff" aria-hidden="true"></div>
+
 ### `broadcast_presence_diff`
+
+```gleam
+pub fn broadcast_presence_diff(
+  Sockets,
+  String,
+  presence.Diff
+) -> Nil
+```
 
 Broadcast a Phoenix-compatible `presence_diff` event for a topic.
 
@@ -277,15 +370,17 @@ Broadcast a Phoenix-compatible `presence_diff` event for a topic.
  When the system was started with PubSub, the broadcast is distributed
  using the same semantics as `broadcast`.
 
-```gleam
-pub fn broadcast_presence_diff(
-  Sockets,
-  String,
-  presence.Diff
-) -> Nil
-```
+<div class="api-entry-anchor" id="api-function-child_spec" aria-hidden="true"></div>
 
 ### `child_spec`
+
+```gleam
+pub fn child_spec(
+  Config,
+  init: fn(socket.ConnectInfo(a)) -> #(b, List(socket.Effect)),
+  update: fn(b, socket.Input(a)) -> socket.Next(b)
+) -> Result(#(Sockets, supervision.ChildSpecification(static_supervisor.Supervisor)), ConfigError)
+```
 
 Build the app-side dispatch supervision child specification.
 
@@ -300,7 +395,7 @@ Build the app-side dispatch supervision child specification.
  shutdown, fire-and-forget handle operations are no-ops and connection
  admission fails cleanly rather than panicking.
 
- ## Example
+ #### Example
 
  ```gleam
  let assert Ok(#(sockets, child_specification)) =
@@ -314,15 +409,13 @@ Build the app-side dispatch supervision child specification.
  // `sockets` is usable once the tree above is running.
  ```
 
-```gleam
-pub fn child_spec(
-  Config,
-  init: fn(socket.ConnectInfo(a)) -> #(b, List(socket.Effect)),
-  update: fn(b, socket.Input(a)) -> socket.Next(b)
-) -> Result(#(Sockets, supervision.ChildSpecification(static_supervisor.Supervisor)), ConfigError)
-```
+<div class="api-entry-anchor" id="api-function-config" aria-hidden="true"></div>
 
 ### `config`
+
+```gleam
+pub fn config(codec.Codec) -> Config
+```
 
 Build a configuration with sensible defaults.
 
@@ -330,17 +423,9 @@ Build a configuration with sensible defaults.
  default. Pass `wire.phoenix_codec()` to keep Phoenix wire compatibility,
  or your own `Codec` for a custom framing.
 
-```gleam
-pub fn config(codec.Codec) -> Config
-```
+<div class="api-entry-anchor" id="api-function-logging_config" aria-hidden="true"></div>
 
 ### `logging_config`
-
-Build a logging configuration.
-
- Payloads are excluded by default to avoid accidental sensitive-data
- exposure. Use `with_payload_preview_bytes` to adjust the bounded preview
- size when payload previews are enabled.
 
 ```gleam
 pub fn logging_config(
@@ -349,7 +434,19 @@ pub fn logging_config(
 ) -> LoggingConfig
 ```
 
+Build a logging configuration.
+
+ Payloads are excluded by default to avoid accidental sensitive-data
+ exposure. Use `with_payload_preview_bytes` to adjust the bounded preview
+ size when payload previews are enabled.
+
+<div class="api-entry-anchor" id="api-function-stop" aria-hidden="true"></div>
+
 ### `stop`
+
+```gleam
+pub fn stop(Sockets) -> Result(Nil, StopError)
+```
 
 Stop a beryl system.
 
@@ -365,28 +462,22 @@ Stop a beryl system.
  acknowledge the stop within the shutdown window. After a successful stop
  the handle should no longer be used.
 
-```gleam
-pub fn stop(Sockets) -> Result(Nil, StopError)
-```
+<div class="api-entry-anchor" id="api-function-validate_config" aria-hidden="true"></div>
 
 ### `validate_config`
+
+```gleam
+pub fn validate_config(Config) -> Result(Nil, ConfigError)
+```
 
 Validate a [`Config`](#config) without starting any process.
 
  This checks that `heartbeat_timeout_ms` is at least 2 and that every
  per-topic rate-limit pattern is valid.
 
-```gleam
-pub fn validate_config(Config) -> Result(Nil, ConfigError)
-```
+<div class="api-entry-anchor" id="api-function-with_channel_rate" aria-hidden="true"></div>
 
 ### `with_channel_rate`
-
-Configure per-channel message rate limiting.
-
- The limiter applies only after a socket has joined a topic. Active
- per-socket channel buckets are capped by default; use
- `with_channel_rate_max_keys_per_socket` to adjust the cap.
 
 ```gleam
 pub fn with_channel_rate(
@@ -396,11 +487,15 @@ pub fn with_channel_rate(
 ) -> Config
 ```
 
+Configure per-channel message rate limiting.
+
+ The limiter applies only after a socket has joined a topic. Active
+ per-socket channel buckets are capped by default; use
+ `with_channel_rate_max_keys_per_socket` to adjust the cap.
+
+<div class="api-entry-anchor" id="api-function-with_channel_rate_max_keys_per_socket" aria-hidden="true"></div>
+
 ### `with_channel_rate_max_keys_per_socket`
-
-Configure the maximum active per-channel rate-limit buckets per socket.
-
- Values <= 0 disable the cap. The default is 1000.
 
 ```gleam
 pub fn with_channel_rate_max_keys_per_socket(
@@ -409,7 +504,21 @@ pub fn with_channel_rate_max_keys_per_socket(
 ) -> Config
 ```
 
+Configure the maximum active per-channel rate-limit buckets per socket.
+
+ Values <= 0 disable the cap. The default is 1000.
+
+<div class="api-entry-anchor" id="api-function-with_connection_rate_per_ip" aria-hidden="true"></div>
+
 ### `with_connection_rate_per_ip`
+
+```gleam
+pub fn with_connection_rate_per_ip(
+  Config,
+  per_second: Int,
+  burst: Int
+) -> Config
+```
 
 Configure a per-IP connection-attempt rate limit.
 
@@ -426,23 +535,9 @@ Configure a per-IP connection-attempt rate limit.
  This uses the same peer IP and trusted-proxy caveats as
  `with_max_connections_per_ip`.
 
-```gleam
-pub fn with_connection_rate_per_ip(
-  Config,
-  per_second: Int,
-  burst: Int
-) -> Config
-```
+<div class="api-entry-anchor" id="api-function-with_frame_rate" aria-hidden="true"></div>
 
 ### `with_frame_rate`
-
-Configure per-connection frame-rate limiting at the transport edge.
-
- Every complete inbound text or binary frame consumes this independent
- bucket before decoding. Configure it alongside `with_message_rate` to
- combine edge shedding with a runtime cap on decoded non-join traffic.
- An over-rate heartbeat is shed before it can refresh the socket's heartbeat
- deadline, so a sustained flood is eventually closed by heartbeat eviction.
 
 ```gleam
 pub fn with_frame_rate(
@@ -452,13 +547,17 @@ pub fn with_frame_rate(
 ) -> Config
 ```
 
+Configure per-connection frame-rate limiting at the transport edge.
+
+ Every complete inbound text or binary frame consumes this independent
+ bucket before decoding. Configure it alongside `with_message_rate` to
+ combine edge shedding with a runtime cap on decoded non-join traffic.
+ An over-rate heartbeat is shed before it can refresh the socket's heartbeat
+ deadline, so a sustained flood is eventually closed by heartbeat eviction.
+
+<div class="api-entry-anchor" id="api-function-with_heartbeat" aria-hidden="true"></div>
+
 ### `with_heartbeat`
-
-Configure the server-side heartbeat staleness window.
-
- The runtime evicts a socket that sends no heartbeat within `timeout_ms`.
- It checks at half this window, so values below 2 are rejected by
- `validate_config` with `HeartbeatTimeoutTooLow`. The default is 60000 ms.
 
 ```gleam
 pub fn with_heartbeat(
@@ -467,9 +566,15 @@ pub fn with_heartbeat(
 ) -> Config
 ```
 
-### `with_join_rate`
+Configure the server-side heartbeat staleness window.
 
-Configure per-socket join rate limiting.
+ The runtime evicts a socket that sends no heartbeat within `timeout_ms`.
+ It checks at half this window, so values below 2 are rejected by
+ `validate_config` with `HeartbeatTimeoutTooLow`. The default is 60000 ms.
+
+<div class="api-entry-anchor" id="api-function-with_join_rate" aria-hidden="true"></div>
+
+### `with_join_rate`
 
 ```gleam
 pub fn with_join_rate(
@@ -479,9 +584,11 @@ pub fn with_join_rate(
 ) -> Config
 ```
 
-### `with_logging`
+Configure per-socket join rate limiting.
 
-Configure beryl's internal logging.
+<div class="api-entry-anchor" id="api-function-with_logging" aria-hidden="true"></div>
+
+### `with_logging`
 
 ```gleam
 pub fn with_logging(
@@ -490,7 +597,18 @@ pub fn with_logging(
 ) -> Config
 ```
 
+Configure beryl's internal logging.
+
+<div class="api-entry-anchor" id="api-function-with_max_connections" aria-hidden="true"></div>
+
 ### `with_max_connections`
+
+```gleam
+pub fn with_max_connections(
+  Config,
+  max_connections: Int
+) -> Config
+```
 
 Configure the maximum number of concurrent connections allowed across the
  whole node, regardless of source IP.
@@ -503,7 +621,7 @@ Configure the maximum number of concurrent connections allowed across the
  increment atomically. Concurrent opens cannot materially exceed the
  ceiling.
 
- ## Composition with per-IP limits
+ #### Composition with per-IP limits
 
  This node-wide ceiling works with `with_max_connections_per_ip`. When both
  are set, a connection must be under *both* limits. The per-IP limit
@@ -513,7 +631,7 @@ Configure the maximum number of concurrent connections allowed across the
  process, socket, and runtime budget. A per-IP limit alone cannot stop this
  case.
 
- ## Composition with external load balancers
+ #### Composition with external load balancers
 
  This ceiling is enforced per BEAM node. If you run several nodes behind a
  load balancer, each node enforces its own limit independently, so the
@@ -522,14 +640,16 @@ Configure the maximum number of concurrent connections allowed across the
  value against a single node's capacity. Use the load balancer's
  global connection/rate controls when you need a cluster-wide cap.
 
+<div class="api-entry-anchor" id="api-function-with_max_connections_per_ip" aria-hidden="true"></div>
+
+### `with_max_connections_per_ip`
+
 ```gleam
-pub fn with_max_connections(
+pub fn with_max_connections_per_ip(
   Config,
   max_connections: Int
 ) -> Config
 ```
-
-### `with_max_connections_per_ip`
 
 Configure the maximum number of concurrent connections allowed per client
  IP address.
@@ -539,7 +659,7 @@ Configure the maximum number of concurrent connections allowed per client
  It rejects other connections. The transport frees the slot when the
  connection closes.
 
- ## Which IP is used
+ #### Which IP is used
 
  The limit is enforced on the **real socket peer IP** as reported by the
  transport (for the Mist transport, the address of the TCP connection).
@@ -554,20 +674,9 @@ Configure the maximum number of concurrent connections allowed per client
  built-in trusted-proxy opt-in may be added in a future release. See the
  WebSocket transport guide for deployment guidance.
 
-```gleam
-pub fn with_max_connections_per_ip(
-  Config,
-  max_connections: Int
-) -> Config
-```
+<div class="api-entry-anchor" id="api-function-with_max_event_length" aria-hidden="true"></div>
 
 ### `with_max_event_length`
-
-Configure the maximum allowed byte length for client-supplied event name
- strings.
-
- Event names longer than `max_length` bytes are dropped before reaching the
- app's `update` function. The default is 64.
 
 ```gleam
 pub fn with_max_event_length(
@@ -576,7 +685,22 @@ pub fn with_max_event_length(
 ) -> Config
 ```
 
+Configure the maximum allowed byte length for client-supplied event name
+ strings.
+
+ Event names longer than `max_length` bytes are dropped before reaching the
+ app's `update` function. The default is 64.
+
+<div class="api-entry-anchor" id="api-function-with_max_inbound_frame_bytes" aria-hidden="true"></div>
+
 ### `with_max_inbound_frame_bytes`
+
+```gleam
+pub fn with_max_inbound_frame_bytes(
+  Config,
+  max_bytes: Int
+) -> Config
+```
 
 Configure the maximum allowed inbound WebSocket frame size in bytes.
 
@@ -598,18 +722,9 @@ Configure the maximum allowed inbound WebSocket frame size in bytes.
 
  Values <= 0 disable the cap. The default is 1 MiB.
 
-```gleam
-pub fn with_max_inbound_frame_bytes(
-  Config,
-  max_bytes: Int
-) -> Config
-```
+<div class="api-entry-anchor" id="api-function-with_max_joined_topics_per_socket" aria-hidden="true"></div>
 
 ### `with_max_joined_topics_per_socket`
-
-Configure the maximum number of topics a socket may join at once.
-
- Values <= 0 disable the cap. The default is 1000.
 
 ```gleam
 pub fn with_max_joined_topics_per_socket(
@@ -618,14 +733,13 @@ pub fn with_max_joined_topics_per_socket(
 ) -> Config
 ```
 
+Configure the maximum number of topics a socket may join at once.
+
+ Values <= 0 disable the cap. The default is 1000.
+
+<div class="api-entry-anchor" id="api-function-with_max_topic_length" aria-hidden="true"></div>
+
 ### `with_max_topic_length`
-
-Configure the maximum allowed byte length for client-supplied topic
- strings.
-
- Topics longer than `max_length` bytes are rejected with a `phx_reply`
- error before reaching your `update` function, bounding the size of keys
- tracked per socket. The default is 256.
 
 ```gleam
 pub fn with_max_topic_length(
@@ -634,15 +748,16 @@ pub fn with_max_topic_length(
 ) -> Config
 ```
 
+Configure the maximum allowed byte length for client-supplied topic
+ strings.
+
+ Topics longer than `max_length` bytes are rejected with a `phx_reply`
+ error before reaching your `update` function, bounding the size of keys
+ tracked per socket. The default is 256.
+
+<div class="api-entry-anchor" id="api-function-with_message_rate" aria-hidden="true"></div>
+
 ### `with_message_rate`
-
-Configure per-socket decoded message-rate limiting in the runtime.
-
- Joins use `with_join_rate`; decoded leaves, heartbeats, events, decoded
- binary, and raw `Binary` inputs consume this bucket. It is independent of
- `with_frame_rate`. An over-rate heartbeat does not refresh the socket's
- heartbeat deadline, so a sustained flood is eventually closed by heartbeat
- eviction. Leave enough rate and burst headroom for legitimate heartbeats.
 
 ```gleam
 pub fn with_message_rate(
@@ -652,9 +767,17 @@ pub fn with_message_rate(
 ) -> Config
 ```
 
-### `with_payload_preview_bytes`
+Configure per-socket decoded message-rate limiting in the runtime.
 
-Configure the maximum payload/frame preview length for logs.
+ Joins use `with_join_rate`; decoded leaves, heartbeats, events, decoded
+ binary, and raw `Binary` inputs consume this bucket. It is independent of
+ `with_frame_rate`. An over-rate heartbeat does not refresh the socket's
+ heartbeat deadline, so a sustained flood is eventually closed by heartbeat
+ eviction. Leave enough rate and burst headroom for legitimate heartbeats.
+
+<div class="api-entry-anchor" id="api-function-with_payload_preview_bytes" aria-hidden="true"></div>
+
+### `with_payload_preview_bytes`
 
 ```gleam
 pub fn with_payload_preview_bytes(
@@ -663,9 +786,11 @@ pub fn with_payload_preview_bytes(
 ) -> LoggingConfig
 ```
 
-### `with_presence_handle`
+Configure the maximum payload/frame preview length for logs.
 
-Attach the presence actor used by socket presence effects.
+<div class="api-entry-anchor" id="api-function-with_presence_handle" aria-hidden="true"></div>
+
+### `with_presence_handle`
 
 ```gleam
 pub fn with_presence_handle(
@@ -674,9 +799,11 @@ pub fn with_presence_handle(
 ) -> Config
 ```
 
-### `with_pubsub`
+Attach the presence actor used by socket presence effects.
 
-Add PubSub to a configuration for distributed broadcasts.
+<div class="api-entry-anchor" id="api-function-with_pubsub" aria-hidden="true"></div>
+
+### `with_pubsub`
 
 ```gleam
 pub fn with_pubsub(
@@ -685,15 +812,30 @@ pub fn with_pubsub(
 ) -> Config
 ```
 
-### `with_telemetry`
+Add PubSub to a configuration for distributed broadcasts.
 
-Enable beryl's `:telemetry` events.
+<div class="api-entry-anchor" id="api-function-with_telemetry" aria-hidden="true"></div>
+
+### `with_telemetry`
 
 ```gleam
 pub fn with_telemetry(Config) -> Config
 ```
 
+Enable beryl's `:telemetry` events.
+
+<div class="api-entry-anchor" id="api-function-with_topic_rate" aria-hidden="true"></div>
+
 ### `with_topic_rate`
+
+```gleam
+pub fn with_topic_rate(
+  Config,
+  pattern: String,
+  per_second: Int,
+  burst: Int
+) -> Config
+```
 
 Configure a per-topic-pattern message rate limit for an app-dispatch
  runtime built with `child_spec`.
@@ -705,12 +847,3 @@ Configure a per-topic-pattern message rate limit for an app-dispatch
  only after a socket has joined the topic. A non-positive `per_second`
  explicitly disables limiting for matching topics, including any global
  channel limit, and allocates no bucket.
-
-```gleam
-pub fn with_topic_rate(
-  Config,
-  pattern: String,
-  per_second: Int,
-  burst: Int
-) -> Config
-```

--- a/website/src/content/docs/reference/api/beryl_ewe.md
+++ b/website/src/content/docs/reference/api/beryl_ewe.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl_ewe"
 description: "Ewe WebSocket Transport - Direct Ewe integration for beryl"
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "Ewe WebSocket Transport - Direct Ewe integration for beryl"
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 Ewe WebSocket Transport - Direct Ewe integration for beryl
 
@@ -25,9 +30,29 @@ Ewe WebSocket Transport - Direct Ewe integration for beryl
  the Ewe-specific glue: the WebSocket upgrade call, frame sending, and
  peer IP extraction.
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-handler"><code>handler</code></a></li>
+<li><a href="#api-function-upgrade"><code>upgrade</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Functions
 
+<div class="api-entry-anchor" id="api-function-handler" aria-hidden="true"></div>
+
 ### `handler`
+
+```gleam
+pub fn handler(
+  beryl.Sockets,
+  server.TransportConfig(http1.Connection),
+  fn(request.Request(http1.Connection)) -> response.Response(ewe.ResponseBody)
+) -> fn(request.Request(http1.Connection)) -> response.Response(ewe.ResponseBody)
+```
 
 Build a combined request handler that serves both WebSocket upgrades and
  regular HTTP from a single Ewe listener.
@@ -47,15 +72,18 @@ Build a combined request handler that serves both WebSocket upgrades and
  |> ewe.start
  ```
 
-```gleam
-pub fn handler(
-  beryl.Sockets,
-  server.TransportConfig(http1.Connection),
-  fn(request.Request(http1.Connection)) -> response.Response(ewe.ResponseBody)
-) -> fn(request.Request(http1.Connection)) -> response.Response(ewe.ResponseBody)
-```
+<div class="api-entry-anchor" id="api-function-upgrade" aria-hidden="true"></div>
 
 ### `upgrade`
+
+```gleam
+pub fn upgrade(
+  request.Request(http1.Connection),
+  beryl.Sockets,
+  server.TransportConfig(http1.Connection),
+  fn() -> response.Response(ewe.ResponseBody)
+) -> response.Response(ewe.ResponseBody)
+```
 
 Upgrade a request to WebSocket if it matches the configured path.
 
@@ -77,12 +105,3 @@ Upgrade a request to WebSocket if it matches the configured path.
  `beryl/transport/server.upgrade` for the full contract. Enforcement
  uses the real socket peer IP from the TCP connection; forwarded headers
  such as `X-Forwarded-For` are not trusted.
-
-```gleam
-pub fn upgrade(
-  request.Request(http1.Connection),
-  beryl.Sockets,
-  server.TransportConfig(http1.Connection),
-  fn() -> response.Response(ewe.ResponseBody)
-) -> response.Response(ewe.ResponseBody)
-```

--- a/website/src/content/docs/reference/api/beryl_mist.md
+++ b/website/src/content/docs/reference/api/beryl_mist.md
@@ -1,6 +1,9 @@
 ---
 title: "beryl_mist"
 description: "Mist WebSocket Transport - Direct Mist integration for beryl"
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
 <!--
@@ -8,6 +11,8 @@ description: "Mist WebSocket Transport - Direct Mist integration for beryl"
   Source: the `///` doc comments in packages/*/src. Edit those, then run
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
+
+<div class="api-reference-marker" aria-hidden="true"></div>
 
 Mist WebSocket Transport - Direct Mist integration for beryl
 
@@ -21,9 +26,29 @@ Mist WebSocket Transport - Direct Mist integration for beryl
  the Mist-specific glue: the WebSocket upgrade call, frame sending, and
  peer IP extraction.
 
+<nav class="api-symbol-index" aria-label="Module contents">
+<section class="api-symbol-index__group">
+  <a class="api-symbol-index__section" href="#functions">Functions</a>
+  <ul>
+<li><a href="#api-function-handler"><code>handler</code></a></li>
+<li><a href="#api-function-upgrade"><code>upgrade</code></a></li>
+  </ul>
+</section>
+</nav>
+
 ## Functions
 
+<div class="api-entry-anchor" id="api-function-handler" aria-hidden="true"></div>
+
 ### `handler`
+
+```gleam
+pub fn handler(
+  beryl.Sockets,
+  server.TransportConfig(http.Connection),
+  fn(request.Request(http.Connection)) -> response.Response(mist.ResponseData)
+) -> fn(request.Request(http.Connection)) -> response.Response(mist.ResponseData)
+```
 
 Build a combined request handler that serves both WebSocket upgrades and
  regular HTTP from a single Mist listener.
@@ -43,15 +68,18 @@ Build a combined request handler that serves both WebSocket upgrades and
  |> mist.start
  ```
 
-```gleam
-pub fn handler(
-  beryl.Sockets,
-  server.TransportConfig(http.Connection),
-  fn(request.Request(http.Connection)) -> response.Response(mist.ResponseData)
-) -> fn(request.Request(http.Connection)) -> response.Response(mist.ResponseData)
-```
+<div class="api-entry-anchor" id="api-function-upgrade" aria-hidden="true"></div>
 
 ### `upgrade`
+
+```gleam
+pub fn upgrade(
+  request.Request(http.Connection),
+  beryl.Sockets,
+  server.TransportConfig(http.Connection),
+  fn() -> response.Response(mist.ResponseData)
+) -> response.Response(mist.ResponseData)
+```
 
 Upgrade a request to WebSocket if it matches the configured path.
 
@@ -73,12 +101,3 @@ Upgrade a request to WebSocket if it matches the configured path.
  `beryl/transport/server.upgrade` for the full contract. Enforcement
  uses the real socket peer IP from the TCP connection; forwarded headers
  such as `X-Forwarded-For` are not trusted.
-
-```gleam
-pub fn upgrade(
-  request.Request(http.Connection),
-  beryl.Sockets,
-  server.TransportConfig(http.Connection),
-  fn() -> response.Response(mist.ResponseData)
-) -> response.Response(mist.ResponseData)
-```

--- a/website/src/content/docs/reference/api/index.md
+++ b/website/src/content/docs/reference/api/index.md
@@ -9,6 +9,8 @@ description: API reference generated from Gleam docs metadata.
   `just docs` (gleam docs build + cd website && pnpm run generate:reference).
 -->
 
+<div class="api-reference-marker" aria-hidden="true"></div>
+
 This reference uses Gleam docs metadata for `beryl`, `beryl_ewe`, and `beryl_mist`.
 
 :::note[Generated content]
@@ -17,33 +19,87 @@ The generator creates pages under `/reference/api/` from Gleam docs metadata. Th
 
 ## `beryl` `0.4.1`
 
-| Module | Description |
-|---|---|
-| [`beryl`](/reference/api/beryl/) | beryl - Type-safe real-time communication |
-| [`beryl/bridge`](/reference/api/beryl-bridge/) | Bridge - Forward an external OTP actor's message stream to a socket via |
-| [`beryl/channel`](/reference/api/beryl-channel/) | The channel composition surface: a channel is a topic pattern paired |
-| [`beryl/error`](/reference/api/beryl-error/) | Shared beryl-owned error helpers. |
-| [`beryl/group`](/reference/api/beryl-group/) | Channel Groups - Named collections of topics for multi-topic broadcasting |
-| [`beryl/presence`](/reference/api/beryl-presence/) | Presence - Distributed presence tracking backed by a CRDT |
-| [`beryl/presence/wire`](/reference/api/beryl-presence-wire/) | Phoenix-compatible wire encoding for presence diffs. |
-| [`beryl/pubsub`](/reference/api/beryl-pubsub/) | PubSub - Distributed publish/subscribe using Erlang pg |
-| [`beryl/socket`](/reference/api/beryl-socket/) | Types for building app-side dispatch systems with `beryl.child_spec`. |
-| [`beryl/stats`](/reference/api/beryl-stats/) | Local runtime statistics. |
-| [`beryl/topic`](/reference/api/beryl-topic/) | Pattern matching for topic routing. |
-| [`beryl/transport`](/reference/api/beryl-transport/) | Transport SPI: the contract between beryl core and WebSocket transport |
-| [`beryl/transport/origin`](/reference/api/beryl-transport-origin/) | Origin and handshake-version checks for WebSocket upgrades. |
-| [`beryl/transport/server`](/reference/api/beryl-transport-server/) | Server-agnostic WebSocket transport infrastructure. |
-| [`beryl/wire`](/reference/api/beryl-wire/) | Phoenix Wire Protocol: encoding/decoding helpers and the canonical |
-| [`beryl/wire/codec`](/reference/api/beryl-wire-codec/) | Pluggable wire codec for beryl. |
+<ul class="api-module-list">
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl/"><code>beryl</code></a>
+  <p>beryl - Type-safe real-time communication</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-bridge/"><code>beryl/bridge</code></a>
+  <p>Bridge - Forward an external OTP actor's message stream to a socket via its <code>Sender</code>.</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-channel/"><code>beryl/channel</code></a>
+  <p>The channel composition surface: a channel is a topic pattern paired with a typed <code>join</code> callback and callbacks over private state.</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-error/"><code>beryl/error</code></a>
+  <p>Shared beryl-owned error helpers.</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-group/"><code>beryl/group</code></a>
+  <p>Channel Groups - Named collections of topics for multi-topic broadcasting</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-presence/"><code>beryl/presence</code></a>
+  <p>Presence - Distributed presence tracking backed by a CRDT</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-presence-wire/"><code>beryl/presence/wire</code></a>
+  <p>Phoenix-compatible wire encoding for presence diffs.</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-pubsub/"><code>beryl/pubsub</code></a>
+  <p>PubSub - Distributed publish/subscribe using Erlang pg</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-socket/"><code>beryl/socket</code></a>
+  <p>Types for building app-side dispatch systems with <code>beryl.child_spec</code>.</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-stats/"><code>beryl/stats</code></a>
+  <p>Local runtime statistics.</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-topic/"><code>beryl/topic</code></a>
+  <p>Pattern matching for topic routing.</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-transport/"><code>beryl/transport</code></a>
+  <p>Transport SPI: the contract between beryl core and WebSocket transport implementations such as the <code>beryl_mist</code> and <code>beryl_ewe</code> packages.</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-transport-origin/"><code>beryl/transport/origin</code></a>
+  <p>Origin and handshake-version checks for WebSocket upgrades.</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-transport-server/"><code>beryl/transport/server</code></a>
+  <p>Server-agnostic WebSocket transport infrastructure.</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-wire/"><code>beryl/wire</code></a>
+  <p>Phoenix Wire Protocol: encoding/decoding helpers and the canonical <code>phoenix_codec()</code> for <code>beryl/wire/codec</code>.</p>
+</li>
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl-wire-codec/"><code>beryl/wire/codec</code></a>
+  <p>Pluggable wire codec for beryl.</p>
+</li>
+</ul>
 
 ## `beryl_ewe` `0.2.2`
 
-| Module | Description |
-|---|---|
-| [`beryl_ewe`](/reference/api/beryl_ewe/) | Ewe WebSocket Transport - Direct Ewe integration for beryl |
+<ul class="api-module-list">
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl_ewe/"><code>beryl_ewe</code></a>
+  <p>Ewe WebSocket Transport - Direct Ewe integration for beryl</p>
+</li>
+</ul>
 
 ## `beryl_mist` `0.3.2`
 
-| Module | Description |
-|---|---|
-| [`beryl_mist`](/reference/api/beryl_mist/) | Mist WebSocket Transport - Direct Mist integration for beryl |
+<ul class="api-module-list">
+<li class="api-module-list__item">
+  <a class="api-module-list__name" href="/reference/api/beryl_mist/"><code>beryl_mist</code></a>
+  <p>Mist WebSocket Transport - Direct Mist integration for beryl</p>
+</li>
+</ul>

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -380,6 +380,139 @@ body {
 }
 
 /* ==========================================================================
+   Generated API reference — a module map followed by signature-first entries.
+   The marker is emitted by the generator so these rules cannot leak into
+   hand-written guides.
+   ========================================================================== */
+
+.api-reference-marker {
+	display: none;
+}
+
+.api-entry-anchor {
+	height: 0;
+	scroll-margin-top: calc(var(--sl-nav-height) + 1rem);
+}
+
+.sl-markdown-content:has(> .api-reference-marker) {
+	--api-rule: color-mix(
+		in oklch,
+		var(--beryl-hairline) 72%,
+		transparent
+	);
+}
+
+.api-module-list {
+	display: grid;
+	gap: 0;
+	margin-block: 1.25rem 3rem;
+	padding: 0;
+	list-style: none;
+	border-block: 1px solid var(--api-rule);
+}
+
+.api-module-list__item {
+	display: grid;
+	grid-template-columns: minmax(11rem, 0.7fr) minmax(0, 1.3fr);
+	gap: 1rem 2rem;
+	align-items: baseline;
+	margin: 0;
+	padding: 1rem 0.25rem;
+	border-bottom: 1px solid var(--api-rule);
+}
+
+.api-module-list__item:last-child {
+	border-bottom: 0;
+}
+
+.api-module-list__item p {
+	max-width: 68ch;
+	margin: 0;
+	color: var(--sl-color-gray-2);
+}
+
+.api-module-list__name {
+	font-weight: 700;
+}
+
+.api-symbol-index {
+	display: grid;
+	gap: 1.5rem;
+	margin-block: 2.25rem 3.5rem;
+	padding-block: 1.25rem;
+	border-block: 1px solid var(--api-rule);
+}
+
+.api-symbol-index__group {
+	display: grid;
+	grid-template-columns: minmax(7rem, 0.22fr) minmax(0, 1fr);
+	gap: 0.75rem 1.5rem;
+	align-items: start;
+}
+
+.api-symbol-index__section {
+	color: var(--sl-color-white);
+	font-weight: 700;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 0.25em;
+}
+
+.api-symbol-index ul {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 12rem), 1fr));
+	gap: 0.4rem 1rem;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.api-symbol-index li {
+	min-width: 0;
+	margin: 0;
+}
+
+.api-symbol-index li a {
+	display: inline-flex;
+	max-width: 100%;
+	padding-block: 0.18rem;
+}
+
+.api-symbol-index li code {
+	overflow-wrap: anywhere;
+}
+
+.sl-markdown-content:has(> .api-reference-marker)
+	.sl-heading-wrapper.level-h3 {
+	margin-top: 3rem;
+	padding-top: 1.5rem;
+	border-top: 1px solid var(--api-rule);
+}
+
+.sl-markdown-content:has(> .api-reference-marker)
+	.sl-heading-wrapper.level-h3
+	+ .expressive-code {
+	margin-top: 0.8rem;
+	margin-bottom: 1.25rem;
+}
+
+.sl-markdown-content:has(> .api-reference-marker)
+	.sl-heading-wrapper.level-h5 {
+	margin-top: 1.75rem;
+}
+
+@media (max-width: 38rem) {
+	.api-module-list__item,
+	.api-symbol-index__group {
+		grid-template-columns: 1fr;
+		gap: 0.45rem;
+	}
+
+	.api-symbol-index ul {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+/* ==========================================================================
    Prev / next pagination — match the card hover language: hairline border,
    accent lift on hover, emerald glow. Active state lives on the link title.
    ========================================================================== */


### PR DESCRIPTION
## Summary

- add responsive module and symbol indexes to generated API pages
- put signatures before descriptions and keep nested headings below API symbols
- limit long-page tables of contents to major sections and add stable jump targets
- refresh the Impeccable design sidecar for the new reference patterns

## Checks

- `just format-check`
- `just check`
- `just docs`
- `cd website && pnpm run check:snippets`
- `just test`
- `just build-strict`
- `just examples-test`
- `just doctor`
- `just changelog-check`
- website reference tests, Astro check, build, link validation, and Impeccable detector