### PR TITLE
docs: tighten website and API copy

### DIFF
--- a/.changes/unreleased/beryl-correct-public-api-documentation.toml
+++ b/.changes/unreleased/beryl-correct-public-api-documentation.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Correct public API documentation for terminal frames, PubSub startup, presence replication, and log preview limits."

--- a/.changes/unreleased/beryl_mist-clarify-the-mist-transport.toml
+++ b/.changes/unreleased/beryl_mist-clarify-the-mist-transport.toml
@@ -1,0 +1,3 @@
+package = "beryl_mist"
+kind = "Fixed"
+body = "Clarify the Mist transport API documentation."

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -1,8 +1,8 @@
-//// beryl - Type-safe real-time communication
+//// beryl: type-safe real-time communication
 ////
-//// A standalone Gleam library for building real-time applications on the BEAM.
-//// Provides app-side WebSocket dispatch, distributed presence tracking,
-//// pub/sub messaging, and topic groups.
+//// beryl is a standalone Gleam library for building real-time applications on
+//// the BEAM. It provides app-side WebSocket dispatch, distributed presence
+//// tracking, PubSub messaging, and topic groups.
 ////
 //// ## Features
 ////
@@ -15,7 +15,7 @@
 //// - **Groups**: Named collections of topics for multi-topic broadcasting
 ////   (`beryl/group`)
 ////
-//// ## Quick Start
+//// ## Quick start
 ////
 //// ```gleam
 //// import beryl
@@ -24,6 +24,7 @@
 //// }
 //// import beryl/pubsub
 //// import beryl/wire
+//// import gleam/json
 //// import gleam/option
 //// import gleam/otp/static_supervisor
 ////
@@ -106,7 +107,7 @@ pub opaque type LoggingConfig {
     level: LogLevel,
     /// Whether debug diagnostics may include bounded payload/frame previews.
     include_payloads: Bool,
-    /// Maximum number of bytes/characters included in payload previews.
+    /// Maximum number of grapheme clusters included in payload previews.
     payload_preview_bytes: Int,
   )
 }
@@ -203,11 +204,10 @@ pub fn logging_config(
   )
 }
 
-/// Build a configuration with sensible defaults.
+/// Build a configuration with the default settings.
 ///
