### PR TITLE
fix(ci): serialize dependency downloads

### DIFF
--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ deps: deps-gleam
 
 # Download gleam dependencies for every workspace member
 deps-gleam:
-    trellis run deps
+    trellis run deps --serial
 
 # === BUILD ===
 


### PR DESCRIPTION
Run Gleam dependency downloads serially to avoid Hex API rate-limit failures from concurrent workspace requests.