### PR TITLE
fix(pubsub): restore broadcasts after scope crashes

### DIFF
--- a/.changes/unreleased/beryl-make-repeated-and-concurrent.toml
+++ b/.changes/unreleased/beryl-make-repeated-and-concurrent.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Make repeated and concurrent PubSub topic joins idempotent per owner process and scope, including multiple handles. Deliver and count each owner once, and remove membership with one leave."

--- a/.changes/unreleased/beryl-restore-live-pubsub-subscriptions.toml
+++ b/.changes/unreleased/beryl-restore-live-pubsub-subscriptions.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Restore live PubSub subscriptions after supervised pg scope restarts, preserve idempotent membership, and report startup or invalid-handle failures instead of silently losing delivery."

--- a/packages/beryl/src/beryl/pubsub.gleam
+++ b/packages/beryl/src/beryl/pubsub.gleam
@@ -197,13 +197,20 @@ pub fn subscriber(pubsub_instance: PubSub(payload)) -> Subscriber(payload) {
 
 /// Join a topic so this subscriber receives broadcasts sent to it.
 ///
-/// A subscriber can join many topics. All topics deliver through its one
-/// subject. Joining a topic is idempotent.
+/// A subscriber can join many topics. All topics deliver to its owner's
+/// mailbox. Repeated or concurrent joins create one membership per owner
+/// process, scope, and topic, including joins through different handles.
+/// Each broadcast delivers once to that owner, and subscriber counts include
+/// it once.
 pub fn join(subscriber: Subscriber(payload), topic: String) -> Nil {
   ffi_join_group(subscriber.scope, topic, subscriber.owner)
 }
 
 /// Leave a topic previously joined with `join`.
+///
+/// One call removes the owner's membership for this scope and topic, even
+/// after repeated joins through different handles. Repeated leaves are
+/// harmless. Other owners, scopes, and topics are unaffected.
 pub fn leave(subscriber: Subscriber(payload), topic: String) -> Nil {
   ffi_leave_group(subscriber.scope, topic, subscriber.owner)
 }
@@ -291,7 +298,6 @@ pub fn broadcast_from_socket(
   |> list.each(ffi_send_to_pid(_, pubsub_instance.scope, message))
 }
 
-// nolint: unused_exports -- public PubSub API intended for downstream consumers
 /// Broadcast a message only to subscribers on the current node.
 pub fn local_broadcast(
   pubsub_instance: PubSub(payload),

--- a/packages/beryl/src/beryl/pubsub.gleam
+++ b/packages/beryl/src/beryl/pubsub.gleam
@@ -13,6 +13,24 @@
 //// browser); payloads that never leave the cluster are cheaper and safer as
 //// plain Gleam types.
 ////
+//// ## Scope recovery and delivery
+////
+//// Each node runs a shared beryl PubSub supervisor. Each scope has its own
+//// supervisor, membership registry, and `pg` process. The service outlives
+//// the process that calls `start`. A `pg` restart preserves the registry,
+//// which restores the topics of live local subscriber owners. Existing
+//// handles remain valid, and repeated joins still create one membership.
+////
+//// Broadcasts are best-effort. During recovery, broadcasts and subscriber
+//// queries can see empty or partial membership. Broadcasts are not buffered
+//// or replayed, and a `Nil` return does not confirm delivery. Each node must
+//// start its own scope; local recovery is not a cluster-wide readiness barrier.
+////
+//// Startup and membership operations can exit with an OTP error during
+//// service failure or recovery. A failed or timed-out join or leave may have
+//// recorded its intent; failure does not roll it back. Retrying is idempotent.
+//// See `start` for startup conflicts and loss of the membership registry.
+////
 //// ## Quick start
 ////
 //// ```gleam
@@ -90,25 +108,39 @@ pub opaque type PubSubConfig {
 /// sent through this instance. The scope identifies the runtime instance.
 /// All handles for one scope must use the same payload type.
 pub opaque type PubSub(payload) {
-  PubSub(scope: atom.Atom)
+  PubSub(scope: atom.Atom, registry: Pid)
 }
 
 // ── FFI declarations ────────────────────────────────────────────────────────
 
 @external(erlang, "beryl_pubsub_ffi", "start_pg_scope")
-fn ffi_start_pg_scope(scope: atom.Atom) -> Nil
+fn ffi_start_pg_scope(scope: atom.Atom) -> Pid
 
 @external(erlang, "beryl_pubsub_ffi", "join_group")
-fn ffi_join_group(scope: atom.Atom, group: String, pid: Pid) -> Nil
+fn ffi_join_group(
+  scope: atom.Atom,
+  registry: Pid,
+  group: String,
+  pid: Pid,
+) -> Nil
 
 @external(erlang, "beryl_pubsub_ffi", "leave_group")
-fn ffi_leave_group(scope: atom.Atom, group: String, pid: Pid) -> Nil
+fn ffi_leave_group(
+  scope: atom.Atom,
+  registry: Pid,
+  group: String,
+  pid: Pid,
+) -> Nil
 
 @external(erlang, "beryl_pubsub_ffi", "get_members")
-fn ffi_get_members(scope: atom.Atom, group: String) -> List(Pid)
+fn ffi_get_members(scope: atom.Atom, registry: Pid, group: String) -> List(Pid)
 
 @external(erlang, "beryl_pubsub_ffi", "get_local_members")
-fn ffi_get_local_members(scope: atom.Atom, group: String) -> List(Pid)
+fn ffi_get_local_members(
+  scope: atom.Atom,
+  registry: Pid,
+  group: String,
+) -> List(Pid)
 
 @external(erlang, "beryl_pubsub_ffi", "send_to_pid")
 fn ffi_send_to_pid(pid: Pid, scope: atom.Atom, message: Message(payload)) -> Nil
@@ -155,18 +187,29 @@ pub fn config_with_scope(name: String) -> PubSubConfig {
 
 /// Start a PubSub instance.
 ///
-/// This starts the configured `pg` scope on the current node. Repeated calls
-/// on the same node are harmless. Each participating node must start the same
-/// scope.
+/// This starts or attaches to a node-owned supervised scope. Repeated calls
+/// share its membership registry; the first caller does not own its lifetime.
+/// The registry restores live local subscriptions after a `pg` process restart.
+/// Each participating node must start the same scope.
+///
+/// Startup errors cause an OTP exit instead of returning a handle. A scope
+/// already owned by an external `pg` process is a startup conflict; beryl does
+/// not adopt or stop it. Startup waits for supervision and local membership
+/// reconciliation, but can fail if the service is recovering.
+///
+/// Loss of the registry itself, including supervisor restart-intensity
+/// exhaustion, invalidates existing handles. Their membership, broadcast, and
+/// subscriber-query calls exit rather than silently using an empty replacement.
+/// Call `start` again, create new subscribers, and rejoin their topics.
+/// This is not persistent storage across service or node failure.
 ///
 /// `payload` is fixed by how the returned value is used or annotated at the
 /// call site. For example: `pubsub.start(config) : PubSub(MySyncPayload)`.
 /// Starting the same scope again returns another handle to the same runtime
 /// instance, so every use of that scope must choose the same payload type.
 pub fn start(config: PubSubConfig) -> PubSub(payload) {
-  // pg:start treats already-started as success; the FFI swallows both
-  ffi_start_pg_scope(config.scope)
-  PubSub(scope: config.scope)
+  let registry = ffi_start_pg_scope(config.scope)
+  PubSub(scope: config.scope, registry: registry)
 }
 
 /// A typed subscription handle owned by a single process.
@@ -179,7 +222,7 @@ pub fn start(config: PubSubConfig) -> PubSub(payload) {
 /// Create it in the receiving process, such as an actor's initializer.
 /// A `Subject` delivers messages only to its owner.
 pub opaque type Subscriber(payload) {
-  Subscriber(scope: atom.Atom, owner: Pid)
+  Subscriber(scope: atom.Atom, registry: Pid, owner: Pid)
 }
 
 /// Create a subscription handle owned by the current process.
@@ -192,7 +235,11 @@ pub opaque type Subscriber(payload) {
 /// `selecting` uses each subscriber's scope to keep their raw mailbox messages
 /// separate.
 pub fn subscriber(pubsub_instance: PubSub(payload)) -> Subscriber(payload) {
-  Subscriber(scope: pubsub_instance.scope, owner: process.self())
+  Subscriber(
+    scope: pubsub_instance.scope,
+    registry: pubsub_instance.registry,
+    owner: process.self(),
+  )
 }
 
 /// Join a topic so this subscriber receives broadcasts sent to it.
@@ -202,8 +249,13 @@ pub fn subscriber(pubsub_instance: PubSub(payload)) -> Subscriber(payload) {
 /// process, scope, and topic, including joins through different handles.
 /// Each broadcast delivers once to that owner, and subscriber counts include
 /// it once.
+///
+/// The registry retains the membership through `pg` restarts and removes it
+/// when its owner exits. During recovery this call can exit with an OTP error.
+/// The call uses a five-second registry timeout; an error or timeout does not
+/// roll back intent already recorded by the registry. Retrying is idempotent.
 pub fn join(subscriber: Subscriber(payload), topic: String) -> Nil {
-  ffi_join_group(subscriber.scope, topic, subscriber.owner)
+  ffi_join_group(subscriber.scope, subscriber.registry, topic, subscriber.owner)
 }
 
 /// Leave a topic previously joined with `join`.
@@ -211,8 +263,17 @@ pub fn join(subscriber: Subscriber(payload), topic: String) -> Nil {
 /// One call removes the owner's membership for this scope and topic, even
 /// after repeated joins through different handles. Repeated leaves are
 /// harmless. Other owners, scopes, and topics are unaffected.
+///
+/// A leave removes recovery intent as well as live membership. Like `join`,
+/// it can exit during recovery or after a five-second registry timeout.
+/// A failed call may still take effect; retrying is idempotent.
 pub fn leave(subscriber: Subscriber(payload), topic: String) -> Nil {
-  ffi_leave_group(subscriber.scope, topic, subscriber.owner)
+  ffi_leave_group(
+    subscriber.scope,
+    subscriber.registry,
+    topic,
+    subscriber.owner,
+  )
 }
 
 /// Add a subscriber's PubSub message delivery to a `Selector`, alongside a
@@ -254,7 +315,8 @@ pub fn broadcast(
 ) -> Nil {
   let message =
     Message(topic: topic, event: event, payload: payload, from: System)
-  let members = ffi_get_members(pubsub_instance.scope, topic)
+  let members =
+    ffi_get_members(pubsub_instance.scope, pubsub_instance.registry, topic)
   list.each(members, fn(pid) {
     ffi_send_to_pid(pid, pubsub_instance.scope, message)
   })
@@ -270,7 +332,7 @@ pub fn broadcast_from(
 ) -> Nil {
   let message =
     Message(topic: topic, event: event, payload: payload, from: FromPid(from))
-  ffi_get_members(pubsub_instance.scope, topic)
+  ffi_get_members(pubsub_instance.scope, pubsub_instance.registry, topic)
   |> list.filter(fn(pid) { pid != from })
   |> list.each(ffi_send_to_pid(_, pubsub_instance.scope, message))
 }
@@ -293,7 +355,7 @@ pub fn broadcast_from_socket(
       payload: payload,
       from: FromSocket(from, except_socket_id),
     )
-  ffi_get_members(pubsub_instance.scope, topic)
+  ffi_get_members(pubsub_instance.scope, pubsub_instance.registry, topic)
   |> list.filter(fn(pid) { pid != from })
   |> list.each(ffi_send_to_pid(_, pubsub_instance.scope, message))
 }
@@ -307,7 +369,12 @@ pub fn local_broadcast(
 ) -> Nil {
   let message =
     Message(topic: topic, event: event, payload: payload, from: System)
-  let members = ffi_get_local_members(pubsub_instance.scope, topic)
+  let members =
+    ffi_get_local_members(
+      pubsub_instance.scope,
+      pubsub_instance.registry,
+      topic,
+    )
   list.each(members, fn(pid) {
     ffi_send_to_pid(pid, pubsub_instance.scope, message)
   })
@@ -318,7 +385,7 @@ pub fn subscribers(
   pubsub_instance: PubSub(payload),
   topic: String,
 ) -> List(Pid) {
-  ffi_get_members(pubsub_instance.scope, topic)
+  ffi_get_members(pubsub_instance.scope, pubsub_instance.registry, topic)
 }
 
 /// Return the number of topic subscribers on all nodes.
@@ -326,5 +393,9 @@ pub fn subscriber_count(
   pubsub_instance: PubSub(payload),
   topic: String,
 ) -> Int {
-  list.length(ffi_get_members(pubsub_instance.scope, topic))
+  list.length(ffi_get_members(
+    pubsub_instance.scope,
+    pubsub_instance.registry,
+    topic,
+  ))
 }

--- a/packages/beryl/src/beryl_pubsub_ffi.erl
+++ b/packages/beryl/src/beryl_pubsub_ffi.erl
@@ -1,30 +1,42 @@
 -module(beryl_pubsub_ffi).
--export([start_pg_scope/1, join_group/3, leave_group/3,
-         get_members/2, get_local_members/2, send_to_pid/3,
+-export([start_pg_scope/1, join_group/4, leave_group/4,
+         get_members/3, get_local_members/3, send_to_pid/3,
          scoped_to_message/1]).
 
-start_pg_scope(Scope) -> _ = pg:start(Scope), nil.
+start_pg_scope(Scope) ->
+    case beryl_pubsub_supervisor:start_scope(Scope) of
+        {ok, Registry} ->
+            case gen_server:call(Registry, ready) of
+                ok -> Registry;
+                {error, Reason} -> exit({pubsub_start_failed, Scope, Reason})
+            end;
+        {error, Reason} -> exit({pubsub_start_failed, Scope, Reason})
+    end.
 
-join_group(Scope, Group, Pid) ->
-    with_membership_lock(Scope, Group, Pid, fun() ->
-        case lists:member(Pid, pg:get_local_members(Scope, Group)) of
-            true -> nil;
-            false -> ok = pg:join(Scope, Group, Pid), nil
-        end
-    end).
+join_group(Scope, Registry, Group, Pid) ->
+    membership_call(Scope, Registry, {join, Group, Pid}).
 
-leave_group(Scope, Group, Pid) ->
-    with_membership_lock(Scope, Group, Pid, fun() ->
-        _ = pg:leave(Scope, Group, Pid), nil
-    end).
+leave_group(Scope, Registry, Group, Pid) ->
+    membership_call(Scope, Registry, {leave, Group, Pid}).
 
-with_membership_lock(Scope, Group, Pid, Operation) ->
-    %% pg allows duplicate membership. Serialize the check and mutation across
-    %% handles and callers; pg only accepts local member pids.
-    global:trans({{?MODULE, Scope, Group, Pid}, self()}, Operation, [node()]).
+membership_call(Scope, Registry, Request) ->
+    case gen_server:call(Registry, Request) of
+        ok -> nil;
+        {error, Reason} -> exit({pubsub_unavailable, Scope, Reason})
+    end.
 
-get_members(Scope, Group) -> pg:get_members(Scope, Group).
-get_local_members(Scope, Group) -> pg:get_local_members(Scope, Group).
+get_members(Scope, Registry, Group) ->
+    ensure_owner(Scope, Registry),
+    pg:get_members(Scope, Group).
+get_local_members(Scope, Registry, Group) ->
+    ensure_owner(Scope, Registry),
+    pg:get_local_members(Scope, Group).
+
+ensure_owner(Scope, Registry) ->
+    case is_process_alive(Registry) of
+        true -> ok;
+        false -> exit({pubsub_unavailable, Scope, owner_down})
+    end.
 send_to_pid(Pid, Scope, {message, Topic, Event, Payload, From}) ->
     Pid ! {Scope, Topic, Event, Payload, From}, nil.
 

--- a/packages/beryl/src/beryl_pubsub_ffi.erl
+++ b/packages/beryl/src/beryl_pubsub_ffi.erl
@@ -5,8 +5,24 @@
 
 start_pg_scope(Scope) -> _ = pg:start(Scope), nil.
 
-join_group(Scope, Group, Pid) -> _ = pg:join(Scope, Group, Pid), nil.
-leave_group(Scope, Group, Pid) -> _ = pg:leave(Scope, Group, Pid), nil.
+join_group(Scope, Group, Pid) ->
+    with_membership_lock(Scope, Group, Pid, fun() ->
+        case lists:member(Pid, pg:get_local_members(Scope, Group)) of
+            true -> nil;
+            false -> ok = pg:join(Scope, Group, Pid), nil
+        end
+    end).
+
+leave_group(Scope, Group, Pid) ->
+    with_membership_lock(Scope, Group, Pid, fun() ->
+        _ = pg:leave(Scope, Group, Pid), nil
+    end).
+
+with_membership_lock(Scope, Group, Pid, Operation) ->
+    %% pg allows duplicate membership. Serialize the check and mutation across
+    %% handles and callers; pg only accepts local member pids.
+    global:trans({{?MODULE, Scope, Group, Pid}, self()}, Operation, [node()]).
+
 get_members(Scope, Group) -> pg:get_members(Scope, Group).
 get_local_members(Scope, Group) -> pg:get_local_members(Scope, Group).
 send_to_pid(Pid, Scope, {message, Topic, Event, Payload, From}) ->

--- a/packages/beryl/src/beryl_pubsub_memberships.erl
+++ b/packages/beryl/src/beryl_pubsub_memberships.erl
@@ -1,0 +1,112 @@
+-module(beryl_pubsub_memberships).
+-behaviour(gen_server).
+-export([start_link/1, init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+-record(state, {scope, owners = #{}, pg = undefined, retry = undefined}).
+
+start_link(Scope) -> gen_server:start_link(?MODULE, Scope, []).
+
+init(Scope) ->
+    %% pg is the next supervisor child, so init must not wait for it.
+    {ok, retry(#state{scope = Scope})}.
+
+handle_call(ready, _From, State) ->
+    {Reply, Next} = synchronise(State, fun() -> ok end),
+    {reply, Reply, Next};
+handle_call({join, Topic, Pid}, _From, State) when node(Pid) =:= node() ->
+    Next = add_owner(State, Topic, Pid),
+    {Reply, Synced} = synchronise(Next, fun() ->
+        join_once(State#state.scope, Topic, Pid)
+    end),
+    {reply, Reply, Synced};
+handle_call({leave, Topic, Pid}, _From, State) ->
+    Next = remove_topic(State, Topic, Pid),
+    {Reply, Synced} = synchronise(Next, fun() ->
+        _ = pg:leave(State#state.scope, Topic, Pid),
+        ok
+    end),
+    {reply, Reply, Synced}.
+
+handle_cast(_Message, State) -> {noreply, State}.
+
+handle_info(recover, State) ->
+    {_Reply, Next} = synchronise(State#state{retry = undefined}, fun() -> ok end),
+    {noreply, Next};
+handle_info({'DOWN', Ref, process, Pid, _Reason},
+            State = #state{pg = {Pid, Ref}}) ->
+    {noreply, retry(State#state{pg = undefined})};
+handle_info({'DOWN', Ref, process, Pid, _Reason}, State = #state{owners = Owners}) ->
+    case maps:find(Pid, Owners) of
+        {ok, {Ref, _Topics}} ->
+            {noreply, State#state{owners = maps:remove(Pid, Owners)}};
+        _ -> {noreply, State}
+    end.
+
+add_owner(State = #state{owners = Owners}, Topic, Pid) ->
+    {Ref, Topics} = case maps:find(Pid, Owners) of
+        {ok, Existing} -> Existing;
+        error -> {monitor(process, Pid), #{}}
+    end,
+    State#state{owners = Owners#{Pid => {Ref, Topics#{Topic => true}}}}.
+
+remove_topic(State = #state{owners = Owners}, Topic, Pid) ->
+    case maps:find(Pid, Owners) of
+        error -> State;
+        {ok, {Ref, Topics}} ->
+            Remaining = maps:remove(Topic, Topics),
+            case map_size(Remaining) of
+                0 ->
+                    demonitor(Ref, [flush]),
+                    State#state{owners = maps:remove(Pid, Owners)};
+                _ -> State#state{owners = Owners#{Pid => {Ref, Remaining}}}
+            end
+    end.
+
+synchronise(State = #state{scope = Scope}, Operation) ->
+    try
+        Pid = whereis(Scope),
+        ok = recover(State, Pid),
+        ok = Operation(),
+        %% A replacement can itself fail during replay or mutation. Never mark
+        %% a mixed generation ready; retry from the same authoritative set.
+        case whereis(Scope) =:= Pid andalso is_process_alive(Pid) of
+            true -> {ok, watch_pg(State, Pid)};
+            false -> throw(scope_recovering)
+        end
+    catch
+        throw:scope_recovering ->
+            {{error, scope_recovering}, retry(forget_pg(State))};
+        exit:{Reason, {gen_server, call, [Scope | _]}} ->
+            {{error, {pg_unavailable, Reason}}, retry(forget_pg(State))}
+    end.
+
+recover(_State, undefined) -> throw(scope_recovering);
+recover(#state{pg = {Pid, _Ref}}, Pid) -> ok;
+recover(#state{scope = Scope, owners = Owners}, _Pid) ->
+    maps:foreach(fun(Owner, {_Monitor, Topics}) ->
+        case is_process_alive(Owner) of
+            true ->
+                maps:foreach(fun(Topic, true) -> join_once(Scope, Topic, Owner) end, Topics);
+            false -> ok
+        end
+    end, Owners).
+
+watch_pg(State = #state{pg = {Pid, _Ref}}, Pid) -> State;
+watch_pg(State, Pid) ->
+    Next = forget_pg(State),
+    Next#state{pg = {Pid, monitor(process, Pid)}}.
+
+join_once(Scope, Topic, Pid) ->
+    case lists:member(Pid, pg:get_local_members(Scope, Topic)) of
+        true -> ok;
+        false -> pg:join(Scope, Topic, Pid)
+    end.
+
+forget_pg(State = #state{pg = undefined}) -> State;
+forget_pg(State = #state{pg = {_Pid, Ref}}) ->
+    demonitor(Ref, [flush]),
+    State#state{pg = undefined}.
+
+retry(State = #state{retry = undefined}) ->
+    State#state{retry = erlang:send_after(10, self(), recover)};
+retry(State) -> State.

--- a/packages/beryl/src/beryl_pubsub_supervisor.erl
+++ b/packages/beryl/src/beryl_pubsub_supervisor.erl
@@ -1,0 +1,57 @@
+-module(beryl_pubsub_supervisor).
+-behaviour(supervisor).
+-export([start_scope/1, start_link/1, init/1]).
+
+start_scope(Scope) ->
+    case start_root() of
+        {ok, Root} ->
+            Child = #{id => Scope, start => {?MODULE, start_link, [Scope]},
+                      type => supervisor},
+            case supervisor:start_child(Root, Child) of
+                {ok, Supervisor} -> registry(Supervisor);
+                {error, {already_started, Supervisor}} -> registry(Supervisor);
+                {error, Reason} -> {error, Reason}
+            end;
+        {error, Reason} -> {error, Reason}
+    end.
+
+registry(Supervisor) ->
+    case lists:keyfind(memberships, 1, supervisor:which_children(Supervisor)) of
+        {memberships, Pid, worker, _} when is_pid(Pid) -> {ok, Pid};
+        _ -> {error, scope_restarting}
+    end.
+
+start_root() ->
+    %% The node service must not inherit the lifetime or links of its first caller.
+    {Bootstrap, Monitor} = spawn_monitor(fun() ->
+        Result = supervisor:start_link({local, ?MODULE}, ?MODULE, root),
+        case Result of
+            {ok, Pid} -> unlink(Pid);
+            {error, _} -> ok
+        end,
+        exit({pubsub_started, Result})
+    end),
+    receive
+        {'DOWN', Monitor, process, Bootstrap, {pubsub_started, {ok, Pid}}} ->
+            {ok, Pid};
+        {'DOWN', Monitor, process, Bootstrap,
+         {pubsub_started, {error, {already_started, Pid}}}} ->
+            {ok, Pid};
+        {'DOWN', Monitor, process, Bootstrap, {pubsub_started, {error, Reason}}} ->
+            {error, Reason};
+        {'DOWN', Monitor, process, Bootstrap, Reason} ->
+            {error, Reason}
+    end.
+
+start_link(Scope) -> supervisor:start_link(?MODULE, {scope, Scope}).
+
+init(root) ->
+    {ok, {#{strategy => one_for_one}, []}};
+init({scope, Scope}) ->
+    %% A pg-only restart preserves the authoritative membership set. A registry
+    %% restart also replaces pg; old handles retain the dead registry pid.
+    Children = [
+        #{id => memberships, start => {beryl_pubsub_memberships, start_link, [Scope]}},
+        #{id => pg, start => {pg, start_link, [Scope]}}
+    ],
+    {ok, {#{strategy => rest_for_one, intensity => 5, period => 10}, Children}}.

--- a/packages/beryl/test/app_broadcast_test.gleam
+++ b/packages/beryl/test/app_broadcast_test.gleam
@@ -8,11 +8,54 @@ import beryl
 import beryl/pubsub
 import beryl/socket.{AcceptJoin, Broadcast, BroadcastFrom, Join, Message, Next}
 import beryl/wire
+import gleam/erlang/atom
 import gleam/erlang/process
 import gleam/json
 import gleam/option.{None}
 import gleam/string
 import gleeunit/should
+import test_helper
+
+@external(erlang, "beryl_pubsub_test_ffi", "kill_scope")
+fn kill_scope(scope: atom.Atom) -> process.Pid
+
+@external(erlang, "beryl_pubsub_test_ffi", "recovered")
+fn recovered(
+  scope: atom.Atom,
+  old_pid: process.Pid,
+  topic: String,
+  count: Int,
+) -> Bool
+
+pub fn pubsub_scope_recovery_preserves_runtime_broadcasts_test() -> Nil {
+  let scope = "app_bcast_scope_recovery"
+  let node_a = start_runtime(scope)
+  let node_b = start_runtime(scope)
+  let sender = join_lobby(node_a, "recovery-sender", "jr-a")
+  let observer = join_lobby(node_b, "recovery-observer", "jr-b")
+  let instance = pubsub.start(pubsub.config_with_scope(scope))
+  test_helper.wait_until(
+    fn() { pubsub.subscriber_count(instance, "room:lobby") == 2 },
+    5000,
+    10,
+  )
+  let old_pid = kill_scope(atom.create(scope))
+  test_helper.wait_until(
+    fn() { recovered(atom.create(scope), old_pid, "room:lobby", 2) },
+    5000,
+    10,
+  )
+  let newcomer = join_lobby(node_b, "recovery-newcomer", "jr-new")
+  app_test_helper.push(node_a, "recovery-sender", "room:lobby", "cast", "r-2")
+  app_test_helper.recv(sender) |> string.contains("shout") |> should.be_true
+  app_test_helper.recv(observer) |> string.contains("shout") |> should.be_true
+  app_test_helper.recv(newcomer) |> string.contains("shout") |> should.be_true
+  app_test_helper.recv_none(sender)
+  app_test_helper.recv_none(observer)
+  app_test_helper.recv_none(newcomer)
+  beryl.stop(node_a) |> should.equal(Ok(Nil))
+  beryl.stop(node_b) |> should.equal(Ok(Nil))
+}
 
 fn start_runtime(scope: String) -> beryl.Sockets {
   let started_pubsub = pubsub.start(pubsub.config_with_scope(scope))

--- a/packages/beryl/test/beryl_pubsub_test_ffi.erl
+++ b/packages/beryl/test/beryl_pubsub_test_ffi.erl
@@ -1,5 +1,63 @@
 -module(beryl_pubsub_test_ffi).
--export([is_scoped_wire_message/5, drain_messages/5]).
+-export([is_scoped_wire_message/5, drain_messages/5,
+         kill_scope/1, recovered/4, unmanaged_scope_rejected/1,
+         during_outage/2, unavailable/1, kill_registry/1, scope_pid/1]).
+
+scope_pid(Scope) -> whereis(Scope).
+
+during_outage(Scope, Operation) ->
+    {dictionary, Dictionary} = process_info(whereis(Scope), dictionary),
+    [Supervisor | _] = proplists:get_value('$ancestors', Dictionary),
+    ok = sys:suspend(Supervisor),
+    try
+        OldPid = kill_scope(Scope),
+        Operation(),
+        OldPid
+    after
+        ok = sys:resume(Supervisor)
+    end.
+
+unavailable(Operation) ->
+    try Operation(), false
+    catch
+        exit:{pubsub_unavailable, _Scope, _Reason} -> true;
+        exit:{pubsub_start_failed, _Scope, _Reason} -> true;
+        exit:{noproc, {gen_server, call, _Args}} -> true
+    end.
+
+kill_registry(Scope) ->
+    Pid = beryl_pubsub_ffi:start_pg_scope(Scope),
+    Ref = monitor(process, Pid),
+    exit(Pid, kill),
+    receive {'DOWN', Ref, process, Pid, killed} -> nil
+    after 5000 -> error(registry_did_not_stop)
+    end.
+
+kill_scope(Scope) ->
+    Pid = whereis(Scope),
+    Ref = monitor(process, Pid),
+    exit(Pid, kill),
+    receive {'DOWN', Ref, process, Pid, killed} -> Pid
+    after 5000 -> error(scope_did_not_stop)
+    end.
+
+recovered(Scope, OldPid, Topic, Count) ->
+    Pid = whereis(Scope),
+    is_pid(Pid) andalso Pid =/= OldPid andalso
+        length(pg:get_local_members(Scope, Topic)) =:= Count.
+
+unmanaged_scope_rejected(Scope) ->
+    {ok, Pid} = pg:start(Scope),
+    Rejected = try
+        beryl_pubsub_ffi:start_pg_scope(Scope),
+        false
+    catch
+        exit:{pubsub_start_failed, Scope, _Reason} ->
+            is_process_alive(Pid)
+    after
+        gen_server:stop(Pid)
+    end,
+    Rejected andalso is_pid(beryl_pubsub_ffi:start_pg_scope(Scope)).
 
 drain_messages(Scope, Topic, Event, Payload, From) ->
     drain_messages(Scope, Topic, Event, Payload, From, 0).

--- a/packages/beryl/test/beryl_pubsub_test_ffi.erl
+++ b/packages/beryl/test/beryl_pubsub_test_ffi.erl
@@ -1,5 +1,16 @@
 -module(beryl_pubsub_test_ffi).
--export([is_scoped_wire_message/5]).
+-export([is_scoped_wire_message/5, drain_messages/5]).
+
+drain_messages(Scope, Topic, Event, Payload, From) ->
+    drain_messages(Scope, Topic, Event, Payload, From, 0).
+
+drain_messages(Scope, Topic, Event, Payload, From, Count) ->
+    receive
+        {Scope, Topic, Event, Payload, From} ->
+            drain_messages(Scope, Topic, Event, Payload, From, Count + 1)
+    after 0 ->
+        Count
+    end.
 
 is_scoped_wire_message(Scope, Topic, Event, Payload, Timeout) ->
     receive

--- a/packages/beryl/test/pubsub_test.gleam
+++ b/packages/beryl/test/pubsub_test.gleam
@@ -1,6 +1,7 @@
 import beryl/pubsub
 import gleam/erlang/atom
 import gleam/erlang/process
+import gleam/list
 import gleeunit/should
 
 @external(erlang, "beryl_pubsub_test_ffi", "is_scoped_wire_message")
@@ -11,6 +12,191 @@ fn is_scoped_wire_message(
   payload: String,
   timeout: Int,
 ) -> Bool
+
+@external(erlang, "beryl_pubsub_test_ffi", "drain_messages")
+fn drain_messages(
+  scope: atom.Atom,
+  topic: String,
+  event: String,
+  payload: String,
+  from: pubsub.PubSubFrom,
+) -> Int
+
+pub fn pubsub_repeated_joins_are_idempotent_test() -> Nil {
+  let scope = atom.create("test_pubsub_repeated_joins")
+  let config = pubsub.config_with_scope(atom.to_string(scope))
+  let instance = pubsub.start(config)
+  let first = pubsub.subscriber(instance)
+  let second = pubsub.subscriber(pubsub.start(config))
+  let topic = "room:repeated"
+  pubsub.join(first, topic)
+  pubsub.join(first, topic)
+  pubsub.join(second, topic)
+  pubsub.join(second, topic)
+  let count = pubsub.subscriber_count(instance, topic)
+  let members = pubsub.subscribers(instance, topic)
+
+  let sender = process.spawn(fn() { Nil })
+  pubsub.broadcast(instance, topic, "broadcast", "payload")
+  pubsub.local_broadcast(instance, topic, "local", "payload")
+  pubsub.broadcast_from(instance, sender, topic, "from", "payload")
+  pubsub.broadcast_from_socket(
+    instance,
+    sender,
+    "socket",
+    topic,
+    "from_socket",
+    "payload",
+  )
+  let deliveries = [
+    drain_messages(scope, topic, "broadcast", "payload", pubsub.System),
+    drain_messages(scope, topic, "local", "payload", pubsub.System),
+    drain_messages(scope, topic, "from", "payload", pubsub.FromPid(sender)),
+    drain_messages(
+      scope,
+      topic,
+      "from_socket",
+      "payload",
+      pubsub.FromSocket(sender, "socket"),
+    ),
+  ]
+
+  pubsub.leave(second, topic)
+  let after_leave = pubsub.subscriber_count(instance, topic)
+  pubsub.broadcast(instance, topic, "after_leave", "payload")
+  let after_leave_deliveries =
+    drain_messages(scope, topic, "after_leave", "payload", pubsub.System)
+  pubsub.leave(first, topic)
+  pubsub.leave(second, topic)
+  pubsub.leave(first, topic)
+
+  count |> should.equal(1)
+  members |> should.equal([process.self()])
+  deliveries |> should.equal([1, 1, 1, 1])
+  after_leave |> should.equal(0)
+  after_leave_deliveries |> should.equal(0)
+  pubsub.subscriber_count(instance, topic) |> should.equal(0)
+}
+
+fn run_concurrently(operations: List(fn() -> Nil)) -> Nil {
+  let ready = process.new_subject()
+  let done = process.new_subject()
+  list.each(operations, fn(operation) {
+    let _worker =
+      process.spawn(fn() {
+        let start = process.new_subject()
+        process.send(ready, start)
+        let assert Ok(Nil) = process.receive(start, 5000)
+        operation()
+        process.send(done, Nil)
+      })
+  })
+  let starts =
+    list.map(operations, fn(_) {
+      let assert Ok(start) = process.receive(ready, 5000)
+      start
+    })
+  list.each(starts, process.send(_, Nil))
+  list.each(operations, fn(_) {
+    let assert Ok(Nil) = process.receive(done, 5000)
+    Nil
+  })
+}
+
+pub fn pubsub_concurrent_joins_are_idempotent_test() -> Nil {
+  let scope = atom.create("test_pubsub_concurrent_joins")
+  let config = pubsub.config_with_scope(atom.to_string(scope))
+  let instance = pubsub.start(config)
+  let first = pubsub.subscriber(instance)
+  let second = pubsub.subscriber(pubsub.start(config))
+  let topic = "room:concurrent"
+  let joins =
+    [first, second]
+    |> list.flat_map(fn(subscriber) {
+      list.repeat(fn() { pubsub.join(subscriber, topic) }, 8)
+    })
+
+  list.each(list.repeat(Nil, 4), fn(_) {
+    run_concurrently(joins)
+    let count = pubsub.subscriber_count(instance, topic)
+    pubsub.broadcast(instance, topic, "broadcast", "payload")
+    let deliveries =
+      drain_messages(scope, topic, "broadcast", "payload", pubsub.System)
+    pubsub.leave(second, topic)
+    let after_leave = pubsub.subscriber_count(instance, topic)
+    pubsub.broadcast(instance, topic, "after_leave", "payload")
+    let after_leave_deliveries =
+      drain_messages(scope, topic, "after_leave", "payload", pubsub.System)
+    run_concurrently(list.repeat(fn() { pubsub.leave(first, topic) }, 16))
+
+    count |> should.equal(1)
+    deliveries |> should.equal(1)
+    after_leave |> should.equal(0)
+    after_leave_deliveries |> should.equal(0)
+    pubsub.subscriber_count(instance, topic) |> should.equal(0)
+  })
+}
+
+pub fn pubsub_repeated_leave_preserves_other_memberships_test() -> Nil {
+  let scope = atom.create("test_pubsub_leave_isolation")
+  let instance = pubsub.start(pubsub.config_with_scope(atom.to_string(scope)))
+  let other_scope = atom.create("test_pubsub_leave_other_scope")
+  let other_instance =
+    pubsub.start(pubsub.config_with_scope(atom.to_string(other_scope)))
+  let subscriber = pubsub.subscriber(instance)
+  let other_subscriber = pubsub.subscriber(other_instance)
+  let topic = "room:shared"
+  let other_topic = "room:other"
+  let ready = process.new_subject()
+  let deliveries = process.new_subject()
+  let _owner =
+    process.spawn(fn() {
+      let finish = process.new_subject()
+      let subscriber = pubsub.subscriber(instance)
+      pubsub.join(subscriber, topic)
+      process.send(ready, finish)
+      let assert Ok(Nil) = process.receive(finish, 5000)
+      let received =
+        drain_messages(scope, topic, "broadcast", "payload", pubsub.System)
+      pubsub.leave(subscriber, topic)
+      process.send(deliveries, received)
+    })
+  let assert Ok(finish) = process.receive(ready, 5000)
+  pubsub.join(subscriber, topic)
+  pubsub.join(subscriber, topic)
+  pubsub.join(subscriber, other_topic)
+  pubsub.join(other_subscriber, topic)
+  pubsub.leave(subscriber, topic)
+  let after_leave = pubsub.subscriber_count(instance, topic)
+  pubsub.broadcast(instance, topic, "broadcast", "payload")
+  let after_leave_deliveries =
+    drain_messages(scope, topic, "broadcast", "payload", pubsub.System)
+  pubsub.leave(subscriber, topic)
+  pubsub.leave(subscriber, topic)
+  let after_repeated_leave = pubsub.subscriber_count(instance, topic)
+  let other_topic_count = pubsub.subscriber_count(instance, other_topic)
+  let other_scope_count = pubsub.subscriber_count(other_instance, topic)
+  pubsub.broadcast(instance, other_topic, "broadcast", "payload")
+  pubsub.broadcast(other_instance, topic, "broadcast", "payload")
+  let other_topic_deliveries =
+    drain_messages(scope, other_topic, "broadcast", "payload", pubsub.System)
+  let other_scope_deliveries =
+    drain_messages(other_scope, topic, "broadcast", "payload", pubsub.System)
+  process.send(finish, Nil)
+  let assert Ok(owner_deliveries) = process.receive(deliveries, 5000)
+  pubsub.leave(subscriber, other_topic)
+  pubsub.leave(other_subscriber, topic)
+
+  after_leave |> should.equal(1)
+  after_leave_deliveries |> should.equal(0)
+  after_repeated_leave |> should.equal(1)
+  other_topic_count |> should.equal(1)
+  other_scope_count |> should.equal(1)
+  other_topic_deliveries |> should.equal(1)
+  other_scope_deliveries |> should.equal(1)
+  owner_deliveries |> should.equal(1)
+  pubsub.subscriber_count(instance, topic) |> should.equal(0)
+}
 
 pub fn pubsub_start_test() -> Nil {
   let config = pubsub.config_with_scope("test_pubsub_start")

--- a/packages/beryl/test/pubsub_test.gleam
+++ b/packages/beryl/test/pubsub_test.gleam
@@ -3,6 +3,33 @@ import gleam/erlang/atom
 import gleam/erlang/process
 import gleam/list
 import gleeunit/should
+import test_helper
+
+@external(erlang, "beryl_pubsub_test_ffi", "kill_scope")
+fn kill_scope(scope: atom.Atom) -> process.Pid
+
+@external(erlang, "beryl_pubsub_test_ffi", "recovered")
+fn recovered(
+  scope: atom.Atom,
+  old_pid: process.Pid,
+  topic: String,
+  count: Int,
+) -> Bool
+
+@external(erlang, "beryl_pubsub_test_ffi", "unmanaged_scope_rejected")
+fn unmanaged_scope_rejected(scope: atom.Atom) -> Bool
+
+@external(erlang, "beryl_pubsub_test_ffi", "during_outage")
+fn during_outage(scope: atom.Atom, operation: fn() -> Nil) -> process.Pid
+
+@external(erlang, "beryl_pubsub_test_ffi", "unavailable")
+fn unavailable(operation: fn() -> Nil) -> Bool
+
+@external(erlang, "beryl_pubsub_test_ffi", "kill_registry")
+fn kill_registry(scope: atom.Atom) -> Nil
+
+@external(erlang, "beryl_pubsub_test_ffi", "scope_pid")
+fn scope_pid(scope: atom.Atom) -> process.Pid
 
 @external(erlang, "beryl_pubsub_test_ffi", "is_scoped_wire_message")
 fn is_scoped_wire_message(
@@ -21,6 +48,179 @@ fn drain_messages(
   payload: String,
   from: pubsub.PubSubFrom,
 ) -> Int
+
+pub fn pubsub_scope_recovery_restores_live_memberships_test() -> Nil {
+  let scope = atom.create("test_pubsub_scope_recovery")
+  let config = pubsub.config_with_scope(atom.to_string(scope))
+  let started = process.new_subject()
+  let starter =
+    process.spawn(fn() { process.send(started, pubsub.start(config)) })
+  let monitor = process.monitor(starter)
+  let assert Ok(instance) = process.receive(started, 5000)
+  let assert Ok(_) =
+    process.new_selector()
+    |> process.select_specific_monitor(monitor, fn(down) { down })
+    |> process.selector_receive(5000)
+  let other_handle = pubsub.start(config)
+  let first = pubsub.subscriber(instance)
+  let second = pubsub.subscriber(other_handle)
+  let isolated_scope = atom.create("test_pubsub_scope_recovery_isolated")
+  let isolated =
+    pubsub.start(pubsub.config_with_scope(atom.to_string(isolated_scope)))
+  let isolated_subscriber = pubsub.subscriber(isolated)
+  let isolated_pid = scope_pid(isolated_scope)
+  let topic = "room:recovery"
+  pubsub.join(first, topic)
+  pubsub.join(second, topic)
+  pubsub.join(first, "room:other")
+  pubsub.join(isolated_subscriber, topic)
+
+  list.each(list.repeat(Nil, 2), fn(_) {
+    let old_pid = kill_scope(scope)
+    test_helper.wait_until(
+      fn() { recovered(scope, old_pid, topic, 1) },
+      5000,
+      10,
+    )
+    pubsub.subscribers(other_handle, topic) |> should.equal([process.self()])
+    pubsub.subscriber_count(instance, "room:other") |> should.equal(1)
+    pubsub.join(second, topic)
+    pubsub.broadcast(other_handle, topic, "recovered", "payload")
+    pubsub.local_broadcast(instance, "room:other", "recovered", "payload")
+    pubsub.broadcast(isolated, topic, "isolated", "payload")
+    drain_messages(scope, topic, "recovered", "payload", pubsub.System)
+    |> should.equal(1)
+    drain_messages(scope, "room:other", "recovered", "payload", pubsub.System)
+    |> should.equal(1)
+    drain_messages(isolated_scope, topic, "isolated", "payload", pubsub.System)
+    |> should.equal(1)
+    scope_pid(isolated_scope) |> should.equal(isolated_pid)
+  })
+
+  let delivered = process.new_subject()
+  let new_owner =
+    process.spawn(fn() {
+      let subscriber = pubsub.subscriber(pubsub.start(config))
+      pubsub.join(subscriber, topic)
+      pubsub.broadcast(instance, topic, "new_owner", "payload")
+      let received =
+        drain_messages(scope, topic, "new_owner", "payload", pubsub.System)
+      process.send(delivered, received)
+    })
+  let monitor = process.monitor(new_owner)
+  process.receive(delivered, 5000) |> should.equal(Ok(1))
+  let assert Ok(_) =
+    process.new_selector()
+    |> process.select_specific_monitor(monitor, fn(down) { down })
+    |> process.selector_receive(5000)
+  drain_messages(scope, topic, "new_owner", "payload", pubsub.System)
+  |> should.equal(1)
+  let old_pid = kill_scope(scope)
+  test_helper.wait_until(fn() { recovered(scope, old_pid, topic, 1) }, 5000, 10)
+  pubsub.leave(second, topic)
+  pubsub.leave(first, topic)
+  let old_pid = kill_scope(scope)
+  test_helper.wait_until(
+    fn() { recovered(scope, old_pid, "room:other", 1) },
+    5000,
+    10,
+  )
+  pubsub.subscriber_count(instance, topic) |> should.equal(0)
+  pubsub.leave(first, "room:other")
+  pubsub.leave(isolated_subscriber, topic)
+}
+
+pub fn pubsub_scope_recovery_rejects_unmanaged_scope_test() -> Nil {
+  unmanaged_scope_rejected(atom.create("test_pubsub_unmanaged_scope"))
+  |> should.be_true
+}
+
+pub fn pubsub_scope_recovery_serialises_outage_joins_and_leaves_test() -> Nil {
+  let scope = atom.create("test_pubsub_gated_recovery")
+  let config = pubsub.config_with_scope(atom.to_string(scope))
+  let instance = pubsub.start(config)
+  let subscriber = pubsub.subscriber(instance)
+  let other = pubsub.subscriber(pubsub.start(config))
+  pubsub.join(subscriber, "room:leave")
+  pubsub.join(subscriber, "room:keep")
+  let old_pid =
+    during_outage(scope, fn() {
+      unavailable(fn() { pubsub.leave(subscriber, "room:leave") })
+      |> should.be_true
+      unavailable(fn() { pubsub.join(other, "room:new") }) |> should.be_true
+      unavailable(fn() { pubsub.join(other, "room:new") }) |> should.be_true
+      pubsub.broadcast(instance, "room:keep", "lost", "payload")
+      drain_messages(scope, "room:keep", "lost", "payload", pubsub.System)
+      |> should.equal(0)
+    })
+  test_helper.wait_until(
+    fn() { recovered(scope, old_pid, "room:keep", 1) },
+    5000,
+    10,
+  )
+  pubsub.subscriber_count(instance, "room:leave") |> should.equal(0)
+  pubsub.subscriber_count(instance, "room:new") |> should.equal(1)
+  pubsub.broadcast(instance, "room:new", "after_outage", "payload")
+  drain_messages(scope, "room:new", "after_outage", "payload", pubsub.System)
+  |> should.equal(1)
+  drain_messages(scope, "room:keep", "lost", "payload", pubsub.System)
+  |> should.equal(0)
+  pubsub.leave(subscriber, "room:keep")
+  pubsub.leave(other, "room:new")
+}
+
+pub fn pubsub_scope_recovery_invalidates_handles_after_registry_loss_test() -> Nil {
+  let scope = atom.create("test_pubsub_registry_loss")
+  let config = pubsub.config_with_scope(atom.to_string(scope))
+  let instance = pubsub.start(config)
+  let subscriber = pubsub.subscriber(instance)
+  pubsub.join(subscriber, "room:old")
+  let old_pid = scope_pid(scope)
+  kill_registry(scope)
+  unavailable(fn() {
+    pubsub.broadcast(instance, "room:old", "event", "payload")
+  })
+  |> should.be_true
+  test_helper.wait_until(
+    fn() { recovered(scope, old_pid, "room:old", 0) },
+    5000,
+    10,
+  )
+  let replacement = pubsub.start(config)
+  let new_subscriber = pubsub.subscriber(replacement)
+  pubsub.join(new_subscriber, "room:new")
+  pubsub.broadcast(replacement, "room:new", "fresh_handle", "payload")
+  drain_messages(scope, "room:new", "fresh_handle", "payload", pubsub.System)
+  |> should.equal(1)
+  pubsub.leave(new_subscriber, "room:new")
+  unavailable(fn() { pubsub.join(subscriber, "room:new") }) |> should.be_true
+  unavailable(fn() { pubsub.leave(subscriber, "room:old") }) |> should.be_true
+  unavailable(fn() {
+    let _ = pubsub.subscribers(instance, "room:old")
+    Nil
+  })
+  |> should.be_true
+}
+
+pub fn pubsub_scope_recovery_concurrent_starts_share_membership_test() -> Nil {
+  let config = pubsub.config_with_scope("test_pubsub_concurrent_start")
+  let handles = process.new_subject()
+  run_concurrently(list.repeat(
+    fn() { process.send(handles, pubsub.start(config)) },
+    16,
+  ))
+  let instances =
+    list.map(list.repeat(Nil, 16), fn(_) {
+      let assert Ok(instance) = process.receive(handles, 5000)
+      instance
+    })
+  let assert [instance, ..] = instances
+  list.each(instances, fn(handle) {
+    pubsub.join(pubsub.subscriber(handle), "room:shared")
+  })
+  pubsub.subscribers(instance, "room:shared") |> should.equal([process.self()])
+  pubsub.leave(pubsub.subscriber(instance), "room:shared")
+}
 
 pub fn pubsub_repeated_joins_are_idempotent_test() -> Nil {
   let scope = atom.create("test_pubsub_repeated_joins")

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -22,6 +22,14 @@ The scope maps to a `pg` scope atom and identifies the PubSub instance.
 Different scopes are isolated and can use different payload types in one
 process mailbox. All handles in one scope must use the same payload type.
 
+beryl starts a node-owned supervisor with a separate subtree for each scope.
+The subtree owns a membership registry and the `pg` process. Repeated `start`
+calls share that registry; the service outlives its first caller. Start the
+scope on each participating node rather than sending a handle between nodes.
+
+Startup errors cause an OTP exit. beryl rejects a scope name already owned by
+an external `pg` process; it does not adopt or stop that process.
+
 :::danger[Use a fixed scope name]
 The scope name is converted to an Erlang atom. Atoms are never
 garbage-collected; exhausting the BEAM atom table crashes the VM. The scope
@@ -58,6 +66,34 @@ owner process and scope, even when you use multiple subscriber handles.
 The owner receives each broadcast once and counts as one subscriber.
 One `leave` removes that membership; further leaves are harmless. Leaving
 does not affect other owners, scopes, or topics.
+
+## Scope recovery
+
+After a `pg` process crash, the scope supervisor restarts it. The surviving
+membership registry restores the topics of live local subscriber owners.
+You can keep existing handles. New joins and repeated joins use the same
+registry, and one leave removes the owner's membership and recovery intent.
+The registry monitors subscriber owners and drops their topics when they exit.
+An ordinary `pg` crash does not restart another scope.
+
+During recovery, a broadcast or subscriber query can see empty or partial
+membership. A broadcast returns `Nil` without confirming delivery. beryl does
+not buffer or replay broadcasts, and local recovery does not wait for
+cluster-wide convergence.
+
+Startup, joins, and leaves can exit with an OTP error during recovery or
+service failure. Membership calls use a five-second registry timeout.
+A failed or timed-out join or leave may have recorded its intent; failure does
+not roll it back. Retrying the operation is idempotent. Handle these exits at
+your application's OTP supervision boundary.
+
+The registry is in-memory state. If the registry itself is lost, including
+when repeated failures exhaust the supervisor's restart budget, old handles
+become invalid. Their membership, broadcast, and subscriber-query calls exit
+instead of silently using a replacement with no subscriptions. Call `start`
+again, create new subscribers, and rejoin. Selector-only receivers do not get a
+separate recovery notification. Service and node failures do not preserve
+subscriptions.
 
 ## Message format
 

--- a/website/src/content/docs/guides/pubsub.md
+++ b/website/src/content/docs/guides/pubsub.md
@@ -53,6 +53,12 @@ PubSub records arrive as raw BEAM messages. `selecting` validates their types
 and matches the subscriber scope. One process can select subscribers with
 different payload types if their scopes differ.
 
+Repeated or concurrent joins to the same topic create one membership per
+owner process and scope, even when you use multiple subscriber handles.
+The owner receives each broadcast once and counts as one subscriber.
+One `leave` removes that membership; further leaves are harmless. Leaving
+does not affect other owners, scopes, or topics.
+
 ## Message format
 
 Subscribers receive typed `Message(payload)` records:

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -29,6 +29,24 @@ Distributed PubSub with Erlang `pg`
  browser); payloads that never leave the cluster are cheaper and safer as
  plain Gleam types.
 
+ ## Scope recovery and delivery
+
+ Each node runs a shared beryl PubSub supervisor. Each scope has its own
+ supervisor, membership registry, and `pg` process. The service outlives
+ the process that calls `start`. A `pg` restart preserves the registry,
+ which restores the topics of live local subscriber owners. Existing
+ handles remain valid, and repeated joins still create one membership.
+
+ Broadcasts are best-effort. During recovery, broadcasts and subscriber
+ queries can see empty or partial membership. Broadcasts are not buffered
+ or replayed, and a `Nil` return does not confirm delivery. Each node must
+ start its own scope; local recovery is not a cluster-wide readiness barrier.
+
+ Startup and membership operations can exit with an OTP error during
+ service failure or recovery. A failed or timed-out join or leave may have
+ recorded its intent; failure does not roll it back. Retrying is idempotent.
+ See `start` for startup conflicts and loss of the membership registry.
+
  ## Quick start
 
  ```gleam
@@ -321,6 +339,11 @@ Join a topic so this subscriber receives broadcasts sent to it.
  Each broadcast delivers once to that owner, and subscriber counts include
  it once.
 
+ The registry retains the membership through `pg` restarts and removes it
+ when its owner exits. During recovery this call can exit with an OTP error.
+ The call uses a five-second registry timeout; an error or timeout does not
+ roll back intent already recorded by the registry. Retrying is idempotent.
+
 <div class="api-entry-anchor" id="api-function-leave" aria-hidden="true"></div>
 
 ### `leave`
@@ -337,6 +360,10 @@ Leave a topic previously joined with `join`.
  One call removes the owner's membership for this scope and topic, even
  after repeated joins through different handles. Repeated leaves are
  harmless. Other owners, scopes, and topics are unaffected.
+
+ A leave removes recovery intent as well as live membership. Like `join`,
+ it can exit during recovery or after a five-second registry timeout.
+ A failed call may still take effect; retrying is idempotent.
 
 <div class="api-entry-anchor" id="api-function-local_broadcast" aria-hidden="true"></div>
 
@@ -396,9 +423,21 @@ pub fn start(PubSubConfig) -> PubSub(a)
 
 Start a PubSub instance.
 
- This starts the configured `pg` scope on the current node. Repeated calls
- on the same node are harmless. Each participating node must start the same
- scope.
+ This starts or attaches to a node-owned supervised scope. Repeated calls
+ share its membership registry; the first caller does not own its lifetime.
+ The registry restores live local subscriptions after a `pg` process restart.
+ Each participating node must start the same scope.
+
+ Startup errors cause an OTP exit instead of returning a handle. A scope
+ already owned by an external `pg` process is a startup conflict; beryl does
+ not adopt or stop it. Startup waits for supervision and local membership
+ reconciliation, but can fail if the service is recovering.
+
+ Loss of the registry itself, including supervisor restart-intensity
+ exhaustion, invalidates existing handles. Their membership, broadcast, and
+ subscriber-query calls exit rather than silently using an empty replacement.
+ Call `start` again, create new subscribers, and rejoin their topics.
+ This is not persistent storage across service or node failure.
 
  `payload` is fixed by how the returned value is used or annotated at the
  call site. For example: `pubsub.start(config) : PubSub(MySyncPayload)`.

--- a/website/src/content/docs/reference/api/beryl-pubsub.md
+++ b/website/src/content/docs/reference/api/beryl-pubsub.md
@@ -315,8 +315,11 @@ pub fn join(
 
 Join a topic so this subscriber receives broadcasts sent to it.
 
- A subscriber can join many topics. All topics deliver through its one
- subject. Joining a topic is idempotent.
+ A subscriber can join many topics. All topics deliver to its owner's
+ mailbox. Repeated or concurrent joins create one membership per owner
+ process, scope, and topic, including joins through different handles.
+ Each broadcast delivers once to that owner, and subscriber counts include
+ it once.
 
 <div class="api-entry-anchor" id="api-function-leave" aria-hidden="true"></div>
 
@@ -330,6 +333,10 @@ pub fn leave(
 ```
 
 Leave a topic previously joined with `join`.
+
+ One call removes the owner's membership for this scope and topic, even
+ after repeated joins through different handles. Repeated leaves are
+ harmless. Other owners, scopes, and topics are unaffected.
 
 <div class="api-entry-anchor" id="api-function-local_broadcast" aria-hidden="true"></div>
 


### PR DESCRIPTION
PubSub subscribers resume receiving broadcasts after a local `pg` scope crash without rejoining. Previously, an unlinked `pg` process held the only membership state, so its failure left live subscribers absent from future broadcasts.

Closes #392.

## What changed

- Add node-owned OTP supervision and a per-scope membership registry that survives `pg` restarts. Monitor subscriber owners and serialize replay, joins, and leaves to preserve #390's idempotency.
- Preserve public signatures, multiple handles, independent scopes, transport boundaries, and the frozen wire tuple. Reject unmanaged scope-name conflicts; invalidate old handles if their registry is lost.
- Add crash/outage and runtime-broadcast regressions, a Fixed fragment, and ownership/recovery documentation. Broadcasts remain best-effort: recovery does not buffer or replay messages, and membership calls can fail without rolling back recorded intent.
