### PR TITLE
docs: define changelog fragment scope

### DIFF
--- a/.changes/unreleased/beryl-add-interactive-tutorial-demos.toml
+++ b/.changes/unreleased/beryl-add-interactive-tutorial-demos.toml
@@ -1,3 +1,0 @@
-package = "beryl"
-kind = "Added"
-body = "Add interactive tutorial demos for socket state and effects, shared poll delivery and cleanup, and raw dispatch versus channels."

--- a/.changes/unreleased/beryl-allow-isc-licensed-dependencies.toml
+++ b/.changes/unreleased/beryl-allow-isc-licensed-dependencies.toml
@@ -1,3 +1,0 @@
-package = "beryl"
-kind = "Changed"
-body = "Allow ISC-licensed dependencies in local licence audits."

--- a/.changes/unreleased/beryl-correct-architecture-and-supervision.toml
+++ b/.changes/unreleased/beryl-correct-architecture-and-supervision.toml
@@ -1,3 +1,0 @@
-package = "beryl"
-kind = "Fixed"
-body = "Correct architecture and supervision documentation to describe socket and topic workers, reconnect recovery, transport writes, and current queue-limit guarantees."

--- a/.changes/unreleased/beryl-improve-the-generated-api.toml
+++ b/.changes/unreleased/beryl-improve-the-generated-api.toml
@@ -1,3 +1,0 @@
-package = "beryl"
-kind = "Changed"
-body = "Improve the generated API reference layout with symbol indexes, signature-first entries, and responsive module lists."

--- a/.changes/unreleased/beryl-use-the-highest-published.toml
+++ b/.changes/unreleased/beryl-use-the-highest-published.toml
@@ -1,3 +1,0 @@
-package = "beryl"
-kind = "Fixed"
-body = "Use the highest published minor-series tag in website installation guidance instead of main."

--- a/.changes/unreleased/beryl_ewe-allow-isc-licensed-dependencies.toml
+++ b/.changes/unreleased/beryl_ewe-allow-isc-licensed-dependencies.toml
@@ -1,3 +1,0 @@
-package = "beryl_ewe"
-kind = "Changed"
-body = "Allow ISC-licensed dependencies in local licence audits."

--- a/.changes/unreleased/beryl_mist-allow-isc-licensed-dependencies.toml
+++ b/.changes/unreleased/beryl_mist-allow-isc-licensed-dependencies.toml
@@ -1,3 +1,0 @@
-package = "beryl_mist"
-kind = "Changed"
-body = "Allow ISC-licensed dependencies in local licence audits."

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,7 +50,8 @@ Example Playwright runs can create untracked test artifacts; clean those before 
 
 - Before creating or updating a PR, fetch the current default branch and validate the branch against it; PR CI tests the merge result, so local `just ci` on an outdated branch can miss failures.
 - PR titles must follow Conventional Commits and should keep type/scope lowercase, for example `fix(pubsub): preserve broadcast_from exclusion`.
-- Add a trellis changelog fragment for public API, behavior, dependency, or user-visible changes. Use `just change <package> <kind> "<body>"` (trellis changelog new) instead of inventing changelog filenames.
+- Add a trellis changelog fragment only for what a released package ships — its `src/`, `gleam.toml`, or `manifest.toml`. This covers public API, observable behavior, dependency requirements, and `///` doc comments (which ship in the API reference). Use `just change <package> <kind> "<body>"` (trellis changelog new) instead of inventing changelog filenames.
+- Do not add a fragment for anything a package does not ship. Website, `docs/`, examples, dev tooling, test files, and behavior-preserving refactors reach no consumer, so a fragment for them bumps a version that nobody sees.
 - Commit only intended source, test, docs, manifest, and changelog fragment files. Do not stage generated Playwright output or temporary PR body files.
 
 ## Code conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,8 @@
 ## Project Summary
 
 beryl is a Gleam library for type-safe real-time channels and presence on the
-Erlang/BEAM runtime. It's a trellis-managed monorepo with three packages — two
-of them currently publishable, since `beryl_ewe` is release-excluded — plus
-runnable examples and an Astro/Starlight documentation website.
+Erlang/BEAM runtime. It's a trellis-managed monorepo with three releasable
+packages, plus runnable examples and an Astro/Starlight documentation website.
 
 ## Essential Commands
 
@@ -30,7 +29,7 @@ Run a single test: `cd packages/beryl && gleam test -- --filter "test_name"`
 packages/
   beryl/           # core library (app dispatch, presence, pubsub, wire, transport SPI)
   beryl_mist/      # Mist WebSocket transport (depends on beryl via path)
-  beryl_ewe/       # Ewe WebSocket transport (depends on beryl via path; NOT published)
+  beryl_ewe/       # Ewe WebSocket transport (depends on beryl via path)
 examples/          # runnable example apps (workspace members, excluded from release)
 website/           # Astro/Starlight docs site (NOT a workspace member)
 docs/              # ADRs, design docs, architecture deck, security docs
@@ -167,11 +166,36 @@ Header max 72 chars. Body max line length 100 chars.
 
 ### Changelog Fragments
 
-Use `just change <package> <kind> "<body>"` for any public API, behavior,
-dependency, or user-visible change. Kinds: `Initial Release` (major),
-`Added`/`Changed`/`Removed` (minor), `Fixed`/`Performance`/`Deprecated`/`Security`/`Dependencies` (patch).
+Create a fragment with `just change <package> <kind> "<body>"`. Kinds:
+`Initial Release` (major), `Added`/`Changed`/`Removed` (minor),
+`Fixed`/`Performance`/`Deprecated`/`Security`/`Dependencies` (patch).
 
