### PR TITLE
chore(dev): add local dependency audits

### DIFF
--- a/.changes/unreleased/beryl-allow-isc-licensed-dependencies.toml
+++ b/.changes/unreleased/beryl-allow-isc-licensed-dependencies.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Changed"
+body = "Allow ISC-licensed dependencies in local licence audits."

--- a/.changes/unreleased/beryl_ewe-allow-isc-licensed-dependencies.toml
+++ b/.changes/unreleased/beryl_ewe-allow-isc-licensed-dependencies.toml
@@ -1,0 +1,3 @@
+package = "beryl_ewe"
+kind = "Changed"
+body = "Allow ISC-licensed dependencies in local licence audits."

--- a/.changes/unreleased/beryl_mist-allow-isc-licensed-dependencies.toml
+++ b/.changes/unreleased/beryl_mist-allow-isc-licensed-dependencies.toml
@@ -1,0 +1,3 @@
+package = "beryl_mist"
+kind = "Changed"
+body = "Allow ISC-licensed dependencies in local licence audits."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_call:
 
+env:
+  HEXPM_READ_API_KEY: ${{ secrets.HEXPM_API_KEY }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,8 @@
 [tools]
 "github:tylerbutler/trellis" = "0.11.2"
 "github:erlang/rebar3" = "3.24.0"
+# Auto-select the platform archive with bundled Erlang, not the OTP 28 escript.
+"github:tylerbutler/licence_audit" = "v0.11.1"
 
 [env]
 LC_ALL = "en_US.UTF-8"

--- a/DEV.md
+++ b/DEV.md
@@ -66,6 +66,41 @@ just format
 just pr
 ```
 
+### Dependency audits
+
+Local audit tasks use `licence_audit` v0.11.1, pinned in `.mise.toml`.
+Install it with `mise install github:tylerbutler/licence_audit`. mise selects
+the self-contained platform archive; the repo's Erlang version is unchanged.
+
+```bash
+just audit-licences          # Report licences and preview the existing policy
+just audit-vulns             # Report known vulnerabilities from OSV
+just audit-check             # Enforce licences and the vulnerability threshold
+just audit-check beryl_mist  # Limit the task to one package
+```
+
+These tasks default to `beryl`, `beryl_mist`, and `beryl_ewe`. Each command runs
+in the package directory and reads its locked manifest. Licence reports and
+enforcement use its existing `[tools.licence_audit]` policy.
+Examples are not included by default. To report on an example, pass its
+package name, such as `just audit-licences cursor`.
+Examples need an approved licence policy before licence enforcement is useful.
+
+The report tasks do not fail on findings; `audit-check` uses `check --vulns`
+and propagates failures. The existing policies allow Apache-2.0, ISC, and MIT.
+The default vulnerability threshold is `high`; unknown severity does not
+block. No audit task is part of CI or `just ci`.
+
+Licence reports cover locked Hex dependencies, not Git or local path sources.
+Vulnerability reports cover Hex and GitHub dependencies; other sources are
+skipped. This does not audit npm dependencies. OSV requires network access;
+an unavailable service means the audit is incomplete.
+
+Use `mise exec -- licence_audit --version` to see the installed version.
+If Hex metadata requests time out, the licence audit is incomplete. Retry the
+task without changing the policy; report-task success alone does not mean
+that all metadata was fetched.
+
 ### Before Merging to Main
 
 ```bash

--- a/gleam.toml
+++ b/gleam.toml
@@ -37,6 +37,15 @@ default = "git_only"
 command = "gleam run -m glinter"
 needs_deps = true
 
+[tools.trellis.tasks.audit-licences]
+command = "mise exec -- licence_audit"
+
+[tools.trellis.tasks.audit-vulns]
+command = "mise exec -- licence_audit vulns"
+
+[tools.trellis.tasks.audit-check]
+command = "mise exec -- licence_audit check --vulns"
+
 [tools.trellis.changelog]
 strictness = "warn"
 kinds = [

--- a/justfile
+++ b/justfile
@@ -60,6 +60,18 @@ lint:
 doctor:
     trellis doctor
 
+# Report locked dependency licences (defaults to the three library packages)
+audit-licences *PACKAGES="beryl beryl_mist beryl_ewe":
+    mise exec -- trellis run audit-licences --serial {{ PACKAGES }}
+
+# Report known vulnerabilities; findings do not fail this task
+audit-vulns *PACKAGES="beryl beryl_mist beryl_ewe":
+    mise exec -- trellis run audit-vulns --serial {{ PACKAGES }}
+
+# Enforce each package's licence policy and vulnerability threshold
+audit-check *PACKAGES="beryl beryl_mist beryl_ewe":
+    mise exec -- trellis run audit-check --serial --keep-going {{ PACKAGES }}
+
 # === DOCUMENTATION ===
 
 # Build Gleam API documentation for publishable workspace packages

--- a/packages/beryl/gleam.toml
+++ b/packages/beryl/gleam.toml
@@ -33,7 +33,7 @@ phoenix_channel_fixtures = { git = "https://github.com/tylerbutler/phoenix_chann
 glinter = ">= 2.19.0 and < 3.0.0"
 
 [tools.licence_audit]
-allow = ["Apache-2.0", "MIT"]
+allow = ["Apache-2.0", "ISC", "MIT"]
 deny = []
 
 [tools.glinter]

--- a/packages/beryl_ewe/gleam.toml
+++ b/packages/beryl_ewe/gleam.toml
@@ -21,7 +21,7 @@ gleam_otp = ">= 1.2.0 and < 2.0.0"
 glinter = ">= 2.19.0 and < 3.0.0"
 
 [tools.licence_audit]
-allow = ["Apache-2.0", "MIT"]
+allow = ["Apache-2.0", "ISC", "MIT"]
 deny = []
 
 [tools.glinter]

--- a/packages/beryl_mist/gleam.toml
+++ b/packages/beryl_mist/gleam.toml
@@ -23,7 +23,7 @@ gluegun = { git = "https://github.com/tylerbutler/gluegun.git", ref = "532af1ac0
 glinter = ">= 2.19.0 and < 3.0.0"
 
 [tools.licence_audit]
-allow = ["Apache-2.0", "MIT"]
+allow = ["Apache-2.0", "ISC", "MIT"]
 deny = []
 
 [tools.glinter]


### PR DESCRIPTION
## Summary

- Pin `licence_audit` v0.11.1 through mise, using the self-contained platform binary without changing Erlang.
- Add `just audit-licences`, `just audit-vulns`, and `just audit-check`, with package selection and all three library packages as the default.
- Allow ISC alongside Apache-2.0 and MIT in each package's existing policy, and add changelog fragments.
- Document local usage, audit coverage, and failure handling in `DEV.md`. Leave CI enforcement and vulnerability thresholds unchanged.
