### PR TITLE
fix(socket): give reply refs unique identities

### DIFF
--- a/.changes/unreleased/beryl-give-each-reply-handle.toml
+++ b/.changes/unreleased/beryl-give-each-reply-handle.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Give each reply handle a unique request identity so stale replies cannot consume requests that reuse wire identifiers, including after a topic closes and rejoins."

--- a/packages/beryl/src/beryl/runtime.gleam
+++ b/packages/beryl/src/beryl/runtime.gleam
@@ -551,11 +551,11 @@ type SocketState(model, message) {
     join_refs: Dict(String, Option(String)),
     /// Presence refs tracked through socket effects, grouped by topic and key.
     presence_refs: Dict(String, Dict(String, #(String, Json))),
-    /// Message reply refs still awaiting a reply. A ref is added when its
-    /// `Message` is delivered, removed when answered (so a reply is
-    /// single-use), and pruned when its topic closes (so a stale ref stored
-    /// across a leave/rejoin is not replied to).
-    pending_reply_refs: Set(ReplyRef),
+    /// Wire keys reject duplicate outstanding requests, but are reusable
+    /// after a reply or topic close.
+    pending_reply_keys: Set(#(String, Option(String), Option(String))),
+    /// Unique reply capabilities and their reservations. Answering or closing
+    /// the receiving topic removes the capability permanently.
     reply_reservations: Dict(ReplyRef, work_queue.Reservation),
     /// The worker for each joined topic when the layer uses one process per
     /// topic. The runtime removes it when the topic starts to close.
@@ -2023,7 +2023,7 @@ fn register_socket(
           subscribed_topics: set.new(),
           join_refs: dict.new(),
           presence_refs: dict.new(),
-          pending_reply_refs: set.new(),
+          pending_reply_keys: set.new(),
           reply_reservations: dict.new(),
           workers: dict.new(),
           last_heartbeat: monotonic_time_ms(),
@@ -3237,7 +3237,12 @@ fn route_message_with_ref(
   started_at: Int,
   kind: telemetry.MessageKind,
 ) -> State(model, message) {
-  case set.contains(socket.pending_reply_refs, message_ref) {
+  case
+    set.contains(
+      socket.pending_reply_keys,
+      socket.reply_ref_wire_key(message_ref),
+    )
+  {
     True -> {
       state.logger
       |> log.warn("Inbound message rejected: reply ref already outstanding", [
@@ -4837,8 +4842,8 @@ fn apply_reply(
   case dict.get(state.sockets, socket_id) {
     Error(Nil) -> state
     Ok(socket) ->
-      case set.contains(socket.pending_reply_refs, ref) {
-        False -> {
+      case dict.get(socket.reply_reservations, ref) {
+        Error(Nil) -> {
           state.logger
           |> log.warn("Reply ignored: unknown or already-answered ref", [
             #("socket_id", socket_id),
@@ -4846,7 +4851,7 @@ fn apply_reply(
           ])
           state
         }
-        True -> {
+        Ok(reservation) -> {
           let frame =
             codec.encode_reply(socket.codec)(
               socket.reply_ref_join_ref(ref),
@@ -4857,14 +4862,15 @@ fn apply_reply(
             )
           let _send_result =
             send_frame_logged(state, socket, socket.reply_ref_topic(ref), frame)
-          dict.get(socket.reply_reservations, ref)
-          |> result.map(work_queue.release(state.inbox, _))
-          |> result.unwrap(Nil)
+          work_queue.release(state.inbox, reservation)
           store_socket(
             state,
             SocketState(
               ..socket,
-              pending_reply_refs: set.delete(socket.pending_reply_refs, ref),
+              pending_reply_keys: set.delete(
+                socket.pending_reply_keys,
+                socket.reply_ref_wire_key(ref),
+              ),
               reply_reservations: dict.delete(socket.reply_reservations, ref),
             ),
           )
@@ -4898,8 +4904,8 @@ fn unsubscribe_topic(
         SocketState(
           ..socket,
           subscribed_topics: set.delete(socket.subscribed_topics, topic_name),
-          pending_reply_refs: set.filter(socket.pending_reply_refs, fn(ref) {
-            socket.reply_ref_topic(ref) != topic_name
+          pending_reply_keys: set.filter(socket.pending_reply_keys, fn(key) {
+            key.0 != topic_name
           }),
           reply_reservations: kept,
         ),
@@ -4922,7 +4928,10 @@ fn register_reply_ref(
         state,
         SocketState(
           ..socket,
-          pending_reply_refs: set.insert(socket.pending_reply_refs, ref),
+          pending_reply_keys: set.insert(
+            socket.pending_reply_keys,
+            socket.reply_ref_wire_key(ref),
+          ),
           reply_reservations: dict.insert(
             socket.reply_reservations,
             ref,

--- a/packages/beryl/src/beryl/socket.gleam
+++ b/packages/beryl/src/beryl/socket.gleam
@@ -53,7 +53,12 @@ pub opaque type JoinRef {
 /// asynchronous lookup. They are single-use. They remain valid only while
 /// the topic instance that received the message stays open.
 pub opaque type ReplyRef {
-  ReplyRef(topic: String, join_ref: Option(String), message_ref: Option(String))
+  ReplyRef(
+    topic: String,
+    join_ref: Option(String),
+    message_ref: Option(String),
+    token: Reference,
+  )
 }
 
 @internal
@@ -76,7 +81,12 @@ pub fn make_message_ref(
   join_ref join_ref: Option(String),
   message_ref message_ref: Option(String),
 ) -> ReplyRef {
-  ReplyRef(topic: topic, join_ref: join_ref, message_ref: message_ref)
+  ReplyRef(
+    topic: topic,
+    join_ref: join_ref,
+    message_ref: message_ref,
+    token: reference.new(),
+  )
 }
 
 @internal
@@ -102,6 +112,13 @@ pub fn reply_ref_join_ref(ref: ReplyRef) -> Option(String) {
 @internal
 pub fn reply_ref_message_ref(ref: ReplyRef) -> Option(String) {
   ref.message_ref
+}
+
+@internal
+pub fn reply_ref_wire_key(
+  ref: ReplyRef,
+) -> #(String, Option(String), Option(String)) {
+  #(ref.topic, ref.join_ref, ref.message_ref)
 }
 
 /// Why a socket or topic is stopping.

--- a/packages/beryl/test/app_ref_test.gleam
+++ b/packages/beryl/test/app_ref_test.gleam
@@ -8,7 +8,7 @@
 import app_test_helper
 import beryl
 import beryl/socket.{
-  type ReplyRef, AcceptJoin, Info, Join, Message, Next, ReplyOk,
+  type ReplyRef, AcceptJoin, Info, Join, Message, Next, ReplyError, ReplyOk,
 }
 import beryl/wire
 import gleam/erlang/process
@@ -19,15 +19,17 @@ import gleeunit/should
 
 pub type AppMessage {
   ReplyStashed
+  ReplyPrevious
 }
 
 type Model {
-  Model(stashed: Option(ReplyRef))
+  Model(stashed: Option(ReplyRef), previous: Option(ReplyRef))
 }
 
 /// - "double": reply to the same ref twice in one effects list (single-use).
 /// - "stash": store the ref without replying (deferred reply).
 /// - `Info(ReplyStashed)`: reply with the stored ref later.
+/// - `Info(ReplyPrevious)`: attempt both reply effects with the previous ref.
 fn start_system(
   senders: process.Subject(socket.Sender(AppMessage)),
 ) -> beryl.Sockets {
@@ -36,7 +38,7 @@ fn start_system(
       beryl.config(wire.phoenix_codec()),
       init: fn(info) {
         process.send(senders, info.self)
-        #(Model(None), [])
+        #(Model(None, None), [])
       },
       update: fn(model: Model, event) {
         case event {
@@ -47,12 +49,21 @@ fn start_system(
               ReplyOk(ref, json.object([#("n", json.int(2))])),
             ])
           Message(_topic, "stash", _payload, Some(ref)) ->
-            Next(Model(Some(ref)), [])
+            Next(Model(Some(ref), model.stashed), [])
           Info(ReplyStashed) ->
             case model.stashed {
               Some(ref) ->
                 Next(model, [
                   ReplyOk(ref, json.object([#("late", json.bool(True))])),
+                ])
+              None -> Next(model, [])
+            }
+          Info(ReplyPrevious) ->
+            case model.previous {
+              Some(ref) ->
+                Next(model, [
+                  ReplyOk(ref, json.string("stale ok")),
+                  ReplyError(ref, json.string("stale error")),
                 ])
               None -> Next(model, [])
             }
@@ -136,6 +147,77 @@ pub fn duplicate_outstanding_ref_is_rejected_then_reusable_test() -> Nil {
   let reused_reply = app_test_helper.recv(frames)
   reused_reply |> string.contains("\"status\":\"ok\"") |> should.be_true
   reused_reply |> string.contains("\"late\":true") |> should.be_true
+}
+
+pub fn completed_reply_ref_cannot_consume_reused_wire_key_test() -> Nil {
+  let #(channels, senders) = start()
+  let frames = app_test_helper.connect(channels, "s1")
+  let assert Ok(sender) = process.receive(senders, 500)
+  app_test_helper.join_ok(channels, frames, "s1", "room:a", "jr-1", "r-1")
+
+  app_test_helper.push(channels, "s1", "room:a", "stash", "r-2")
+  app_test_helper.recv_none(frames)
+  let assert Ok(_) = socket.notify(sender, ReplyStashed)
+  app_test_helper.recv(frames)
+  |> string.contains("\"status\":\"ok\"")
+  |> should.be_true
+
+  // Keep the completed handle alongside a new handle with identical wire fields.
+  app_test_helper.push(channels, "s1", "room:a", "stash", "r-2")
+  app_test_helper.recv_none(frames)
+  assert_current_ref_survives_stale_replies(channels, sender, frames)
+}
+
+pub fn closed_reply_ref_cannot_consume_rejoined_wire_key_test() -> Nil {
+  let #(channels, senders) = start()
+  let frames = app_test_helper.connect(channels, "s1")
+  let assert Ok(sender) = process.receive(senders, 500)
+  app_test_helper.join_ok(channels, frames, "s1", "room:a", "jr-1", "r-1")
+
+  app_test_helper.push(channels, "s1", "room:a", "stash", "r-2")
+  app_test_helper.route(
+    channels,
+    "s1",
+    "[\"jr-1\",\"r-3\",\"room:a\",\"phx_leave\",{}]",
+  )
+  let _leave_reply = app_test_helper.recv(frames)
+  app_test_helper.recv(frames)
+  |> string.contains("phx_close")
+  |> should.be_true
+
+  // Reuse the join ref as well as the message ref from the closed instance.
+  app_test_helper.join_ok(channels, frames, "s1", "room:a", "jr-1", "r-1")
+  app_test_helper.push(channels, "s1", "room:a", "stash", "r-2")
+  app_test_helper.recv_none(frames)
+  assert_current_ref_survives_stale_replies(channels, sender, frames)
+}
+
+fn assert_current_ref_survives_stale_replies(
+  channels: beryl.Sockets,
+  sender: socket.Sender(AppMessage),
+  frames: process.Subject(String),
+) -> Nil {
+  let assert Ok(_) = socket.notify(sender, ReplyPrevious)
+  app_test_helper.recv_none(frames)
+
+  // Rejecting the stale effects must leave the new request outstanding.
+  app_test_helper.route(
+    channels,
+    "s1",
+    "[\"jr-1\",\"r-2\",\"room:a\",\"stash\",{}]",
+  )
+  let duplicate = app_test_helper.recv(frames)
+  duplicate |> string.contains("\"status\":\"error\"") |> should.be_true
+  duplicate |> string.contains("duplicate_ref") |> should.be_true
+
+  let assert Ok(_) = socket.notify(sender, ReplyStashed)
+  app_test_helper.recv(frames)
+  |> should.equal(
+    "[\"jr-1\",\"r-2\",\"room:a\",\"phx_reply\","
+    <> "{\"status\":\"ok\",\"response\":{\"late\":true}}]",
+  )
+  let assert Ok(_) = socket.notify(sender, ReplyStashed)
+  app_test_helper.recv_none(frames)
 }
 
 pub fn reply_after_topic_close_is_dropped_test() -> Nil {


### PR DESCRIPTION
## Fix

Give each `ReplyRef` a fresh BEAM reference, following `JoinRef`. Validate reply effects against the existing capability-keyed reservation map and track duplicate outstanding wire keys in a separate set. A stale handle cannot send a reply, release the new request's reservation, or consume its wire key.

Keep wire-key reuse valid after completion, preserve deferred replies while the receiving topic instance remains open, and remove both indexes on topic close. Add the required beryl `Fixed` changelog fragment.

## Regression coverage

Retain old and new handles with identical topic, join-ref, and message-ref fields. Exercise both `ReplyOk` and `ReplyError` with the old handle, confirm that duplicate requests still report `duplicate_ref`, and then complete the new request through its own handle. Cover both reuse after completion and leave/rejoin with the same wire fields. Keep the existing single-use, deferred-reply, and duplicate-outstanding assertions.

Closes #387
