### PR TITLE
fix(pubsub): prevent duplicate deliveries after repeated joins

### DIFF
--- a/.changes/unreleased/beryl-make-repeated-and-concurrent.toml
+++ b/.changes/unreleased/beryl-make-repeated-and-concurrent.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Make repeated and concurrent PubSub topic joins idempotent per owner process and scope, including multiple handles. Deliver and count each owner once, and remove membership with one leave."

--- a/packages/beryl/src/beryl/pubsub.gleam
+++ b/packages/beryl/src/beryl/pubsub.gleam
@@ -197,13 +197,20 @@ pub fn subscriber(pubsub_instance: PubSub(payload)) -> Subscriber(payload) {
 
 /// Join a topic so this subscriber receives broadcasts sent to it.
 ///
-/// A subscriber can join many topics. All topics deliver through its one
-/// subject. Joining a topic is idempotent.
+/// A subscriber can join many topics. All topics deliver to its owner's
+/// mailbox. Repeated or concurrent joins create one membership per owner
+/// process, scope, and topic, including joins through different handles.
+/// Each broadcast delivers once to that owner, and subscriber counts include
+/// it once.
 pub fn join(subscriber: Subscriber(payload), topic: String) -> Nil {
   ffi_join_group(subscriber.scope, topic, subscriber.owner)
 }
 
 /// Leave a topic previously joined with `join`.
+///
+/// One call removes the owner's membership for this scope and topic, even
+/// after repeated joins through different handles. Repeated leaves are
+/// harmless. Other owners, scopes, and topics are unaffected.
 pub fn leave(subscriber: Subscriber(payload), topic: String) -> Nil {
   ffi_leave_group(subscriber.scope, topic, subscriber.owner)
 }
@@ -291,7 +298,6 @@ pub fn broadcast_from_socket(
   |> list.each(ffi_send_to_pid(_, pubsub_instance.scope, message))
 }
 
-// nolint: unused_exports -- public PubSub API intended for downstream consumers
 /// Broadcast a message only to subscribers on the current node.
 pub fn local_broadcast(
   pubsub_instance: PubSub(payload),

--- a/packages/beryl/src/beryl_pubsub_ffi.erl
+++ b/packages/beryl/src/beryl_pubsub_ffi.erl
@@ -5,8 +5,24 @@
 
 start_pg_scope(Scope) -> _ = pg:start(Scope), nil.
 
-join_group(Scope, Group, Pid) -> _ = pg:join(Scope, Group, Pid), nil.
-leave_group(Scope, Group, Pid) -> _ = pg:leave(Scope, Group, Pid), nil.
+join_group(Scope, Group, Pid) ->
+    with_membership_lock(Scope, Group, Pid, fun() ->
+        case lists:member(Pid, pg:get_local_members(Scope, Group)) of
+            true -> nil;
+            false -> ok = pg:join(Scope, Group, Pid), nil
+        end
+    end).
+
+leave_group(Scope, Group, Pid) ->
+    with_membership_lock(Scope, Group, Pid, fun() ->
+        _ = pg:leave(Scope, Group, Pid), nil
+    end).
+
+with_membership_lock(Scope, Group, Pid, Operation) ->
+    %% pg allows duplicate membership. Serialize the check and mutation across
+    %% handles and callers; pg only accepts local member pids.
+    global:trans({{?MODULE, Scope, Group, Pid}, self()}, Operation, [node()]).
+
 get_members(Scope, Group) -> pg:get_members(Scope, Group).
 get_local_members(Scope, Group) -> pg:get_local_members(Scope, Group).
 send_to_pid(Pid, Scope, {message, Topic, Event, Payload, From}) ->

--- a/packages/beryl/test/beryl_pubsub_test_ffi.erl
+++ b/packages/beryl/test/beryl_pubsub_test_ffi.erl
@@ -1,5 +1,16 @@
 -module(beryl_pubsub_test_ffi).
--export([is_scoped_wire_message/5]).
+-export([is_scoped_wire_message/5, drain_messages/5]).
+
+drain_messages(Scope, Topic, Event, Payload, From) ->
+    drain_messages(Scope, Topic, Event, Payload, From, 0).
+
+drain_messages(Scope, Topic, Event, Payload, From, Count) ->
+    receive
+        {Scope, Topic, Event, Payload, From} ->
+            drain_messages(Scope, Topic, Event, Payload, From, Count + 1)
+    after 0 ->
+        Count
+    end.
 
 is_scoped_wire_message(Scope, Topic, Event, Payload, Timeout) ->
     receive

--- a/packages/beryl/test/pubsub_test.gleam
+++ b/packages/beryl/test/pubsub_test.gleam
@@ -1,6 +1,7 @@
 import beryl/pubsub
 import gleam/erlang/atom
 import gleam/erlang/process
+import gleam/list
 import gleeunit/should
 
 @external(erlang, "beryl_pubsub_test_ffi", "is_scoped_wire_message")
@@ -11,6 +12,191 @@ fn is_scoped_wire_message(
   payload: String,
   timeout: Int,
 ) -> Bool
+
+@external(erlang, "beryl_pubsub_test_ffi", "drain_messages")
+fn drain_messages(
+  scope: atom.Atom,
+  topic: String,
+  event: String,
+  payload: String,
+  from: pubsub.PubSubFrom,
+) -> Int
+
+pub fn pubsub_repeated_joins_are_idempotent_test() -> Nil {
+  let scope = atom.create("test_pubsub_repeated_joins")
+  let config = pubsub.config_with_scope(atom.to_string(scope))
+  let instance = pubsub.start(config)
+  let first = pubsub.subscriber(instance)
+  let second = pubsub.subscriber(pubsub.start(config))
+  let topic = "room:repeated"
+  pubsub.join(first, topic)
+  pubsub.join(first, topic)
+  pubsub.join(second, topic)
+  pubsub.join(second, topic)
+  let count = pubsub.subscriber_count(instance, topic)
+  let members = pubsub.subscribers(instance, topic)
+
+  let sender = process.spawn(fn() { Nil })
+  pubsub.broadcast(instance, topic, "broadcast", "payload")
+  pubsub.local_broadcast(instance, topic, "local", "payload")
+  pubsub.broadcast_from(instance, sender, topic, "from", "payload")
+  pubsub.broadcast_from_socket(
+    instance,
+    sender,
+    "socket",
+    topic,
+    "from_socket",
+    "payload",
+  )
+  let deliveries = [
+    drain_messages(scope, topic, "broadcast", "payload", pubsub.System),
+    drain_messages(scope, topic, "local", "payload", pubsub.System),
+    drain_messages(scope, topic, "from", "payload", pubsub.FromPid(sender)),
+    drain_messages(
+      scope,
+      topic,
+      "from_socket",
+      "payload",
+      pubsub.FromSocket(sender, "socket"),
+    ),
+  ]
+
+  pubsub.leave(second, topic)
+  let after_leave = pubsub.subscriber_count(instance, topic)
+  pubsub.broadcast(instance, topic, "after_leave", "payload")
+  let after_leave_deliveries =
+    drain_messages(scope, topic, "after_leave", "payload", pubsub.System)
+  pubsub.leave(first, topic)
+  pubsub.leave(second, topic)
+  pubsub.leave(first, topic)
+
+  count |> should.equal(1)
+  members |> should.equal([process.self()])
+  deliveries |> should.equal([1, 1, 1, 1])
+  after_leave |> should.equal(0)
+  after_leave_deliveries |> should.equal(0)
+  pubsub.subscriber_count(instance, topic) |> should.equal(0)
+}
+
+fn run_concurrently(operations: List(fn() -> Nil)) -> Nil {
+  let ready = process.new_subject()
+  let done = process.new_subject()
+  list.each(operations, fn(operation) {
+    let _worker =
+      process.spawn(fn() {
+        let start = process.new_subject()
+        process.send(ready, start)
+        let assert Ok(Nil) = process.receive(start, 5000)
+        operation()
+        process.send(done, Nil)
+      })
+  })
+  let starts =
+    list.map(operations, fn(_) {
+      let assert Ok(start) = process.receive(ready, 5000)
+      start
+    })
+  list.each(starts, process.send(_, Nil))
+  list.each(operations, fn(_) {
+    let assert Ok(Nil) = process.receive(done, 5000)
+    Nil
+  })
+}
+
+pub fn pubsub_concurrent_joins_are_idempotent_test() -> Nil {
+  let scope = atom.create("test_pubsub_concurrent_joins")
+  let config = pubsub.config_with_scope(atom.to_string(scope))
+  let instance = pubsub.start(config)
+  let first = pubsub.subscriber(instance)
+  let second = pubsub.subscriber(pubsub.start(config))
+  let topic = "room:concurrent"
+  let joins =
+    [first, second]
+    |> list.flat_map(fn(subscriber) {
+      list.repeat(fn() { pubsub.join(subscriber, topic) }, 8)
+    })
+
+  list.each(list.repeat(Nil, 4), fn(_) {
+    run_concurrently(joins)
+    let count = pubsub.subscriber_count(instance, topic)
+    pubsub.broadcast(instance, topic, "broadcast", "payload")
+    let deliveries =
+      drain_messages(scope, topic, "broadcast", "payload", pubsub.System)
+    pubsub.leave(second, topic)
+    let after_leave = pubsub.subscriber_count(instance, topic)
+    pubsub.broadcast(instance, topic, "after_leave", "payload")
+    let after_leave_deliveries =
+      drain_messages(scope, topic, "after_leave", "payload", pubsub.System)
+    run_concurrently(list.repeat(fn() { pubsub.leave(first, topic) }, 16))
+
+    count |> should.equal(1)
+    deliveries |> should.equal(1)
+    after_leave |> should.equal(0)
+    after_leave_deliveries |> should.equal(0)
+    pubsub.subscriber_count(instance, topic) |> should.equal(0)
+  })
+}
+
+pub fn pubsub_repeated_leave_preserves_other_memberships_test() -> Nil {
+  let scope = atom.create("test_pubsub_leave_isolation")
+  let instance = pubsub.start(pubsub.config_with_scope(atom.to_string(scope)))
+  let other_scope = atom.create("test_pubsub_leave_other_scope")
+  let other_instance =
+    pubsub.start(pubsub.config_with_scope(atom.to_string(other_scope)))
+  let subscriber = pubsub.subscriber(instance)
+  let other_subscriber = pubsub.subscriber(other_instance)
+  let topic = "room:shared"
+  let other_topic = "room:other"
+  let ready = process.new_subject()
+  let deliveries = process.new_subject()
+  let _owner =
+    process.spawn(fn() {
+      let finish = process.new_subject()
+      let subscriber = pubsub.subscriber(instance)
+      pubsub.join(subscriber, topic)
+      process.send(ready, finish)
+      let assert Ok(Nil) = process.receive(finish, 5000)
+      let received =
+        drain_messages(scope, topic, "broadcast", "payload", pubsub.System)
+      pubsub.leave(subscriber, topic)
+      process.send(deliveries, received)
+    })
+  let assert Ok(finish) = process.receive(ready, 5000)
+  pubsub.join(subscriber, topic)
+  pubsub.join(subscriber, topic)
+  pubsub.join(subscriber, other_topic)
+  pubsub.join(other_subscriber, topic)
+  pubsub.leave(subscriber, topic)
+  let after_leave = pubsub.subscriber_count(instance, topic)
+  pubsub.broadcast(instance, topic, "broadcast", "payload")
+  let after_leave_deliveries =
+    drain_messages(scope, topic, "broadcast", "payload", pubsub.System)
+  pubsub.leave(subscriber, topic)
+  pubsub.leave(subscriber, topic)
+  let after_repeated_leave = pubsub.subscriber_count(instance, topic)
+  let other_topic_count = pubsub.subscriber_count(instance, other_topic)
+  let other_scope_count = pubsub.subscriber_count(other_instance, topic)
+  pubsub.broadcast(instance, other_topic, "broadcast", "payload")
+  pubsub.broadcast(other_instance, topic, "broadcast", "payload")
+  let other_topic_deliveries =
+    drain_messages(scope, other_topic, "broadcast", "payload", pubsub.System)
+  let other_scope_deliveries =
+    drain_messages(other_scope, topic, "broadcast", "payload", pubsub.System)
+  process.send(finish, Nil)
+  let assert Ok(owner_deliveries) = process.receive(deliveries, 5000)
+  pubsub.leave(subscriber, other_topic)
+  pubsub.leave(other_subscriber, topic)
+
+  after_leave |> should.equal(1)
+  after_leave_deliveries |> should.equal(0)
+  after_repeated_leave |> should.equal(1)
+  other_topic_count |> should.equal(1)
+  other_scope_count |> should.equal(1)
+  other_topic_deliveries |> should.equal(1)
+  other_scope_deliveries |> should.equal(1)
+  owner_deliveries |> should.equal(1)
+  pubsub.subscriber_count(instance, topic) |> should.equal(0)
+}
 
 pub fn pubsub_start_test() -> Nil {
   let config = pubsub.config_with_scope("test_pubsub_start")

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -53,6 +53,12 @@ PubSub records arrive as raw BEAM messages. `selecting` validates their types
 and matches the subscriber scope. One process can select subscribers with
 different payload types if their scopes differ.
 
+Repeated or concurrent joins to the same topic create one membership per
+owner process and scope, even when you use multiple subscriber handles.
+The owner receives each broadcast once and counts as one subscriber.
+One `leave` removes that membership; further leaves are harmless. Leaving
+does not affect other owners, scopes, or topics.
+
 ## Message format
 
 Subscribers receive typed `Message(payload)` records:

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -315,8 +315,11 @@ pub fn join(
 
 Join a topic so this subscriber receives broadcasts sent to it.
 
- A subscriber can join many topics. All topics deliver through its one
- subject. Joining a topic is idempotent.
+ A subscriber can join many topics. All topics deliver to its owner's
+ mailbox. Repeated or concurrent joins create one membership per owner
+ process, scope, and topic, including joins through different handles.
+ Each broadcast delivers once to that owner, and subscriber counts include
+ it once.
 
 <div class="api-entry-anchor" id="api-function-leave" aria-hidden="true"></div>
 
@@ -330,6 +333,10 @@ pub fn leave(
 ```
 
 Leave a topic previously joined with `join`.
+
+ One call removes the owner's membership for this scope and topic, even
+ after repeated joins through different handles. Repeated leaves are
+ harmless. Other owners, scopes, and topics are unaffected.
 
 <div class="api-entry-anchor" id="api-function-local_broadcast" aria-hidden="true"></div>
 


### PR DESCRIPTION
Repeated topic joins no longer cause duplicate PubSub delivery, inflated subscriber counts, or subscriptions that survive one leave. This also covers concurrent callers and multiple handles for the same owner and scope.

Closes #390.

## What changed

- Serialize membership checks and mutations with a node-local lock keyed by owner PID, scope, and topic. Erlang `pg` permits duplicate membership; a check without serialization would still race.
- Add regressions for shared handles, concurrent joins/leaves, all four broadcast variants, and owner/scope/topic isolation. Exact five-field mailbox matches drain deliveries before assertions.
- Clarify the join/leave contract in API docs, the guide, and generated reference; add a `Fixed` changelog fragment. Preserve the frozen wire tuple and transport boundaries. Scope supervision/recovery remains in #392.