### PR TITLE
ci(release): authenticate and cache Gleam deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,32 @@ jobs:
         with:
           run-deps: false
 
+      - name: Restore Gleam dependencies
+        id: cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cache/gleam
+            packages/*/build/packages
+            examples/*/build/packages
+            examples/*/client/build/packages
+          key: gleam-deps-${{ runner.os }}-${{ hashFiles('.tool-versions', '.mise.toml', '**/gleam.toml', '**/manifest.toml') }}
+          restore-keys: |
+            gleam-deps-${{ runner.os }}-
+
       - name: Install Gleam dependencies
         run: just deps-gleam
+
+      - name: Save Gleam dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache/save@v4
+        with:
+          path: |
+            ~/.cache/gleam
+            packages/*/build/packages
+            examples/*/build/packages
+            examples/*/client/build/packages
+          key: ${{ steps.cache.outputs.cache-primary-key }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  HEXPM_READ_API_KEY: ${{ secrets.HEXPM_API_KEY }}
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The Release PR job fails with `The rate limit for the Hex API has been exceeded` during `just deps-gleam`.

Reuse the Hex read credential from CI and add dependency cache restore/save steps with the same paths and keys. Save the cache before switching to the release branch so it matches the main-branch dependency state.

Failed job: https://github.com/tylerbutler/beryl/actions/runs/34294993518/job/102289569456