### PR TITLE
feat(channel): refuse unmatched topics before a worker spawns

### DIFF
--- a/.changes/unreleased/beryl-a-join-to-an.toml
+++ b/.changes/unreleased/beryl-a-join-to-an.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Changed"
+body = "A join to an unmatched topic is now refused before the runtime starts a worker process."

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -850,15 +850,19 @@ pub fn child_spec(
 
 /// Build a socket system that runs one process per accepted topic.
 ///
-/// This is the package-internal entry point for `channel.child_spec`. Each
-/// new topic worker runs `open` during initialization. The socket-level
-/// `init` and `update` functions return no effects. Each worker owns its
-/// joined topic. Thus, `update` receives only `Binary` frames and `Closed`
-/// events for workers that stopped unexpectedly.
+/// This is the package-internal entry point for `channel.child_spec`. The
+/// socket actor calls `accepts` with the topic name before it starts a
+/// worker for a join: `Error(reason)` rejects the join with that reason and
+/// spawns no process. Each new topic worker runs `open` during
+/// initialization. The socket-level `init` and `update` functions return no
+/// effects. Each worker owns its joined topic. Thus, `update` receives only
+/// `Binary` frames and `Closed` events for workers that stopped
+/// unexpectedly.
 @internal
 pub fn worker_child_spec(
   config: Config,
-  open: fn(socket.WorkerContext) -> socket.WorkerOutcome,
+  accepts accepts: fn(String) -> Result(Nil, json.Json),
+  open open: fn(socket.WorkerContext) -> socket.WorkerOutcome,
 ) -> Result(
   #(Sockets, supervision.ChildSpecification(static_supervisor.Supervisor)),
   ConfigError,
@@ -867,7 +871,7 @@ pub fn worker_child_spec(
     config,
     fn(_info) { #(Nil, []) },
     fn(_model, _input) { socket.Next(Nil, []) },
-    Some(open),
+    Some(runtime.WorkerOpener(accepts:, open:)),
   )
 }
 
@@ -875,7 +879,7 @@ fn child_spec_with(
   config: Config,
   init: fn(socket.ConnectInfo(msg)) -> #(model, List(socket.Effect)),
   update: fn(model, socket.Input(msg)) -> socket.Next(model),
-  open_worker: Option(fn(socket.WorkerContext) -> socket.WorkerOutcome),
+  open_worker: Option(runtime.WorkerOpener),
 ) -> Result(
   #(Sockets, supervision.ChildSpecification(static_supervisor.Supervisor)),
   ConfigError,
@@ -924,7 +928,7 @@ fn build_app_subtree(
   config: Config,
   init: fn(socket.ConnectInfo(msg)) -> #(model, List(socket.Effect)),
   update: fn(model, socket.Input(msg)) -> socket.Next(model),
-  open_worker: Option(fn(socket.WorkerContext) -> socket.WorkerOutcome),
+  open_worker: Option(runtime.WorkerOpener),
 ) -> Result(AppSubtree, ConfigError) {
   use _ <- result.map(validate_config(config))
   warn_if_unprotected(config)
@@ -993,7 +997,7 @@ fn child_spec_supervisor(
   limiter_name: Option(process.Name(connection_limit.Message)),
   init: fn(socket.ConnectInfo(msg)) -> #(model, List(socket.Effect)),
   update: fn(model, socket.Input(msg)) -> socket.Next(model),
-  open_worker: Option(fn(socket.WorkerContext) -> socket.WorkerOutcome),
+  open_worker: Option(runtime.WorkerOpener),
 ) -> Result(actor.Started(static_supervisor.Supervisor), actor.StartError) {
   // Socket actors are `Temporary` children of this factory: it owns their
   // process lifetime and forced shutdown, but never reconstructs the

--- a/packages/beryl/src/beryl/channel.gleam
+++ b/packages/beryl/src/beryl/channel.gleam
@@ -145,7 +145,11 @@ pub fn child_spec(
 ) {
   use table <- result.try(compile(handlers))
 
-  beryl.worker_child_spec(config, open_topic(table))
+  beryl.worker_child_spec(
+    config,
+    accepts: accepts_topic(table),
+    open: open_topic(table),
+  )
   |> result.map_error(InvalidConfig)
 }
 
@@ -806,6 +810,21 @@ fn table(handlers: List(Handler)) -> List(Registered) {
   list.map(handlers, fn(handler) {
     Registered(pattern: topic.parse_pattern(handler.pattern), handler: handler)
   })
+}
+
+/// Refuse an unmatched topic before the runtime starts a worker.
+///
+/// Uses the same table and match as `open_topic`, so the two agree on
+/// every topic name.
+fn accepts_topic(
+  handlers: List(Registered),
+) -> fn(String) -> Result(Nil, json.Json) {
+  fn(name) {
+    case select(handlers, name) {
+      Ok(_) -> Ok(Nil)
+      Error(Nil) -> Error(unmatched_topic())
+    }
+  }
 }
 
 /// Open a handler table in each new topic worker.

--- a/packages/beryl/src/beryl/runtime.gleam
+++ b/packages/beryl/src/beryl/runtime.gleam
@@ -301,7 +301,7 @@ type RuntimeRole(msg) {
     /// topics for one socket. The socket actor starts and links the
     /// supervisor. Thus, the workers stop with the socket. Joins on different
     /// sockets do not wait for each other.
-    workers: Option(factory_supervisor.Supervisor(WorkerSpawn, WorkerStarted)),
+    workers: Option(TopicWorkers),
   )
 }
 
@@ -692,7 +692,7 @@ pub fn socket_factory_child(
   config config: Config,
   init init: fn(ConnectInfo(msg)) -> #(model, List(Effect)),
   update update: fn(model, Input(msg)) -> Next(model),
-  open_worker open_worker: Option(fn(WorkerContext) -> WorkerOutcome),
+  open_worker open_worker: Option(WorkerOpener),
   router router: Subject(Msg(msg)),
   name name: process.Name(SocketFactoryMessage(msg)),
 ) -> supervision.ChildSpecification(
@@ -753,7 +753,7 @@ fn start_socket_actor(
   config config: Config,
   init init: fn(ConnectInfo(msg)) -> #(model, List(Effect)),
   update update: fn(model, Input(msg)) -> Next(model),
-  open_worker open_worker: Option(fn(WorkerContext) -> WorkerOutcome),
+  open_worker open_worker: Option(WorkerOpener),
   router router: Subject(Msg(msg)),
   router_pid router_pid: process.Pid,
 ) -> Result(actor.Started(Subject(Msg(msg))), actor.StartError) {
@@ -764,13 +764,15 @@ fn start_socket_actor(
     // with the socket.
     use workers <- result.try(case open_worker {
       None -> Ok(None)
-      Some(open) ->
+      Some(opener) ->
         factory_supervisor.worker_child(fn(spawn) {
-          start_worker(open, subject, config.telemetry, spawn)
+          start_worker(opener.open, subject, config.telemetry, spawn)
         })
         |> factory_supervisor.restart_strategy(supervision.Temporary)
         |> factory_supervisor.start
-        |> result.map(fn(started) { Some(started.data) })
+        |> result.map(fn(started) {
+          Some(TopicWorkers(accepts: opener.accepts, factory: started.data))
+        })
         |> result.map_error(fn(_) { "topic worker supervisor failed to start" })
     })
     let state =
@@ -2965,14 +2967,14 @@ fn exec_input(
         // message is cast to it. `Binary` and `Info` are socket-scoped and
         // still reach `update`; `Closed` for a worker topic never gets
         // here, because `exec_close_topic` routes the close to the worker.
-        SocketActorRole(workers: Some(factory), ..),
+        SocketActorRole(workers: Some(workers), ..),
           sock.Join(topic: topic_name, payload:, ref:)
         ->
           exec_worker_join(
             state,
             socket_id,
             socket,
-            factory,
+            workers,
             topic_name,
             payload,
             ref,
@@ -5179,6 +5181,28 @@ const worker_join_timeout_ms = 5000
 /// `worker_join_timeout_ms`.
 const worker_terminate_timeout_ms = 5000
 
+/// The worker contract that `beryl.worker_child_spec` hands to the runtime.
+///
+/// The socket actor calls `accepts` with the topic name before it starts a
+/// worker for a join. `Error(reason)` rejects the join with that reason and
+/// spawns no process. `open` runs in the new worker process for an accepted
+/// topic.
+pub type WorkerOpener {
+  WorkerOpener(
+    accepts: fn(String) -> Result(Nil, Json),
+    open: fn(WorkerContext) -> WorkerOutcome,
+  )
+}
+
+/// One socket actor's topic-worker machinery: the contract's pre-check and
+/// the factory that starts one worker per accepted join.
+type TopicWorkers {
+  TopicWorkers(
+    accepts: fn(String) -> Result(Nil, Json),
+    factory: factory_supervisor.Supervisor(WorkerSpawn, WorkerStarted),
+  )
+}
+
 /// The factory supervisor's child argument: one join attempt.
 type WorkerSpawn {
   WorkerSpawn(
@@ -5387,10 +5411,48 @@ fn worker_step(
 
 /// Start the worker for a join and answer the join from its outcome.
 ///
+/// The contract's `accepts` runs first: a refused topic is rejected with
+/// its reason and no worker is spawned.
+///
 /// The accept-time effects are lowered behind the `AcceptJoin` in the
 /// same list, so the acknowledgment precedes the join's own pushes and
 /// the subscription exists when they are applied.
 fn exec_worker_join(
+  state: State(model, msg),
+  socket_id: String,
+  socket: SocketState(model, msg),
+  workers: TopicWorkers,
+  topic_name: String,
+  payload: Dynamic,
+  ref: JoinRef,
+  source: Source,
+  cont: Cont,
+) -> Exec(model, msg) {
+  case workers.accepts(topic_name) {
+    Error(reason) ->
+      exec_update_result(
+        state,
+        socket_id,
+        source,
+        cont,
+        Ok(sock.Next(socket.model, [sock.RejectJoin(ref, reason)])),
+      )
+    Ok(Nil) ->
+      exec_accepted_worker_join(
+        state,
+        socket_id,
+        socket,
+        workers.factory,
+        topic_name,
+        payload,
+        ref,
+        source,
+        cont,
+      )
+  }
+}
+
+fn exec_accepted_worker_join(
   state: State(model, msg),
   socket_id: String,
   socket: SocketState(model, msg),

--- a/packages/beryl/test/worker_precheck_test.gleam
+++ b/packages/beryl/test/worker_precheck_test.gleam
@@ -1,0 +1,70 @@
+//// The runtime consults the worker contract's `accepts` before it starts a
+//// topic worker. A refused topic gets a `RejectJoin` with the contract's
+//// reason, and `open` never runs — no worker process is spawned.
+
+import beryl
+import beryl/socket
+import beryl/wire
+import channel_dispatch_helper as helper
+import gleam/erlang/process
+import gleam/json
+import gleam/otp/static_supervisor
+import gleam/string
+import gleeunit/should
+
+fn start(
+  accepts accepts: fn(String) -> Result(Nil, json.Json),
+  open open: fn(socket.WorkerContext) -> socket.WorkerOutcome,
+) -> beryl.Sockets {
+  let assert Ok(#(sockets, spec)) =
+    beryl.worker_child_spec(beryl.config(wire.phoenix_codec()), accepts:, open:)
+    as "the config is valid"
+  let assert Ok(_) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(spec)
+    |> static_supervisor.start()
+    as "the worker supervision tree starts"
+  sockets
+}
+
+fn reason(text: String) -> json.Json {
+  json.object([#("reason", json.string(text))])
+}
+
+pub fn a_refused_topic_is_rejected_without_running_open_test() {
+  let opened = process.new_subject()
+  let channels =
+    start(
+      accepts: fn(_topic) { Error(reason("unmatched topic")) },
+      open: fn(_context) {
+        process.send(opened, "open ran")
+        socket.WorkerRejected(reason("unmatched topic"))
+      },
+    )
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "nope:1", "jr-1", "r-1")
+
+  let reply = helper.recv(frames)
+  reply |> string.contains("\"status\":\"error\"") |> should.be_true
+  reply
+  |> string.contains("{\"reason\":\"unmatched topic\"}")
+  |> should.be_true
+  // `open` never ran, so no worker was spawned for the refused join.
+  process.receive(opened, 100) |> should.be_error
+  Nil
+}
+
+pub fn an_accepted_topic_still_reaches_open_test() {
+  let channels =
+    start(accepts: fn(_topic) { Ok(Nil) }, open: fn(_context) {
+      socket.WorkerRejected(reason("forbidden"))
+    })
+  let frames = helper.connect(channels, "s1")
+
+  helper.join(channels, "s1", "room:1", "jr-1", "r-1")
+
+  let reply = helper.recv(frames)
+  reply |> string.contains("\"status\":\"error\"") |> should.be_true
+  reply |> string.contains("forbidden") |> should.be_true
+}

--- a/website/src/content/docs/architecture/message-lifecycle.md
+++ b/website/src/content/docs/architecture/message-lifecycle.md
@@ -147,7 +147,7 @@ worker runs the channel's callbacks and reports its actions back.
 
 | Runtime input | Channel layer behavior |
 |---|---|
-| `Join(topic, payload, ref)` | First matching handler wins. Its `join` runs while the worker starts, and the socket actor waits for it. The result emits `AcceptJoin` followed by ordered join actions, or `RejectJoin`. No match is refused with `{"reason": "unmatched topic"}` |
+| `Join(topic, payload, ref)` | First matching handler wins. Its `join` runs while the worker starts, and the socket actor waits for it. The result emits `AcceptJoin` followed by ordered join actions, or `RejectJoin`. No match is refused with `{"reason": "unmatched topic"}` before a worker starts |
 | `Message(topic, ..)` | The socket actor sends it to the topic worker. The worker runs `on_message` and reports its actions |
 | `Binary(topic, ..)` | Ignored by the channel layer |
 | `channel.notify` mail | The sender sends it to its join worker. Mail for an ended join reaches no process |


### PR DESCRIPTION
Closes #372. Follow-up from the review of #337 (process-per-channel).

## Problem

`channel.open_topic` only discovered an unmatched topic inside the freshly spawned worker, so each join of a bogus topic cost a `start_child`, a process, an init ack, and a self-sent `WorkerHalt` on the socket actor's blocking path. Before #337 the router refused these with a pure list scan and spawned nothing.

## Change

- `beryl.worker_child_spec` gains an `accepts: fn(String) -> Result(Nil, Json)` next to `open`. `Result` instead of the issue's suggested `Bool` keeps the refusal reason (`{"reason": "unmatched topic"}`) defined in `channel` — the runtime never invents wire payloads.
- `channel` derives `accepts` from the same `select` over the same compiled handler table as `open_topic`, so the pre-check and the worker-side match cannot disagree. The `select` fallback inside `open_topic` stays as a defensive path.
- The socket actor runs `accepts` in `exec_worker_join` before `start_child`; a refused topic becomes a plain `RejectJoin` with no spawn.
- New `worker_precheck_test.gleam`: a refused topic gets the documented rejection while `open` (which signals a subject if it ever runs) never executes; an accepted topic still reaches `open`. Written first, failed against the old contract.