-PR CI enforces fragments via `trellis changelog check`.
+**A fragment applies only to what a released package ships** — its `src/`,
+`gleam.toml`, or `manifest.toml`. The fragment describes what a consumer of
+the published package receives. Write a fragment when you change a released
+package's:
+
+- public API (types, functions, labels, or signatures)
+- observable runtime behavior, or a bug in that behavior
+- dependency requirements in `gleam.toml` or `manifest.toml`
+- `///` or `////` doc comments, because these ship in the API reference
+
+**Do not write a fragment** for anything a package does not ship. The website,
+`docs/`, examples, and dev tooling reach no consumer, so a fragment for them
+bumps a version that nobody sees:
+
+- `website/` content, components, styles, or generator scripts
+- `docs/` ADRs, design notes, and decks
+- `examples/` (release-excluded workspace members)
+- root config, `justfile`, `.github/` workflows, and audit or lint settings
+- `packages/*/test/`, internal refactors, and formatting that keep the
+  consumer-visible behavior the same
+
+All three packages under `packages/` are releasable, so each one takes its own
+fragments. Only `examples/**` is release-excluded.
+
+PR CI enforces fragments via `trellis changelog check`. Preview the effect of
+the current fragments with `just version-plan`.
 
 ### Release Flow
 
@@ -209,9 +233,11 @@ users; keep everything else in `.mise.toml` limited to mise-only helper tools.
 
 ### Trellis Exclusions
 
-`beryl_ewe` is excluded from release (`@release` key in `gleam.toml`) — it's
-built, tested, and linted but excluded from changelog, versioning, tagging,
-and publishing.
+Only `examples/**` is excluded from release (`@release` key in the root
+`gleam.toml`). Examples are built and tested, but they get no changelog,
+version, tag, or fragment. All three packages under `packages/` are
+releasable on the `git_only` lifecycle: they get tags and GitHub releases,
+but Hex.pm publishing is disabled.
 
 ## Examples
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,7 @@
 
 Type-safe real-time channels and presence for Gleam, targeting the Erlang
 (BEAM) runtime. The repository is a [trellis](https://trellis.tylerbutler.com)-managed
-monorepo with three packages (two currently publishable — `beryl_ewe` is
-excluded from release via the `@release` key in the root `gleam.toml`):
+monorepo with three releasable packages:
 
 - **`packages/beryl`** — raw app dispatch plus `beryl/channel` (runtime,
   typed events/effects, presence, PubSub, wire protocol, abuse controls,
@@ -167,7 +166,11 @@ installed in CI via `.github/actions/mise`.
 
 ### Release Flow
 1. Push commits with conventional commit messages
-2. Add changelog fragments with `just change <package> <kind> "<body>"`
+2. Add changelog fragments with `just change <package> <kind> "<body>"`.
+   Fragments apply only to what a released package ships (`src/`,
+   `gleam.toml`, `manifest.toml`). Website, `docs/`, examples, and
+   dev-tooling changes get no fragment — see the "Changelog Fragments"
+   section in `AGENTS.md` for the full rule
 3. `trellis release pr` maintains a release PR (branch `release/pending`)
    with version bumps and CHANGELOGs
 4. Merge the release PR → per-package tags (`beryl-v1.2.3`) and GitHub

--- a/DEV.md
+++ b/DEV.md
@@ -252,6 +252,22 @@ test: add edge case tests for topic matching
 Releases are driven by trellis changelog fragments (TOML files in
 `.changes/unreleased/` with `project`, `kind`, and `body` fields).
 
+### When a fragment is required
+
+A fragment applies only to what a released package ships — its `src/`,
+`gleam.toml`, or `manifest.toml`. It describes what a consumer of the
+published package receives. Add a fragment when you change a package's public
+API, its observable behavior, its dependency requirements, or its `///` doc
+comments (these ship in the API reference).
+
+Do not add a fragment for anything a package does not ship. The `website/`,
+`docs/`, and `examples/` directories and the dev tooling reach no consumer, so
+a fragment for them bumps a version that nobody sees. Test files, internal
+refactors, and formatting that keep the consumer-visible behavior the same
+also need no fragment.
+
+### Steps
+
 1. Make changes following the commit message convention
 2. Add a changelog entry: `just change <package> <kind> "<body>"`
    (e.g. `just change beryl Fixed "handle concurrent leave/join"`); PR CI

--- a/README.md
+++ b/README.md
@@ -224,7 +224,9 @@ its creator and stops if that process exits.
 See [GitHub Releases](https://github.com/tylerbutler/beryl/releases) for release
 notes. Releases use
 [Conventional Commits](https://www.conventionalcommits.org/). The project uses
-[trellis](https://trellis.tylerbutler.com) changelog fragments.
+[trellis](https://trellis.tylerbutler.com) changelog fragments. A fragment is
+required only for what a released package ships. See
+[DEV.md](DEV.md#when-a-fragment-is-required) for the rule.
 
 ## Security
 


### PR DESCRIPTION
## Summary

- define fragments as release notes for files that ship in a package
- remove seven fragments for website, documentation infrastructure, and local audit changes
- correct stale guidance that marked `beryl_ewe` as release-excluded

## Checks

- `just doctor`
- `just version-plan`
- `git diff --check`