### PR TITLE
fix(transport): bound outbound queues and evict slow clients

### DIFF
--- a/.changes/unreleased/beryl-bound-each-connection-s.toml
+++ b/.changes/unreleased/beryl-bound-each-connection-s.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Bound each connection's outbound queue by frames and bytes, and close slow clients before enqueueing beyond the configured budget."

--- a/.changes/unreleased/beryl_mist-handle-outbound-write-failures.toml
+++ b/.changes/unreleased/beryl_mist-handle-outbound-write-failures.toml
@@ -1,0 +1,3 @@
+package = "beryl_mist"
+kind = "Fixed"
+body = "Handle outbound write failures and slow-client eviction with the shared finite connection budget."

--- a/packages/beryl/src/beryl/runtime.gleam
+++ b/packages/beryl/src/beryl/runtime.gleam
@@ -5279,14 +5279,14 @@ fn send_frame_logged(
   case send_result {
     Ok(Nil) ->
       state.logger
-      |> log.debug("Outbound frame sent", [
+      |> log.debug("Outbound frame enqueued", [
         #("socket_id", socket.id),
         #("topic", topic_name),
         #("frame_kind", frame_kind(frame)),
       ])
     Error(Nil) ->
       state.logger
-      |> log.warn("Outbound frame failed", [
+      |> log.warn("Outbound frame rejected", [
         #("socket_id", socket.id),
         #("topic", topic_name),
         #("frame_kind", frame_kind(frame)),

--- a/packages/beryl/src/beryl/transport/server.gleam
+++ b/packages/beryl/src/beryl/transport/server.gleam
@@ -5,7 +5,8 @@
 //// its builders, the upgrade admission pipeline (path matching, origin
 //// policy, `?vsn` negotiation, connection limits, `on_connect`
 //// authentication), per-connection lifecycle choreography, and the inbound
-//// frame pipeline (size caps, frame-rate limiting, decoding, routing).
+//// frame pipeline (size caps, frame-rate limiting, decoding, routing), plus
+//// bounded outbound admission and write accounting.
 ////
 //// Transport packages such as `beryl_mist` and `beryl_ewe` supply only the
 //// server-specific glue: the WebSocket upgrade call, frame sending, and peer
@@ -34,6 +35,14 @@ import gleam/string
 
 // --- Transport configuration ---
 
+const default_max_outbound_frames = 256
+
+const default_max_outbound_bytes = 1_048_576
+
+const largest_max_outbound_frames = 8_388_607
+
+const largest_max_outbound_bytes = 1_099_511_627_775
+
 /// Configuration for a WebSocket transport.
 ///
 /// The `body` parameter is the server's request body type. The same
@@ -58,6 +67,10 @@ pub opaque type TransportConfig(body) {
     /// Policy applied to the request `Origin` header before the WebSocket
     /// handshake. Defaults to `origin.SameOrigin`.
     origin_policy: OriginPolicy,
+    /// Maximum frames reserved for writes by one connection.
+    max_outbound_frames: Int,
+    /// Maximum payload bytes reserved for writes by one connection.
+    max_outbound_bytes: Int,
   )
 }
 
@@ -67,14 +80,31 @@ pub type ConnectError {
   ConnectRejected
 }
 
-// nolint: unused_exports -- transport SPI, consumed by transport packages such as beryl_mist
+/// Errors returned when configuring a connection's outbound budget.
+pub type OutboundConfigError {
+  /// The frame limit was less than one.
+  InvalidMaxOutboundFrames
+  /// The byte limit was less than one.
+  InvalidMaxOutboundBytes
+  /// The frame limit cannot fit in the transport's atomic counter.
+  MaxOutboundFramesTooLarge
+  /// The byte limit cannot fit in the transport's atomic counter.
+  MaxOutboundBytesTooLarge
+}
+
+/// An unexpected error while forcibly closing a connection.
+pub type ForceCloseError {
+  ForceCloseFailed(reason: String)
+}
+
 /// Create a default transport config with no connect hook.
 ///
 /// The resulting configuration sets `ConnectSeed.metadata` to `[]` and applies
 /// the `origin.SameOrigin` origin policy, which rejects cross-site WebSocket
 /// upgrades before the handshake as CSWSH protection. Same-origin upgrades and
 /// non-browser clients (no `Origin` header) are admitted without
-/// configuration.
+/// configuration. Each connection also has an outbound budget of 256 frames
+/// and 1 MiB of payload data. A connection that exceeds either limit is closed.
 ///
 /// Add `with_on_connect` to authenticate connections and/or seed connect
 /// metadata. Use `with_allowed_origins` to set an explicit allow-list. Use
@@ -84,6 +114,8 @@ pub fn default_config(path: String) -> TransportConfig(body) {
     path: normalize_path(path),
     on_connect: None,
     origin_policy: origin.SameOrigin,
+    max_outbound_frames: default_max_outbound_frames,
+    max_outbound_bytes: default_max_outbound_bytes,
   )
 }
 
@@ -147,6 +179,40 @@ pub fn with_allow_all_origins(
   config: TransportConfig(body),
 ) -> TransportConfig(body) {
   TransportConfig(..config, origin_policy: origin.AllowAll)
+}
+
+/// Set the per-connection outbound frame and payload-byte limits.
+///
+/// `max_frames` must be from 1 through 8,388,607. `max_bytes` must be from 1
+/// through 1,099,511,627,775 (one byte less than 1 TiB). Before beryl enqueues
+/// a text or binary frame, it reserves one frame and the payload's byte size.
+/// If either limit would be exceeded, the frame is rejected and the slow
+/// connection is closed. Capacity is released after a successful write, a
+/// write error, or connection close.
+pub fn with_outbound_limits(
+  config: TransportConfig(body),
+  max_frames max_frames: Int,
+  max_bytes max_bytes: Int,
+) -> Result(TransportConfig(body), OutboundConfigError) {
+  case
+    max_frames < 1,
+    max_bytes < 1,
+    max_frames > largest_max_outbound_frames,
+    max_bytes > largest_max_outbound_bytes
+  {
+    True, _, _, _ -> Error(InvalidMaxOutboundFrames)
+    _, True, _, _ -> Error(InvalidMaxOutboundBytes)
+    _, _, True, _ -> Error(MaxOutboundFramesTooLarge)
+    _, _, _, True -> Error(MaxOutboundBytesTooLarge)
+    False, False, False, False ->
+      Ok(
+        TransportConfig(
+          ..config,
+          max_outbound_frames: max_frames,
+          max_outbound_bytes: max_bytes,
+        ),
+      )
+  }
 }
 
 // --- Upgrade admission pipeline ---
@@ -418,11 +484,38 @@ fn finish_upgrade(
 /// Transports receive these as custom or user WebSocket messages. They send
 /// the frame or close the connection.
 pub type SendRequest {
-  SendText(String)
-  SendBinary(BitArray)
+  SendText(String, bytes: Int)
+  SendBinary(BitArray, bytes: Int)
   /// Runtime-initiated close (e.g. heartbeat eviction).
   Close
 }
+
+type OutboundBudget
+
+@external(erlang, "beryl_outbound_ffi", "new")
+fn new_outbound_budget() -> OutboundBudget
+
+@external(erlang, "beryl_outbound_ffi", "reserve_and_send")
+fn reserve_and_send(
+  budget: OutboundBudget,
+  subject: process.Subject(SendRequest),
+  request: SendRequest,
+  bytes: Int,
+  max_frames: Int,
+  max_bytes: Int,
+) -> Bool
+
+@external(erlang, "beryl_outbound_ffi", "release")
+fn release_outbound(budget: OutboundBudget, bytes: Int) -> Nil
+
+@external(erlang, "beryl_outbound_ffi", "close_and_send")
+fn close_outbound(
+  budget: OutboundBudget,
+  subject: process.Subject(SendRequest),
+) -> Nil
+
+@external(erlang, "beryl_outbound_ffi", "cancel")
+fn cancel_outbound(budget: OutboundBudget) -> Nil
 
 /// State maintained per WebSocket connection.
 pub opaque type ConnectionState {
@@ -441,6 +534,7 @@ pub opaque type ConnectionState {
     /// It is independent of the runtime's decoded-message limiter.
     frame_limiter: Option(rate_limit.Bucket),
     logger: log.Logger,
+    outbound_budget: OutboundBudget,
   )
 }
 
@@ -483,11 +577,18 @@ pub fn connect_seed(
 /// the connection closes. `logger_name` names the transport in decode warnings
 /// (e.g. `"beryl_mist"`). `codec` is the codec negotiated for this socket;
 /// `None` inherits the app-wide codec.
+///
+/// `force_close` must immediately close the underlying socket. beryl calls
+/// it if binding fails or the outbound budget is full, so a blocked writer
+/// cannot retain an unbounded mailbox. Return an error when the close fails
+/// unexpectedly; beryl logs that failure.
 pub fn init_connection(
   sockets sockets: Sockets,
   seed seed: ConnectSeed,
   connection_permit connection_permit: ConnectionPermit,
   base_selector base_selector: Selector(SendRequest),
+  config config: TransportConfig(body),
+  force_close force_close: fn() -> Result(Nil, ForceCloseError),
   logger_name logger_name: String,
   telemetry telemetry: transport.Telemetry,
   codec socket_codec: Option(Codec),
@@ -497,16 +598,49 @@ pub fn init_connection(
   let socket_id = generate_socket_id()
   let send_subject = process.new_subject()
   let selector = process.select(base_selector, send_subject)
+  let outbound_budget = new_outbound_budget()
+  let logger = internal.logger(logger_name)
 
-  // Create send functions that the runtime can use.
+  // `Ok` means that the frame was admitted to the connection process mailbox.
+  // It does not mean that the frame was written or received by the peer.
   let send_fn = fn(text: String) -> Result(Nil, Nil) {
-    process.send(send_subject, SendText(text))
-    Ok(Nil)
+    let bytes = string.byte_size(text)
+    case
+      reserve_and_send(
+        outbound_budget,
+        send_subject,
+        SendText(text, bytes),
+        bytes,
+        config.max_outbound_frames,
+        config.max_outbound_bytes,
+      )
+    {
+      True -> Ok(Nil)
+      False -> {
+        force_close_logged(logger, socket_id, force_close)
+        Error(Nil)
+      }
+    }
   }
 
   let send_binary_fn = fn(data: BitArray) -> Result(Nil, Nil) {
-    process.send(send_subject, SendBinary(data))
-    Ok(Nil)
+    let bytes = bit_array.byte_size(data)
+    case
+      reserve_and_send(
+        outbound_budget,
+        send_subject,
+        SendBinary(data, bytes),
+        bytes,
+        config.max_outbound_frames,
+        config.max_outbound_bytes,
+      )
+    {
+      True -> Ok(Nil)
+      False -> {
+        force_close_logged(logger, socket_id, force_close)
+        Error(Nil)
+      }
+    }
   }
 
   // Capture and monitor the exact runtime before registration. Admission is
@@ -517,7 +651,8 @@ pub fn init_connection(
       // A timed-out bind may still be queued. Release follows it from this
       // process, so the limiter cannot retain a late transfer.
       transport.release_connection_slot(connection_permit)
-      process.send(send_subject, Close)
+      close_outbound(outbound_budget, send_subject)
+      force_close_logged(logger, socket_id, force_close)
       selector
     }
     Ok(Nil), Ok(runtime_pid) -> {
@@ -533,12 +668,12 @@ pub fn init_connection(
           send_binary: send_binary_fn,
           codec: socket_codec,
           seed: seed,
-          close: fn() { process.send(send_subject, Close) },
+          close: fn() { close_outbound(outbound_budget, send_subject) },
         )
       selector
     }
     Ok(Nil), Error(Nil) -> {
-      process.send(send_subject, Close)
+      close_outbound(outbound_budget, send_subject)
       selector
     }
   }
@@ -553,18 +688,58 @@ pub fn init_connection(
       telemetry: telemetry,
       frame_limiter: beryl.frame_limits(sockets)
         |> option.map(rate_limit.new_bucket),
-      logger: internal.logger(logger_name),
+      logger: logger,
+      outbound_budget: outbound_budget,
     )
 
   #(state, selector)
+}
+
+fn force_close_logged(
+  logger: log.Logger,
+  socket_id: String,
+  force_close: fn() -> Result(Nil, ForceCloseError),
+) -> Nil {
+  case force_close() {
+    Ok(Nil) -> Nil
+    Error(ForceCloseFailed(reason)) ->
+      log.warn(logger, "Failed to force-close WebSocket connection", [
+        #("socket_id", socket_id),
+        #("error", reason),
+      ])
+  }
 }
 
 /// Clean up a closed connection.
 ///
 /// Release the held connection slot and report the disconnect to the runtime.
 pub fn close_connection(state: ConnectionState) -> Nil {
+  cancel_outbound(state.outbound_budget)
   transport.release_connection_slot(state.connection_permit)
   transport.socket_disconnected(state.sockets, state.socket_id)
+}
+
+/// Complete one outbound write.
+///
+/// On success, this releases the frame and byte reservation and keeps the
+/// connection open. On error, it releases the reservation, records the
+/// connection as closed, logs the failure, and tells the transport to stop.
+pub fn finish_outbound_write(
+  state: ConnectionState,
+  bytes: Int,
+  succeeded: Bool,
+) -> FrameDisposition {
+  release_outbound(state.outbound_budget, bytes)
+  case succeeded {
+    True -> Continue(state)
+    False -> {
+      cancel_outbound(state.outbound_budget)
+      log.warn(state.logger, "Failed to write outbound WebSocket frame", [
+        #("socket_id", state.socket_id),
+      ])
+      Stop
+    }
+  }
 }
 
 // --- Inbound frame pipeline ---
@@ -573,7 +748,7 @@ pub fn close_connection(state: ConnectionState) -> Nil {
 pub type FrameDisposition {
   /// Keep the connection open with the updated state.
   Continue(ConnectionState)
-  /// Close the connection (the frame exceeded the configured size cap).
+  /// Close the connection after a frame limit or transport write failure.
   Stop
 }
 

--- a/packages/beryl/src/beryl_outbound_ffi.erl
+++ b/packages/beryl/src/beryl_outbound_ffi.erl
@@ -1,0 +1,77 @@
+-module(beryl_outbound_ffi).
+-export([new/0, reserve_and_send/6, release/2, close_and_send/2, cancel/1]).
+
+%% One CAS updates both budgets: 23 frame bits above 40 payload-byte bits.
+%% A negative value permanently closes admission; no process owns a lock.
+new() ->
+    Budget = atomics:new(1, [{signed, true}]),
+    atomics:put(Budget, 1, 0),
+    Budget.
+
+reserve_and_send(Budget, Subject, Message, Bytes, MaxFrames, MaxBytes) ->
+    reserve_and_send(
+        Budget, Subject, Message, Bytes, MaxFrames, MaxBytes,
+        atomics:get(Budget, 1)).
+
+release(Budget, Bytes) ->
+    release(Budget, Bytes, atomics:get(Budget, 1)).
+
+close_and_send(Budget, Subject) ->
+    close_and_send(Budget, Subject, atomics:get(Budget, 1)).
+
+cancel(Budget) ->
+    atomics:put(Budget, 1, -1),
+    nil.
+
+reserve_and_send(_Budget, _Subject, _Message, _Bytes, _MaxFrames, _MaxBytes,
+                 State) when State < 0 ->
+    false;
+reserve_and_send(Budget, Subject, Message, Bytes, MaxFrames, MaxBytes, State) ->
+    Frames = State div (1 bsl 40),
+    ReservedBytes = State rem (1 bsl 40),
+    case Frames + 1 =< MaxFrames
+         andalso ReservedBytes + Bytes =< MaxBytes of
+        false ->
+            close(Budget, State),
+            false;
+        true ->
+            NewState = State + (1 bsl 40) + Bytes,
+            case atomics:compare_exchange(Budget, 1, State, NewState) of
+                ok ->
+                    send_subject(Subject, Message),
+                    true;
+                Actual ->
+                    reserve_and_send(
+                        Budget, Subject, Message, Bytes, MaxFrames, MaxBytes,
+                        Actual)
+            end
+    end.
+
+release(_Budget, _Bytes, State) when State < 0 ->
+    nil;
+release(Budget, Bytes, State) ->
+    NewState = max(State - (1 bsl 40) - Bytes, 0),
+    case atomics:compare_exchange(Budget, 1, State, NewState) of
+        ok -> nil;
+        Actual -> release(Budget, Bytes, Actual)
+    end.
+
+close_and_send(_Budget, _Subject, State) when State < 0 ->
+    nil;
+close_and_send(Budget, Subject, State) ->
+    case atomics:compare_exchange(Budget, 1, State, -1) of
+        ok -> send_subject(Subject, close);
+        Actual -> close_and_send(Budget, Subject, Actual)
+    end.
+
+close(_Budget, State) when State < 0 ->
+    nil;
+close(Budget, State) ->
+    case atomics:compare_exchange(Budget, 1, State, -1) of
+        ok -> nil;
+        Actual -> close(Budget, Actual)
+    end.
+
+send_subject({subject, Pid, Tag}, Message) ->
+    Pid ! {Tag, Message},
+    nil.

--- a/packages/beryl/test/transport_server_rate_test.gleam
+++ b/packages/beryl/test/transport_server_rate_test.gleam
@@ -62,6 +62,8 @@ fn connect(channels: beryl.Sockets, ip: String) -> Connection {
       seed: socket.empty_seed(),
       connection_permit: permit,
       base_selector: process.new_selector(),
+      config: server.default_config("/socket"),
+      force_close: fn() { Ok(Nil) },
       logger_name: "transport_server_rate_test",
       telemetry: transport.telemetry(channels, transport.Mist),
       codec: option.None,
@@ -86,8 +88,8 @@ fn heartbeat(ref: String) -> String {
 /// arrives within the timeout.
 fn receive_text(connection: Connection) -> Result(String, Nil) {
   case process.selector_receive(from: connection.selector, within: 300) {
-    Ok(server.SendText(text)) -> Ok(text)
-    Ok(server.SendBinary(_)) -> Error(Nil)
+    Ok(server.SendText(text, _)) -> Ok(text)
+    Ok(server.SendBinary(_, _)) -> Error(Nil)
     Ok(server.Close) -> Error(Nil)
     Error(Nil) -> Error(Nil)
   }

--- a/packages/beryl/test/transport_server_test.gleam
+++ b/packages/beryl/test/transport_server_test.gleam
@@ -1,5 +1,6 @@
 import app_test_helper
 import beryl
+import beryl/snapshot
 import beryl/socket
 import beryl/transport
 import beryl/transport/server
@@ -54,6 +55,8 @@ pub fn shared_server_preserves_negotiated_socket_codec_test() -> Nil {
       ),
       connection_permit: connection_permit,
       base_selector: process.new_selector(),
+      config: server.default_config("/socket"),
+      force_close: fn() { Ok(Nil) },
       logger_name: "beryl.transport.server.test",
       telemetry: telemetry,
       codec: Some(tagged_codec()),
@@ -65,7 +68,7 @@ pub fn shared_server_preserves_negotiated_socket_codec_test() -> Nil {
       "[null,\"heartbeat-ref\",\"phoenix\",\"heartbeat\",{}]",
     )
 
-  let assert Ok(server.SendText(reply)) =
+  let assert Ok(server.SendText(reply, _)) =
     process.selector_receive(from: selector, within: 500)
   reply |> should.equal("TAGGED-HB")
   server.close_connection(state)
@@ -102,19 +105,184 @@ pub fn shared_server_closes_when_request_reservation_was_reclaimed_test() -> Nil
     10,
   )
 
+  let forced_closed = process.new_subject()
   let #(state, selector) =
     server.init_connection(
       sockets: sockets,
       seed: socket.empty_seed(),
       connection_permit: connection_permit,
       base_selector: process.new_selector(),
+      config: server.default_config("/socket"),
+      force_close: fn() {
+        process.send(forced_closed, Nil)
+        Ok(Nil)
+      },
       logger_name: "beryl.transport.server.test",
       telemetry: transport.telemetry(sockets, transport.Mist),
       codec: None,
     )
   process.selector_receive(selector, 500)
   |> should.equal(Ok(server.Close))
+  process.receive(forced_closed, 500) |> should.equal(Ok(Nil))
+  let assert Ok(current) = snapshot.get(sockets)
+  snapshot.connected_sockets(current) |> should.equal(0)
   server.close_connection(state)
   let assert Ok(Nil) = beryl.stop(sockets)
+  Nil
+}
+
+pub fn outbound_frame_budget_evicts_before_enqueue_test() -> Nil {
+  let assert Ok(config) =
+    server.default_config("/socket")
+    |> server.with_outbound_limits(max_frames: 2, max_bytes: 1024)
+  let evicted = process.new_subject()
+  let #(state, selector) =
+    start_connection(config, fn() {
+      process.send(evicted, Nil)
+      Ok(Nil)
+    })
+
+  send_heartbeat(state, "one")
+  send_heartbeat(state, "two")
+  send_heartbeat(state, "three")
+
+  let assert Ok(server.SendText(_, _)) =
+    process.selector_receive(from: selector, within: 500)
+  let assert Ok(server.SendText(_, _)) =
+    process.selector_receive(from: selector, within: 500)
+  let assert Error(Nil) = process.selector_receive(from: selector, within: 20)
+  let assert Ok(Nil) = process.receive(evicted, 500)
+  server.close_connection(state)
+}
+
+pub fn outbound_byte_budget_releases_after_write_test() -> Nil {
+  let assert Ok(config) =
+    server.default_config("/socket")
+    |> server.with_outbound_limits(max_frames: 10, max_bytes: 64)
+  let #(state, selector) = start_connection(config, fn() { Ok(Nil) })
+
+  send_heartbeat(state, "one")
+  let assert Ok(server.SendText(_, bytes)) =
+    process.selector_receive(from: selector, within: 500)
+  let assert server.Continue(state) =
+    server.finish_outbound_write(state, bytes, True)
+
+  send_heartbeat(state, "two")
+  let assert Ok(server.SendText(_, second_bytes)) =
+    process.selector_receive(from: selector, within: 500)
+  second_bytes |> should.equal(bytes)
+  server.close_connection(state)
+}
+
+pub fn outbound_byte_budget_evicts_before_enqueue_test() -> Nil {
+  let assert Ok(config) =
+    server.default_config("/socket")
+    |> server.with_outbound_limits(max_frames: 10, max_bytes: 8)
+  let evicted = process.new_subject()
+  let #(state, selector) =
+    start_connection(config, fn() {
+      process.send(evicted, Nil)
+      Ok(Nil)
+    })
+
+  send_heartbeat(state, "too-large")
+
+  let assert Error(Nil) = process.selector_receive(from: selector, within: 20)
+  let assert Ok(Nil) = process.receive(evicted, 500)
+  server.close_connection(state)
+}
+
+pub fn outbound_write_error_cancels_future_enqueues_test() -> Nil {
+  let assert Ok(config) =
+    server.default_config("/socket")
+    |> server.with_outbound_limits(max_frames: 10, max_bytes: 1024)
+  let evicted = process.new_subject()
+  let #(state, selector) =
+    start_connection(config, fn() {
+      process.send(evicted, Nil)
+      Ok(Nil)
+    })
+
+  send_heartbeat(state, "write-error")
+  let assert Ok(server.SendText(_, bytes)) =
+    process.selector_receive(from: selector, within: 500)
+  let assert server.Stop = server.finish_outbound_write(state, bytes, False)
+
+  send_heartbeat(state, "after-error")
+  let assert Error(Nil) = process.selector_receive(from: selector, within: 20)
+  let assert Ok(Nil) = process.receive(evicted, 500)
+  server.close_connection(state)
+}
+
+pub fn outbound_completion_after_close_is_safe_test() -> Nil {
+  let assert Ok(config) =
+    server.default_config("/socket")
+    |> server.with_outbound_limits(max_frames: 1, max_bytes: 1024)
+  let #(state, selector) = start_connection(config, fn() { Ok(Nil) })
+
+  send_heartbeat(state, "closing")
+  let assert Ok(server.SendText(_, bytes)) =
+    process.selector_receive(from: selector, within: 500)
+  server.close_connection(state)
+
+  let assert server.Continue(_) =
+    server.finish_outbound_write(state, bytes, True)
+  Nil
+}
+
+pub fn outbound_config_rejects_non_positive_limits_test() -> Nil {
+  server.default_config("/socket")
+  |> server.with_outbound_limits(max_frames: 0, max_bytes: 1)
+  |> should.equal(Error(server.InvalidMaxOutboundFrames))
+
+  server.default_config("/socket")
+  |> server.with_outbound_limits(max_frames: 1, max_bytes: 0)
+  |> should.equal(Error(server.InvalidMaxOutboundBytes))
+
+  server.default_config("/socket")
+  |> server.with_outbound_limits(max_frames: 8_388_608, max_bytes: 1)
+  |> should.equal(Error(server.MaxOutboundFramesTooLarge))
+
+  server.default_config("/socket")
+  |> server.with_outbound_limits(max_frames: 1, max_bytes: 1_099_511_627_776)
+  |> should.equal(Error(server.MaxOutboundBytesTooLarge))
+}
+
+fn start_connection(
+  config: server.TransportConfig(body),
+  force_close: fn() -> Result(Nil, server.ForceCloseError),
+) -> #(server.ConnectionState, process.Selector(server.SendRequest)) {
+  let assert Ok(sockets) =
+    app_test_helper.start_app(
+      beryl.config(wire.phoenix_codec()),
+      init: app_test_helper.accepting_init,
+      update: app_test_helper.accepting_update,
+    )
+  let assert Ok(connection_permit) =
+    transport.acquire_connection_slot(sockets, "127.0.0.1")
+  server.init_connection(
+    sockets: sockets,
+    seed: socket.ConnectSeed(
+      path: "/socket",
+      query: [],
+      headers: [],
+      metadata: [],
+    ),
+    connection_permit: connection_permit,
+    base_selector: process.new_selector(),
+    config: config,
+    force_close: force_close,
+    logger_name: "beryl.transport.server.test",
+    telemetry: transport.telemetry(sockets, transport.Mist),
+    codec: Some(tagged_codec()),
+  )
+}
+
+fn send_heartbeat(state: server.ConnectionState, message_ref: String) -> Nil {
+  let assert server.Continue(_) =
+    server.handle_text_frame(
+      state,
+      "[null,\"" <> message_ref <> "\",\"phoenix\",\"heartbeat\",{}]",
+    )
   Nil
 }

--- a/packages/beryl_ewe/gleam.toml
+++ b/packages/beryl_ewe/gleam.toml
@@ -13,6 +13,7 @@ gleam_erlang = ">= 1.3.0 and < 2.0.0"
 gleam_crypto = ">= 1.6.0 and < 2.0.0"
 gleam_http = ">= 4.3.0 and < 5.0.0"
 ewe = ">= 4.0.0 and < 5.0.0"
+glisten = ">= 9.0.1 and < 10.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/packages/beryl_ewe/manifest.toml
+++ b/packages/beryl_ewe/manifest.toml
@@ -48,3 +48,4 @@ gleam_otp = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glinter = { version = ">= 2.19.0 and < 3.0.0" }
+glisten = { version = ">= 9.0.1 and < 10.0.0" }

--- a/packages/beryl_ewe/src/beryl_ewe.gleam
+++ b/packages/beryl_ewe/src/beryl_ewe.gleam
@@ -22,6 +22,8 @@ import gleam/http/request.{type Request}
 import gleam/http/response.{type Response}
 import gleam/option.{None}
 import gleam/result
+import glisten/socket as glisten_socket
+import glisten/transport as glisten_transport
 
 /// Upgrade a request to WebSocket if it matches the configured path.
 ///
@@ -58,7 +60,14 @@ pub fn upgrade(
     request_ip: request_ip,
     reject: reject,
     accept: fn(metadata, connection_permit) {
-      do_upgrade(request, channels, metadata, connection_permit, telemetry)
+      do_upgrade(
+        request,
+        channels,
+        config,
+        metadata,
+        connection_permit,
+        telemetry,
+      )
     },
     next: next,
   )
@@ -106,6 +115,7 @@ pub fn handler(
 fn do_upgrade(
   request: Request(Connection),
   channels: Sockets,
+  config: server.TransportConfig(Connection),
   connect_metadata: List(#(String, String)),
   connection_permit: transport.ConnectionPermit,
   telemetry: transport.Telemetry,
@@ -113,7 +123,7 @@ fn do_upgrade(
   let seed = server.connect_seed(request, connect_metadata)
   ewe.upgrade_websocket(
     request,
-    on_init: fn(_connection, base_selector: Selector(SendRequest)) {
+    on_init: fn(connection, base_selector: Selector(SendRequest)) {
       // Extend the selector Ewe provides so the runtime can push outbound
       // frames to this connection's process as `ewe.User(SendRequest)`
       // messages.
@@ -122,6 +132,8 @@ fn do_upgrade(
         seed: seed,
         connection_permit: connection_permit,
         base_selector: base_selector,
+        config: config,
+        force_close: fn() { force_close(connection) },
         logger_name: "beryl_ewe",
         telemetry: telemetry,
         codec: None,
@@ -130,6 +142,17 @@ fn do_upgrade(
     handler: on_message,
     on_close: fn(_connection, state) { server.close_connection(state) },
   )
+}
+
+fn force_close(
+  connection: WebsocketConnection,
+) -> Result(Nil, server.ForceCloseError) {
+  case glisten_transport.close(connection.transport, connection.socket) {
+    Ok(Nil) | Error(glisten_socket.Closed) | Error(glisten_socket.Enotconn) ->
+      Ok(Nil)
+    Error(reason) ->
+      Error(server.ForceCloseFailed(glisten_socket.reason_to_string(reason)))
+  }
 }
 
 /// Handle incoming WebSocket messages.
@@ -147,14 +170,18 @@ fn on_message(
     ewe.Text(text) -> resume(server.handle_text_frame(state, text))
     ewe.Binary(data) -> resume(server.handle_binary_frame(state, data))
     ewe.User(server.Close) -> ewe.websocket_stop()
-    ewe.User(server.SendText(text)) -> {
-      let _send_result = ewe.send_text_frame(connection, text)
-      ewe.websocket_continue(state)
-    }
-    ewe.User(server.SendBinary(data)) -> {
-      let _send_result = ewe.send_binary_frame(connection, data)
-      ewe.websocket_continue(state)
-    }
+    ewe.User(server.SendText(text, bytes)) ->
+      resume(server.finish_outbound_write(
+        state,
+        bytes,
+        ewe.send_text_frame(connection, text) |> result.is_ok,
+      ))
+    ewe.User(server.SendBinary(data, bytes)) ->
+      resume(server.finish_outbound_write(
+        state,
+        bytes,
+        ewe.send_binary_frame(connection, data) |> result.is_ok,
+      ))
   }
 }
 

--- a/packages/beryl_ewe/test/beryl_ewe_transport_test_ffi.erl
+++ b/packages/beryl_ewe/test/beryl_ewe_transport_test_ffi.erl
@@ -3,6 +3,7 @@
          websocket_upgrade_status/2, websocket_upgrade_status_with_origin/3,
          send_text/2, send_binary/2, receive_text/2, receive_binary/2,
          close/1, http_get/2, stop_supervisor/1,
+         suspend_server_peer/1, resume_process/1, outbound_queue_usage/1,
          attach_transport_events/0, detach_transport_events/1,
          receive_upgrade_event/1, receive_frame_event/1,
          receive_message_event/1]).
@@ -262,6 +263,44 @@ close(Socket) ->
     _ = gen_tcp:send(Socket, <<16#88, 16#80, 0, 0, 0, 0>>),
     gen_tcp:close(Socket),
     nil.
+
+suspend_server_peer(Socket) ->
+    {ok, Peer} = inet:sockname(Socket),
+    case find_server_peer(erlang:ports(), Peer) of
+        {ok, Pid} ->
+            true = erlang:suspend_process(Pid),
+            {ok, Pid};
+        error ->
+            {error, nil}
+    end.
+
+find_server_peer([], _Peer) ->
+    error;
+find_server_peer([Port | Rest], Peer) ->
+    case inet:peername(Port) of
+        {ok, Peer} ->
+            case erlang:port_info(Port, connected) of
+                {connected, Pid} -> {ok, Pid};
+                _ -> find_server_peer(Rest, Peer)
+            end;
+        _ ->
+            find_server_peer(Rest, Peer)
+    end.
+
+resume_process(Pid) ->
+    true = erlang:resume_process(Pid),
+    nil.
+
+outbound_queue_usage(Pid) ->
+    {messages, Messages} = erlang:process_info(Pid, messages),
+    lists:foldl(fun
+        ({_Tag, {send_text, _Payload, Bytes}}, {Frames, TotalBytes}) ->
+            {Frames + 1, TotalBytes + Bytes};
+        ({_Tag, {send_binary, _Payload, Bytes}}, {Frames, TotalBytes}) ->
+            {Frames + 1, TotalBytes + Bytes};
+        (_, Usage) ->
+            Usage
+    end, {0, 0}, Messages).
 
 read_headers(Socket, Acc) ->
     case binary:match(Acc, <<"\r\n\r\n">>) of

--- a/packages/beryl_ewe/test/ewe_handler_test.gleam
+++ b/packages/beryl_ewe/test/ewe_handler_test.gleam
@@ -9,6 +9,7 @@ import beryl
 import beryl/socket
 import beryl/transport/server
 import beryl/wire
+import beryl/wire/codec
 import beryl_ewe as ewe_transport
 import ewe
 import gleam/bit_array
@@ -83,6 +84,12 @@ fn receive_message_event(timeout: Int) -> Result(#(String, String, String), Nil)
 @external(erlang, "beryl_ewe_transport_test_ffi", "receive_text")
 fn receive_text(client: WebsocketClient, timeout: Int) -> Result(String, Nil)
 
+@external(erlang, "beryl_ewe_transport_test_ffi", "receive_binary")
+fn receive_binary(
+  client: WebsocketClient,
+  timeout: Int,
+) -> Result(BitArray, Nil)
+
 @external(erlang, "beryl_ewe_transport_test_ffi", "close")
 fn close(client: WebsocketClient) -> Nil
 
@@ -91,6 +98,15 @@ fn http_get(port: Int, path: String) -> Result(Int, Nil)
 
 @external(erlang, "beryl_ewe_transport_test_ffi", "stop_supervisor")
 fn stop_supervisor(pid: process.Pid) -> Nil
+
+@external(erlang, "beryl_ewe_transport_test_ffi", "suspend_server_peer")
+fn suspend_server_peer(client: WebsocketClient) -> Result(process.Pid, Nil)
+
+@external(erlang, "beryl_ewe_transport_test_ffi", "resume_process")
+fn resume_process(pid: process.Pid) -> Nil
+
+@external(erlang, "beryl_ewe_transport_test_ffi", "outbound_queue_usage")
+fn outbound_queue_usage(pid: process.Pid) -> #(Int, Int)
 
 // Runtime log capture distinguishes edge shedding from runtime shedding.
 type CapturedLog {
@@ -559,6 +575,136 @@ pub fn handler_closes_socket_on_oversized_text_frame_test() -> Nil {
 
   close(client)
   stop_supervisor(server_pid)
+}
+
+pub fn outbound_budget_evicts_and_releases_for_healthy_clients_test() -> Nil {
+  let channels = start_channels()
+  let assert Ok(healthy_config) =
+    server.default_config("/socket")
+    |> server.with_outbound_limits(max_frames: 1, max_bytes: 1024)
+  let #(healthy_port, healthy_server) =
+    start_server_with_config(channels, healthy_config)
+  let assert Ok(healthy_client) = connect_websocket(healthy_port, "/socket")
+
+  let assert Ok(healthy_client) =
+    send_text(healthy_client, "[null,\"one\",\"phoenix\",\"heartbeat\",{}]")
+  receive_text(healthy_client, 1000) |> should.be_ok
+  let assert Ok(healthy_client) =
+    send_text(healthy_client, "[null,\"two\",\"phoenix\",\"heartbeat\",{}]")
+  receive_text(healthy_client, 1000) |> should.be_ok
+  close(healthy_client)
+  stop_supervisor(healthy_server)
+
+  let channels = start_channels()
+  let assert Ok(restrictive_config) =
+    server.default_config("/socket")
+    |> server.with_outbound_limits(max_frames: 1, max_bytes: 1)
+  let #(restricted_port, restricted_server) =
+    start_server_with_config(channels, restrictive_config)
+  let assert Ok(slow_client) = connect_websocket(restricted_port, "/socket")
+  let assert Ok(_) =
+    send_text(slow_client, "[null,\"too-large\",\"phoenix\",\"heartbeat\",{}]")
+  receive_text(slow_client, 1000) |> should.equal(Error(Nil))
+
+  let assert Ok(reconnected) = connect_websocket(restricted_port, "/socket")
+  close(reconnected)
+  stop_supervisor(restricted_server)
+}
+
+pub fn stalled_client_outbound_queue_is_bounded_test() -> Nil {
+  let channels = start_mixed_outbound_system()
+  let assert Ok(config) =
+    server.default_config("/socket")
+    |> server.with_outbound_limits(max_frames: 32, max_bytes: 256)
+  let #(port, server_pid) = start_server_with_config(channels, config)
+  let assert Ok(slow_client) = connect_websocket(port, "/socket")
+  let assert Ok(healthy_client) = connect_websocket(port, "/socket")
+  let assert Ok(slow_client) =
+    send_text(slow_client, "[null,\"slow\",\"room:lobby\",\"phx_join\",{}]")
+  let assert Ok(healthy_client) =
+    send_text(
+      healthy_client,
+      "[null,\"healthy\",\"room:lobby\",\"phx_join\",{}]",
+    )
+  receive_text(slow_client, 1000) |> should.be_ok
+  receive_text(healthy_client, 1000) |> should.be_ok
+  let assert Ok(connection_pid) = suspend_server_peer(slow_client)
+
+  send_mixed_broadcasts(channels, healthy_client, 1, 50)
+  let #(frames, bytes) = outbound_queue_usage(connection_pid)
+  { frames > 0 && frames <= 32 } |> should.be_true
+  { bytes > 0 && bytes <= 256 } |> should.be_true
+
+  resume_process(connection_pid)
+  receive_text(slow_client, 1000) |> should.equal(Error(Nil))
+  let assert Ok(reconnected) = connect_websocket(port, "/socket")
+  let assert Ok(reconnected) =
+    send_text(reconnected, "[null,\"healthy\",\"phoenix\",\"heartbeat\",{}]")
+  receive_text(reconnected, 1000) |> should.be_ok
+  close(reconnected)
+  stop_supervisor(server_pid)
+}
+
+fn send_mixed_broadcasts(
+  channels: beryl.Sockets,
+  healthy_client: WebsocketClient,
+  index: Int,
+  remaining: Int,
+) -> Nil {
+  case remaining <= 0 {
+    True -> Nil
+    False -> {
+      let text_event = "text-" <> int.to_string(index)
+      beryl.broadcast(channels, "room:lobby", text_event, json.object([]))
+      receive_text(healthy_client, 1000) |> should.equal(Ok(text_event))
+
+      let binary_event = "binary-" <> int.to_string(index)
+      beryl.broadcast(channels, "room:lobby", binary_event, json.object([]))
+      receive_binary(healthy_client, 1000)
+      |> should.equal(Ok(bit_array.from_string(binary_event)))
+
+      send_mixed_broadcasts(channels, healthy_client, index + 1, remaining - 1)
+    }
+  }
+}
+
+fn start_mixed_outbound_system() -> beryl.Sockets {
+  let phoenix = wire.phoenix_codec()
+  let mixed_codec =
+    codec.new(
+      decode_text: wire.decode_message,
+      encode_reply: codec.encode_reply(phoenix),
+      encode_push: fn(_topic, event, _payload) {
+        case string.starts_with(event, "binary-") {
+          True -> codec.BinaryFrame(bit_array.from_string(event))
+          False -> codec.TextFrame(event)
+        }
+      },
+      encode_heartbeat_reply: codec.encode_heartbeat_reply(phoenix),
+    )
+  start_app_system_with_update(beryl.config(mixed_codec), fn(model, event) {
+    case event {
+      socket.Join(_, _, reference) ->
+        socket.Next(model, [socket.AcceptJoin(reference, option.None)])
+      socket.Message(_, _, _, _)
+      | socket.Binary(_, _)
+      | socket.Closed(_, _)
+      | socket.Info(_) -> socket.Next(model, [])
+    }
+  })
+}
+
+fn start_app_system_with_update(
+  config: beryl.Config,
+  update: fn(Nil, socket.Input(Nil)) -> socket.Next(Nil),
+) -> beryl.Sockets {
+  let assert Ok(channels) =
+    app_test_helper.start(
+      config,
+      init: fn(_info) { #(Nil, []) },
+      update: update,
+    )
+  channels
 }
 
 pub fn runtime_death_closes_the_connection_test() -> Nil {

--- a/packages/beryl_ewe/test/ewe_transport_test.gleam
+++ b/packages/beryl_ewe/test/ewe_transport_test.gleam
@@ -29,6 +29,14 @@ pub fn config_builders_instantiate_for_ewe_test() -> Nil {
   should.be_true(True)
 }
 
+pub fn outbound_limits_builder_instantiate_for_ewe_test() -> Nil {
+  let assert Ok(_config) =
+    server.default_config("/socket")
+    |> server.with_outbound_limits(max_frames: 8, max_bytes: 4096)
+
+  should.be_true(True)
+}
+
 // `upgrade` is the path-matching entry point used by callers that compose their
 // own request handler. Reference it here so the export stays covered.
 pub fn upgrade_is_exported_test() -> Nil {

--- a/packages/beryl_mist/gleam.toml
+++ b/packages/beryl_mist/gleam.toml
@@ -13,6 +13,7 @@ gleam_erlang = ">= 1.3.0 and < 2.0.0"
 gleam_crypto = ">= 1.6.0 and < 2.0.0"
 gleam_http = ">= 4.3.0 and < 5.0.0"
 mist = ">= 6.0.0 and < 7.0.0"
+glisten = ">= 9.0.1 and < 10.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/packages/beryl_mist/manifest.toml
+++ b/packages/beryl_mist/manifest.toml
@@ -54,5 +54,6 @@ gleam_otp = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glinter = { version = ">= 2.19.0 and < 3.0.0" }
+glisten = { version = ">= 9.0.1 and < 10.0.0" }
 gluegun = { git = "https://github.com/tylerbutler/gluegun.git", ref = "532af1ac0308ff93c8a957467dbb638859593c93" }
 mist = { version = ">= 6.0.0 and < 7.0.0" }

--- a/packages/beryl_mist/src/beryl_mist.gleam
+++ b/packages/beryl_mist/src/beryl_mist.gleam
@@ -18,6 +18,8 @@ import gleam/http/request.{type Request}
 import gleam/http/response.{type Response}
 import gleam/option.{None, Some}
 import gleam/result
+import glisten/socket as glisten_socket
+import glisten/transport as glisten_transport
 import mist.{type Connection, type ResponseData, type WebsocketConnection}
 
 /// Upgrade a request to WebSocket if it matches the configured path.
@@ -55,7 +57,14 @@ pub fn upgrade(
     request_ip: request_ip,
     reject: reject,
     accept: fn(metadata, connection_permit) {
-      do_upgrade(request, channels, metadata, connection_permit, telemetry)
+      do_upgrade(
+        request,
+        channels,
+        config,
+        metadata,
+        connection_permit,
+        telemetry,
+      )
     },
     next: next,
   )
@@ -103,6 +112,7 @@ pub fn handler(
 fn do_upgrade(
   request: Request(Connection),
   channels: Sockets,
+  config: server.TransportConfig(Connection),
   connect_metadata: List(#(String, String)),
   connection_permit: transport.ConnectionPermit,
   telemetry: transport.Telemetry,
@@ -111,13 +121,15 @@ fn do_upgrade(
   mist.websocket(
     request: request,
     handler: on_message,
-    on_init: fn(_connection) {
+    on_init: fn(connection) {
       let #(state, selector) =
         server.init_connection(
           sockets: channels,
           seed: seed,
           connection_permit: connection_permit,
           base_selector: process.new_selector(),
+          config: config,
+          force_close: fn() { force_close(connection) },
           logger_name: "beryl_mist",
           telemetry: telemetry,
           codec: None,
@@ -126,6 +138,17 @@ fn do_upgrade(
     },
     on_close: server.close_connection,
   )
+}
+
+fn force_close(
+  connection: WebsocketConnection,
+) -> Result(Nil, server.ForceCloseError) {
+  case glisten_transport.close(connection.transport, connection.socket) {
+    Ok(Nil) | Error(glisten_socket.Closed) | Error(glisten_socket.Enotconn) ->
+      Ok(Nil)
+    Error(reason) ->
+      Error(server.ForceCloseFailed(glisten_socket.reason_to_string(reason)))
+  }
 }
 
 /// Handle incoming WebSocket messages.
@@ -142,14 +165,18 @@ fn on_message(
     mist.Binary(data) -> resume(server.handle_binary_frame(state, data))
     mist.Closed | mist.Shutdown -> mist.stop()
     mist.Custom(server.Close) -> mist.stop()
-    mist.Custom(server.SendText(text)) -> {
-      let _send_result = mist.send_text_frame(connection, text)
-      mist.continue(state)
-    }
-    mist.Custom(server.SendBinary(data)) -> {
-      let _send_result = mist.send_binary_frame(connection, data)
-      mist.continue(state)
-    }
+    mist.Custom(server.SendText(text, bytes)) ->
+      resume(server.finish_outbound_write(
+        state,
+        bytes,
+        mist.send_text_frame(connection, text) |> result.is_ok,
+      ))
+    mist.Custom(server.SendBinary(data, bytes)) ->
+      resume(server.finish_outbound_write(
+        state,
+        bytes,
+        mist.send_binary_frame(connection, data) |> result.is_ok,
+      ))
   }
 }
 

--- a/packages/beryl_mist/test/beryl_mist_transport_test_ffi.erl
+++ b/packages/beryl_mist/test/beryl_mist_transport_test_ffi.erl
@@ -3,6 +3,7 @@
          websocket_upgrade_status/2, websocket_upgrade_status_with_origin/3,
          send_text/2, send_binary/2, receive_text/2, receive_binary/2,
          close/1, http_get/2, stop_supervisor/1,
+         suspend_server_peer/1, resume_process/1, outbound_queue_usage/1,
          attach_transport_events/0, detach_transport_events/1,
          receive_upgrade_event/1, receive_frame_event/1,
          receive_message_event/1]).
@@ -262,6 +263,44 @@ close(Socket) ->
     _ = gen_tcp:send(Socket, <<16#88, 16#80, 0, 0, 0, 0>>),
     gen_tcp:close(Socket),
     nil.
+
+suspend_server_peer(Socket) ->
+    {ok, Peer} = inet:sockname(Socket),
+    case find_server_peer(erlang:ports(), Peer) of
+        {ok, Pid} ->
+            true = erlang:suspend_process(Pid),
+            {ok, Pid};
+        error ->
+            {error, nil}
+    end.
+
+find_server_peer([], _Peer) ->
+    error;
+find_server_peer([Port | Rest], Peer) ->
+    case inet:peername(Port) of
+        {ok, Peer} ->
+            case erlang:port_info(Port, connected) of
+                {connected, Pid} -> {ok, Pid};
+                _ -> find_server_peer(Rest, Peer)
+            end;
+        _ ->
+            find_server_peer(Rest, Peer)
+    end.
+
+resume_process(Pid) ->
+    true = erlang:resume_process(Pid),
+    nil.
+
+outbound_queue_usage(Pid) ->
+    {messages, Messages} = erlang:process_info(Pid, messages),
+    lists:foldl(fun
+        ({_Tag, {send_text, _Payload, Bytes}}, {Frames, TotalBytes}) ->
+            {Frames + 1, TotalBytes + Bytes};
+        ({_Tag, {send_binary, _Payload, Bytes}}, {Frames, TotalBytes}) ->
+            {Frames + 1, TotalBytes + Bytes};
+        (_, Usage) ->
+            Usage
+    end, {0, 0}, Messages).
 
 read_headers(Socket, Acc) ->
     case binary:match(Acc, <<"\r\n\r\n">>) of

--- a/packages/beryl_mist/test/mist_handler_test.gleam
+++ b/packages/beryl_mist/test/mist_handler_test.gleam
@@ -8,6 +8,7 @@ import beryl
 import beryl/socket
 import beryl/transport/server
 import beryl/wire
+import beryl/wire/codec
 import beryl_mist as mist_transport
 import gleam/bit_array
 import gleam/bytes_tree
@@ -19,6 +20,7 @@ import gleam/erlang/process
 import gleam/http/request
 import gleam/http/response
 import gleam/int
+import gleam/json
 import gleam/option.{None}
 import gleam/string
 import gleeunit/should
@@ -80,6 +82,12 @@ fn receive_message_event(timeout: Int) -> Result(#(String, String, String), Nil)
 @external(erlang, "beryl_mist_transport_test_ffi", "receive_text")
 fn receive_text(client: WebsocketClient, timeout: Int) -> Result(String, Nil)
 
+@external(erlang, "beryl_mist_transport_test_ffi", "receive_binary")
+fn receive_binary(
+  client: WebsocketClient,
+  timeout: Int,
+) -> Result(BitArray, Nil)
+
 @external(erlang, "beryl_mist_transport_test_ffi", "close")
 fn close(client: WebsocketClient) -> Nil
 
@@ -88,6 +96,15 @@ fn http_get(port: Int, path: String) -> Result(Int, Nil)
 
 @external(erlang, "beryl_mist_transport_test_ffi", "stop_supervisor")
 fn stop_supervisor(pid: process.Pid) -> Nil
+
+@external(erlang, "beryl_mist_transport_test_ffi", "suspend_server_peer")
+fn suspend_server_peer(client: WebsocketClient) -> Result(process.Pid, Nil)
+
+@external(erlang, "beryl_mist_transport_test_ffi", "resume_process")
+fn resume_process(pid: process.Pid) -> Nil
+
+@external(erlang, "beryl_mist_transport_test_ffi", "outbound_queue_usage")
+fn outbound_queue_usage(pid: process.Pid) -> #(Int, Int)
 
 // Runtime log capture distinguishes edge shedding from runtime shedding.
 type CapturedLog {
@@ -580,4 +597,134 @@ pub fn handler_closes_socket_on_oversized_text_frame_test() -> Nil {
 
   close(client)
   stop_supervisor(server_pid)
+}
+
+pub fn outbound_budget_evicts_and_releases_for_healthy_clients_test() -> Nil {
+  let channels = start_channels()
+  let assert Ok(healthy_config) =
+    server.default_config("/socket")
+    |> server.with_outbound_limits(max_frames: 1, max_bytes: 1024)
+  let #(healthy_port, healthy_server) =
+    start_server_with_config(channels, healthy_config)
+  let assert Ok(healthy_client) = connect_websocket(healthy_port, "/socket")
+
+  let assert Ok(healthy_client) =
+    send_text(healthy_client, "[null,\"one\",\"phoenix\",\"heartbeat\",{}]")
+  receive_text(healthy_client, 1000) |> should.be_ok
+  let assert Ok(healthy_client) =
+    send_text(healthy_client, "[null,\"two\",\"phoenix\",\"heartbeat\",{}]")
+  receive_text(healthy_client, 1000) |> should.be_ok
+  close(healthy_client)
+  stop_supervisor(healthy_server)
+
+  let channels = start_channels()
+  let assert Ok(restrictive_config) =
+    server.default_config("/socket")
+    |> server.with_outbound_limits(max_frames: 1, max_bytes: 1)
+  let #(restricted_port, restricted_server) =
+    start_server_with_config(channels, restrictive_config)
+  let assert Ok(slow_client) = connect_websocket(restricted_port, "/socket")
+  let assert Ok(_) =
+    send_text(slow_client, "[null,\"too-large\",\"phoenix\",\"heartbeat\",{}]")
+  receive_text(slow_client, 1000) |> should.equal(Error(Nil))
+
+  let assert Ok(reconnected) = connect_websocket(restricted_port, "/socket")
+  close(reconnected)
+  stop_supervisor(restricted_server)
+}
+
+pub fn stalled_client_outbound_queue_is_bounded_test() -> Nil {
+  let channels = start_mixed_outbound_system()
+  let assert Ok(config) =
+    server.default_config("/socket")
+    |> server.with_outbound_limits(max_frames: 32, max_bytes: 256)
+  let #(port, server_pid) = start_server_with_config(channels, config)
+  let assert Ok(slow_client) = connect_websocket(port, "/socket")
+  let assert Ok(healthy_client) = connect_websocket(port, "/socket")
+  let assert Ok(slow_client) =
+    send_text(slow_client, "[null,\"slow\",\"room:lobby\",\"phx_join\",{}]")
+  let assert Ok(healthy_client) =
+    send_text(
+      healthy_client,
+      "[null,\"healthy\",\"room:lobby\",\"phx_join\",{}]",
+    )
+  receive_text(slow_client, 1000) |> should.be_ok
+  receive_text(healthy_client, 1000) |> should.be_ok
+  let assert Ok(connection_pid) = suspend_server_peer(slow_client)
+
+  send_mixed_broadcasts(channels, healthy_client, 1, 50)
+  let #(frames, bytes) = outbound_queue_usage(connection_pid)
+  { frames > 0 && frames <= 32 } |> should.be_true
+  { bytes > 0 && bytes <= 256 } |> should.be_true
+
+  resume_process(connection_pid)
+  receive_text(slow_client, 1000) |> should.equal(Error(Nil))
+  let assert Ok(reconnected) = connect_websocket(port, "/socket")
+  let assert Ok(reconnected) =
+    send_text(reconnected, "[null,\"healthy\",\"phoenix\",\"heartbeat\",{}]")
+  receive_text(reconnected, 1000) |> should.be_ok
+  close(reconnected)
+  stop_supervisor(server_pid)
+}
+
+fn send_mixed_broadcasts(
+  channels: beryl.Sockets,
+  healthy_client: WebsocketClient,
+  index: Int,
+  remaining: Int,
+) -> Nil {
+  case remaining <= 0 {
+    True -> Nil
+    False -> {
+      let text_event = "text-" <> int.to_string(index)
+      beryl.broadcast(channels, "room:lobby", text_event, json.object([]))
+      receive_text(healthy_client, 1000) |> should.equal(Ok(text_event))
+
+      let binary_event = "binary-" <> int.to_string(index)
+      beryl.broadcast(channels, "room:lobby", binary_event, json.object([]))
+      receive_binary(healthy_client, 1000)
+      |> should.equal(Ok(bit_array.from_string(binary_event)))
+
+      send_mixed_broadcasts(channels, healthy_client, index + 1, remaining - 1)
+    }
+  }
+}
+
+fn start_mixed_outbound_system() -> beryl.Sockets {
+  let phoenix = wire.phoenix_codec()
+  let mixed_codec =
+    codec.new(
+      decode_text: wire.decode_message,
+      encode_reply: codec.encode_reply(phoenix),
+      encode_push: fn(_topic, event, _payload) {
+        case string.starts_with(event, "binary-") {
+          True -> codec.BinaryFrame(bit_array.from_string(event))
+          False -> codec.TextFrame(event)
+        }
+      },
+      encode_heartbeat_reply: codec.encode_heartbeat_reply(phoenix),
+    )
+  start_app_system_with_update(beryl.config(mixed_codec), fn(model, event) {
+    case event {
+      socket.Join(_, _, reference) ->
+        socket.Next(model, [socket.AcceptJoin(reference, None)])
+      socket.Message(_, _, _, _)
+      | socket.Binary(_, _)
+      | socket.Closed(_, _)
+      | socket.Info(_) -> socket.Next(model, [])
+    }
+  })
+}
+
+fn start_app_system_with_update(
+  config: beryl.Config,
+  update: fn(Nil, socket.Input(Nil)) -> socket.Next(Nil),
+) -> beryl.Sockets {
+  let assert Ok(channels) =
+    app_test_helper.start(
+      config,
+      init: fn(_info) { #(Nil, []) },
+      update: update,
+    )
+  channels
 }

--- a/packages/beryl_mist/test/mist_transport_test.gleam
+++ b/packages/beryl_mist/test/mist_transport_test.gleam
@@ -26,3 +26,11 @@ pub fn config_builders_instantiate_for_mist_test() -> Nil {
 
   should.be_true(True)
 }
+
+pub fn outbound_limits_builder_instantiate_for_mist_test() -> Nil {
+  let assert Ok(_config) =
+    server.default_config("/socket")
+    |> server.with_outbound_limits(max_frames: 8, max_bytes: 4096)
+
+  should.be_true(True)
+}

--- a/website/src/content/docs/architecture/wire-and-transport.md
+++ b/website/src/content/docs/architecture/wire-and-transport.md
@@ -105,6 +105,12 @@ and peer-IP functions:
 
 **`server.with_allowed_origins(config, origins)`**: attaches an exact-match allow-list for browser `Origin` headers, such as `["https://app.example.com"]`. Use this when cookie-authenticated WebSockets need CSWSH protection.
 
+**`server.with_outbound_limits(config, max_frames:, max_bytes:)`**: sets the
+finite per-connection budget reserved before outbound frames enter the
+connection mailbox. The defaults are 256 frames and 1 MiB. Exceeding either
+limit closes the connection; frames are not silently dropped. An `Ok` send
+result means enqueued, not delivered.
+
 **`upgrade(request, channels, config, next)`**: checks whether the request path matches the configured socket path, runs the `on_connect` hook, and performs the WebSocket upgrade. Calls `next()` when the path does not match, enabling use as middleware.
 
 **`is_websocket_request(request)`**: checks the `Upgrade: websocket` header.

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -25,6 +25,10 @@ Even with no configuration, beryl enforces:
   and messages carrying a stale `join_ref` are dropped.
 - **Heartbeat eviction**: sockets that stop sending heartbeats are evicted
   and their connections closed (60 s window by default, `with_heartbeat`).
+- **Outbound queue budget**: each connection may reserve at most 256 frames
+  and 1 MiB of payload data while writes are pending. beryl closes a slow
+  connection instead of dropping frames. Use `with_outbound_limits` on the
+  transport config to adjust both limits.
 
 The frame-size check limits decoding and routing work. It does **not** limit
 transport memory because buffering and reassembly occur before beryl receives
@@ -54,6 +58,10 @@ let config =
   // Node-wide ceiling on concurrent connections across all IPs. Size to a
   // single node's process/socket/runtime budget; see below.
   |> beryl.with_max_connections(max_connections: 10_000)
+
+let assert Ok(websocket_config) =
+  server.default_config("/socket/websocket")
+  |> server.with_outbound_limits(max_frames: 256, max_bytes: 1_048_576)
 ```
 
 `with_frame_rate` and `with_message_rate` are independent. Joins use frame and
@@ -67,6 +75,18 @@ Size both rate and burst allowances with enough headroom for legitimate client
 traffic **plus heartbeats**. A limit that admits an application's normal events
 but leaves no heartbeat capacity can evict healthy clients during ordinary
 bursts.
+
+The outbound budget is enforced before a frame enters the connection
+mailbox. `Ok` from the runtime send callback means that the frame was
+enqueued; it does not mean that the transport wrote it or that the peer
+received it. Successful writes release their frame and byte reservations.
+Write errors and connection close release all remaining reservations. If a
+connection exceeds either limit, beryl closes it so the client can reconnect
+and resynchronize instead of receiving a stream with silently dropped frames.
+
+Set the byte budget above the largest legitimate encoded outbound frame. Size
+the frame budget for short write stalls, not sustained client outages. The
+defaults allow 256 frames and 1 MiB per connection.
 
 Optionally, `with_channel_rate` adds a per-socket-per-topic limit on top of
 the global per-socket message rate, useful when a single busy topic must not

--- a/website/src/content/docs/reference/api/beryl-transport-server.md
+++ b/website/src/content/docs/reference/api/beryl-transport-server.md
@@ -21,7 +21,8 @@ Server-agnostic WebSocket transport infrastructure.
  its builders, the upgrade admission pipeline (path matching, origin
  policy, `?vsn` negotiation, connection limits, `on_connect`
  authentication), per-connection lifecycle choreography, and the inbound
- frame pipeline (size caps, frame-rate limiting, decoding, routing).
+ frame pipeline (size caps, frame-rate limiting, decoding, routing), plus
+ bounded outbound admission and write accounting.
 
  Transport packages such as `beryl_mist` and `beryl_ewe` supply only the
  server-specific glue: the WebSocket upgrade call, frame sending, and peer
@@ -35,7 +36,9 @@ Server-agnostic WebSocket transport infrastructure.
   <ul>
 <li><a href="#api-type-connecterror"><code>ConnectError</code></a></li>
 <li><a href="#api-type-connectionstate"><code>ConnectionState</code></a></li>
+<li><a href="#api-type-forcecloseerror"><code>ForceCloseError</code></a></li>
 <li><a href="#api-type-framedisposition"><code>FrameDisposition</code></a></li>
+<li><a href="#api-type-outboundconfigerror"><code>OutboundConfigError</code></a></li>
 <li><a href="#api-type-sendrequest"><code>SendRequest</code></a></li>
 <li><a href="#api-type-transportconfig"><code>TransportConfig</code></a></li>
   </ul>
@@ -46,6 +49,7 @@ Server-agnostic WebSocket transport infrastructure.
 <li><a href="#api-function-close_connection"><code>close_connection</code></a></li>
 <li><a href="#api-function-connect_seed"><code>connect_seed</code></a></li>
 <li><a href="#api-function-default_config"><code>default_config</code></a></li>
+<li><a href="#api-function-finish_outbound_write"><code>finish_outbound_write</code></a></li>
 <li><a href="#api-function-handle_binary_frame"><code>handle_binary_frame</code></a></li>
 <li><a href="#api-function-handle_text_frame"><code>handle_text_frame</code></a></li>
 <li><a href="#api-function-handler"><code>handler</code></a></li>
@@ -55,6 +59,7 @@ Server-agnostic WebSocket transport infrastructure.
 <li><a href="#api-function-with_allow_all_origins"><code>with_allow_all_origins</code></a></li>
 <li><a href="#api-function-with_allowed_origins"><code>with_allowed_origins</code></a></li>
 <li><a href="#api-function-with_on_connect"><code>with_on_connect</code></a></li>
+<li><a href="#api-function-with_outbound_limits"><code>with_outbound_limits</code></a></li>
   </ul>
 </section>
 </nav>
@@ -93,6 +98,18 @@ pub type ConnectionState
 
 State maintained per WebSocket connection.
 
+<div class="api-entry-anchor" id="api-type-forcecloseerror" aria-hidden="true"></div>
+
+### `ForceCloseError`
+
+```gleam
+pub type ForceCloseError {
+  ForceCloseFailed(reason: String)
+}
+```
+
+An unexpected error while forcibly closing a connection.
+
 <div class="api-entry-anchor" id="api-type-framedisposition" aria-hidden="true"></div>
 
 ### `FrameDisposition`
@@ -122,7 +139,56 @@ Keep the connection open with the updated state.
 Stop
 ```
 
-Close the connection (the frame exceeded the configured size cap).
+Close the connection after a frame limit or transport write failure.
+
+<div class="api-entry-anchor" id="api-type-outboundconfigerror" aria-hidden="true"></div>
+
+### `OutboundConfigError`
+
+```gleam
+pub type OutboundConfigError {
+  InvalidMaxOutboundFrames
+  InvalidMaxOutboundBytes
+  MaxOutboundFramesTooLarge
+  MaxOutboundBytesTooLarge
+}
+```
+
+Errors returned when configuring a connection's outbound budget.
+
+#### Constructors
+
+##### `InvalidMaxOutboundFrames`
+
+```gleam
+InvalidMaxOutboundFrames
+```
+
+The frame limit was less than one.
+
+##### `InvalidMaxOutboundBytes`
+
+```gleam
+InvalidMaxOutboundBytes
+```
+
+The byte limit was less than one.
+
+##### `MaxOutboundFramesTooLarge`
+
+```gleam
+MaxOutboundFramesTooLarge
+```
+
+The frame limit cannot fit in the transport's atomic counter.
+
+##### `MaxOutboundBytesTooLarge`
+
+```gleam
+MaxOutboundBytesTooLarge
+```
+
+The byte limit cannot fit in the transport's atomic counter.
 
 <div class="api-entry-anchor" id="api-type-sendrequest" aria-hidden="true"></div>
 
@@ -130,8 +196,14 @@ Close the connection (the frame exceeded the configured size cap).
 
 ```gleam
 pub type SendRequest {
-  SendText(String)
-  SendBinary(BitArray)
+  SendText(
+    String,
+    bytes: Int
+  )
+  SendBinary(
+    BitArray,
+    bytes: Int
+  )
   Close
 }
 ```
@@ -213,11 +285,30 @@ Create a default transport config with no connect hook.
  the `origin.SameOrigin` origin policy, which rejects cross-site WebSocket
  upgrades before the handshake as CSWSH protection. Same-origin upgrades and
  non-browser clients (no `Origin` header) are admitted without
- configuration.
+ configuration. Each connection also has an outbound budget of 256 frames
+ and 1 MiB of payload data. A connection that exceeds either limit is closed.
 
  Add `with_on_connect` to authenticate connections and/or seed connect
  metadata. Use `with_allowed_origins` to set an explicit allow-list. Use
  `with_allow_all_origins` to opt out of origin checking entirely.
+
+<div class="api-entry-anchor" id="api-function-finish_outbound_write" aria-hidden="true"></div>
+
+### `finish_outbound_write`
+
+```gleam
+pub fn finish_outbound_write(
+  ConnectionState,
+  Int,
+  Bool
+) -> FrameDisposition
+```
+
+Complete one outbound write.
+
+ On success, this releases the frame and byte reservation and keeps the
+ connection open. On error, it releases the reservation, records the
+ connection as closed, logs the failure, and tells the transport to stop.
 
 <div class="api-entry-anchor" id="api-function-handle_binary_frame" aria-hidden="true"></div>
 
@@ -279,6 +370,8 @@ pub fn init_connection(
   seed: socket.ConnectSeed,
   connection_permit: transport.ConnectionPermit,
   base_selector: process.Selector(SendRequest),
+  config: TransportConfig(a),
+  force_close: fn() -> Result(Nil, ForceCloseError),
   logger_name: String,
   telemetry: transport.Telemetry,
   codec: option.Option(codec.Codec)
@@ -302,6 +395,11 @@ Initialize a new WebSocket connection in its connection process.
  the connection closes. `logger_name` names the transport in decode warnings
  (e.g. `"beryl_mist"`). `codec` is the codec negotiated for this socket;
  `None` inherits the app-wide codec.
+
+ `force_close` must immediately close the underlying socket. beryl calls
+ it if binding fails or the outbound budget is full, so a blocked writer
+ cannot retain an unbounded mailbox. Return an error when the close fails
+ unexpectedly; beryl logs that failure.
 
 <div class="api-entry-anchor" id="api-function-is_websocket_request" aria-hidden="true"></div>
 
@@ -443,3 +541,24 @@ Set a socket-level connect/authentication callback on the transport config.
 
  `ConnectSeed.metadata` preserves callback order and duplicate keys.
  Transports never log metadata values.
+
+<div class="api-entry-anchor" id="api-function-with_outbound_limits" aria-hidden="true"></div>
+
+### `with_outbound_limits`
+
+```gleam
+pub fn with_outbound_limits(
+  TransportConfig(a),
+  max_frames: Int,
+  max_bytes: Int
+) -> Result(TransportConfig(a), OutboundConfigError)
+```
+
+Set the per-connection outbound frame and payload-byte limits.
+
+ `max_frames` must be from 1 through 8,388,607. `max_bytes` must be from 1
+ through 1,099,511,627,775 (one byte less than 1 TiB). Before beryl enqueues
+ a text or binary frame, it reserves one frame and the payload's byte size.
+ If either limit would be exceeded, the frame is rejected and the slow
+ connection is closed. Capacity is released after a successful write, a
+ write error, or connection close.


### PR DESCRIPTION
## Summary

Bound pending outbound writes in Mist and Ewe before enqueueing frames. Each connection defaults to 256 frames and 1 MiB of payload data. Exceeding either budget closes the connection so the client can reconnect and resynchronize.

Use lock-free atomic accounting, release reservations after writes or closure, and handle transport write and force-close errors. Cover stalled clients, bounded frame and byte queues, concurrent healthy clients, mixed text/binary traffic, and reconnects.

Update production-hardening guidance, generated API docs, dependencies, and changelog fragments.

Closes #249.