### PR TITLE
docs(website): pin installs to latest minor tag

### DIFF
--- a/.changes/unreleased/beryl-use-the-highest-published.toml
+++ b/.changes/unreleased/beryl-use-the-highest-published.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Use the highest published minor-series tag in website installation guidance instead of main."

--- a/DEV.md
+++ b/DEV.md
@@ -144,6 +144,12 @@ case result {
 
 ### Documentation
 
+The website installation example selects the highest published `vMAJOR.MINOR`
+tag with `git ls-remote` during rendering. Website builds need Git and network
+access to GitHub; they fail if the lookup fails or no minor tag exists. Local
+tags and shallow clone depth do not affect the selected ref. Rebuild the
+website after publishing a new minor tag to update the example.
+
 Document all public functions with `///` comments:
 
 ```gleam

--- a/website/e2e/installation.spec.ts
+++ b/website/e2e/installation.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/test";
+
+test("installation pins core and transport to the same minor release", async ({ page, request }) => {
+	await page.goto("/installation/");
+	const lines = await page.locator('pre[data-language="toml"] .ec-line').allTextContents();
+	const dependencies = lines.join("\n");
+	const refs = [...dependencies.matchAll(/ref = "(v\d+\.\d+)"/g)].map((match) => match[1]);
+	expect(refs).toHaveLength(2);
+	expect(refs[0]).toBe(refs[1]);
+	expect(dependencies).toContain('path = "packages/beryl"');
+	expect(dependencies).toContain('path = "packages/beryl_mist"');
+
+	const llms = await request.get("/llms-full.txt");
+	expect(llms.ok()).toBe(true);
+	expect(await llms.text()).toContain(dependencies);
+});

--- a/website/src/components/InstallDependencies.astro
+++ b/website/src/components/InstallDependencies.astro
@@ -1,0 +1,22 @@
+---
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { Code } from "@astrojs/starlight/components";
+
+const repository = "https://github.com/tylerbutler/beryl.git";
+const { stdout } = await promisify(execFile)(
+	"git",
+	["ls-remote", "--refs", "--tags", "--sort=-version:refname", repository, "v*"],
+	{ timeout: 30_000 },
+);
+const ref = stdout.match(/\trefs\/tags\/(v\d+\.\d+)$/m)?.[1];
+if (!ref) {
+	throw new Error("No beryl minor release tag (vMAJOR.MINOR) found.");
+}
+
+const dependencies = `[dependencies]
+beryl = { git = "${repository}", ref = "${ref}", path = "packages/beryl" }
+beryl_mist = { git = "${repository}", ref = "${ref}", path = "packages/beryl_mist" }`;
+---
+
+<Code code={dependencies} lang="toml" />

--- a/website/src/content/docs/installation.mdx
+++ b/website/src/content/docs/installation.mdx
@@ -2,6 +2,8 @@
 title: Installation
 ---
 
+import InstallDependencies from '../../components/InstallDependencies.astro';
+
 :::note[Pre-1.0]
 beryl is not yet version 1.0. Minor releases can change the API, and the
 library is not ready for production. Report problems to help define version
@@ -12,11 +14,7 @@ Install beryl packages from
 [GitHub](https://github.com/tylerbutler/beryl). They are not on Hex. Add them
 as Git dependencies in `gleam.toml`:
 
-```toml
-[dependencies]
-beryl = { git = "https://github.com/tylerbutler/beryl.git", ref = "main", path = "packages/beryl" }
-beryl_mist = { git = "https://github.com/tylerbutler/beryl.git", ref = "main", path = "packages/beryl_mist" }
-```
+<InstallDependencies />
 
 Download the dependencies:
 
@@ -77,7 +75,7 @@ An error occurred while trying to parse this file:
     gleam.toml
 
   |
-7 | beryl = { git = "...", ref = "main", path = "packages/beryl" }
+7 | beryl = { git = "...", ref = "...", path = "packages/beryl" }
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 data did not match any variant of untagged enum Requirement
 ```
@@ -87,9 +85,15 @@ upgrade Gleam.
 
 ## Pin a Git ref
 
-The example uses `main`, which matches these docs. The branch can change without
-warning. Check [GitHub Releases](https://github.com/tylerbutler/beryl/releases).
-When one tag contains all required packages, replace `main` with that tag.
+The install example uses the highest published minor-series tag (`vMAJOR.MINOR`)
+at the time of the website build. Use this tag to stay on one API series rather
+than follow `main`. Check
+[repository tags](https://github.com/tylerbutler/beryl/tags) before you move to
+a newer minor release.
+
+Minor-series tags can move to newer patch releases. For an immutable pin, use
+the commit SHA that the tag points to. These docs follow `main` and can describe
+features that are not in a release yet.
 
 Gleam resolves Git dependencies at the specified ref. Use the same ref for
 `beryl` and its transport package. Do not mix versions.


### PR DESCRIPTION
Replace the website install example that follows main with a build-time lookup of the highest published vMAJOR.MINOR tag. Use the same ref for beryl and beryl_mist, and keep the rendered example in llms-full.txt consistent.

The highest published minor tag is currently v0.4; v0.5 does not exist yet. A website build after the next minor tag is published will select it without a source edit. The lookup uses Git version sorting, needs GitHub access during the build, and fails rather than falling back to main.

Document that minor-series tags can move to newer patches and that a commit SHA gives an immutable pin. No new dependencies.