### PR TITLE
fix(transport): reclaim abandoned connection reservations

### DIFF
--- a/.changes/unreleased/beryl-reclaim-abandoned-and-timed.toml
+++ b/.changes/unreleased/beryl-reclaim-abandoned-and-timed.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Reclaim abandoned and timed-out connection reservations."

--- a/packages/beryl/src/beryl/connection_limit.gleam
+++ b/packages/beryl/src/beryl/connection_limit.gleam
@@ -20,6 +20,7 @@ import beryl/rate_limit
 import gleam/bool
 import gleam/dict.{type Dict}
 import gleam/erlang/process.{type Monitor, type Pid, type Subject}
+import gleam/erlang/reference
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
@@ -36,6 +37,17 @@ const one_second_ns = 1_000_000_000
 @external(erlang, "beryl_ffi", "monotonic_time_ns")
 fn monotonic_time_ns() -> Int
 
+type ReservationToken
+
+@external(erlang, "beryl_ffi", "admission_token_new")
+fn new_reservation_token() -> ReservationToken
+
+@external(erlang, "beryl_ffi", "admission_token_cancel")
+fn cancel_reservation_token(token: ReservationToken) -> Bool
+
+@external(erlang, "beryl_ffi", "admission_token_pending")
+fn reservation_token_pending(token: ReservationToken) -> Bool
+
 /// Opaque connection limiter registry.
 pub opaque type ConnectionLimiter {
   ConnectionLimiter(subject: Subject(Message))
@@ -43,11 +55,19 @@ pub opaque type ConnectionLimiter {
 
 /// A checked-out connection slot. Release it when the socket closes.
 pub opaque type Permit {
-  Permit(limiter: ConnectionLimiter, ip: String)
+  Permit(
+    limiter: ConnectionLimiter,
+    reservation: reference.Reference,
+    token: ReservationToken,
+  )
 }
 
 type RateBucket {
   RateBucket(bucket: rate_limit.Bucket, last_seen_ns: Int)
+}
+
+type Reservation {
+  Reservation(ip: String, owner: Pid, monitor: Monitor, token: ReservationToken)
 }
 
 type State {
@@ -66,23 +86,30 @@ type State {
     total: Int,
     counts: Dict(String, Int),
     rate_buckets: Dict(String, RateBucket),
-    /// Monitors on bound permit-holder processes, so slots self-release when
-    /// the holder dies without running its close path (crash, brutal kill).
-    monitors: Dict(Monitor, #(Pid, String)),
-    /// Reverse index from holder pid to its monitor, so an explicit release
-    /// can drop the monitor and never double-decrement.
-    holders: Dict(Pid, Monitor),
+    /// Every acquired reservation has an owner and monitor. The unique
+    /// reservation identity keeps release, cancellation, and transfer
+    /// idempotent when their messages race.
+    reservations: Dict(reference.Reference, Reservation),
+    monitors: Dict(Monitor, reference.Reference),
   )
 }
 
 pub opaque type Message {
   Acquire(
+    reservation: reference.Reference,
     ip: String,
     limiter: ConnectionLimiter,
+    owner: Pid,
+    token: ReservationToken,
     reply: Subject(Result(Permit, Nil)),
   )
-  Bind(ip: String, owner: Pid)
-  Release(ip: String, owner: Pid)
+  Bind(
+    reservation: reference.Reference,
+    owner: Pid,
+    reply: Subject(Result(Nil, Nil)),
+  )
+  Cancel(reservation: reference.Reference)
+  Release(reservation: reference.Reference)
   HolderDown(down: process.Down)
   Sweep(subject: Subject(Message))
   Stop(reply: Subject(Nil))
@@ -104,42 +131,27 @@ fn handle_message(
   message: Message,
 ) -> actor.Next(State, Message) {
   case message {
-    Acquire(ip, limiter, reply) -> {
-      let #(state, outcome) = acquire_slot(state, ip, limiter)
+    Acquire(reservation, ip, limiter, owner, token, reply) -> {
+      let #(state, outcome) =
+        acquire_slot(state, reservation, ip, limiter, owner, token)
       let state = persist(state)
       process.send(reply, outcome)
       actor.continue(state)
     }
-    Bind(ip, owner) -> actor.continue(bind_holder(state, ip, owner) |> persist)
-    Release(ip, owner) -> {
-      // Drop the holder's monitor (when bound) before decrementing, so a
-      // later exit of the same process cannot decrement this IP twice.
-      let state = case dict.get(state.holders, owner) {
-        Ok(monitor) -> {
-          process.demonitor_process(monitor)
-          State(
-            ..state,
-            monitors: dict.delete(state.monitors, monitor),
-            holders: dict.delete(state.holders, owner),
-          )
-        }
-        Error(Nil) -> state
-      }
-      actor.continue(release_slot(state, ip) |> persist)
+    Bind(reservation, owner, reply) -> {
+      let #(state, outcome) = bind_holder(state, reservation, owner)
+      let state = persist(state)
+      process.send(reply, outcome)
+      actor.continue(state)
     }
+    Cancel(reservation) | Release(reservation) ->
+      actor.continue(release_reservation(state, reservation) |> persist)
     HolderDown(down) ->
       case down {
-        process.ProcessDown(monitor, pid, _reason) ->
+        process.ProcessDown(monitor, _pid, _reason) ->
           case dict.get(state.monitors, monitor) {
-            Ok(#(_owner, ip)) -> {
-              let state =
-                State(
-                  ..state,
-                  monitors: dict.delete(state.monitors, monitor),
-                  holders: dict.delete(state.holders, pid),
-                )
-              actor.continue(release_slot(state, ip) |> persist)
-            }
+            Ok(reservation) ->
+              actor.continue(release_reservation(state, reservation) |> persist)
             // Already explicitly released (or an unrelated monitor).
             Error(Nil) -> actor.continue(state)
           }
@@ -158,9 +170,17 @@ fn handle_message(
 
 fn acquire_slot(
   state: State,
+  reservation: reference.Reference,
   ip: String,
   limiter: ConnectionLimiter,
+  owner: Pid,
+  reservation_token: ReservationToken,
 ) -> #(State, Result(Permit, Nil)) {
+  use <- bool.guard(
+    when: !process.is_alive(owner)
+      || !reservation_token_pending(reservation_token),
+    return: #(state, Error(Nil)),
+  )
   let current =
     dict.get(state.counts, ip)
     |> result.unwrap(0)
@@ -168,17 +188,34 @@ fn acquire_slot(
   let total_full = state.max_total > 0 && state.total >= state.max_total
   use <- bool.guard(when: ip_full || total_full, return: #(state, Error(Nil)))
 
-  let #(state, token) = take_connection_token(state, ip)
-  case token {
+  let #(state, connection_token) = take_connection_token(state, ip)
+  case connection_token {
     Error(Nil) -> #(state, Error(Nil))
-    Ok(Nil) -> #(
-      State(
-        ..state,
-        total: state.total + 1,
-        counts: dict.insert(state.counts, ip, current + 1),
-      ),
-      Ok(Permit(limiter: limiter, ip: ip)),
-    )
+    Ok(Nil) -> {
+      use <- bool.guard(
+        when: !reservation_token_pending(reservation_token),
+        return: #(state, Error(Nil)),
+      )
+      let monitor = process.monitor(owner)
+      #(
+        State(
+          ..state,
+          total: state.total + 1,
+          counts: dict.insert(state.counts, ip, current + 1),
+          reservations: dict.insert(
+            state.reservations,
+            reservation,
+            Reservation(ip:, owner:, monitor:, token: reservation_token),
+          ),
+          monitors: dict.insert(state.monitors, monitor, reservation),
+        ),
+        Ok(Permit(
+          limiter: limiter,
+          reservation: reservation,
+          token: reservation_token,
+        )),
+      )
+    }
   }
 }
 
@@ -228,16 +265,56 @@ fn schedule_sweep(
   }
 }
 
-/// Monitor a permit holder so its slot is reclaimed if the process dies
-/// without releasing. Rebinding the same pid is a no-op.
-fn bind_holder(state: State, ip: String, owner: Pid) -> State {
-  use <- bool.guard(when: dict.has_key(state.holders, owner), return: state)
-  let monitor = process.monitor(owner)
-  State(
-    ..state,
-    monitors: dict.insert(state.monitors, monitor, #(owner, ip)),
-    holders: dict.insert(state.holders, owner, monitor),
-  )
+/// Transfer a reservation to the connection process. Monitor the new owner
+/// before dropping the old monitor so the reservation is never unowned.
+fn bind_holder(
+  state: State,
+  reservation: reference.Reference,
+  owner: Pid,
+) -> #(State, Result(Nil, Nil)) {
+  case dict.get(state.reservations, reservation) {
+    Error(Nil) -> #(state, Error(Nil))
+    Ok(Reservation(ip, current_owner, current_monitor, token)) ->
+      case reservation_token_pending(token), current_owner == owner {
+        False, _ -> #(release_reservation(state, reservation), Error(Nil))
+        True, True -> #(state, Ok(Nil))
+        True, False -> {
+          let monitor = process.monitor(owner)
+          process.demonitor_process(current_monitor)
+          #(
+            State(
+              ..state,
+              reservations: dict.insert(
+                state.reservations,
+                reservation,
+                Reservation(ip:, owner:, monitor:, token:),
+              ),
+              monitors: state.monitors
+                |> dict.delete(current_monitor)
+                |> dict.insert(monitor, reservation),
+            ),
+            Ok(Nil),
+          )
+        }
+      }
+  }
+}
+
+fn release_reservation(
+  state: State,
+  reservation: reference.Reference,
+) -> State {
+  case dict.get(state.reservations, reservation) {
+    Error(Nil) -> state
+    Ok(Reservation(ip, _owner, monitor, _token)) -> {
+      process.demonitor_process(monitor)
+      State(
+        ..release_slot(state, ip),
+        reservations: dict.delete(state.reservations, reservation),
+        monitors: dict.delete(state.monitors, monitor),
+      )
+    }
+  }
 }
 
 /// Reclaim a slot in both dimensions: decrement the node-wide total and the
@@ -258,17 +335,21 @@ fn release_slot(state: State, ip: String) -> State {
 }
 
 fn recover_holders(state: State) -> State {
-  let holders = dict.values(state.monitors)
-  let state = State(..state, monitors: dict.new(), holders: dict.new())
-  list.fold(holders, state, fn(state, holder) {
-    let #(owner, ip) = holder
-    case process.is_alive(owner) {
+  let reservations = dict.to_list(state.reservations)
+  let state = State(..state, reservations: dict.new(), monitors: dict.new())
+  list.fold(reservations, state, fn(state, entry) {
+    let #(reservation, Reservation(ip, owner, _old_monitor, token)) = entry
+    case process.is_alive(owner) && reservation_token_pending(token) {
       True -> {
         let monitor = process.monitor(owner)
         State(
           ..state,
-          monitors: dict.insert(state.monitors, monitor, #(owner, ip)),
-          holders: dict.insert(state.holders, owner, monitor),
+          reservations: dict.insert(
+            state.reservations,
+            reservation,
+            Reservation(ip:, owner:, monitor:, token:),
+          ),
+          monitors: dict.insert(state.monitors, monitor, reservation),
         )
       }
       False -> release_slot(state, ip)
@@ -277,17 +358,36 @@ fn recover_holders(state: State) -> State {
 }
 
 fn request(
+  limiter: ConnectionLimiter,
+  ip: String,
   subject: Subject(Message),
-  build_message: fn(Subject(Result(Permit, Nil))) -> Message,
 ) -> Result(Permit, Nil) {
   case process.subject_owner(subject) {
     Error(Nil) -> Error(Nil)
     Ok(_) -> {
+      let reservation = reference.new()
+      let token = new_reservation_token()
       let reply_subject = process.new_subject()
-      process.send(subject, build_message(reply_subject))
+      process.send(
+        subject,
+        Acquire(
+          reservation: reservation,
+          ip: ip,
+          limiter: limiter,
+          owner: process.self(),
+          token: token,
+          reply: reply_subject,
+        ),
+      )
       case process.receive(reply_subject, registry_call_timeout_ms) {
         Ok(value) -> value
-        Error(Nil) -> Error(Nil)
+        Error(Nil) -> {
+          let _cancelled = cancel_reservation_token(token)
+          // Signals from one process arrive in order. If Acquire is still
+          // queued, this cancellation follows it and reclaims any late slot.
+          process.send(subject, Cancel(reservation))
+          Error(Nil)
+        }
       }
     }
   }
@@ -325,8 +425,8 @@ fn build(
       total: 0,
       counts: dict.new(),
       rate_buckets: dict.new(),
+      reservations: dict.new(),
       monitors: dict.new(),
-      holders: dict.new(),
     )
   actor.new_with_initialiser(1000, fn(subject) {
     schedule_sweep(subject, rate_config)
@@ -375,9 +475,7 @@ pub fn enabled(max_per_ip: Int, max_total: Int, connection_rate: Int) -> Bool {
 
 /// Acquire a connection slot, failing when the IP already has too many sockets.
 fn acquire(limiter: ConnectionLimiter, ip: String) -> Result(Permit, Nil) {
-  request(limiter.subject, fn(reply) {
-    Acquire(ip: ip, limiter: limiter, reply: reply)
-  })
+  request(limiter, ip, limiter.subject)
 }
 
 /// Acquire from an optional limiter. `None` means unlimited.
@@ -393,24 +491,33 @@ pub fn acquire_optional(
 
 /// Bind a permit to the calling process (the long-lived connection process),
 /// so its slot is reclaimed if that process dies without releasing.
-fn bind(permit: Permit) -> Nil {
-  process.send(permit.limiter.subject, Bind(permit.ip, process.self()))
+fn bind(permit: Permit) -> Result(Nil, Nil) {
+  case process.subject_owner(permit.limiter.subject) {
+    Error(Nil) -> Error(Nil)
+    Ok(_) -> {
+      let reply = process.new_subject()
+      process.send(
+        permit.limiter.subject,
+        Bind(permit.reservation, process.self(), reply),
+      )
+      process.receive(reply, registry_call_timeout_ms)
+      |> result.flatten
+    }
+  }
 }
 
 /// Bind a slot to the calling process if one was acquired.
-pub fn bind_optional(permit: Option(Permit)) -> Nil {
+pub fn bind_optional(permit: Option(Permit)) -> Result(Nil, Nil) {
   case permit {
     Some(permit) -> bind(permit)
-    None -> Nil
+    None -> Ok(Nil)
   }
 }
 
 /// Release a previously acquired slot.
-///
-/// Call from the process the permit was bound to (or from an unbound
-/// process, e.g. when the handshake fails before binding).
 fn release(permit: Permit) -> Nil {
-  process.send(permit.limiter.subject, Release(permit.ip, process.self()))
+  let _cancelled = cancel_reservation_token(permit.token)
+  process.send(permit.limiter.subject, Release(permit.reservation))
 }
 
 /// Release a slot if one was acquired.

--- a/packages/beryl/src/beryl/transport.gleam
+++ b/packages/beryl/src/beryl/transport.gleam
@@ -26,7 +26,8 @@ pub type Sockets =
 /// Hold it for the connection's lifetime. Pass it to
 /// `release_connection_slot` when the connection closes. When no connection
 /// limit is configured, the permit allows all connections. Releasing it does
-/// nothing.
+/// nothing. A configured permit belongs to the acquiring process until
+/// `bind_connection_slot` transfers it to the connection process.
 pub opaque type ConnectionPermit {
   ConnectionPermit(inner: Option(connection_limit.Permit))
 }
@@ -47,11 +48,14 @@ pub fn acquire_connection_slot(
   |> result.map(ConnectionPermit)
 }
 
-/// Bind an acquired connection slot to the calling connection process.
+/// Transfer an acquired connection slot to the calling connection process.
 ///
-/// The limiter monitors the caller. It reclaims the slot if the process dies
-/// without running its close path.
-pub fn bind_connection_slot(permit: ConnectionPermit) -> Nil {
+/// Acquisition already monitors the requesting process. This function replaces
+/// that monitor without leaving the reservation unowned, so either process
+/// dying reclaims the slot at the correct lifecycle stage. Returns
+/// `Error(Nil)` when the reservation was already reclaimed or the limiter
+/// cannot acknowledge the transfer. The connection must close on error.
+pub fn bind_connection_slot(permit: ConnectionPermit) -> Result(Nil, Nil) {
   connection_limit.bind_optional(permit.inner)
 }
 

--- a/packages/beryl/src/beryl/transport/server.gleam
+++ b/packages/beryl/src/beryl/transport/server.gleam
@@ -477,10 +477,12 @@ pub fn connect_seed(
 ///
 /// Returns the connection state and a selector (extending `base_selector`)
 /// that delivers `SendRequest` values from the runtime; the transport must
-/// select on it and act on each request. Call `close_connection` when the
-/// connection closes, and `logger_name` names the transport in decode
-/// warnings (e.g. `"beryl_mist"`). `codec` is the codec negotiated for this
-/// socket; `None` inherits the app-wide codec.
+/// select on it and act on each request. If the request owner died before the
+/// transfer, the reservation bind fails, runtime admission is skipped, and
+/// the selector immediately delivers `Close`. Call `close_connection` when
+/// the connection closes. `logger_name` names the transport in decode warnings
+/// (e.g. `"beryl_mist"`). `codec` is the codec negotiated for this socket;
+/// `None` inherits the app-wide codec.
 pub fn init_connection(
   sockets sockets: Sockets,
   seed seed: ConnectSeed,
@@ -490,9 +492,7 @@ pub fn init_connection(
   telemetry telemetry: transport.Telemetry,
   codec socket_codec: Option(Codec),
 ) -> #(ConnectionState, Selector(SendRequest)) {
-  // Bind the connection slot to this WebSocket process so it is reclaimed
-  // even if the process dies without running the transport's close callback.
-  transport.bind_connection_slot(connection_permit)
+  let bind_result = transport.bind_connection_slot(connection_permit)
 
   let socket_id = generate_socket_id()
   let send_subject = process.new_subject()
@@ -512,8 +512,15 @@ pub fn init_connection(
   // Capture and monitor the exact runtime before registration. Admission is
   // atomic: a restart between capture and registration rejects the socket
   // instead of redirecting it into the successor runtime.
-  let selector = case transport.runtime_pid(sockets) {
-    Ok(runtime_pid) -> {
+  let selector = case bind_result, transport.runtime_pid(sockets) {
+    Error(Nil), _ -> {
+      // A timed-out bind may still be queued. Release follows it from this
+      // process, so the limiter cannot retain a late transfer.
+      transport.release_connection_slot(connection_permit)
+      process.send(send_subject, Close)
+      selector
+    }
+    Ok(Nil), Ok(runtime_pid) -> {
       let monitor = process.monitor(runtime_pid)
       let selector =
         process.select_specific_monitor(selector, monitor, fn(_down) { Close })
@@ -530,7 +537,7 @@ pub fn init_connection(
         )
       selector
     }
-    Error(Nil) -> {
+    Ok(Nil), Error(Nil) -> {
       process.send(send_subject, Close)
       selector
     }

--- a/packages/beryl/test/app_supervision_test.gleam
+++ b/packages/beryl/test/app_supervision_test.gleam
@@ -202,7 +202,7 @@ pub fn limiter_restart_preserves_connection_state_test() -> Nil {
 
   let count_ip = "192.0.2.21"
   let assert Ok(counted) = transport.acquire_connection_slot(sockets, count_ip)
-  transport.bind_connection_slot(counted)
+  let assert Ok(Nil) = transport.bind_connection_slot(counted)
 
   let old_limiter = limiter_pid(sockets)
   process.kill(old_limiter)
@@ -620,7 +620,7 @@ pub fn timed_out_admission_cannot_register_or_apply_init_effects_test() -> Nil {
     process.spawn(fn() {
       let assert Ok(permit) =
         transport.acquire_connection_slot(sockets, "203.0.113.10")
-      transport.bind_connection_slot(permit)
+      let assert Ok(Nil) = transport.bind_connection_slot(permit)
       let assert Ok(owner) = transport.runtime_pid(sockets)
       let result =
         transport.admit_socket(

--- a/packages/beryl/test/connection_limit_test.gleam
+++ b/packages/beryl/test/connection_limit_test.gleam
@@ -12,6 +12,7 @@ import beryl/transport
 import beryl/wire
 import gleam/erlang/process
 import gleeunit/should
+import test_helper
 
 fn start_with_limit(max_connections: Int) -> beryl.Sockets {
   let assert Ok(channels) =
@@ -120,25 +121,172 @@ pub fn limit_is_per_ip_test() -> Nil {
   Nil
 }
 
-// A slot is reclaimed when its holder process dies without releasing —
-// crashed connection handlers must not permanently exhaust an IP's slots.
-pub fn slot_reclaimed_when_holder_dies_without_release_test() -> Nil {
+// Acquisition immediately belongs to its requester. A process that dies
+// before binding the permit to a WebSocket process cannot leak the slot.
+pub fn slot_reclaimed_when_requester_dies_before_bind_test() -> Nil {
   let channels = start_with_limit(1)
 
   let acquired = process.new_subject()
   let _pid =
     process.spawn_unlinked(fn() {
-      let assert Ok(permit) =
+      let assert Ok(_permit) =
         transport.acquire_connection_slot(channels, "10.0.0.7")
-      transport.bind_connection_slot(permit)
       process.send(acquired, Nil)
     })
   let assert Ok(Nil) = process.receive(acquired, 500)
 
-  // Give the limiter time to observe the holder's exit.
-  process.sleep(50)
+  test_helper.wait_until(
+    fn() {
+      case transport.acquire_connection_slot(channels, "10.0.0.7") {
+        Ok(permit) -> {
+          transport.release_connection_slot(permit)
+          True
+        }
+        Error(Nil) -> False
+      }
+    },
+    500,
+    10,
+  )
+  let assert Ok(Nil) = beryl.stop(channels)
+  Nil
+}
 
-  should.be_ok(transport.acquire_connection_slot(channels, "10.0.0.7"))
+// A timed-out request sends a cancellation behind its queued acquire. When
+// the limiter resumes, it cannot leave a reservation without a caller.
+pub fn timed_out_queued_acquire_is_cancelled_test() -> Nil {
+  let channels = start_with_limit(1)
+  let assert Ok(limiter) = beryl.app_limiter_pid(channels)
+  test_helper.suspend_process(limiter)
+
+  let outcome = process.new_subject()
+  let _pid =
+    process.spawn_unlinked(fn() {
+      let exit = process.new_subject()
+      process.send(outcome, #(
+        transport.acquire_connection_slot(channels, "10.0.0.8"),
+        exit,
+      ))
+      let assert Ok(Nil) = process.receive(exit, 2000)
+    })
+  let assert Ok(#(Error(Nil), exit)) = process.receive(outcome, 500)
+
+  test_helper.resume_process(limiter)
+  test_helper.wait_until(
+    fn() {
+      case transport.acquire_connection_slot(channels, "10.0.0.8") {
+        Ok(permit) -> {
+          transport.release_connection_slot(permit)
+          True
+        }
+        Error(Nil) -> False
+      }
+    },
+    500,
+    10,
+  )
+  process.send(exit, Nil)
+
+  let assert Ok(Nil) = beryl.stop(channels)
+  Nil
+}
+
+pub fn transfer_tracks_new_owner_until_it_dies_test() -> Nil {
+  let channels = start_with_limit(1)
+  let assert Ok(permit) =
+    transport.acquire_connection_slot(channels, "10.0.0.10")
+  let bound = process.new_subject()
+  let _owner =
+    process.spawn_unlinked(fn() {
+      let exit = process.new_subject()
+      process.send(bound, #(transport.bind_connection_slot(permit), exit))
+      let assert Ok(Nil) = process.receive(exit, 30_000)
+    })
+  let assert Ok(#(Ok(Nil), exit)) = process.receive(bound, 500)
+
+  transport.acquire_connection_slot(channels, "10.0.0.10")
+  |> should.be_error
+  process.send(exit, Nil)
+  test_helper.wait_until(
+    fn() {
+      case transport.acquire_connection_slot(channels, "10.0.0.10") {
+        Ok(next) -> {
+          transport.release_connection_slot(next)
+          True
+        }
+        Error(Nil) -> False
+      }
+    },
+    500,
+    10,
+  )
+
+  let assert Ok(Nil) = beryl.stop(channels)
+  Nil
+}
+
+pub fn transfer_fails_after_request_owner_dies_test() -> Nil {
+  let channels = start_with_limit(1)
+  let acquired = process.new_subject()
+  let _requester =
+    process.spawn_unlinked(fn() {
+      let assert Ok(permit) =
+        transport.acquire_connection_slot(channels, "10.0.0.11")
+      process.send(acquired, permit)
+    })
+  let assert Ok(permit) = process.receive(acquired, 500)
+
+  test_helper.wait_until(
+    fn() {
+      case transport.acquire_connection_slot(channels, "10.0.0.11") {
+        Ok(next) -> {
+          transport.release_connection_slot(next)
+          True
+        }
+        Error(Nil) -> False
+      }
+    },
+    500,
+    10,
+  )
+  transport.bind_connection_slot(permit) |> should.be_error
+
+  let assert Ok(Nil) = beryl.stop(channels)
+  Nil
+}
+
+pub fn cancellation_survives_limiter_restart_test() -> Nil {
+  let channels = start_with_limit(1)
+  let assert Ok(permit) =
+    transport.acquire_connection_slot(channels, "10.0.0.12")
+  let assert Ok(old_limiter) = beryl.app_limiter_pid(channels)
+
+  process.kill(old_limiter)
+  transport.release_connection_slot(permit)
+  test_helper.wait_until(
+    fn() {
+      case beryl.app_limiter_pid(channels) {
+        Ok(limiter) -> limiter != old_limiter
+        Error(Nil) -> False
+      }
+    },
+    1000,
+    10,
+  )
+  test_helper.wait_until(
+    fn() {
+      case transport.acquire_connection_slot(channels, "10.0.0.12") {
+        Ok(next) -> {
+          transport.release_connection_slot(next)
+          True
+        }
+        Error(Nil) -> False
+      }
+    },
+    500,
+    10,
+  )
+
   let assert Ok(Nil) = beryl.stop(channels)
   Nil
 }
@@ -151,6 +299,24 @@ pub fn permit_can_be_released_test() -> Nil {
     transport.acquire_connection_slot(channels, "10.0.0.6")
   transport.release_connection_slot(permit)
 
+  let assert Ok(Nil) = beryl.stop(channels)
+  Nil
+}
+
+pub fn duplicate_release_does_not_free_another_reservation_test() -> Nil {
+  let channels = start_with_limit(2)
+  let assert Ok(first) = transport.acquire_connection_slot(channels, "10.0.0.9")
+  let assert Ok(second) =
+    transport.acquire_connection_slot(channels, "10.0.0.9")
+
+  transport.release_connection_slot(first)
+  transport.release_connection_slot(first)
+  let assert Ok(third) = transport.acquire_connection_slot(channels, "10.0.0.9")
+  transport.acquire_connection_slot(channels, "10.0.0.9")
+  |> should.be_error
+
+  transport.release_connection_slot(second)
+  transport.release_connection_slot(third)
   let assert Ok(Nil) = beryl.stop(channels)
   Nil
 }

--- a/packages/beryl/test/global_connection_limit_test.gleam
+++ b/packages/beryl/test/global_connection_limit_test.gleam
@@ -122,7 +122,7 @@ pub fn global_slot_reclaimed_when_holder_dies_without_release_test() -> Nil {
     process.spawn_unlinked(fn() {
       let assert Ok(permit) =
         transport.acquire_connection_slot(channels, "10.0.3.1")
-      transport.bind_connection_slot(permit)
+      let assert Ok(Nil) = transport.bind_connection_slot(permit)
       process.send(acquired, Nil)
       // Return immediately: the process exits without releasing, which must
       // still free the node-wide slot via the limiter's monitor.
@@ -187,7 +187,7 @@ pub fn concurrent_opens_do_not_exceed_global_ceiling_test() -> Nil {
       let ip = "10.9." <> int.to_string(i) <> ".1"
       let outcome = case transport.acquire_connection_slot(channels, ip) {
         Ok(permit) -> {
-          transport.bind_connection_slot(permit)
+          let assert Ok(Nil) = transport.bind_connection_slot(permit)
           True
         }
         Error(Nil) -> False

--- a/packages/beryl/test/transport_server_test.gleam
+++ b/packages/beryl/test/transport_server_test.gleam
@@ -7,8 +7,9 @@ import beryl/wire
 import beryl/wire/codec
 import gleam/erlang/process
 import gleam/json
-import gleam/option.{Some}
+import gleam/option.{None, Some}
 import gleeunit/should
+import test_helper
 
 fn tagged_codec() -> codec.Codec {
   codec.new(
@@ -68,4 +69,52 @@ pub fn shared_server_preserves_negotiated_socket_codec_test() -> Nil {
     process.selector_receive(from: selector, within: 500)
   reply |> should.equal("TAGGED-HB")
   server.close_connection(state)
+}
+
+pub fn shared_server_closes_when_request_reservation_was_reclaimed_test() -> Nil {
+  let assert Ok(sockets) =
+    app_test_helper.start_app(
+      beryl.config(wire.phoenix_codec())
+        |> beryl.with_max_connections(max_connections: 1),
+      init: app_test_helper.accepting_init,
+      update: app_test_helper.accepting_update,
+    )
+  let acquired = process.new_subject()
+  let _requester =
+    process.spawn_unlinked(fn() {
+      let assert Ok(permit) =
+        transport.acquire_connection_slot(sockets, "127.0.0.1")
+      process.send(acquired, permit)
+    })
+  let assert Ok(connection_permit) = process.receive(acquired, 500)
+
+  test_helper.wait_until(
+    fn() {
+      case transport.acquire_connection_slot(sockets, "127.0.0.1") {
+        Ok(permit) -> {
+          transport.release_connection_slot(permit)
+          True
+        }
+        Error(Nil) -> False
+      }
+    },
+    500,
+    10,
+  )
+
+  let #(state, selector) =
+    server.init_connection(
+      sockets: sockets,
+      seed: socket.empty_seed(),
+      connection_permit: connection_permit,
+      base_selector: process.new_selector(),
+      logger_name: "beryl.transport.server.test",
+      telemetry: transport.telemetry(sockets, transport.Mist),
+      codec: None,
+    )
+  process.selector_receive(selector, 500)
+  |> should.equal(Ok(server.Close))
+  server.close_connection(state)
+  let assert Ok(Nil) = beryl.stop(sockets)
+  Nil
 }

--- a/packages/beryl_mist/test/mist_handler_test.gleam
+++ b/packages/beryl_mist/test/mist_handler_test.gleam
@@ -16,6 +16,7 @@ import gleam/dynamic
 import gleam/dynamic/decode
 import gleam/erlang/atom
 import gleam/erlang/process
+import gleam/http/request
 import gleam/http/response
 import gleam/int
 import gleam/option.{None}
@@ -433,6 +434,30 @@ pub fn handler_rejects_connections_over_per_ip_limit_test() -> Nil {
 
   let assert Ok(next_client) = connect_websocket(port, "/socket")
   close(next_client)
+  stop_supervisor(server_pid)
+}
+
+pub fn crashing_authentication_releases_connection_slot_test() -> Nil {
+  let channels =
+    start_app_system(
+      beryl.config(wire.phoenix_codec())
+      |> beryl.with_max_connections(max_connections: 1),
+    )
+  let config =
+    server.default_config("/socket")
+    |> server.with_on_connect(fn(http_request) {
+      case request.get_query(http_request) {
+        Ok([#("crash", "true")]) -> panic as "authentication crashed"
+        Ok(_) | Error(Nil) -> Ok([])
+      }
+    })
+  let #(port, server_pid) = start_server_with_config(channels, config)
+
+  websocket_upgrade_status(port, "/socket?crash=true")
+  |> should.equal(Ok(500))
+
+  let assert Ok(client) = connect_websocket(port, "/socket")
+  close(client)
   stop_supervisor(server_pid)
 }
 

--- a/website/src/content/docs/reference/api/beryl-transport-server.md
+++ b/website/src/content/docs/reference/api/beryl-transport-server.md
@@ -296,10 +296,12 @@ Initialize a new WebSocket connection in its connection process.
 
  Returns the connection state and a selector (extending `base_selector`)
  that delivers `SendRequest` values from the runtime; the transport must
- select on it and act on each request. Call `close_connection` when the
- connection closes, and `logger_name` names the transport in decode
- warnings (e.g. `"beryl_mist"`). `codec` is the codec negotiated for this
- socket; `None` inherits the app-wide codec.
+ select on it and act on each request. If the request owner died before the
+ transfer, the reservation bind fails, runtime admission is skipped, and
+ the selector immediately delivers `Close`. Call `close_connection` when
+ the connection closes. `logger_name` names the transport in decode warnings
+ (e.g. `"beryl_mist"`). `codec` is the codec negotiated for this socket;
+ `None` inherits the app-wide codec.
 
 <div class="api-entry-anchor" id="api-function-is_websocket_request" aria-hidden="true"></div>
 

--- a/website/src/content/docs/reference/api/beryl-transport.md
+++ b/website/src/content/docs/reference/api/beryl-transport.md
@@ -78,7 +78,8 @@ A held connection slot returned by `acquire_connection_slot`.
  Hold it for the connection's lifetime. Pass it to
  `release_connection_slot` when the connection closes. When no connection
  limit is configured, the permit allows all connections. Releasing it does
- nothing.
+ nothing. A configured permit belongs to the acquiring process until
+ `bind_connection_slot` transfers it to the connection process.
 
 <div class="api-entry-anchor" id="api-type-framekind" aria-hidden="true"></div>
 
@@ -223,13 +224,16 @@ Register a socket and its closer against the captured connection owner.
 ### `bind_connection_slot`
 
 ```gleam
-pub fn bind_connection_slot(ConnectionPermit) -> Nil
+pub fn bind_connection_slot(ConnectionPermit) -> Result(Nil, Nil)
 ```
 
-Bind an acquired connection slot to the calling connection process.
+Transfer an acquired connection slot to the calling connection process.
 
- The limiter monitors the caller. It reclaims the slot if the process dies
- without running its close path.
+ Acquisition already monitors the requesting process. This function replaces
+ that monitor without leaving the reservation unowned, so either process
+ dying reclaims the slot at the correct lifecycle stage. Returns
+ `Error(Nil)` when the reservation was already reclaimed or the limiter
+ cannot acknowledge the transfer. The connection must close on error.
 
 <div class="api-entry-anchor" id="api-function-max_inbound_frame_bytes" aria-hidden="true"></div>
 


### PR DESCRIPTION
## Summary

Give each connection reservation a unique identity and a monitored owner. Reclaim reservations after requester death or timeout, preserve cancellation across limiter restarts, and acknowledge ownership transfer before admitting a WebSocket.

Cover duplicate release, owner handoff, limiter restart, rejected admission, and crashing authentication.

Closes #388.
