### PR TITLE
docs: align architecture with runtime

### DIFF
--- a/.changes/unreleased/beryl-correct-architecture-and-supervision.toml
+++ b/.changes/unreleased/beryl-correct-architecture-and-supervision.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Correct architecture and supervision documentation to describe socket and topic workers, reconnect recovery, transport writes, and current queue-limit guarantees."

--- a/docs/adr/0002-app-side-dispatch.md
+++ b/docs/adr/0002-app-side-dispatch.md
@@ -106,6 +106,16 @@ the generated [API reference](https://beryl.tylerbutler.com/reference/api/);
 
 ## Scalability and post-1.0 compatibility
 
+> **Superseded topology discussion:** This appendix records the single-actor
+> implementation at the time of this decision. [ADR 0004](0004-channel-process-fault-boundaries.md)
+> subsequently adopted a shared router, one actor per socket for raw dispatch,
+> and one worker per socket/topic pair for the channel layer.
+> [ADR 0005](0005-socket-actor-supervision.md) added the shared socket factory
+> that supervises socket actors as `Temporary` children. Those changes are
+> implemented, not deferred until after 1.0. The socket actor orders protocol
+> effects; the transport connection process performs the writes. The historical
+> decision and compatibility analysis below are retained.
+
 The current implementation runs every application's callbacks in one runtime
 actor. This keeps state ownership and ordering simple, but it also serializes
 all callback work for a channel system in one BEAM process. Therefore, only one

--- a/docs/adr/0004-channel-process-fault-boundaries.md
+++ b/docs/adr/0004-channel-process-fault-boundaries.md
@@ -379,20 +379,23 @@ beryl adopts option 2 for raw dispatch and option 3 for `beryl/channel`.
   Each socket actor starts a linked factory supervisor and one `Temporary`
   worker for each accepted join. The worker owns the channel state and runs
   `join`, `on_message`, `on_info`, and `on_terminate`. The socket actor owns
-  the protocol state, capabilities, subscriptions, presence data, and frame
-  writes.
+  the protocol state, capabilities, subscriptions, presence data, and ordered
+  send requests. The transport connection process performs frame writes.
 
 beryl uses these sequence rules:
 
-- Workers on one socket run concurrently. A slow callback delays only its
-  own topic.
+- Workers on one socket run message and info callbacks concurrently. A slow
+  callback delays its worker, but joins, ordered closes, and presence
+  suspension can also delay the socket actor's effect processing.
 - beryl does not define an order between different topics on one socket.
   Within one topic, action order is wire order.
 - The worker runs `join` during initialization. The socket actor waits for a
   maximum of 5 seconds. It rejects the join after this timeout. Joins on
   different sockets do not wait for each other.
 - beryl does not limit worker mailboxes or pending reports.
-  [#249](https://github.com/tylerbutler/beryl/issues/249) tracks this work.
+  [#397](https://github.com/tylerbutler/beryl/issues/397) tracks these and other
+  runtime queue contracts. [#249](https://github.com/tylerbutler/beryl/issues/249)
+  separately tracks outbound connection queues and slow-client eviction.
 - The socket actor owns presence suspension. Workers send presence actions to
   the socket actor. The socket actor applies the existing order rules.
 - The socket actor sends a close to the worker before it drops the topic's
@@ -413,9 +416,20 @@ Contract changes recorded with this decision:
   `phx_error`. The runtime cannot run `on_terminate` because the worker held
   the channel state. The client must rejoin. This behavior matches Phoenix.
 
-[#371](https://github.com/tylerbutler/beryl/pull/371) contains the performance
-results. ADRs 0002 and 0003 remain authoritative for the raw and channel APIs.
-This ADR changes only their process topology.
+[#371](https://github.com/tylerbutler/beryl/pull/371) provides protocol-smoke
+evidence, not comparative performance evidence for this topology. The
+[ADR 0005 results](0005-socket-actor-supervision.md#results) compare direct
+and factory startup at a requested 2,000 connections per second with Mist on
+Erlang 27.2.1 and 12 schedulers, with three runs per design. That narrow
+start-rate result does not establish general capacity, queue bounds, or
+healthy-sibling latency under load.
+
+[#400](https://github.com/tylerbutler/beryl/issues/400) tracks the broader
+workload baselines. ADRs 0002 and 0003 remain authoritative for the raw and
+channel APIs. This ADR changes their process topology;
+[ADR 0005](0005-socket-actor-supervision.md) subsequently adds the shared
+factory that owns socket actors as `Temporary` children. Neither socket nor
+topic supervision reconstructs a session: clients reconnect and rejoin.
 
 ## Sources
 

--- a/docs/architecture-deck.md
+++ b/docs/architecture-deck.md
@@ -32,7 +32,7 @@ to start contributing.
 - App-side dispatch on OTP actors and Erlang `pg`: one `init`/`update` pair per app
 - Pluggable wire codec + WebSocket transport (Mist, Ewe)
 - Presence and groups are independent, app-owned OTP actors
-- One runtime actor per app dispatches events and applies effects
+- One shared router, a temporary actor per socket, and optional per-topic workers
 - PubSub is the only cross-node primitive
 
 ```mermaid
@@ -51,11 +51,11 @@ flowchart TB
 <!--
 Speaker notes:
 Read the diagram from top to bottom. A raw WebSocket frame enters the
-transport. The wire codec converts bytes into typed messages. One OTP runtime
-actor for each app sends typed `Input` values to the app's `update` function
-and applies the returned `Effect` list. beryl has no channel registry or
-per-channel callback modules. One `update` function handles all relevant
-topics and routes them by matching the topic string. PubSub is the only
+transport. The wire codec converts bytes into typed messages. The shared
+router forwards them to the socket actor. Raw dispatch runs `init` and
+`update` there; the channel layer runs callbacks in a worker for each
+socket/topic join. The socket actor applies effects in order and enqueues
+outbound frames for the transport connection process to write. PubSub is the only
 primitive that crosses node boundaries. All layers above PubSub are local to
 one node. Each box is an independent layer that you can inspect and test. The
 runtime connects these layers.
@@ -69,7 +69,8 @@ runtime connects these layers.
 |---|---|
 | `beryl` | Public entry-point: `config`, `child_spec`, `stop`, `broadcast` |
 | `beryl/socket` | App dispatch contract: `Input`, `Next`, `Effect`, `Sender`, `ConnectInfo` |
-| `beryl/runtime` | Internal OTP actor: socket tracking, dispatch, effect interpretation, heartbeat |
+| `beryl/runtime` | Router, supervised socket actors, topic workers, effects, heartbeat |
+| `beryl/channel` | Typed handlers and per-topic state, run in topic workers |
 | `beryl/pubsub` | Distributed pub-sub via Erlang `pg`; typed `Subscriber(payload)` |
 | `beryl/presence` | Add-wins OR-set CRDT; track/untrack, dirty full-state replication |
 | `beryl/wire` | Pluggable codec; ships `phoenix_codec()` |
@@ -95,31 +96,30 @@ match a `Join` or `Message` topic against an application pattern.
 
 ## The runtime: effect interpreter at the center
 
-The runtime is a **single OTP actor**, one for each `Sockets` handle. It tracks:
+The runtime divides work between **a shared router and per-socket actors**:
 
-- **Socket state**: `socket_id → {model, send_fn, joined topics, last_heartbeat}`
-- **App contract**: calls `init`/`update` and applies the returned `Effect`s
-- **PubSub subscriptions**: one pg group for each joined topic
-- **Heartbeat timer**: removes stale sockets at the deadline
+- **Router**: admission, socket table, topic subscriber index, PubSub fan-out
+- **Socket actor**: raw model, `init`/`update`, refs, effects, heartbeat timer
+- **Topic worker**: channel state and callbacks for one socket/topic join
+- **Transport connection process**: WebSocket state and frame writes
 
-All inbound frames, PubSub deliveries, and `Info` messages pass through its
-mailbox in sequence. Effects apply in strict list order within one turn.
+The socket actor orders effects and enqueues frames. The connection process
+writes them. Topic workers can run concurrently; raw callbacks on one socket
+remain sequential.
 
 <!--
 Speaker notes:
-This slide replaces the former coordinator and channel registry model. beryl
-does not need a registry because it does not look up per-topic handlers. One
-`update` function handles each event for each socket on this runtime.
+Runtime names the whole process arrangement, not one actor. The router does
+not run application callbacks. Each socket actor owns its raw model and
+protocol state. With channel.child_spec, each accepted socket/topic join
+also has a worker that owns its private channel state.
 
-The runtime owns four types of state. Socket state contains the app's `model`,
-not a beryl `assigns` record. The app contract contains `init`, `update`, and
-the `Effect` list that `update` returns. PubSub subscriptions receive
-broadcasts. The heartbeat timer removes dead sockets.
-
-One actor processes each mailbox message in sequence. This design avoids
-mutexes and races in socket or topic state. Effect order equals wire order.
-The actor performs bookkeeping, dispatch, and effect application. Applications
-scale across nodes through `pg`.
+The socket actor applies ordered effect lists, including worker reports.
+Presence mutations can suspend a list. Send functions enqueue requests for
+Mist or Ewe; they do not confirm a completed network write. Workers on
+different topics can run concurrently, but their effects still pass through
+the socket actor. Shared router work and connection writes remain possible
+sources of delay.
 -->
 
 ---
@@ -130,25 +130,38 @@ scale across nodes through `pg`.
 flowchart LR
   subgraph App["your application supervision tree"]
     AppSup["application supervisor"] --> Sup["beryl subtree supervisor<br/>OneForOne"]
-    Sup --> Rt["runtime<br/>Transient · significant"]
+    Sup --> Factory["socket factory<br/>Permanent"]
+    Factory --> Socket["socket actors<br/>Temporary"]
+    Socket --> Topics["linked topic supervisor (channel layer)<br/>Temporary topic workers"]
+    Sup --> Rt["router<br/>Transient · significant"]
     Sup --> Lim["connection limiter (optional)"]
   end
 ```
 
 - `child_spec` returns a child specification for the runtime subtree and a stable handle
 - Add the subtree to *your* application supervisor
+- Temporary children do not restart sessions: clients reconnect and rejoin
 - beryl **borrows** PubSub, presence, and groups. They are not children of this subtree.
 
 <!--
 Speaker notes:
 `beryl.child_spec` provides one supervised entry point. It validates and builds the
-OneForOne subtree (runtime as the significant, transient child, plus an
-optional connection limiter sibling), then hands back a
+OneForOne subtree (socket factory, significant transient router, and an
+optional connection limiter), then hands back a
 `ChildSpecification` that the caller passes to `static_supervisor.add`. The
 application supervisor owns the lifecycle. Presence, PubSub, and groups are
 not part of this tree. The application starts and owns them, and the runtime
 borrows their handles. `beryl.stop` terminates only beryl's subtree. It does
 not terminate the PubSub instance, presence actor, or group actors.
+
+The transport requests a temporary socket child from the shared factory.
+The router registers that child before init runs in the socket actor, so
+slow init does not block the factory's start operation. Router and socket
+actors retain mutual monitors. A socket fault closes one connection; a
+topic-worker fault closes one topic. A router or factory fault closes all
+connections in that runtime. A factory restart does not restart the router.
+The factory starts before the router so graceful shutdown drains the router
+and sockets before the factory terminates remaining children.
 -->
 
 ---
@@ -260,8 +273,9 @@ runtime delivers a `Message` event to `update`, and the returned `Effect`
 list controls the next operations. `ReplyOk` and `ReplyError` answer the
 message ref. `Push` sends an unsolicited message to this socket.
 `Broadcast` and `BroadcastFrom` send an event to a topic's subscribers.
-`Stop` in `Next` closes the complete socket. Effects run in list order during
-one actor turn, so list order is wire order. This rule matters when an
+`Stop` in `Next` closes the complete socket. The socket actor applies effects
+and enqueues frames in list order. A presence mutation pauses the remaining
+list until its acknowledgement or timeout. This rule matters when an
 `AcceptJoin` precedes a `Push` in the same list.
 
 The bottom diagram shows fan-out. A broadcast effect enters PubSub (`pg`),
@@ -302,9 +316,9 @@ sequenceDiagram
 <!--
 Speaker notes:
 Both diagrams show liveness and cleanup. In the top flow, Phoenix clients send
-a periodic `heartbeat` on the special `"phoenix"` topic. The runtime replies
-and records the last-seen time. A separate timer checks tracked sockets and
-removes each socket that passes its deadline. This process detects clients
+a periodic `heartbeat` on the special `"phoenix"` topic. The socket actor replies
+and records the last-seen time. Each socket actor has its own timer and
+removes its socket if it passes the deadline. This process detects clients
 that lose their network connection or close without a clean disconnect.
 
 The bottom flow covers clean closes, crashes, kicks, and timeouts. When a
@@ -364,14 +378,15 @@ garbage-collect atoms.
 ```mermaid
 sequenceDiagram
   participant App as app update
-  participant Worker as app presence worker
-  participant Runtime as runtime
+  participant Socket as socket actor
   participant Pres as presence actor
   participant PS as pubsub
   participant Remote as remote replica
-  App->>Worker: nonblocking track / untrack command
-  Worker->>Pres: track / untrack / list
-  Worker->>Runtime: broadcast after completion
+  App->>Socket: PresenceTrack / PresenceUntrack effect
+  Socket->>Pres: asynchronous mutation
+  Note over Socket: pause this socket's ordered effects
+  Pres-->>Socket: acknowledgement
+  Socket->>Socket: broadcast diff, resume effects
   loop every broadcast_interval
     Pres->>PS: broadcast CRDT state
   end
@@ -383,7 +398,7 @@ sequenceDiagram
 
 - Add-wins OR-set CRDT via `lattice_presence/presence_state`
 - App-owned actor: started and supervised separately
-- Synchronous presence calls stay outside the shared runtime
+- Presence effects pause one socket; the presence actor remains shared
 
 <!--
 Speaker notes:
@@ -392,17 +407,19 @@ without a central coordinator or database. Each node runs a presence actor
 that holds one replica of an add-wins OR-set CRDT from `lattice_presence`.
 The application starts and supervises this actor outside beryl's subtree.
 
-Public presence calls are synchronous. An application-owned worker performs
-them outside the shared socket runtime and then broadcasts the result. On a
+Public mutation calls are synchronous; do not call them from app callbacks.
+Use presence effects or channel actions. The socket actor sends a mutation,
+parks its ordered work, and resumes after acknowledgement or timeout.
+Snapshot effects read the published ETS read model. On a
 timer, the presence actor broadcasts its state through PubSub. It also merges
 states from remote replicas. CRDT merges are commutative and idempotent.
 Therefore, replicas converge when messages arrive in different orders or more
 than once. The system does not need locks, a leader, or application conflict
 resolution.
 
-The design defers the asynchronous presence read-model and effect work as one
-bundle. It does not expose a partial runtime feature that blocks the shared
-actor.
+A slow presence callback can delay mutations from multiple sockets because
+they share the presence actor. The per-socket deferred queues are not bounded
+by the acknowledgement timeout.
 -->
 
 ---
@@ -417,7 +434,7 @@ flowchart LR
   MI -->|binary, no decoder| RB["raw Binary event fan-out"]
   CD -->|route_decoded / route_decoded_binary| RT["runtime"]
   RB -->|route_binary| RT
-  RT --> EN["encode reply/push"] --> SF["socket send fn"] --> CL["client"]
+  RT --> EN["encode reply/push"] --> SF["enqueue send request"] --> CP["connection process writes"] --> CL["client"]
 ```
 
 - Phoenix wire format: `[join_ref, ref, topic, event, payload]`
@@ -433,7 +450,9 @@ codec's text decoder. Binary frames use its binary decoder when one exists and
 retain binary telemetry classification through `route_decoded_binary`. A
 codec without a binary decoder uses the raw `Binary` event path. For outbound
 data, the same codec encodes runtime replies and pushes. The runtime then gives
-them to the socket's send function.
+them to the socket's send function. That function enqueues SendText or
+SendBinary for the connection process. The connection process calls the
+transport's frame-write function. Enqueue success is not delivery confirmation.
 
 `Codec` is a data value, not fixed runtime logic. An application can change
 framing without changing the runtime or application code. beryl has no
@@ -450,9 +469,11 @@ socket to the replacement runtime.
 
 ## Concurrency note
 
-The runtime uses a **single OTP mailbox**. It processes messages in sequence
-and does not need locks.
+Each actor processes its own mailbox in sequence. There is **no shared
+callback mailbox** for all sockets.
 
+- Slow raw callbacks delay one socket; channel message/info callbacks run per topic
+- Joins, ordered closes, and presence work can delay other work on the same socket
 - Broadcasts arrive as Erlang messages; tests must **select the exact message shape**
 - Stale queued messages can cause nondeterministic test failures
 - Drain messages that your tests create. Do not use broad "any message"
@@ -461,8 +482,12 @@ and does not need locks.
 
 <!--
 Speaker notes:
-This slide gives architecture information and test guidance. One mailbox
-processes messages in sequence without locks. Effect order equals wire order.
+This slide gives architecture information and test guidance. Per-socket
+effect order is preserved through the connection writer. There is no total
+callback order between sockets or between channel workers on different topics.
+This isolates callback execution, not all resource use or latency: the router,
+presence actor, socket effect interpreter, and transport queues can still
+accumulate work.
 
 Broadcasts and pushes arrive as ordinary Erlang messages in a process
 mailbox. A test must select the exact expected message shape. A broad
@@ -474,20 +499,47 @@ common source of intermittent test failures in this codebase.
 
 ---
 
+## Queue limits and evidence
+
+- Rate limits control admission, not end-to-end queued messages or bytes
+- Worker input, reports, socket queues, router fan-out, and presence remain unbounded
+- Outbound send queues have no configured slow-reader eviction policy
+- [#397](https://github.com/tylerbutler/beryl/issues/397): runtime queue contracts; [#249](https://github.com/tylerbutler/beryl/issues/249): outbound backpressure
+- [#371](https://github.com/tylerbutler/beryl/pull/371) is protocol smoke, not comparative performance evidence
+- ADR 0005 compares startup at 2,000 connections/s; [#400](https://github.com/tylerbutler/beryl/issues/400) tracks broader baselines
+
+<!--
+Speaker notes:
+Do not infer bounded memory or healthy-client latency from process isolation.
+The runtime guide lists current controls, defaults, and overflow behavior:
+https://beryl.tylerbutler.com/architecture/runtime/#queue-limits-and-overload
+Generic PubSub and external consumer mailboxes have no global beryl budget.
+Queue units, reservation release paths, overload ordering, and occupancy/age
+telemetry are pending contracts in #397, not shipped guarantees.
+
+ADR 0005 used Mist, Erlang 27.2.1, 12 schedulers, and three runs per design at
+a requested 2,000 starts/s. It compares direct and factory startup at that
+rate; it does not establish a general throughput, memory, or recovery bound.
+#400 covers slow readers, hot workers, slow presence, combined router
+pressure, and crash/reconnect workloads.
+-->
+
+---
+
 ## Where to start contributing
 
 | Start here | Module | Purpose |
 |---|---|---|
 | 💡 Public surface | `src/beryl.gleam` | `config`, `child_spec`, `stop`, broadcast helpers |
 | 🔌 Dispatch contract | `src/beryl/socket.gleam` | `Input`, `Next`, `Effect`, `Sender`, `ConnectInfo` |
-| ⚙️ Heart of beryl | `src/beryl/runtime.gleam` | Actor, dispatch, effect interpreter, heartbeat (internal) |
+| ⚙️ Heart of beryl | `src/beryl/runtime.gleam` | Router, socket actors, workers, effects, heartbeat (internal) |
 | 📨 Message flow | `packages/beryl_mist/src/beryl_mist.gleam` | Connect → decode → route |
 | 📡 Fan-out | `src/beryl/pubsub.gleam` | pg-based broadcast, typed `Subscriber` |
 | 👥 Presence | `src/beryl/presence.gleam` | CRDT actor, track/untrack, diffs |
 | 🔤 Framing | `src/beryl/wire.gleam` | Phoenix codec, encode/decode |
 
 Start with `beryl.gleam` and `beryl/socket.gleam` for the public contract.
-Then read `runtime.gleam`. This single process connects all components.
+Then read `runtime.gleam`. It implements the router, socket actors, and topic workers.
 The website contains architecture documents under `/architecture/`.
 
 <!--

--- a/docs/talks/beryl-interview/deck.md
+++ b/docs/talks/beryl-interview/deck.md
@@ -130,8 +130,8 @@ familiar, and Gleam adds static typing.
 
 - Millions of tiny, isolated, share-nothing processes per node
 - No shared memory or locks; processes only send messages
-- beryl uses connection processes at the transport edge and one shared app runtime
-- Per-socket models stay isolated by ID and callback failures are contained
+- beryl uses a shared router, temporary socket actors, and per-socket/topic workers
+- Socket actors order effects; transport connection processes write frames
 
 <!--
 Give these numbers:
@@ -151,12 +151,19 @@ Isolation is the main point: share no state. The only way two
 processes interact is by copying a message into the other's mailbox.
 No shared memory means no locks or data races.
 
-Be precise about beryl's topology: it does not spawn an application actor per
-socket. Mist/Ewe own their normal WebSocket connection processes, while one
-shared runtime actor stores every socket's typed model and topic membership.
-The runtime handles app callback crashes and applies a scoped policy: reject a
-crashing join, close a topic for a crashing message, and tear down only that
-socket for a crashing `Info`. Other sockets and the runtime survive.
+Be precise about beryl's topology: the shared socket factory supervises a
+Temporary actor per socket. Raw init/update callbacks run in that actor.
+With the channel layer, a linked topic supervisor owns a Temporary worker
+for each socket/topic join. Workers own channel state and callbacks.
+The shared router owns admission, indexes, and fan-out, not app callbacks.
+Mist/Ewe connection processes own the WebSocket and perform frame writes.
+
+A raw Join panic rejects the join; a raw Message/Binary panic closes its
+topic; a raw Info panic closes the socket. A channel on_info panic closes
+only its topic. A slow raw callback delays its socket; slow channel
+message/info callbacks do not block sibling workers. Joins, ordered closes,
+presence suspension, shared router load, and transport queues can still
+delay progress. Process isolation does not guarantee bounded memory or latency.
 
 TRANSITION: "Isolation also changes the effect of a crash. Next, I will
 explain Erlang supervision."
@@ -173,7 +180,11 @@ explain Erlang supervision."
 ```
 application supervisor
  └─ beryl subtree (Transient)
-     ├─ runtime (significant Transient)
+     ├─ socket factory (Permanent)
+     │   └─ socket actors (Temporary)
+     │       └─ linked topic supervisor
+     │           └─ topic workers (Temporary)
+     ├─ router (significant Transient)
      └─ connection limiter (optional)
 
 presence · groups     application-owned sibling actors
@@ -195,9 +206,13 @@ PubSub                Erlang pg lifecycle
 Explain the actual tree:
 - `beryl.child_spec(config, init:, update:)` returns a stable `Sockets`
   handle plus the beryl subtree's child specification.
-- The runtime is the significant transient child. A genuine runtime crash is
-  restarted under the same registered name; the optional limiter is its
-  sibling.
+- The router is the significant transient child. An abnormal router exit is
+  restarted under the same registered name. The Permanent socket factory
+  and optional limiter are siblings.
+- The factory starts socket actors without running app init. The router
+  registers each actor before init runs there. A factory crash stops its
+  sockets; the router cleans their entries and closes connections, without
+  itself restarting. The replacement factory accepts new connections.
 - Transports monitor the exact runtime pid. If it dies, existing WebSockets
   close instead of becoming zombies attached to a successor.
 - `beryl.stop` drains only this subtree. Presence and groups are borrowed,
@@ -208,7 +223,9 @@ LIKELY QUESTION: "What happens to in-flight state after a restart?" Explain
 that the runtime restarts with the app's `init`/`update` closures,
 but connected-socket models and topic membership are gone. Monitored
 transports close, clients reconnect and rejoin, and anything durable belongs
-in your database. Real-time state is a cache of "now," not a ledger.
+in your database. Temporary socket and topic children are not restarted:
+supervision owns cleanup, not session reconstruction. A worker-only failure
+needs a topic rejoin; a socket failure needs reconnect and rejoin.
 -->
 
 ---
@@ -457,8 +474,8 @@ Demo script, about two minutes:
 1. Open two browser windows side by side, join the same room. Move the
    mouse. The cursor appears in the other window. Pause before you explain it.
 2. "Each tab is one WebSocket whose connection process handles edge work,
-   while beryl's shared runtime holds a separate typed model for each socket."
-   (Refer to the processes slide without claiming an app actor for each socket.)
+   while beryl's socket actor holds that connection's typed model."
+   (Refer to the shared router and temporary socket actors on the processes slide.)
 3. Point at the code. `broadcast_from` sends to everyone except the sender,
    so the sender does not receive its own cursor event.
 4. Open a third tab. The presence list grows. Close it without a clean
@@ -579,9 +596,11 @@ WebSocket transport     beryl_mist / beryl_ewe  (public transport SPI)
         │
 Configured codec        beryl/wire  (required; Phoenix is one option)
         │
-Shared runtime          per-socket models · topics · heartbeat · effects
+Shared router           admission · socket table · topic index · fan-out
         │
-App update              Join · Message · Binary · Closed · typed Info
+Socket actor            raw init/update · model · refs · heartbeat · effects
+        │
+Topic workers           channel callbacks · per-socket/topic state
         │
 PubSub                  Erlang pg — the ONLY cross-node layer
 
@@ -597,9 +616,12 @@ Describe the life of one message from top to bottom:
    frames into topic/event/payload/ref values. Decoded binary keeps binary
    telemetry classification; without a binary decoder it becomes a raw
    `Binary` event.
-3. The RUNTIME, one shared OTP actor for each app, tracks socket models, joined
-   topics, heartbeat state, and outstanding refs. There is no registry.
-4. Your app's one `update` function runs and returns an ordered effect list.
+3. The shared ROUTER forwards admitted frames to a supervised socket actor.
+   That actor owns its model, joined topics, heartbeat, and outstanding refs.
+4. Raw `update` runs in the socket actor. Channel callbacks run in per-topic
+   workers and report actions to the socket actor. It orders effects and
+   enqueues SendText/SendBinary requests. The transport connection process
+   writes them; enqueue success does not confirm client delivery.
 5. If an effect broadcasts, PUBSUB sends it over pg, including
    to subscribers on other nodes. Each node's transports push to
    their local sockets.
@@ -613,11 +635,24 @@ State these two design rules slowly:
   different HTTP server, or a non-WebSocket transport, implements the
   same contract." This design explains the two-package repository structure.
 
-LIKELY QUESTION: "Is the shared runtime actor a bottleneck?" Explain that app
-dispatch and local fan-out are serialized there. Frame
-size checks, message-rate shedding, and decoding happen in transport
-connection processes before enqueueing. The actor is per app/node, not
-per cluster; published capacity benchmarks remain important post-1.0 work.
+LIKELY QUESTION: "Is the shared router a bottleneck?" Explain that admission,
+ingress, and local fan-out are shared, while callbacks run in socket actors
+or topic workers. Frame-size checks, frame-rate shedding, and decoding happen
+in transport connection processes before routing; decoded-message limits
+run in socket actors. Do not assert a bottleneck or capacity without measurements.
+
+Queue limits are separate from input rates. Worker input, pending reports,
+socket/deferred-presence queues, router fan-out, and shared presence do not
+have finite configured budgets. Neither do generic PubSub or external
+consumer mailboxes. #397 tracks runtime overload contracts; #249 tracks
+outbound queue limits and slow-reader eviction. These are not shipped bounds.
+See https://beryl.tylerbutler.com/architecture/runtime/#queue-limits-and-overload.
+
+#371 is protocol-smoke evidence, not comparative performance evidence.
+ADR 0005 compares direct and factory startup at a requested 2,000 starts/s
+with Mist, Erlang 27.2.1, 12 schedulers, and three runs per design. It does
+not establish a general capacity or recovery envelope. #400 tracks broader
+workload baselines: https://github.com/tylerbutler/beryl/issues/400.
 -->
 
 ---

--- a/website/src/content/docs/architecture/overview.md
+++ b/website/src/content/docs/architecture/overview.md
@@ -10,6 +10,10 @@ It can also pass a typed handler table to `channel.child_spec`. The runtime
 dispatches decoded messages and applies the returned effects. Separate actors
 manage presence and groups. Only PubSub sends data across nodes.
 
+Here, **runtime** means the router, socket actors, and optional channel workers
+together, not one process. A **topic worker** belongs to one socket/topic join,
+not to every subscriber of a topic name.
+
 ## Choose a page
 
 Each page describes one subsystem and lists its source files.
@@ -69,18 +73,39 @@ flowchart TB
 ```mermaid
 flowchart TB
   S["beryl internal supervisor<br/>one-for-one, 3 restarts / 5s"]
-  S --> RT["router actor (Transient)"]
-  RT <-. "monitor" .-> SA["socket actors<br/>one per connection"]
-  SA --> TW["topic workers<br/>one per joined channel"]
+  S --> SF["socket factory supervisor (Permanent)"]
+  SF --> SA["socket actors<br/>one per connection, Temporary"]
+  S --> RT["router actor (significant Transient)"]
+  S -. optional .-> CL["connection limiter"]
+  RT <-. "mutual monitors" .-> SA
+  SA --> TS["topic worker supervisor<br/>channel layer, linked"]
+  TS --> TW["topic workers<br/>one per socket/topic join, Temporary"]
+  SA -. "ordered send requests" .-> T["transport connection process<br/>WebSocket writes"]
   PR["presence (app-started)"]
   GR["groups (app-started)"]
   SA -. "async mutation" .-> PR
 ```
 
-`child_spec` supervises the router. Transport connections start the socket
-actors, which monitor the router and are monitored by it. The application
-starts and owns the presence and group actors. See the
+`child_spec` supervises the router and socket factory. Transport connections
+request temporary socket children from the factory. Socket actors preserve
+protocol/effect order; transport connection processes perform network writes.
+Channel workers own per-topic state and callbacks.
+
+A socket actor fault closes that socket. A worker fault closes its topic.
+A router or factory fault closes the affected runtime's connections.
+Temporary children are not restarted: clients reconnect and rejoin rather
+than recover an old session. The application starts and owns the presence and
+group actors. See the
 [Supervision guide](/guides/supervision/).
+
+Slow channel callbacks do not block sibling workers, but joins, ordered
+closes, and presence work can delay the socket's effect processing. The router
+and presence actor remain shared resources, and transport queues can grow
+behind slow readers. See [Queue limits and overload](/architecture/runtime/#queue-limits-and-overload)
+and [Performance evidence](/architecture/runtime/#performance-evidence) for
+the current limits and the work tracked in
+[#397](https://github.com/tylerbutler/beryl/issues/397) and
+[#400](https://github.com/tylerbutler/beryl/issues/400).
 
 ## Source files
 

--- a/website/src/content/docs/architecture/runtime.md
+++ b/website/src/content/docs/architecture/runtime.md
@@ -2,7 +2,8 @@
 title: Socket processes & restarts
 ---
 
-The runtime uses one router actor and one actor for each connected socket.
+The runtime uses one shared router actor and one supervised, temporary actor
+for each connected socket.
 Transports send admitted, decoded frames to the router. The router sends each
 frame to the actor that owns the socket. Your application's `init` and `update`
 functions run in that socket actor. With the channel layer, the socket actor
@@ -14,17 +15,25 @@ presence and groups. PubSub wraps Erlang `pg` and is not a runtime child.
 
 Each socket actor stores the app model, wire-send functions, joined topics, and
 heartbeat time for one socket. It processes mailbox messages in sequence. This
-serializes that socket's `update` calls and frame writes without locks. A slow
-callback for one socket does not stop other sockets.
+serializes that socket's `update` calls and protocol effects without locks.
+A slow raw callback delays that socket, not callbacks on other sockets.
 
 With the channel layer, each joined topic has a worker under a supervisor
 that the socket actor starts and links. The worker runs `join` during startup,
 and the socket actor waits for the result. The worker also runs `on_message`
 and `on_info`. It sends effects to the socket actor. The socket actor applies
-them in arrival order and writes each frame. Thus, effects for one topic keep
-their order. Effects for different topics can interleave. The socket actor
-sends a close to the worker before it drops the topic's reply refs. Thus, it
+them in arrival order and enqueues each frame for the transport. Thus, effects
+for one topic keep their order. Effects for different topics can interleave.
+The socket actor sends a close to the worker before it drops the topic's reply refs. Thus, it
 can deliver a push or reply that the worker computed before a leave.
+
+Channel `on_message` and `on_info` callbacks on different topics can run
+concurrently. This is not complete latency isolation: worker startup during a
+join and ordered worker shutdown can make the socket actor wait. Worker join
+and termination each have a 5-second timeout. A slow raw callback blocks all
+topics on its socket. Presence suspension also delays
+ordered work for that socket, and a slow shared presence actor can delay
+mutations from multiple sockets.
 
 The router manages admission, the topic subscriber index, the PubSub
 subscription, and stats. It only matches and forwards messages. It does not run
@@ -77,11 +86,17 @@ Inbound WebSocket frames follow a two-step path:
 
 ## Order of replies, pushes, and broadcasts
 
-The runtime applies effects in list order. The same actor interprets the list
-and writes the frames. Thus, list order is wire order. An `AcceptJoin` reaches
-the wire before a later `Push`. A `Broadcast` goes through the router, which
-sends a copy to each recipient actor. The source socket writes its own copy
-first, so the broadcast keeps its effect-list position on that socket's wire.
+The socket actor applies effects in list order and calls its send functions in
+that order. For Mist and Ewe, these functions enqueue `SendText` or
+`SendBinary` requests to the transport connection process. That process calls
+the transport's frame-write functions. The socket actor owns protocol/effect
+ordering; the connection process owns the WebSocket and performs the writes.
+
+Thus, an `AcceptJoin` is queued before a later `Push`, preserving wire order.
+A successful send-function result means the request was enqueued, not that a
+network write completed or that the client received it. A `Broadcast` goes
+through the router, which sends a copy to each recipient actor. The source
+socket enqueues its own copy at the broadcast's effect-list position.
 
 The socket actor applies most lists in one turn. The presence actor applies
 `PresenceTrack` and `PresenceUntrack`. The runtime pauses the rest of that
@@ -126,17 +141,25 @@ below 2 because integer division would set the check interval to zero.
 
 ## Restart behavior
 
-`child_spec` has no unsupervised mode. The router always starts under an internal one-for-one supervisor with a **3 restarts / 5 seconds** tolerance. Socket actors are not supervisor children: each is started by the transport's connection process at admission, monitored by the router (a crashed actor's entries are swept, closing only that socket), and monitors the router in return, stopping on its `Down`:
+`child_spec` has no unsupervised mode. The router and shared socket factory
+start under an internal one-for-one supervisor with a **3 restarts / 5
+seconds** tolerance. Socket actors are `Temporary` children of the factory.
+The transport requests a child, then the router registers it before its
+application `init` runs. The router and socket actor monitor each other.
 
 ```mermaid
 flowchart TB
-  APP["process that called child_spec"]
-  APP --- SUP["beryl internal supervisor<br/>one-for-one, 3 restarts / 5s"]
+  APP["application supervisor"]
+  APP --> SUP["beryl internal supervisor<br/>one-for-one, 3 restarts / 5s"]
+  SUP --> FACTORY["socket factory supervisor (Permanent)"]
+  FACTORY --> SA1["socket actor (one per connection, Temporary)<br/>model, heartbeat, protocol effects"]
   SUP --> RT["router actor (significant Transient)<br/>init/update captured in child spec"]
   SUP -. optional .-> LIMITER["connection limiter"]
-  RT <-. "monitor ×2" .-> SA1["socket actor (one per connection)<br/>model, heartbeat, frame writes"]
+  RT <-. "mutual monitors" .-> SA1
   SA1 --> WS["topic worker supervisor<br/>(channel layer, linked)"]
-  WS --> W["topic workers (one per joined topic, Temporary)<br/>channel state and callbacks"]
+  WS --> W["topic workers (one per socket/topic join, Temporary)<br/>channel state and callbacks"]
+  SA1 -. "ordered send requests" .-> TRANSPORT["transport connection process<br/>WebSocket frame writes"]
+  TRANSPORT -. "monitors" .-> RT
 ```
 
 - The child specification contains the `init` and `update` closures. A restart
@@ -145,16 +168,73 @@ flowchart TB
   restart. Sends during the restart window do nothing.
 - Router death stops all socket actors. The transports also monitor the router
   and close their connections. A restart starts with no sockets, so clients
-  must rejoin.
-- The child is `Transient`, so a graceful `beryl.stop` is final. A stop first
+  must reconnect and rejoin.
+- Factory death stops all socket actors it owns. The router sweeps their
+  routing and presence state and closes their transports. The router keeps
+  its generation; the `Permanent` factory restarts under its stable name and
+  accepts new connections.
+- A socket actor fault closes only its connection and topics. Socket actors
+  and topic workers are `Temporary`: supervision does not restart them or
+  reconstruct models, refs, or memberships. Recovery requires a new connection
+  and joins, or a topic rejoin if only its worker stopped.
+- The router is significant and `Transient`, so a graceful `beryl.stop` is
+  final. A stop first
   completes in-flight presence work, then stops the socket actors. It kills an
-  actor that remains blocked in an app callback.
+  actor that remains blocked in an app callback. The router drains before the
+  factory shuts down; the factory terminates any surviving children.
 
 PubSub is **not** part of this tree. Erlang `pg` starts and stops it.
 Presence and groups provide child specifications for the application
 supervision tree. See the [Supervision guide](/guides/supervision/).
 
+## Queue limits and overload
+
+beryl currently has no finite end-to-end queue or memory budget. Process
+isolation and rate limits do not establish one. The current controls limit
+admission or input rate, not all work that can accumulate after admission.
+See [Production hardening](/guides/production-hardening/) for configuration.
+
+| Boundary | Current control and overload behavior |
+|---|---|
+| Connection admission | Optional per-IP attempt-rate and concurrent connection limits, plus a node-wide concurrent connection limit. All default to disabled. The limiter owns accounting; a rejected upgrade receives HTTP `429`. |
+| Complete inbound frames | The connection process closes the connection for frames over 1 MiB by default, after assembly. Optional frame-rate limiting drops over-rate frames before decoding. Neither bounds pre-assembly buffers or router queues. |
+| Decoded socket input | Socket actors own optional message, join, and channel/topic rate buckets. Rates default to disabled. Over-rate messages are dropped; over-rate joins receive an error reply. These are not worker queue limits. |
+| Topic-worker input | No configured message or byte budget. A slow worker can accumulate input. |
+| Worker reports and action batches | No configured budget for pending `WorkerRan` reports or the effects they contain. |
+| Socket mailbox and deferred presence work | No configured queue budget. The presence operation timeout defaults to 5 seconds; it limits the acknowledgement wait, not queued messages or effect-list size. On timeout, the runtime logs and resumes without claiming success. |
+| Shared router ingress and fan-out | No aggregate queue budget. Per-socket input rates do not bound combined ingress, broadcasts, or fan-out work. |
+| Presence and PubSub admission | No global queue budget. Shared presence work, generic PubSub consumers, and external consumer mailboxes are not bounded by socket rate limits. |
+| Outbound connection queue | Send requests have no configured count/byte budget or slow-reader eviction policy. A slow writer can accumulate requests independently of the socket actor. |
+
+[#397](https://github.com/tylerbutler/beryl/issues/397) tracks finite supported
+budgets, accounting and release paths, overflow semantics, occupancy/queue-age
+telemetry, and bounded-memory evidence. These are not current guarantees.
+[#249](https://github.com/tylerbutler/beryl/issues/249) separately tracks the
+outbound queue and slow-client eviction. beryl cannot promise a global bound
+for arbitrary PubSub subscribers or external consumers.
+
+Until those contracts are implemented, do not treat rate settings, heartbeat
+eviction, or temporary supervision as backpressure. In particular, heartbeat
+checks need the socket actor to process its mailbox; they cannot interrupt a
+blocked callback. Use deployment-level limits and measure queue growth under
+your workload.
+
+## Performance evidence
+
+[#371](https://github.com/tylerbutler/beryl/pull/371) provides protocol-smoke
+evidence, not a comparative capacity result. The
+[ADR 0005 measurements](https://github.com/tylerbutler/beryl/blob/main/docs/adr/0005-socket-actor-supervision.md#results)
+compare direct and factory startup at a requested 2,000 connections per second
+with Mist on Erlang 27.2.1 and 12 schedulers, with three runs per design.
+They support that narrow start-rate comparison, not a general throughput,
+latency, memory, or recovery guarantee.
+
+[#400](https://github.com/tylerbutler/beryl/issues/400) tracks broader workload
+baselines, including slow readers, hot workers, presence delays, combined
+router load, and crash/reconnect recovery.
+
 ## Source files
 
 - `src/beryl/runtime.gleam` — socket and model tracking, event delivery, returned effects, heartbeat timers, crash handling, admission, and shutdown.
 - `src/beryl.gleam` — `child_spec`, the supervised child specification, and the typed functions used to start the runtime and socket actors.
+- `src/beryl/transport/server.gleam` — connection admission and ordered outbound send requests consumed by Mist and Ewe.

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -207,5 +207,9 @@ for the full distribution security reference.
   router does not handle every subscriber.
 - The runtime always starts supervised (`child_spec` has no unsupervised
   mode); restarts are bounded at 3 per 5 seconds, after which the crash
-  propagates to the process that called `child_spec`. See the
+  propagates through the application's supervision tree. See the
   [Supervision guide](/guides/supervision/).
+- Rate limits do not bound worker input, pending action reports, router
+  fan-out, or outbound connection queues. See
+  [Queue limits and overload](/architecture/runtime/#queue-limits-and-overload)
+  for current controls and non-guarantees.

--- a/website/src/content/docs/guides/supervision.md
+++ b/website/src/content/docs/guides/supervision.md
@@ -13,21 +13,25 @@ converts the handler table to a core `init` and `update` pair.
 
 ```text
 beryl internal supervisor (one-for-one, 3 restarts / 5 seconds)
-|- router actor (Transient)
+|- socket factory supervisor (Permanent)
+|  `- socket actor (one per connection, Temporary)
+|     `- topic worker supervisor (channel layer only, linked to the socket actor)
+|        `- topic worker (one per accepted socket/topic join, Temporary)
+|- router actor (Transient, significant)
 `- connection limiter (optional)
 
-transport connection
-`- socket actor (one per connection, monitored by the router)
-   `- topic worker supervisor (channel layer only, linked to the socket actor)
-      `- topic worker (one per joined topic, Temporary)
+transport connection process (outside the beryl subtree)
+`- owns the WebSocket and performs frame writes
 ```
 
 - The **router actor** maintains the socket actor table and topic subscriber
   index. If the router crashes, the supervisor restarts it. The child
   specification still contains the `init` and `update` functions.
 - Each **socket actor** holds one model and sends events to your `update`
-  function. Socket actors are not supervisor children. The transport starts
-  them, and the router monitors them.
+  function. The transport requests a `Temporary` child from the shared
+  **socket factory supervisor**. The router monitors and registers it before
+  `init` runs in the socket actor. A slow `init` does not hold the factory's
+  child-start operation or the router's admission turn.
 - With the channel layer, each socket actor starts a **topic worker
   supervisor** and one **topic worker** for each accepted join. Workers are
   `Temporary`. The supervisor does not restart a stopped worker. The client
@@ -35,11 +39,19 @@ transport connection
 - The router uses a stable registered name. The `Sockets` handle accepts new
   work after a restart. Existing connections close. Sends during the restart
   window do nothing.
-- The child is `Transient`: a graceful `beryl.stop` is final and is not
-  resurrected.
+- The factory is `Permanent`. If it crashes, its socket actors stop and their
+  connections close. The router removes their routing and presence state but
+  does not restart. The replacement factory accepts new connections.
+- The router is the significant `Transient` child: a graceful `beryl.stop`
+  shuts down the subtree and is not restarted.
 
 After **3 restarts in 5 seconds** the internal supervisor gives up and the
 failure propagates through your application's supervision tree.
+
+`Temporary` supervision owns process shutdown; it does not reconstruct a
+session. A stopped socket actor is not restarted. The client must reconnect
+and rejoin. A stopped topic worker is not restarted either; the client must
+rejoin that topic. Store durable application data outside these processes.
 
 ## Runtime restarts close connections
 
@@ -72,6 +84,22 @@ Channel callbacks run in the topic's worker. A `join`, `on_message`, or
 discards that callback's actions but does not stop cleanup for sibling
 channels. See
 [When callbacks panic](/guides/channels/#when-callbacks-panic).
+
+## Slow callbacks and transport writes
+
+Socket actors apply protocol effects in order. Their send functions enqueue
+frames for the transport connection process; they do not write to the network.
+A successful enqueue is not confirmation that the client received the frame.
+
+A slow raw callback delays its whole socket. Channel message and info
+callbacks run independently in topic workers, but joins and ordered closes
+can make the socket actor wait for a worker. Presence mutations pause that
+socket's ordered effect list. A slow shared presence actor can delay mutations
+from many sockets. Router ingress and fan-out are also shared work.
+
+Process isolation does not bound queues or guarantee latency for healthy
+clients. See [Queue limits and overload](/architecture/runtime/#queue-limits-and-overload)
+for the supported controls and the boundaries that remain unbounded.
 
 ## Supervise presence and groups
 


### PR DESCRIPTION
## Summary

- Align architecture decks and website guides with the shared router, supervised temporary socket actors, and per-socket/topic workers.
- Explain transport writes, crash and slowness scopes, and reconnect/rejoin recovery without session reconstruction.
- Preserve ADR 0002 with a supersession note, correct the performance evidence, and document queue non-guarantees tracked in #397 and #249 with broader baselines in #400.
- Add a documentation changelog fragment. No runtime behavior changes.

## Validation

- Branch based on the freshly fetched `origin/main`.
- Website build with strict internal-link validation passed (`CI=true npm --prefix website run build:site`). Used npm because the local pnpm command rejected the workspace configuration.
- Architecture and interview decks rendered successfully.
- `git diff --check` passed. No runtime tests run for documentation-only changes.

Closes #399