-/// A `codec` is required. beryl no longer provides an implicit Phoenix
-/// default. Pass `wire.phoenix_codec()` to keep Phoenix wire compatibility,
-/// or your own `Codec` for a custom framing.
+/// Pass `wire.phoenix_codec()` for Phoenix framing or a custom `Codec` for
+/// another framing.
 pub fn config(codec: codec.Codec) -> Config {
   Config(
     codec: codec,
@@ -320,9 +320,8 @@ pub fn with_heartbeat(config: Config, timeout_ms timeout_ms: Int) -> Config {
 /// If beryl runs behind a trusted reverse proxy or load balancer, every
 /// connection shares the proxy's address, so a per-IP limit throttles all
 /// clients as a single IP. In that topology you must resolve the real client
-/// IP yourself at the proxy layer (for example, by enforcing limits there). A
-/// built-in trusted-proxy opt-in may be added in a future release. See the
-/// WebSocket transport guide for deployment guidance.
+/// IP yourself at the proxy layer, for example by enforcing limits there. See
+/// the WebSocket transport guide for deployment guidance.
 pub fn with_max_connections_per_ip(
   config: Config,
   max_connections max_connections: Int,
@@ -394,7 +393,9 @@ pub fn with_logging(config: Config, logging: LoggingConfig) -> Config {
 }
 
 // nolint: unused_exports -- public logging builder intended for downstream users
-/// Configure the maximum payload/frame preview length for logs.
+/// Configure the maximum payload and frame preview length for logs.
+///
+/// The `bytes` argument is measured in grapheme clusters.
 pub fn with_payload_preview_bytes(
   logging: LoggingConfig,
   bytes bytes: Int,

--- a/packages/beryl/src/beryl/bridge.gleam
+++ b/packages/beryl/src/beryl/bridge.gleam
@@ -1,5 +1,5 @@
-//// Bridge - Forward an external OTP actor's message stream to a socket via
-//// its `Sender`.
+//// Forward an external OTP actor's message stream to a socket through its
+//// `Sender`.
 ////
 //// A common pattern is a long-lived domain actor (e.g. a per-document
 //// session) that emits updates which need to be pushed to a connected

--- a/packages/beryl/src/beryl/group.gleam
+++ b/packages/beryl/src/beryl/group.gleam
@@ -1,8 +1,7 @@
-//// Channel Groups - Named collections of topics for multi-topic broadcasting
+//// Topic groups
 ////
-//// Groups let you organize topics and broadcast to all of them at once.
-//// Useful for scenarios like broadcasting to all channels in a "team" or
-//// sending a system-wide notification.
+//// Groups organize topics for broadcasts to several topics at once, such as
+//// every channel in a team or a system-wide notification.
 ////
 //// Groups are independent of the beryl runtime and run under your
 //// application's supervision tree.
@@ -40,8 +39,9 @@ import gleam/set.{type Set}
 ///
 /// The stable registered subject is resolved on the caller's node. Keep a
 /// `Groups` handle on the node where its child specification runs. Calls from
-/// another BEAM node cannot reach the owning actor; synchronous operations
-/// panic as unavailable, and fire-and-forget broadcasts are not delivered.
+/// another BEAM node cannot reach the owning actor. All public operations,
+/// including `broadcast`, panic if the actor is unavailable or the call times
+/// out.
 pub opaque type Groups {
   Groups(subject: Subject(Message), call_timeout_ms: Int)
 }

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -1,11 +1,12 @@
-//// Presence - Distributed presence tracking backed by a CRDT
+//// Distributed presence tracking with a CRDT
 ////
-//// Wraps the pure `lattice_presence/presence_state` CRDT in an OTP actor that:
+//// This module wraps the pure `lattice_presence/presence_state` CRDT in an
+//// OTP actor that:
 //// - Handles track/update/untrack calls
 //// - Publishes an actor-owned ETS read model
 //// - Periodically broadcasts state via PubSub for cross-node replication
 //// - Receives remote state from PubSub and merges it internally
-//// - Invokes `on_diff` callback when merges produce non-empty diffs
+//// - Invokes `on_diff` when local changes or merges produce non-empty diffs
 ////
 //// Presence is independent of the beryl runtime and runs under your
 //// application's supervision tree.
@@ -216,7 +217,8 @@ pub opaque type Config {
     /// of the same base is pruned automatically. Two *live* nodes sharing
     /// a base will continuously prune each other — do not do that.
     replica: String,
-    /// How often to broadcast state for replication (ms). 0 = disabled.
+    /// How often to broadcast state for replication (ms). Non-positive values
+    /// disable periodic broadcasts.
     broadcast_interval_ms: Int,
     /// Timeout for synchronous presence mutations (ms).
     call_timeout_ms: Int,
@@ -453,10 +455,10 @@ type ActorState {
 
 /// Default configuration (no PubSub).
 ///
-/// The broadcast interval defaults to 1500 ms. Adding `with_pubsub` therefore
-/// enables two-way replication without more configuration. Without PubSub,
-/// the interval is unused. Use `with_broadcast_interval(0)` to disable
-/// periodic broadcasts and control replication manually.
+/// The broadcast interval defaults to 1500 ms. Adding `with_pubsub` enables
+/// periodic outbound broadcasts and inbound replication. Without PubSub, the
+/// interval is unused. Use a non-positive interval to disable periodic
+/// outbound broadcasts.
 pub fn default_config(replica: String) -> Config {
   Config(
     pubsub: None,
@@ -474,7 +476,7 @@ pub fn with_pubsub(config: Config, pubsub: PubSub(SyncPayload)) -> Config {
 
 /// Set how often presence state is broadcast for replication.
 ///
-/// Use `0` to disable periodic broadcasts.
+/// Use a non-positive value to disable periodic broadcasts.
 pub fn with_broadcast_interval(config: Config, interval_ms: Int) -> Config {
   Config(..config, broadcast_interval_ms: interval_ms)
 }
@@ -491,7 +493,7 @@ pub fn with_call_timeout(config: Config, timeout_ms: Int) -> Config {
 /// Set the callback for diffs from local changes or remote merges.
 ///
 /// The callback runs synchronously on the presence actor, for both local
-/// mutations (`track`/`untrack`/`untrack_all`, and the asynchronous
+/// mutations (`track`/`update`/`untrack`/`untrack_all`, and the asynchronous
 /// mutations the runtime issues for presence effects) and remote merges,
 /// before the affected topics' read-model snapshots are (re)published and
 /// before the triggering call replies or the mutation is acknowledged.
@@ -510,8 +512,9 @@ pub fn with_call_timeout(config: Config, timeout_ms: Int) -> Config {
 /// the reply to (or acknowledgement of) the mutating operation, and every
 /// other message behind it in the actor's mailbox. Concurrent
 /// `list`/`get_by_key`/`count` calls from other processes do not use the
-/// mailbox and are not delayed. Only the socket with an active presence
-/// effect waits for the callback.
+/// mailbox and are not delayed. A socket with an active presence effect waits
+/// for the callback. Callers of synchronous mutations also wait for their
+/// replies.
 pub fn with_on_diff(config: Config, callback: fn(Diff) -> Nil) -> Config {
   Config(..config, on_diff: Some(callback))
 }

--- a/packages/beryl/src/beryl/pubsub.gleam
+++ b/packages/beryl/src/beryl/pubsub.gleam
@@ -1,8 +1,8 @@
-//// PubSub - Distributed publish/subscribe using Erlang pg
+//// Distributed PubSub with Erlang `pg`
 ////
-//// Provides topic-based pub/sub messaging backed by Erlang's built-in `pg`
-//// module. Subscribers are tracked by process group, so messages are delivered
-//// to all nodes in the cluster automatically.
+//// This module provides topic-based PubSub backed by Erlang's built-in `pg`
+//// module. Subscribers are tracked by process group, so messages are
+//// delivered to all connected nodes in the cluster.
 ////
 //// The payload is generic: `PubSub(payload)` and `Message(payload)` carry
 //// whatever Gleam type a given scope is started with. A broadcast sends that
@@ -13,7 +13,7 @@
 //// browser); payloads that never leave the cluster are cheaper and safer as
 //// plain Gleam types.
 ////
-//// ## Quick Start
+//// ## Quick start
 ////
 //// ```gleam
 //// let pubsub_handle = pubsub.start(pubsub.default_config())
@@ -155,8 +155,9 @@ pub fn config_with_scope(name: String) -> PubSubConfig {
 
 /// Start a PubSub instance.
 ///
-/// This starts a pg scope. If another node or an earlier call started the
-/// scope, this function does nothing.
+/// This starts the configured `pg` scope on the current node. Repeated calls
+/// on the same node are harmless. Each participating node must start the same
+/// scope.
 ///
 /// `payload` is fixed by how the returned value is used or annotated at the
 /// call site. For example: `pubsub.start(config) : PubSub(MySyncPayload)`.

--- a/packages/beryl/src/beryl/socket.gleam
+++ b/packages/beryl/src/beryl/socket.gleam
@@ -150,7 +150,8 @@ pub type Next(model) {
   /// Continue with the given model, applying the effects in order.
   Next(model: model, effects: List(Effect))
   /// Tear down the socket: every joined topic receives a `Closed` input,
-  /// terminal frames are sent, and the transport connection is closed.
+  /// configured terminal frames are sent, and the transport connection is
+  /// closed.
   Stop(reason: StopReason)
 }
 
@@ -218,8 +219,9 @@ pub type Effect {
     event: String,
     encode: fn(List(PresenceEntry)) -> Json,
   )
-  /// Close this socket's subscription to a topic. The topic receives a
-  /// `Closed(topic, Shutdown)` input and the client a terminal frame.
+  /// Close this socket's subscription to a topic. The topic receives
+  /// `Closed(topic, Shutdown)`. If the codec has a close encoder, the client
+  /// also receives its terminal frame.
   KickTopic(topic: String)
 }
 

--- a/packages/beryl/src/beryl/transport/origin.gleam
+++ b/packages/beryl/src/beryl/transport/origin.gleam
@@ -119,11 +119,9 @@ fn origin_authority(origin: String) -> Result(String, Nil) {
 /// Check a client's requested wire protocol version (the `?vsn=` query
 /// parameter sent by Phoenix clients) before upgrading.
 ///
-/// beryl uses the Phoenix V2 array framing, so it accepts `vsn=2.x`. A
-/// missing `vsn` (`None`) is accepted for non-Phoenix clients speaking the
-/// configured codec. Anything else (e.g. the V1 object framing's `vsn=1.0.0`)
-/// is rejected. Transports fail the handshake with `403 Forbidden` instead
-/// of accepting a connection with frames that cannot be decoded.
+/// Accept a missing `vsn` or a value beginning with `2.`. Custom-codec clients
+/// must omit `vsn` unless they use that version form. Other values, such as
+/// the V1 object framing's `vsn=1.0.0`, are rejected with `403 Forbidden`.
 pub fn vsn_supported(vsn vsn: Option(String)) -> Bool {
   case vsn {
     Some(version) -> string.starts_with(version, "2.")

--- a/packages/beryl/src/beryl/wire.gleam
+++ b/packages/beryl/src/beryl/wire.gleam
@@ -1,4 +1,4 @@
-//// Phoenix Wire Protocol: encoding/decoding helpers and the canonical
+//// Phoenix wire protocol: encoding and decoding helpers and the canonical
 //// `phoenix_codec()` for `beryl/wire/codec`.
 ////
 //// Phoenix uses a JSON array format: `[join_ref, ref, topic, event, payload]`.
@@ -57,8 +57,8 @@ pub fn phoenix_codec() -> Codec {
 
 /// Parse a JSON string into an `Inbound`.
 ///
-/// Expected format: `[join_ref, ref, topic, event, payload]` where
-/// The `join_ref` and `ref` values can be `null`.
+/// Expected format: `[join_ref, ref, topic, event, payload]`. The `join_ref`
+/// and `ref` values can be `null`.
 pub fn decode_message(json_string: String) -> Result(Inbound, DecodeError) {
   case json.parse(from: json_string, using: decode.dynamic) {
     Ok(value) -> decode_inbound_value(value)
@@ -140,7 +140,10 @@ fn validate_inbound_depth(message: Inbound) -> Result(Inbound, DecodeError) {
   Ok(message)
 }
 
-/// Encode an `Inbound` back to a Phoenix wire JSON string.
+/// Encode an `Inbound` as a Phoenix wire JSON string.
+///
+/// If the payload cannot be represented as JSON or exceeds the maximum
+/// nesting depth, it is encoded as `null`.
 pub fn encode(message: Inbound) -> String {
   let join_ref_json = option_to_json(codec.inbound_join_ref(message))
   let ref_json = option_to_json(codec.inbound_ref(message))

--- a/packages/beryl/src/beryl/wire/codec.gleam
+++ b/packages/beryl/src/beryl/wire/codec.gleam
@@ -148,7 +148,7 @@ pub opaque type Codec {
   )
 }
 
-/// Build a text-only wire codec.
+/// Build a codec without an inbound binary decoder.
 ///
 /// - `decode_text`: decode raw inbound text into a normalized `Inbound`.
 /// - `encode_reply`: encode a reply to a client message:

--- a/packages/beryl_ewe/src/beryl_ewe.gleam
+++ b/packages/beryl_ewe/src/beryl_ewe.gleam
@@ -1,4 +1,4 @@
-//// Ewe WebSocket Transport - Direct Ewe integration for beryl
+//// Ewe WebSocket transport for beryl
 ////
 //// This module provides the bridge between Ewe's native WebSocket handling
 //// and the beryl runtime using Ewe request and response types directly.

--- a/packages/beryl_mist/src/beryl_mist.gleam
+++ b/packages/beryl_mist/src/beryl_mist.gleam
@@ -1,4 +1,4 @@
-//// Mist WebSocket Transport - Direct Mist integration for beryl
+//// Mist WebSocket transport for beryl
 ////
 //// This module provides the bridge between Mist's native WebSocket handling
 //// and the beryl runtime using Mist request and response types directly.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -107,7 +107,7 @@ export default defineConfig({
 							slug: "tutorial",
 						},
 						{
-							label: "1. Elm Architecture without a DOM",
+							label: "1. Elm architecture without a DOM",
 							slug: "tutorial/the-elm-architecture-without-a-dom",
 						},
 						{

--- a/website/src/content/docs/architecture/presence.md
+++ b/website/src/content/docs/architecture/presence.md
@@ -4,9 +4,9 @@ title: Presence
 
 ## How presence stores changes
 
-beryl presence uses an OTP actor and
+beryl presence uses an OTP actor and an **add-wins, observed-remove
+conflict-free replicated data type (CRDT)** from
 [`lattice_presence/presence_state`](https://hex.pm/packages/lattice_presence).
-an **add-wins, observed-remove conflict-free replicated data type (CRDT)**.
 Each cluster node keeps one copy. Nodes can merge their copies in any order.
 Joins and leaves that happen at the same time produce the same final result.
 

--- a/website/src/content/docs/architecture/pubsub-and-distribution.md
+++ b/website/src/content/docs/architecture/pubsub-and-distribution.md
@@ -24,8 +24,6 @@ The Gleam module `beryl/pubsub` calls
 `src/beryl_pubsub_ffi.erl` through `@external` declarations. This small Erlang
 module translates Gleam calls into built-in `pg` functions.
 
-**PubSub functions:**
-
 | Function | Description |
 |---|---|
 | `start(config)` | Start a pg scope (idempotent, safe to call multiple times) |

--- a/website/src/content/docs/examples.mdx
+++ b/website/src/content/docs/examples.mdx
@@ -5,11 +5,10 @@ description: Four runnable beryl examples, including the channel showcase.
 
 import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
 
-This page highlights four runnable applications in the
+Four runnable applications in the
 [`examples/`](https://github.com/tylerbutler/beryl/tree/main/examples)
-directory. The repository also contains the live-poll tutorial, load-test
-server, and shared example helpers. Each featured application uses a
-Gleam/BEAM backend and a browser frontend.
+directory use a Gleam/BEAM backend and a browser frontend. The repository also
+contains the live-poll tutorial, load-test server, and shared example helpers.
 
 The installed package does not include the examples. Clone the repository:
 
@@ -19,7 +18,7 @@ cd beryl
 ```
 
 <Aside type="note" title="Pre-1.0">
-beryl is not yet version 1.0. Minor releases can change the API. The library is not ready for production. Try it and report problems. Your feedback will help define version 1.0.
+beryl is not yet version 1.0. Minor releases can change the API, and the library is not ready for production. Report problems to help define version 1.0.
 </Aside>
 
 ## Showcase

--- a/website/src/content/docs/guides/backend-integration.md
+++ b/website/src/content/docs/guides/backend-integration.md
@@ -158,13 +158,11 @@ For typed updates from a long-lived application actor, use the socket's
 `socket.Sender(message)` with `beryl/bridge`. The bridge forwards messages from
 the actor to `socket.Info(message)`.
 
-## Benefits
+## Why publish from the backend
 
-- **One source of truth:** Your backend manages authentication and the
-  database. beryl sends updates to connected clients.
-- **Publish from trusted processes:** An HTTP handler, worker, or webhook
-  consumer can publish.
-- **Cluster-wide delivery:** With PubSub, one `beryl.broadcast` reaches
-  subscribers on every connected node.
+Your backend remains the source of truth for authentication and database
+writes. Trusted HTTP handlers, workers, and webhook consumers can publish
+updates. With PubSub, one `beryl.broadcast` reaches subscribers on every
+connected node.
 
 For connect-time verification of the tokens your backend issues, see [Authentication](/guides/authentication/).

--- a/website/src/content/docs/guides/dispatch.md
+++ b/website/src/content/docs/guides/dispatch.md
@@ -223,7 +223,7 @@ and choose one of the two models:
   with `channel.child_spec`.
 
 Delete calls to `namespace`, `accept_only`, `unknown_topic`, and `route`; do
-do not rebuild similar routing code. `gleam check` then points to the
+not rebuild similar routing code. `gleam check` then points to the
 remaining `Match` and `Namespace` types that need direct topic values or
 `JoinContext.params`.
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -247,5 +247,5 @@ import { Aside } from '@astrojs/starlight/components';
 </div>
 
 <Aside type="note" title="Pre-1.0">
-beryl is not yet version 1.0. Minor releases can change the API. The library is not ready for production. Try it and report problems. Your feedback will help define version 1.0.
+beryl is not yet version 1.0. Minor releases can change the API, and the library is not ready for production. Report problems to help define version 1.0.
 </Aside>

--- a/website/src/content/docs/installation.md
+++ b/website/src/content/docs/installation.md
@@ -3,9 +3,9 @@ title: Installation
 ---
 
 :::note[Pre-1.0]
-beryl is not yet version 1.0. Minor releases can change the API. The library is
-not ready for production. Try it and report problems. Your feedback will help
-define version 1.0.
+beryl is not yet version 1.0. Minor releases can change the API, and the
+library is not ready for production. Report problems to help define version
+1.0.
 :::
 
 Install beryl packages from

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -3,14 +3,13 @@ title: What is beryl?
 ---
 
 :::note[Pre-1.0]
-beryl is not yet version 1.0. Minor releases can change the API. The library is
-not ready for production. Try it and report problems. Your feedback will help
-define version 1.0.
+beryl is not yet version 1.0. Minor releases can change the API, and the
+library is not ready for production. Report problems to help define version
+1.0.
 :::
 
-beryl is a **type-safe real-time channels and presence library** for Gleam,
-for the Erlang (BEAM) runtime. It helps you add real-time features to Gleam web
-applications.
+beryl is a **type-safe library for real-time Gleam channels and presence** on
+the Erlang (BEAM) runtime.
 
 ## beryl's model in one minute
 

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -6,7 +6,7 @@ description: Build a beryl socket app with a channel handler, WebSocket server, 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
 <Aside type="note" title="Pre-1.0">
-beryl is not yet version 1.0. Minor releases can change the API. The library is not ready for production. Try it and report problems. Your feedback will help define version 1.0.
+beryl is not yet version 1.0. Minor releases can change the API, and the library is not ready for production. Report problems to help define version 1.0.
 </Aside>
 
 This guide shows how to build a real-time app. You will create a Gleam server

--- a/website/src/content/docs/reference/api/beryl-bridge.md
+++ b/website/src/content/docs/reference/api/beryl-bridge.md
@@ -1,6 +1,6 @@
 ---
 title: "beryl/bridge"
-description: "Bridge - Forward an external OTP actor's message stream to a socket via its `Sender`."
+description: "Forward an external OTP actor's message stream to a socket through its `Sender`."
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 2
@@ -14,8 +14,8 @@ tableOfContents:
 
 <div class="api-reference-marker" aria-hidden="true"></div>
 
-Bridge - Forward an external OTP actor's message stream to a socket via
- its `Sender`.
+Forward an external OTP actor's message stream to a socket through its
+ `Sender`.
 
  A common pattern is a long-lived domain actor (e.g. a per-document
  session) that emits updates which need to be pushed to a connected

--- a/website/src/content/docs/reference/api/beryl-group.md
+++ b/website/src/content/docs/reference/api/beryl-group.md
@@ -1,6 +1,6 @@
 ---
 title: "beryl/group"
-description: "Channel Groups - Named collections of topics for multi-topic broadcasting"
+description: "Topic groups"
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 2
@@ -14,11 +14,10 @@ tableOfContents:
 
 <div class="api-reference-marker" aria-hidden="true"></div>
 
-Channel Groups - Named collections of topics for multi-topic broadcasting
+Topic groups
 
- Groups let you organize topics and broadcast to all of them at once.
- Useful for scenarios like broadcasting to all channels in a "team" or
- sending a system-wide notification.
+ Groups organize topics for broadcasts to several topics at once, such as
+ every channel in a team or a system-wide notification.
 
  Groups are independent of the beryl runtime and run under your
  application's supervision tree.
@@ -127,8 +126,9 @@ A running groups instance.
 
  The stable registered subject is resolved on the caller's node. Keep a
  `Groups` handle on the node where its child specification runs. Calls from
- another BEAM node cannot reach the owning actor; synchronous operations
- panic as unavailable, and fire-and-forget broadcasts are not delivered.
+ another BEAM node cannot reach the owning actor. All public operations,
+ including `broadcast`, panic if the actor is unavailable or the call times
+ out.
 
 <div class="api-entry-anchor" id="api-type-message" aria-hidden="true"></div>
 

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -1,6 +1,6 @@
 ---
 title: "beryl/presence"
-description: "Presence - Distributed presence tracking backed by a CRDT"
+description: "Distributed presence tracking with a CRDT"
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 2
@@ -14,14 +14,15 @@ tableOfContents:
 
 <div class="api-reference-marker" aria-hidden="true"></div>
 
-Presence - Distributed presence tracking backed by a CRDT
+Distributed presence tracking with a CRDT
 
- Wraps the pure `lattice_presence/presence_state` CRDT in an OTP actor that:
+ This module wraps the pure `lattice_presence/presence_state` CRDT in an
+ OTP actor that:
  - Handles track/update/untrack calls
  - Publishes an actor-owned ETS read model
  - Periodically broadcasts state via PubSub for cross-node replication
  - Receives remote state from PubSub and merges it internally
- - Invokes `on_diff` callback when merges produce non-empty diffs
+ - Invokes `on_diff` when local changes or merges produce non-empty diffs
 
  Presence is independent of the beryl runtime and runs under your
  application's supervision tree.
@@ -257,10 +258,10 @@ pub fn default_config(String) -> Config
 
 Default configuration (no PubSub).
 
- The broadcast interval defaults to 1500 ms. Adding `with_pubsub` therefore
- enables two-way replication without more configuration. Without PubSub,
- the interval is unused. Use `with_broadcast_interval(0)` to disable
- periodic broadcasts and control replication manually.
+ The broadcast interval defaults to 1500 ms. Adding `with_pubsub` enables
+ periodic outbound broadcasts and inbound replication. Without PubSub, the
+ interval is unused. Use a non-positive interval to disable periodic
+ outbound broadcasts.
 
 <div class="api-entry-anchor" id="api-function-diff" aria-hidden="true"></div>
 
@@ -461,7 +462,7 @@ pub fn with_broadcast_interval(
 
 Set how often presence state is broadcast for replication.
 
- Use `0` to disable periodic broadcasts.
+ Use a non-positive value to disable periodic broadcasts.
 
 <div class="api-entry-anchor" id="api-function-with_call_timeout" aria-hidden="true"></div>
 
@@ -494,7 +495,7 @@ pub fn with_on_diff(
 Set the callback for diffs from local changes or remote merges.
 
  The callback runs synchronously on the presence actor, for both local
- mutations (`track`/`untrack`/`untrack_all`, and the asynchronous
+ mutations (`track`/`update`/`untrack`/`untrack_all`, and the asynchronous
  mutations the runtime issues for presence effects) and remote merges,
  before the affected topics' read-model snapshots are (re)published and
  before the triggering call replies or the mutation is acknowledged.
@@ -513,8 +514,9 @@ Set the callback for diffs from local changes or remote merges.
  the reply to (or acknowledgement of) the mutating operation, and every
  other message behind it in the actor's mailbox. Concurrent
  `list`/`get_by_key`/`count` calls from other processes do not use the
- mailbox and are not delayed. Only the socket with an active presence
- effect waits for the callback.
+ mailbox and are not delayed. A socket with an active presence effect waits
+ for the callback. Callers of synchronous mutations also wait for their
+ replies.
 
 <div class="api-entry-anchor" id="api-function-with_pubsub" aria-hidden="true"></div>
 

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -1,6 +1,6 @@
 ---
 title: "beryl/pubsub"
-description: "PubSub - Distributed publish/subscribe using Erlang pg"
+description: "Distributed PubSub with Erlang `pg`"
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 2
@@ -14,11 +14,11 @@ tableOfContents:
 
 <div class="api-reference-marker" aria-hidden="true"></div>
 
-PubSub - Distributed publish/subscribe using Erlang pg
+Distributed PubSub with Erlang `pg`
 
- Provides topic-based pub/sub messaging backed by Erlang's built-in `pg`
- module. Subscribers are tracked by process group, so messages are delivered
- to all nodes in the cluster automatically.
+ This module provides topic-based PubSub backed by Erlang's built-in `pg`
+ module. Subscribers are tracked by process group, so messages are
+ delivered to all connected nodes in the cluster.
 
  The payload is generic: `PubSub(payload)` and `Message(payload)` carry
  whatever Gleam type a given scope is started with. A broadcast sends that
@@ -29,7 +29,7 @@ PubSub - Distributed publish/subscribe using Erlang pg
  browser); payloads that never leave the cluster are cheaper and safer as
  plain Gleam types.
 
- ## Quick Start
+ ## Quick start
 
  ```gleam
  let pubsub_handle = pubsub.start(pubsub.default_config())
@@ -389,8 +389,9 @@ pub fn start(PubSubConfig) -> PubSub(a)
 
 Start a PubSub instance.
 
- This starts a pg scope. If another node or an earlier call started the
- scope, this function does nothing.
+ This starts the configured `pg` scope on the current node. Repeated calls
+ on the same node are harmless. Each participating node must start the same
+ scope.
 
  `payload` is fixed by how the returned value is used or annotated at the
  call site. For example: `pubsub.start(config) : PubSub(MySyncPayload)`.

--- a/website/src/content/docs/reference/api/beryl-socket.md
+++ b/website/src/content/docs/reference/api/beryl-socket.md
@@ -333,8 +333,9 @@ Broadcast a presence snapshot for a topic to all its subscribers,
 KickTopic(topic: String)
 ```
 
-Close this socket's subscription to a topic. The topic receives a
- `Closed(topic, Shutdown)` input and the client a terminal frame.
+Close this socket's subscription to a topic. The topic receives
+ `Closed(topic, Shutdown)`. If the codec has a close encoder, the client
+ also receives its terminal frame.
 
 <div class="api-entry-anchor" id="api-type-input" aria-hidden="true"></div>
 
@@ -485,7 +486,8 @@ Stop(reason: StopReason)
 ```
 
 Tear down the socket: every joined topic receives a `Closed` input,
- terminal frames are sent, and the transport connection is closed.
+ configured terminal frames are sent, and the transport connection is
+ closed.
 
 <div class="api-entry-anchor" id="api-type-replyref" aria-hidden="true"></div>
 

--- a/website/src/content/docs/reference/api/beryl-transport-origin.md
+++ b/website/src/content/docs/reference/api/beryl-transport-origin.md
@@ -142,8 +142,6 @@ pub fn vsn_supported(vsn: option.Option(String)) -> Bool
 Check a client's requested wire protocol version (the `?vsn=` query
  parameter sent by Phoenix clients) before upgrading.
 
- beryl uses the Phoenix V2 array framing, so it accepts `vsn=2.x`. A
- missing `vsn` (`None`) is accepted for non-Phoenix clients speaking the
- configured codec. Anything else (e.g. the V1 object framing's `vsn=1.0.0`)
- is rejected. Transports fail the handshake with `403 Forbidden` instead
- of accepting a connection with frames that cannot be decoded.
+ Accept a missing `vsn` or a value beginning with `2.`. Custom-codec clients
+ must omit `vsn` unless they use that version form. Other values, such as
+ the V1 object framing's `vsn=1.0.0`, are rejected with `403 Forbidden`.

--- a/website/src/content/docs/reference/api/beryl-wire-codec.md
+++ b/website/src/content/docs/reference/api/beryl-wire-codec.md
@@ -460,7 +460,7 @@ pub fn new(
 ) -> Codec
 ```
 
-Build a text-only wire codec.
+Build a codec without an inbound binary decoder.
 
  - `decode_text`: decode raw inbound text into a normalized `Inbound`.
  - `encode_reply`: encode a reply to a client message:

--- a/website/src/content/docs/reference/api/beryl-wire.md
+++ b/website/src/content/docs/reference/api/beryl-wire.md
@@ -1,6 +1,6 @@
 ---
 title: "beryl/wire"
-description: "Phoenix Wire Protocol: encoding/decoding helpers and the canonical `phoenix_codec()` for `beryl/wire/codec`."
+description: "Phoenix wire protocol: encoding and decoding helpers and the canonical `phoenix_codec()` for `beryl/wire/codec`."
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 2
@@ -14,7 +14,7 @@ tableOfContents:
 
 <div class="api-reference-marker" aria-hidden="true"></div>
 
-Phoenix Wire Protocol: encoding/decoding helpers and the canonical
+Phoenix wire protocol: encoding and decoding helpers and the canonical
  `phoenix_codec()` for `beryl/wire/codec`.
 
  Phoenix uses a JSON array format: `[join_ref, ref, topic, event, payload]`.
@@ -198,8 +198,8 @@ pub fn decode_message(String) -> Result(codec.Inbound, codec.DecodeError)
 
 Parse a JSON string into an `Inbound`.
 
- Expected format: `[join_ref, ref, topic, event, payload]` where
- The `join_ref` and `ref` values can be `null`.
+ Expected format: `[join_ref, ref, topic, event, payload]`. The `join_ref`
+ and `ref` values can be `null`.
 
 <div class="api-entry-anchor" id="api-function-dynamic_to_json" aria-hidden="true"></div>
 
@@ -222,7 +222,10 @@ Convert a `Dynamic` value decoded from JSON back to `json.Json`.
 pub fn encode(codec.Inbound) -> String
 ```
 
-Encode an `Inbound` back to a Phoenix wire JSON string.
+Encode an `Inbound` as a Phoenix wire JSON string.
+
+ If the payload cannot be represented as JSON or exceeds the maximum
+ nesting depth, it is encoded as `null`.
 
 <div class="api-entry-anchor" id="api-function-format_decode_error" aria-hidden="true"></div>
 

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -1,6 +1,6 @@
 ---
 title: "beryl"
-description: "beryl - Type-safe real-time communication"
+description: "beryl: type-safe real-time communication"
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 2
@@ -14,11 +14,11 @@ tableOfContents:
 
 <div class="api-reference-marker" aria-hidden="true"></div>
 
-beryl - Type-safe real-time communication
+beryl: type-safe real-time communication
 
- A standalone Gleam library for building real-time applications on the BEAM.
- Provides app-side WebSocket dispatch, distributed presence tracking,
- pub/sub messaging, and topic groups.
+ beryl is a standalone Gleam library for building real-time applications on
+ the BEAM. It provides app-side WebSocket dispatch, distributed presence
+ tracking, PubSub messaging, and topic groups.
 
  ## Features
 
@@ -31,7 +31,7 @@ beryl - Type-safe real-time communication
  - **Groups**: Named collections of topics for multi-topic broadcasting
    (`beryl/group`)
 
- ## Quick Start
+ ## Quick start
 
  ```gleam
  import beryl
@@ -40,6 +40,7 @@ beryl - Type-safe real-time communication
  }
  import beryl/pubsub
  import beryl/wire
+ import gleam/json
  import gleam/option
  import gleam/otp/static_supervisor
 
@@ -417,11 +418,10 @@ Build the app-side dispatch supervision child specification.
 pub fn config(codec.Codec) -> Config
 ```
 
-Build a configuration with sensible defaults.
+Build a configuration with the default settings.
 
- A `codec` is required. beryl no longer provides an implicit Phoenix
- default. Pass `wire.phoenix_codec()` to keep Phoenix wire compatibility,
- or your own `Codec` for a custom framing.
+ Pass `wire.phoenix_codec()` for Phoenix framing or a custom `Codec` for
+ another framing.
 
 <div class="api-entry-anchor" id="api-function-logging_config" aria-hidden="true"></div>
 
@@ -670,9 +670,8 @@ Configure the maximum number of concurrent connections allowed per client
  If beryl runs behind a trusted reverse proxy or load balancer, every
  connection shares the proxy's address, so a per-IP limit throttles all
  clients as a single IP. In that topology you must resolve the real client
- IP yourself at the proxy layer (for example, by enforcing limits there). A
- built-in trusted-proxy opt-in may be added in a future release. See the
- WebSocket transport guide for deployment guidance.
+ IP yourself at the proxy layer, for example by enforcing limits there. See
+ the WebSocket transport guide for deployment guidance.
 
 <div class="api-entry-anchor" id="api-function-with_max_event_length" aria-hidden="true"></div>
 
@@ -786,7 +785,9 @@ pub fn with_payload_preview_bytes(
 ) -> LoggingConfig
 ```
 
-Configure the maximum payload/frame preview length for logs.
+Configure the maximum payload and frame preview length for logs.
+
+ The `bytes` argument is measured in grapheme clusters.
 
 <div class="api-entry-anchor" id="api-function-with_presence_handle" aria-hidden="true"></div>
 

--- a/website/src/content/docs/reference/api/beryl_ewe.md
+++ b/website/src/content/docs/reference/api/beryl_ewe.md
@@ -1,6 +1,6 @@
 ---
 title: "beryl_ewe"
-description: "Ewe WebSocket Transport - Direct Ewe integration for beryl"
+description: "Ewe WebSocket transport for beryl"
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 2
@@ -14,7 +14,7 @@ tableOfContents:
 
 <div class="api-reference-marker" aria-hidden="true"></div>
 
-Ewe WebSocket Transport - Direct Ewe integration for beryl
+Ewe WebSocket transport for beryl
 
  This module provides the bridge between Ewe's native WebSocket handling
  and the beryl runtime using Ewe request and response types directly.

--- a/website/src/content/docs/reference/api/beryl_mist.md
+++ b/website/src/content/docs/reference/api/beryl_mist.md
@@ -1,6 +1,6 @@
 ---
 title: "beryl_mist"
-description: "Mist WebSocket Transport - Direct Mist integration for beryl"
+description: "Mist WebSocket transport for beryl"
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 2
@@ -14,7 +14,7 @@ tableOfContents:
 
 <div class="api-reference-marker" aria-hidden="true"></div>
 
-Mist WebSocket Transport - Direct Mist integration for beryl
+Mist WebSocket transport for beryl
 
  This module provides the bridge between Mist's native WebSocket handling
  and the beryl runtime using Mist request and response types directly.

--- a/website/src/content/docs/reference/api/index.md
+++ b/website/src/content/docs/reference/api/index.md
@@ -22,11 +22,11 @@ The generator creates pages under `/reference/api/` from Gleam docs metadata. Th
 <ul class="api-module-list">
 <li class="api-module-list__item">
   <a class="api-module-list__name" href="/reference/api/beryl/"><code>beryl</code></a>
-  <p>beryl - Type-safe real-time communication</p>
+  <p>beryl: type-safe real-time communication</p>
 </li>
 <li class="api-module-list__item">
   <a class="api-module-list__name" href="/reference/api/beryl-bridge/"><code>beryl/bridge</code></a>
-  <p>Bridge - Forward an external OTP actor's message stream to a socket via its <code>Sender</code>.</p>
+  <p>Forward an external OTP actor's message stream to a socket through its <code>Sender</code>.</p>
 </li>
 <li class="api-module-list__item">
   <a class="api-module-list__name" href="/reference/api/beryl-channel/"><code>beryl/channel</code></a>
@@ -38,11 +38,11 @@ The generator creates pages under `/reference/api/` from Gleam docs metadata. Th
 </li>
 <li class="api-module-list__item">
   <a class="api-module-list__name" href="/reference/api/beryl-group/"><code>beryl/group</code></a>
-  <p>Channel Groups - Named collections of topics for multi-topic broadcasting</p>
+  <p>Topic groups</p>
 </li>
 <li class="api-module-list__item">
   <a class="api-module-list__name" href="/reference/api/beryl-presence/"><code>beryl/presence</code></a>
-  <p>Presence - Distributed presence tracking backed by a CRDT</p>
+  <p>Distributed presence tracking with a CRDT</p>
 </li>
 <li class="api-module-list__item">
   <a class="api-module-list__name" href="/reference/api/beryl-presence-wire/"><code>beryl/presence/wire</code></a>
@@ -50,7 +50,7 @@ The generator creates pages under `/reference/api/` from Gleam docs metadata. Th
 </li>
 <li class="api-module-list__item">
   <a class="api-module-list__name" href="/reference/api/beryl-pubsub/"><code>beryl/pubsub</code></a>
-  <p>PubSub - Distributed publish/subscribe using Erlang pg</p>
+  <p>Distributed PubSub with Erlang <code>pg</code></p>
 </li>
 <li class="api-module-list__item">
   <a class="api-module-list__name" href="/reference/api/beryl-socket/"><code>beryl/socket</code></a>
@@ -78,7 +78,7 @@ The generator creates pages under `/reference/api/` from Gleam docs metadata. Th
 </li>
 <li class="api-module-list__item">
   <a class="api-module-list__name" href="/reference/api/beryl-wire/"><code>beryl/wire</code></a>
-  <p>Phoenix Wire Protocol: encoding/decoding helpers and the canonical <code>phoenix_codec()</code> for <code>beryl/wire/codec</code>.</p>
+  <p>Phoenix wire protocol: encoding and decoding helpers and the canonical <code>phoenix_codec()</code> for <code>beryl/wire/codec</code>.</p>
 </li>
 <li class="api-module-list__item">
   <a class="api-module-list__name" href="/reference/api/beryl-wire-codec/"><code>beryl/wire/codec</code></a>
@@ -91,7 +91,7 @@ The generator creates pages under `/reference/api/` from Gleam docs metadata. Th
 <ul class="api-module-list">
 <li class="api-module-list__item">
   <a class="api-module-list__name" href="/reference/api/beryl_ewe/"><code>beryl_ewe</code></a>
-  <p>Ewe WebSocket Transport - Direct Ewe integration for beryl</p>
+  <p>Ewe WebSocket transport for beryl</p>
 </li>
 </ul>
 
@@ -100,6 +100,6 @@ The generator creates pages under `/reference/api/` from Gleam docs metadata. Th
 <ul class="api-module-list">
 <li class="api-module-list__item">
   <a class="api-module-list__name" href="/reference/api/beryl_mist/"><code>beryl_mist</code></a>
-  <p>Mist WebSocket Transport - Direct Mist integration for beryl</p>
+  <p>Mist WebSocket transport for beryl</p>
 </li>
 </ul>

--- a/website/src/content/docs/tutorial/the-elm-architecture-without-a-dom.md
+++ b/website/src/content/docs/tutorial/the-elm-architecture-without-a-dom.md
@@ -1,5 +1,5 @@
 ---
-title: The Elm Architecture, without a DOM
+title: The Elm architecture, without a DOM
 description: Learn beryl's model-update architecture by building the first read-only stage of a live poll.
 ---
 

--- a/website/src/content/docs/tutorial/where-the-analogy-ends.md
+++ b/website/src/content/docs/tutorial/where-the-analogy-ends.md
@@ -11,7 +11,7 @@ It does not bring your socket state back after a crash. One router actor keeps
 the list of sockets and sends broadcasts to them. Each socket actor calls your
 update function and runs the effects it returns, in order.
 
-The production decisions start where the frontend analogy ends.
+The frontend analogy does not cover beryl's production behavior.
 
 ## Follow one frame
 
@@ -94,8 +94,7 @@ The channel's sender can still reach the old channel until the client joins the
 topic again or the socket ends. Client traffic cannot reach it, because the
 topic is closed. Keep `on_terminate` small. Do not do half-finished work there.
 
-This policy contains crashes in your callbacks. It does not pretend that every
-crash has the same size.
+The runtime limits callback crashes to the affected join, topic, or socket.
 
 ## A restart restores the service, not socket state
 


### PR DESCRIPTION
## Summary

- tighten website copy and remove formulaic phrasing
- correct inaccurate public API comments and examples
- regenerate API reference pages from the Gleam source docs
- add beryl and beryl_mist changelog fragments

## Checks

- Gleam format, check, tests, strict build, and docs
- documentation snippet type-checking and website build
- example builds and Playwright tests
- trellis changelog check and doctor