### PR TITLE
fix(presence): repair quiet replica synchronization

### DIFF
--- a/.changes/unreleased/beryl-repair-quiet-presence-replication.toml
+++ b/.changes/unreleased/beryl-repair-quiet-presence-replication.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Repair quiet presence replication with initial and periodic snapshots. All replicas in a presence scope must use sync version 2."

--- a/docs/architecture-deck.md
+++ b/docs/architecture-deck.md
@@ -72,7 +72,7 @@ runtime connects these layers.
 | `beryl/runtime` | Router, supervised socket actors, topic workers, effects, heartbeat |
 | `beryl/channel` | Typed handlers and per-topic state, run in topic workers |
 | `beryl/pubsub` | Distributed pub-sub via Erlang `pg`; typed `Subscriber(payload)` |
-| `beryl/presence` | Add-wins OR-set CRDT; track/untrack, dirty full-state replication |
+| `beryl/presence` | Add-wins OR-set CRDT; track/untrack, periodic snapshot repair |
 | `beryl/wire` | Pluggable codec; ships `phoenix_codec()` |
 | `beryl_mist` / `beryl_ewe` | WebSocket adapters; assign socket ids, route frames |
 | `beryl/group` | Named topic collections; supports grouped broadcast |

--- a/docs/talks/beryl-interview/deck.md
+++ b/docs/talks/beryl-interview/deck.md
@@ -574,9 +574,9 @@ The animation shows that the same incorrect message order produces the correct
 result.
 
 Implementation notes (brief): the CRDT comes from the `lattice_presence`
-package. beryl wraps it in an OTP actor on each node. When local state is dirty,
-periodic ticks publish the versioned **full CRDT state** over PubSub. Peers
-merge it and surface non-empty local/merge diffs through `with_on_diff`.
+package. beryl wraps it in an OTP actor on each node. Initial and periodic
+requests exchange versioned **full CRDT snapshots**, including while replicas
+are quiet. Peers merge them and report local/merge diffs through `with_on_diff`.
 Those replication payloads are not the client wire format. The app separately
 emits Phoenix-compatible `presence_state` / `presence_diff` joins/leaves maps,
 so the Phoenix JS Presence class renders beryl presence without modification.

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -4,8 +4,8 @@
 //// OTP actor that:
 //// - Handles track/update/untrack calls
 //// - Publishes an actor-owned ETS read model
-//// - Periodically broadcasts state via PubSub for cross-node replication
-//// - Receives remote state from PubSub and merges it internally
+//// - Requests snapshots at startup and periodically through PubSub
+//// - Receives remote snapshots and merges them internally
 //// - Invokes `on_diff` when local changes or merges produce non-empty diffs
 ////
 //// Presence is independent of the beryl runtime and runs under your
@@ -60,6 +60,7 @@ import gleam/crypto
 import gleam/dict.{type Dict}
 import gleam/dynamic/decode
 import gleam/erlang/process.{type Subject}
+import gleam/erlang/reference.{type Reference}
 import gleam/int
 import gleam/json
 import gleam/list
@@ -193,16 +194,25 @@ fn state_entries_to_presence_entries(
   |> dict.from_list
 }
 
-/// The replication envelope carried over PubSub between presence replicas.
+/// The snapshot request carried over PubSub between presence replicas.
 ///
-/// Sent as a native BEAM term (no JSON encoding), so `version` is presence's own
-/// version guard: a node that does not recognise `version` discards the message
-/// rather than risk interpreting a shape it wasn't built to read. Bump it if
-/// this envelope's fields ever need to change.
-/// The native tuple field order is version, sender, state.
+/// Version 2 replaces unsolicited state gossip with request/reply snapshots.
+/// The version stays in the first tuple field so version 1 peers can reject
+/// it before reading the changed fields. The outer PubSub tuple is unchanged.
 @internal
 pub type SyncPayload {
-  SyncPayload(version: Int, sender: String, state: state.State)
+  SyncPayload(
+    version: Int,
+    request: Reference,
+    reply: Subject(SyncReply),
+    request_back: Bool,
+  )
+}
+
+/// A snapshot answering one outstanding request to a specific group member.
+@internal
+pub type SyncReply {
+  SyncReply(request: Reference, owner: process.Pid, state: state.State)
 }
 
 /// Configuration for starting presence.
@@ -220,8 +230,8 @@ pub opaque type Config {
     /// of the same base is pruned automatically. Two *live* nodes sharing
     /// a base will continuously prune each other — do not do that.
     replica: String,
-    /// How often to broadcast state for replication (ms). Non-positive values
-    /// disable periodic broadcasts.
+    /// How often to request snapshots for replication (ms). Non-positive
+    /// values disable periodic requests, but not the initial exchange or replies.
     broadcast_interval_ms: Int,
     /// Timeout for synchronous presence mutations (ms).
     call_timeout_ms: Int,
@@ -294,8 +304,9 @@ pub opaque type Message {
   /// and refs from replacement socket owners remain independently owned.
   UntrackRuntimeOwner(owner: process.Pid)
   BroadcastTick
-  /// Incoming PubSub sync message from a remote replica
+  /// Incoming PubSub snapshot request from a remote replica.
   RemoteSync(pubsub_message: pubsub.Message(SyncPayload))
+  RemoteSnapshot(reply: SyncReply)
 }
 
 /// Acknowledgement of an asynchronous presence mutation.
@@ -450,6 +461,18 @@ type TrackedPresence {
   )
 }
 
+type PendingSync {
+  PendingSync(request: Reference, round: Int)
+}
+
+type SyncState {
+  SyncState(
+    reply: Subject(SyncReply),
+    requests: Dict(process.Pid, PendingSync),
+    round: Int,
+  )
+}
+
 /// Internal actor state
 type ActorState {
   ActorState(
@@ -457,9 +480,7 @@ type ActorState {
     config: Config,
     /// The actor's own subject, used by timers and owner monitors.
     self_subject: Option(Subject(Message)),
-    /// Set whenever the local CRDT mutates; cleared after a broadcast tick.
-    /// Skips the encode+broadcast when there is nothing new to gossip.
-    dirty: Bool,
+    sync: Option(SyncState),
     /// Maps each server-generated tracking ref to the presence it created, so
     /// `untrack` can locate the correct CRDT entry to leave. Populated on
     /// `Track` and pruned on `Untrack`/`UntrackAll`.
@@ -475,10 +496,10 @@ type ActorState {
 
 /// Default configuration (no PubSub).
 ///
-/// The broadcast interval defaults to 1500 ms. Adding `with_pubsub` enables
-/// periodic outbound broadcasts and inbound replication. Without PubSub, the
-/// interval is unused. Use a non-positive interval to disable periodic
-/// outbound broadcasts.
+/// The repair interval defaults to 1500 ms. Adding `with_pubsub` enables an
+/// initial snapshot request and periodic repair, even without local changes.
+/// Without PubSub, the interval is unused. A non-positive interval disables
+/// periodic requests, but the initial exchange and replies remain enabled.
 pub fn default_config(replica: String) -> Config {
   Config(
     pubsub: None,
@@ -506,9 +527,15 @@ pub fn with_telemetry(config: Config) -> Config {
   Config(..config, telemetry: True)
 }
 
-/// Set how often presence state is broadcast for replication.
+/// Set how often presence requests full snapshots from its PubSub peers.
 ///
-/// Use a non-positive value to disable periodic broadcasts.
+/// Requests run at startup and every `interval_ms` thereafter, including when
+/// no application state changes. Lost requests or replies are retried on later
+/// ticks. The default is 1500 ms; this is a repair cadence, not a convergence
+/// deadline. Delivery, membership propagation, and actor work can delay repair.
+///
+/// A non-positive value disables periodic requests, not the initial request or
+/// replies to peers. Without periodic requests, quiet recovery is not guaranteed.
 pub fn with_broadcast_interval(config: Config, interval_ms: Int) -> Config {
   Config(..config, broadcast_interval_ms: interval_ms)
 }
@@ -635,7 +662,7 @@ fn build_presence(
         crdt: crdt,
         config: config,
         self_subject: Some(subject),
-        dirty: False,
+        sync: None,
         refs: dict.new(),
         runtime_owners: set.new(),
         read_table: read_table,
@@ -647,6 +674,12 @@ fn build_presence(
         // Subscribe to the well-known sync topic for replication
         let subscriber = pubsub.subscriber(pubsub_instance)
         pubsub.join(subscriber, sync_topic)
+        let reply = process.new_subject()
+        let initial =
+          ActorState(
+            ..initial,
+            sync: Some(SyncState(reply: reply, requests: dict.new(), round: 0)),
+          )
         let logger = internal.logger("beryl.presence")
         logger
         |> log.debug("Subscribed to PubSub sync topic", [
@@ -658,10 +691,10 @@ fn build_presence(
         let selector =
           process.new_selector()
           |> process.select(subject)
+          |> process.select_map(reply, RemoteSnapshot)
           |> pubsub.selecting(subscriber, RemoteSync)
 
-        // Schedule the first broadcast tick if enabled
-        schedule_broadcast_tick(subject, config.broadcast_interval_ms)
+        process.send(subject, BroadcastTick)
 
         actor.initialised(initial)
         |> actor.selecting(selector)
@@ -678,32 +711,63 @@ fn build_presence(
   |> actor.on_message(handle_message)
 }
 
-/// Broadcast the current CRDT state over PubSub when dirty, returning the
-/// updated actor state. Extracted from the `BroadcastTick` handler to keep
-/// that branch from nesting too deeply.
-fn maybe_broadcast_state(
+/// Keep one outstanding request per member. Retry its ref until a reply arrives
+/// so a slow peer need not finish within a single repair interval.
+fn request_snapshots(
   actor_state: ActorState,
   pubsub_instance: PubSub(SyncPayload),
 ) -> ActorState {
-  use <- bool.guard(when: !actor_state.dirty, return: actor_state)
-  let payload =
-    SyncPayload(
-      version: 1,
-      // The sender is the full incarnation name; receivers use its base to
-      // prune state left behind by this node's previous incarnations.
-      sender: state.replica(actor_state.crdt),
-      state: actor_state.crdt,
-    )
+  case actor_state.sync {
+    None -> actor_state
+    Some(sync) -> {
+      let members =
+        pubsub.subscribers(pubsub_instance, sync_topic)
+        |> list.filter(fn(member) { member != process.self() })
+        |> set.from_list
+      let sync =
+        SyncState(
+          ..sync,
+          requests: dict.filter(sync.requests, fn(member, _) {
+            set.contains(members, member)
+          }),
+          round: sync.round + 1,
+        )
+      let sync =
+        set.fold(members, sync, fn(sync, member) {
+          request_snapshot(sync, pubsub_instance, member, True)
+        })
+      ActorState(..actor_state, sync: Some(sync))
+    }
+  }
+}
 
-  pubsub.broadcast_from(
+fn request_snapshot(
+  sync: SyncState,
+  pubsub_instance: PubSub(SyncPayload),
+  member: process.Pid,
+  request_back: Bool,
+) -> SyncState {
+  let round = sync.round + 1
+  let pending =
+    dict.get(sync.requests, member)
+    |> result.lazy_unwrap(fn() { PendingSync(reference.new(), round) })
+  pubsub.send_to(
     pubsub_instance,
-    process.self(),
+    member,
     sync_topic,
     sync_event,
-    payload,
+    SyncPayload(
+      version: 2,
+      request: pending.request,
+      reply: sync.reply,
+      request_back: request_back,
+    ),
   )
-
-  ActorState(..actor_state, dirty: False)
+  SyncState(
+    ..sync,
+    requests: dict.insert(sync.requests, member, pending),
+    round: round,
+  )
 }
 
 /// Schedule the next broadcast tick if the interval is positive
@@ -1208,7 +1272,7 @@ fn handle_message(
     BroadcastTick -> {
       case actor_state.config.pubsub, actor_state.self_subject {
         Some(pubsub_instance), Some(subject) -> {
-          let new_state = maybe_broadcast_state(actor_state, pubsub_instance)
+          let new_state = request_snapshots(actor_state, pubsub_instance)
           schedule_broadcast_tick(
             subject,
             actor_state.config.broadcast_interval_ms,
@@ -1226,9 +1290,11 @@ fn handle_message(
         pubsub_message.topic == sync_topic && pubsub_message.event == sync_event
       {
         False -> actor.continue(actor_state)
-        True -> handle_sync_payload(actor_state, pubsub_message.payload)
+        True -> handle_sync_payload(actor_state, pubsub_message)
       }
     }
+
+    RemoteSnapshot(reply) -> handle_snapshot(actor_state, reply)
   }
 }
 
@@ -1482,11 +1548,7 @@ fn do_track(
     new_crdt,
     unique_strings([topic, ..removed.topics], set.new(), []),
   )
-  #(
-    ActorState(..actor_state, crdt: new_crdt, dirty: True, refs: new_refs),
-    ref,
-    stored_meta,
-  )
+  #(ActorState(..actor_state, crdt: new_crdt, refs: new_refs), ref, stored_meta)
 }
 
 /// Remove every named ref in one turn. Unknown or already-removed refs are
@@ -1512,7 +1574,7 @@ fn do_untrack_refs(actor_state: ActorState, refs: List(String)) -> ActorState {
     removed.crdt,
     unique_strings(removed.topics, set.new(), []),
   )
-  ActorState(..actor_state, crdt: removed.crdt, dirty: True, refs: removed.refs)
+  ActorState(..actor_state, crdt: removed.crdt, refs: removed.refs)
 }
 
 fn do_untrack_all(actor_state: ActorState, session_id: String) -> ActorState {
@@ -1528,7 +1590,7 @@ fn do_untrack_all(actor_state: ActorState, session_id: String) -> ActorState {
   // A single session can hold presences in several topics; republish
   // every topic the leave touched (from the pre-mutation diff).
   publish_topics(actor_state.read_table, new_crdt, dict.keys(diff.leaves))
-  ActorState(..actor_state, crdt: new_crdt, dirty: True, refs: new_refs)
+  ActorState(..actor_state, crdt: new_crdt, refs: new_refs)
 }
 
 fn do_untrack_runtime_owner(
@@ -1572,14 +1634,27 @@ fn maybe_invoke_on_diff(config: Config, diff: Diff) -> Nil {
   }
 }
 
-/// Check the envelope version and merge the remote state.
-/// Self-delivery is already prevented by broadcast_from at the PubSub layer.
+/// Check the envelope version before accessing its version-specific fields.
 fn handle_sync_payload(
   actor_state: ActorState,
-  payload: SyncPayload,
+  message: pubsub.Message(SyncPayload),
 ) -> actor.Next(ActorState, Message) {
+  let payload = message.payload
   case payload.version {
-    1 -> merge_remote_sync(actor_state, payload.sender, payload.state)
+    2 -> {
+      process.send(
+        payload.reply,
+        SyncReply(
+          request: payload.request,
+          owner: process.self(),
+          state: actor_state.crdt,
+        ),
+      )
+      case payload.request_back {
+        True -> actor.continue(request_snapshot_back(actor_state, message.from))
+        False -> actor.continue(actor_state)
+      }
+    }
     version -> {
       let logger = internal.logger("beryl.presence")
       logger
@@ -1592,9 +1667,61 @@ fn handle_sync_payload(
   }
 }
 
+/// One reciprocal request keeps replicas with periodic repair disabled able to
+/// receive updates. Reciprocal requests never trigger another request back.
+fn request_snapshot_back(
+  actor_state: ActorState,
+  from: pubsub.PubSubFrom,
+) -> ActorState {
+  case actor_state.config.pubsub, actor_state.sync, from {
+    Some(pubsub_instance), Some(sync), pubsub.FromPid(owner) -> {
+      let members = pubsub.subscribers(pubsub_instance, sync_topic)
+      case owner != process.self() && list.contains(members, owner) {
+        True ->
+          ActorState(
+            ..actor_state,
+            sync: Some(request_snapshot(sync, pubsub_instance, owner, False)),
+          )
+        False -> actor_state
+      }
+    }
+    None, _, _
+    | _, None, _
+    | _, _, pubsub.System
+    | _, _, pubsub.FromSocket(_, _)
+    -> actor_state
+  }
+}
+
+fn handle_snapshot(
+  actor_state: ActorState,
+  reply: SyncReply,
+) -> actor.Next(ActorState, Message) {
+  case actor_state.sync {
+    None -> actor.continue(actor_state)
+    Some(sync) ->
+      case dict.get(sync.requests, reply.owner) {
+        Ok(pending) if pending.request == reply.request ->
+          merge_remote_sync(
+            ActorState(
+              ..actor_state,
+              sync: Some(
+                SyncState(
+                  ..sync,
+                  requests: dict.delete(sync.requests, reply.owner),
+                ),
+              ),
+            ),
+            reply.state,
+          )
+        // Duplicates and replies to requests cancelled by membership loss.
+        Ok(_) | Error(Nil) -> actor.continue(actor_state)
+      }
+  }
+}
+
 fn merge_remote_sync(
   actor_state: ActorState,
-  sender: String,
   remote_state: State,
 ) -> actor.Next(ActorState, Message) {
   // Crash boundary — see internal.rescue. Version skew or bugs can produce
@@ -1606,7 +1733,6 @@ fn merge_remote_sync(
       let #(new_crdt, state_diff) =
         state.merge_with_diff(actor_state.crdt, remote_state)
       let diff = wrap_state_diff(state_diff)
-      let changed = !{ dict.is_empty(diff.joins) && dict.is_empty(diff.leaves) }
       maybe_invoke_on_diff(actor_state.config, diff)
       // The merge may have (re)admitted state from dead incarnations —
       // the sender's predecessors, or our own pre-restart self echoed back
@@ -1614,7 +1740,7 @@ fn merge_remote_sync(
       // to be live right now: the sender and ourselves.
       let #(new_crdt, pruned_topics) =
         prune_superseded(actor_state.config, new_crdt, [
-          sender,
+          state.replica(remote_state),
           state.replica(new_crdt),
         ])
       // Republish every topic touched by either the merge or the prune,
@@ -1625,11 +1751,7 @@ fn merge_remote_sync(
         |> list.append(pruned_topics)
         |> unique_strings(set.new(), [])
       publish_topics(actor_state.read_table, new_crdt, touched_topics)
-      ActorState(
-        ..actor_state,
-        crdt: new_crdt,
-        dirty: actor_state.dirty || changed,
-      )
+      ActorState(..actor_state, crdt: new_crdt)
     })
   case processed {
     Ok(next_state) -> actor.continue(next_state)

--- a/packages/beryl/src/beryl/pubsub.gleam
+++ b/packages/beryl/src/beryl/pubsub.gleam
@@ -337,6 +337,24 @@ pub fn broadcast_from(
   |> list.each(ffi_send_to_pid(_, pubsub_instance.scope, message))
 }
 
+/// Send an internal message to one member obtained from `subscribers`.
+///
+/// Uses the same scoped wire tuple as broadcasts and records the calling PID.
+@internal
+pub fn send_to(
+  pubsub_instance: PubSub(payload),
+  member: Pid,
+  topic: String,
+  event: String,
+  payload: payload,
+) -> Nil {
+  ffi_send_to_pid(
+    member,
+    pubsub_instance.scope,
+    Message(topic:, event:, payload:, from: FromPid(process.self())),
+  )
+}
+
 /// Broadcast a message to all subscribers except a process.
 ///
 /// Preserve a socket ID that receiving runtimes must exclude locally.

--- a/packages/beryl/test/beryl_presence_distributed_test.erl
+++ b/packages/beryl/test/beryl_presence_distributed_test.erl
@@ -1,0 +1,235 @@
+-module(beryl_presence_distributed_test).
+-include_lib("eunit/include/eunit.hrl").
+-export([start_replica/3, view/1, sync_round/1, kill_replica/1,
+         begin_outage/1, end_outage/1, take_diffs/1]).
+
+-define(TOPIC, <<"room:distributed">>).
+-define(SYNC_TOPIC, <<"beryl:presence:sync">>).
+-define(SCOPE, <<"beryl_presence_distributed_test">>).
+
+late_joiner_gets_quiet_snapshot_test_() ->
+    {timeout, 30, fun() ->
+        with_peers(2, fun([A, B]) ->
+            connect(A, B),
+            Source = start(A, <<"source">>, 30),
+            {ok, _} = track(A, Source, <<"before-join">>),
+            await_round(A, Source),
+            await_members(B, 1),
+            %% No periodic timer on the newcomer: this must use its initial
+            %% exchange, not a new application mutation or its next tick.
+            Late = start(B, <<"late">>, 0),
+            await_view(B, Late, [<<"before-join">>])
+        end)
+    end}.
+
+quiet_partition_repair_test_() ->
+    {timeout, 30, fun() ->
+        with_peers(2, fun([A, B]) ->
+            connect(A, B),
+            Source = start(A, <<"source">>, 30),
+            Receiver = start(B, <<"receiver">>, 30),
+            {ok, OldRef} = track(A, Source, <<"before-partition">>),
+            await_view(B, Receiver, [<<"before-partition">>]),
+            disconnect(A, B),
+            {ok, nil} = presence_call(A, untrack, [handle(Source), OldRef]),
+            {ok, _} = track(A, Source, <<"during-partition">>),
+            await_round(A, Source),
+            ?assertEqual([], call(A, erlang, nodes, [])),
+            ?assertEqual([], call(B, erlang, nodes, [])),
+            connect(A, B),
+            await_members(A, 2),
+            await_members(B, 2),
+            await_view(A, Source, [<<"during-partition">>]),
+            await_view(B, Receiver, [<<"during-partition">>])
+        end)
+    end}.
+
+quiet_pg_recovery_test_() ->
+    {timeout, 30, fun() ->
+        with_peers(2, fun([A, B]) ->
+            connect(A, B),
+            Source = start(A, <<"source">>, 30),
+            Receiver = start(B, <<"receiver">>, 30),
+            {ok, OldRef} = track(A, Source, <<"before-outage">>),
+            await_view(B, Receiver, [<<"before-outage">>]),
+            Outage = call(A, ?MODULE, begin_outage, [?SCOPE]),
+            try
+                await_members(B, 1),
+                await_round(B, Receiver),
+                {ok, nil} = presence_call(A, untrack, [handle(Source), OldRef]),
+                {ok, _} = track(A, Source, <<"during-outage">>),
+                await_round(A, Source),
+                #{entries := BeforeRecovery} = call(B, ?MODULE, view, [Receiver]),
+                ?assertNot(lists:member(
+                    {<<"during-outage">>, <<"during-outage">>}, BeforeRecovery))
+            after
+                nil = call(A, ?MODULE, end_outage, [Outage])
+            end,
+            await_members(A, 2),
+            await_members(B, 2),
+            await_view(B, Receiver, [<<"during-outage">>])
+        end)
+    end}.
+
+empty_restart_repairs_without_track_test_() ->
+    {timeout, 30, fun() ->
+        with_peers(2, fun([A, B]) ->
+            connect(A, B),
+            Source = start(A, <<"source">>, 30),
+            Receiver = start(B, <<"receiver">>, 30),
+            {ok, _} = track(A, Source, <<"source-entry">>),
+            {ok, _} = track(B, Receiver, <<"receiver-entry">>),
+            await_view(A, Source, [<<"receiver-entry">>, <<"source-entry">>]),
+            nil = call(A, ?MODULE, kill_replica, [Source]),
+            Restarted = start(A, <<"source">>, 30),
+            await_view(A, Restarted, [<<"receiver-entry">>]),
+            await_view(B, Receiver, [<<"receiver-entry">>])
+        end)
+    end}.
+
+%% The control channel is standard I/O, not distribution. Polling a partitioned
+%% peer therefore cannot reconnect the nodes under test. Linked controllers and
+%% nested after blocks also clean up nodes when boot or an assertion fails.
+with_peers(0, Run) ->
+    Run([]);
+with_peers(Count, Run) ->
+    Paths = [filename:absname(Path) || Path <- code:get_path()],
+    {ok, Controller, Node} = peer:start_link(#{
+        name => peer:random_name("beryl_presence"),
+        connection => standard_io,
+        peer_down => continue,
+        args => ["+S", "2:2", "+A", "1", "-connect_all", "false",
+                 "-setcookie", "beryl_presence_distributed_test", "-pa" | Paths]
+    }),
+    Peer = {Controller, Node},
+    try
+        _ = presence_pubsub(Peer),
+        with_peers(Count - 1, fun(Peers) -> Run([Peer | Peers]) end)
+    after
+        peer:stop(Controller)
+    end.
+
+call({Controller, _Node}, Module, Function, Arguments) ->
+    peer:call(Controller, Module, Function, Arguments).
+
+presence_call(Peer, Function, Arguments) ->
+    call(Peer, 'beryl@presence', Function, Arguments).
+
+presence_pubsub(Peer) ->
+    Config = call(Peer, 'beryl@pubsub', config_with_scope, [?SCOPE]),
+    call(Peer, 'beryl@pubsub', start, [Config]).
+
+connect(A, {_Controller, Node} = B) ->
+    true = call(A, net_kernel, connect_node, [Node]),
+    {_OtherController, OtherNode} = A,
+    await({connected, Node}, fun() ->
+        lists:member(OtherNode, call(B, erlang, nodes, []))
+    end).
+
+disconnect(A, {_Controller, Node} = B) ->
+    true = call(A, erlang, disconnect_node, [Node]),
+    await_members(A, 1),
+    await_members(B, 1),
+    ?assertEqual([], call(A, erlang, nodes, [])),
+    ?assertEqual([], call(B, erlang, nodes, [])).
+
+start(Peer, Replica, Interval) ->
+    call(Peer, ?MODULE, start_replica, [?SCOPE, Replica, Interval]).
+
+start_replica(Scope, Replica, Interval) ->
+    PubSub = 'beryl@pubsub':start('beryl@pubsub':config_with_scope(Scope)),
+    Collector = spawn(fun() -> collect_diffs([]) end),
+    Config0 = 'beryl@presence':default_config(Replica),
+    Config1 = 'beryl@presence':with_pubsub(Config0, PubSub),
+    Config2 = 'beryl@presence':with_broadcast_interval(Config1, Interval),
+    Config = 'beryl@presence':with_on_diff(Config2, fun(Diff) ->
+        Collector ! {presence_diff, Diff},
+        nil
+    end),
+    {ok, Presence} = 'beryl@presence':start(Config),
+    {ok, Pid} = 'gleam@erlang@process':subject_owner(
+        'beryl@presence':subject(Presence)),
+    unlink(Pid),
+    #{handle => Presence, pid => Pid, collector => Collector}.
+
+handle(#{handle := Presence}) -> Presence.
+
+track(Peer, Instance, Key) ->
+    presence_call(Peer, track,
+        [handle(Instance), ?TOPIC, Key, Key, 'gleam@json':null()]).
+
+view(#{handle := Presence, pid := Pid}) ->
+    {ok, Entries} = 'beryl@presence':list(Presence, ?TOPIC),
+    {ok, Count} = 'beryl@presence':count(Presence, ?TOPIC),
+    Crdt = element(2, sys:get_state(Pid)),
+    Online = 'lattice_presence@presence_state':get_by_topic(Crdt, ?TOPIC),
+    #{entries => lists:sort([{Session, Key} ||
+                             {presence_entry, Session, Key, _Meta} <- Entries]),
+      count => Count,
+      crdt => lists:sort([{Session, Key} || {Session, Key, _Meta} <- Online])}.
+
+sync_round(#{pid := Pid}) ->
+    %% Inspect the private sync bookkeeping only for an ordered tick barrier.
+    {some, Sync} = element(5, sys:get_state(Pid)),
+    element(4, Sync).
+
+await_round(Peer, Instance) ->
+    Before = call(Peer, ?MODULE, sync_round, [Instance]),
+    await({quiet_repair_tick, element(2, Peer)}, fun() ->
+        call(Peer, ?MODULE, sync_round, [Instance]) > Before
+    end).
+
+await_members(Peer, Count) ->
+    PubSub = presence_pubsub(Peer),
+    await({pg_members, element(2, Peer), Count}, fun() ->
+        call(Peer, 'beryl@pubsub', subscriber_count, [PubSub, ?SYNC_TOPIC])
+            =:= Count
+    end).
+
+await_view(Peer, Instance, Keys) ->
+    Entries = lists:sort([{Key, Key} || Key <- Keys]),
+    Expected = #{entries => Entries, count => length(Keys), crdt => Entries},
+    await({presence_view, element(2, Peer), Keys}, fun() ->
+        call(Peer, ?MODULE, view, [Instance]) =:= Expected
+    end),
+    ?assertEqual(Expected, call(Peer, ?MODULE, view, [Instance])).
+
+await(Phase, Check) ->
+    try 'test_helper':wait_until(Check, 5000, 10)
+    catch
+        error:Reason:Stack -> erlang:raise(error, {Phase, Reason}, Stack)
+    end.
+
+kill_replica(#{pid := Pid}) ->
+    Monitor = monitor(process, Pid),
+    exit(Pid, kill),
+    receive {'DOWN', Monitor, process, Pid, killed} -> nil
+    after 5000 -> error({presence_did_not_stop, Pid})
+    end.
+
+begin_outage(ScopeName) ->
+    Scope = binary_to_existing_atom(ScopeName, utf8),
+    {dictionary, Dictionary} = process_info(whereis(Scope), dictionary),
+    [Supervisor | _] = proplists:get_value('$ancestors', Dictionary),
+    ok = sys:suspend(Supervisor),
+    _ = beryl_pubsub_test_ffi:kill_scope(Scope),
+    Supervisor.
+
+end_outage(Supervisor) ->
+    ok = sys:resume(Supervisor),
+    nil.
+
+collect_diffs(Diffs) ->
+    receive
+        {presence_diff, Diff} -> collect_diffs([Diff | Diffs]);
+        {take_diffs, Caller, Ref} ->
+            Caller ! {Ref, lists:reverse(Diffs)},
+            collect_diffs([])
+    end.
+
+take_diffs(#{collector := Collector}) ->
+    Ref = make_ref(),
+    Collector ! {take_diffs, self(), Ref},
+    receive {Ref, Diffs} -> Diffs
+    after 5000 -> error(diff_collector_timeout)
+    end.

--- a/packages/beryl/test/presence_replication_test.gleam
+++ b/packages/beryl/test/presence_replication_test.gleam
@@ -1,11 +1,11 @@
 import beryl/presence
 import beryl/pubsub
 import gleam/erlang/process
+import gleam/erlang/reference
 import gleam/json
 import gleam/list
 import gleeunit
 import gleeunit/should
-import lattice_presence/presence_state
 import test_helper
 
 pub fn main() -> Nil {
@@ -32,12 +32,13 @@ fn test_config(
 
 // ── BroadcastTick sends state via PubSub ────────────────────────────
 
-pub fn broadcast_tick_sends_state_test() -> Nil {
+pub fn broadcast_tick_requests_state_test() -> Nil {
   let pubsub_instance = test_pubsub("bcast_tick")
 
   // Start presence with a short broadcast interval
   let config = test_config(pubsub_instance, "node1", 50)
   let assert Ok(tracker) = presence.start(config)
+  let assert Ok(owner) = process.subject_owner(presence.subject(tracker))
 
   // Track an entry
   let assert Ok(_) =
@@ -56,12 +57,17 @@ pub fn broadcast_tick_sends_state_test() -> Nil {
   // Poll until a PubSub message arrives from the broadcast tick
   let selector =
     process.new_selector()
-    |> pubsub.selecting(subscriber, fn(_message) { True })
+    |> pubsub.selecting(subscriber, fn(message) {
+      message.topic == "beryl:presence:sync"
+      && message.event == "presence_sync"
+      && message.from == pubsub.FromPid(owner)
+      && message.payload.version == 2
+    })
 
   test_helper.wait_until(
     fn() {
       case process.selector_receive(from: selector, within: 0) {
-        Ok(_) -> True
+        Ok(matches) -> matches
         Error(_) -> False
       }
     },
@@ -73,7 +79,7 @@ pub fn broadcast_tick_sends_state_test() -> Nil {
   pubsub.leave(subscriber, "beryl:presence:sync")
 
   // Drain any remaining messages from the mailbox
-  drain_mailbox()
+  drain_sync(subscriber)
 }
 
 // ── Two presence actors converge via PubSub ─────────────────────────
@@ -148,7 +154,8 @@ pub fn remote_state_triggers_merge_via_pubsub_test() -> Nil {
   let config2 = test_config(pubsub_instance, "node2", 50)
   let assert Ok(tracker2) = presence.start(config2)
 
-  // Track on node2
+  // Periodic requests from node2 include one reciprocal request, so node1
+  // still receives updates even though its own periodic repair is disabled.
   let assert Ok(_) =
     presence.track(tracker2, "room:lobby", "user:2", "socket-2", json.null())
 
@@ -319,8 +326,9 @@ pub fn survives_unknown_envelope_version_test() -> Nil {
     "presence_sync",
     presence.SyncPayload(
       version: 99,
-      sender: "node2@ghost",
-      state: presence_state.new("node2@ghost"),
+      request: reference.new(),
+      reply: process.new_subject(),
+      request_back: False,
     ),
   )
 
@@ -453,13 +461,13 @@ pub fn merge_failure_leaves_read_model_unchanged_test() -> Nil {
 
 // ── Helper to drain stray messages ──────────────────────────────────
 
-fn drain_mailbox() -> Nil {
+fn drain_sync(subscriber: pubsub.Subscriber(presence.SyncPayload)) -> Nil {
   let selector =
     process.new_selector()
-    |> process.select_other(fn(_message) { True })
+    |> pubsub.selecting(subscriber, fn(message) { message })
 
   case process.selector_receive(from: selector, within: 10) {
-    Ok(_) -> drain_mailbox()
+    Ok(_) -> drain_sync(subscriber)
     Error(_) -> Nil
   }
 }

--- a/website/src/content/docs/architecture/presence.md
+++ b/website/src/content/docs/architecture/presence.md
@@ -62,7 +62,7 @@ PubSub copies presence state between nodes.
 |---|---|
 | `default_config(replica)` | Create a config with no PubSub and a 1500 ms interval that remains unused until PubSub is attached |
 | `with_pubsub(config, ps)` | Attach a PubSub instance for cross-node state replication |
-| `with_broadcast_interval(config, ms)` | Set how often (in ms) the actor broadcasts its CRDT state; `0` disables |
+| `with_broadcast_interval(config, ms)` | Set the snapshot repair cadence in ms; `0` disables periodic requests |
 | `with_on_diff(config, callback)` | Register a callback invoked whenever a local change or merge produces a non-empty diff |
 | `with_queue_limits(config, limits)` | Set positive local mutation and cleanup budgets |
 | `with_telemetry(config)` | Enable queue occupancy events |
@@ -95,24 +95,39 @@ PubSub copies presence state between nodes.
 
 ## Sync between nodes
 
-When you configure `with_pubsub`, the presence actor runs a broadcast loop at
-the configured interval, which defaults to 1500 ms:
+When you configure `with_pubsub`, the presence actor requests snapshots once
+at startup and then at the configured interval, which defaults to 1500 ms:
 
-1. On each tick, the actor checks the `dirty` value. If local state changed,
-   it sends `SyncPayload(v, sender, state)` to `"beryl:presence:sync"`.
-   `broadcast_from` prevents self-delivery.
-2. Remote replicas receive the typed payload through PubSub. They merge it with
-   `state.merge_with_diff` and update their CRDT state.
+1. Each tick reads the current `pg` membership of `"beryl:presence:sync"`.
+   The actor sends each other member a request with a unique ref and a reply
+   subject. It keeps one outstanding ref per member and retries unanswered
+   requests, so a slow reply can span multiple ticks.
+2. Each member replies directly with its full CRDT state, even when it has no
+   new mutations. The requester accepts only a reply to that member's current
+   request, merges it with `state.merge_with_diff`, and updates its read model.
+   A request permits one reciprocal request, so a replica with its periodic
+   timer disabled can still receive updates. Reciprocal requests do not repeat.
 3. If the merge changes membership, the actor calls `on_diff` with the
    resulting `Diff`. It calls the function for each merge, so rapid merges do
    not lose diffs.
 
-Use `with_broadcast_interval(0)` to disable periodic broadcasts. Without
-PubSub, the configured interval is unused.
+This repairs late joins, missed delivery, and restored `pg` membership without
+an unrelated application mutation. The interval is a retry cadence, not a
+convergence deadline: membership propagation, network delivery, and actor work
+can take longer. Repair requires continued successful exchanges.
 
-Automated tests currently exercise replication with multiple presence actors
-on one BEAM node. [Issue #365](https://github.com/tylerbutler/beryl/issues/365)
-tracks integration coverage across separate distributed Erlang nodes.
+Use `with_broadcast_interval(0)` to disable periodic requests. The initial
+request and replies to peers still run, but quiet recovery is not guaranteed.
+Without PubSub, the configured interval is unused.
+
+Presence uses version 2 of its internal sync envelope. Version 1 unsolicited
+snapshots and version 2 requests do not interoperate; upgrade the replicas in
+a presence scope together. The frozen five-element PubSub tuple is unchanged.
+
+Automated tests cover quiet bootstrap, partition repair, empty restart, and
+`pg` recovery across separate BEAM nodes, as well as same-node replication.
+[Issue #365](https://github.com/tylerbutler/beryl/issues/365) tracks the broader
+distributed PubSub and presence matrix.
 
 ## Request and sync flow
 
@@ -130,10 +145,10 @@ sequenceDiagram
   Pres-->>Runtime: mutation ack
   Runtime->>Read: list / count (direct read)
   loop every broadcast_interval
-    Pres->>PS: broadcast CRDT state
+    Pres->>PS: request snapshots from current members
+    PS-->>Remote: snapshot request
+    Remote-->>Pres: requested CRDT snapshot
   end
-  Remote->>PS: its state
-  PS-->>Pres: remote state
   Pres->>Pres: merge -> diff
   Pres-->>App: on_diff(diff)
 ```

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -246,12 +246,21 @@ PubSub, `broadcast_presence_diff` uses the same cross-node delivery as
 
 When you configure PubSub, the presence actor:
 
-1. Sends its full CRDT state to `beryl:presence:sync` at set intervals.
-2. Receives remote state from other nodes through PubSub.
+1. Requests full CRDT snapshots from the current `pg` members at startup and
+   every configured interval (1500 ms by default).
+2. Replies to peer requests even when local state has not changed.
 3. Merges remote state with the AWORSet merge algorithm.
 4. Calls `on_diff` for changes from the merge.
 
-Self-delivery is prevented by `pubsub.broadcast_from`, so nodes don't process their own sync messages.
+Requests exclude the actor itself and carry a unique reply ref. Periodic
+requests repair missed delivery and late joins without a new `track`. The
+interval is a repair cadence, not a maximum convergence time; membership and
+delivery must recover, and actors must finish processing their work.
+
+A non-positive interval disables periodic requests, not the initial exchange
+or replies. Keep a positive interval for quiet recovery. Presence sync
+version 2 does not interoperate with version 1; upgrade all replicas in one
+presence scope together. The outer PubSub wire format has not changed.
 
 The underlying CRDT state is intentionally internal. Applications should use PubSub replication rather than constructing or merging raw presence state values.
 

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -20,8 +20,8 @@ Distributed presence tracking with a CRDT
  OTP actor that:
  - Handles track/update/untrack calls
  - Publishes an actor-owned ETS read model
- - Periodically broadcasts state via PubSub for cross-node replication
- - Receives remote state from PubSub and merges it internally
+ - Requests snapshots at startup and periodically through PubSub
+ - Receives remote snapshots and merges them internally
  - Invokes `on_diff` when local changes or merges produce non-empty diffs
 
  Presence is independent of the beryl runtime and runs under your
@@ -262,10 +262,10 @@ pub fn default_config(String) -> Config
 
 Default configuration (no PubSub).
 
- The broadcast interval defaults to 1500 ms. Adding `with_pubsub` enables
- periodic outbound broadcasts and inbound replication. Without PubSub, the
- interval is unused. Use a non-positive interval to disable periodic
- outbound broadcasts.
+ The repair interval defaults to 1500 ms. Adding `with_pubsub` enables an
+ initial snapshot request and periodic repair, even without local changes.
+ Without PubSub, the interval is unused. A non-positive interval disables
+ periodic requests, but the initial exchange and replies remain enabled.
 
 <div class="api-entry-anchor" id="api-function-diff" aria-hidden="true"></div>
 
@@ -475,9 +475,15 @@ pub fn with_broadcast_interval(
 ) -> Config
 ```
 
-Set how often presence state is broadcast for replication.
+Set how often presence requests full snapshots from its PubSub peers.
 
- Use a non-positive value to disable periodic broadcasts.
+ Requests run at startup and every `interval_ms` thereafter, including when
+ no application state changes. Lost requests or replies are retried on later
+ ticks. The default is 1500 ms; this is a repair cadence, not a convergence
+ deadline. Delivery, membership propagation, and actor work can delay repair.
+
+ A non-positive value disables periodic requests, not the initial request or
+ replies to peers. Without periodic requests, quiet recovery is not guaranteed.
 
 <div class="api-entry-anchor" id="api-function-with_call_timeout" aria-hidden="true"></div>
 


### PR DESCRIPTION
## Scope

Closes #424.

**Base:** `main`. **Stack:** 1 of 3, with no PR dependency. This PR is merged.
#456 addresses #425 and now targets `main`; #458 addresses #426 on #456. This PR does not
claim to fix replica failure visibility or permanent incarnation retirement.

Replace dirty-only gossip with an initial exchange and periodic snapshot
requests to current `pg` members. Keep one outstanding request ref per member,
retry unanswered requests, and reject duplicate or cancelled replies. One
reciprocal request preserves inbound updates for replicas with their periodic
timer disabled, without a request loop.

The existing interval sets the repair cadence (1500 ms by default). Quiet
late joiners, restored membership, missed delivery, and empty restarts recover
without a new application mutation. Convergence still requires successful
delivery and actor progress; the interval is not a delivery deadline.

Presence sync uses **envelope version 2** and requires upgrading replicas in
one presence scope together. The frozen five-element PubSub tuple is
unchanged. No new dependencies or public configuration builders.

## Coverage and validation

- Four deterministic regressions use separate OTP `peer` nodes: quiet late
  join, clean partition repair, missed delivery during `pg` recovery, and
  empty restart. Standard-I/O control keeps polling independent of Erlang
  distribution. Assertions cover both CRDT entries and ETS identities/counts.
- `just test beryl beryl_mist beryl_ewe`: 583, 33, and 24 tests passed after
  including main's runtime-yield fix. One transient router-overload snapshot
  assertion failed in the first run; the repeated full run passed.
- Focused EUnit replication/distributed suites: 20 tests passed on Erlang 27
  and Erlang 28. The installed gleeunit runner ignores `--filter`, so these
  focused runs use EUnit directly.
- Strict builds for all three library packages, core glinter, formatting,
  generated reference docs, and `just doctor` passed. Doctor reports existing
  dependency-range advisory warnings.
- Workspace type checks, format checks, and strict builds passed for all 11
  packages after retrying Hex API throttling.
- After the latest rebase onto `main` (`20f797a0`), workspace type checks,
  the core strict build, and 60 focused EUnit tests passed. This run includes
  the updated reply-ref and asynchronous runtime-presence integration suites.
- GitHub CI passed for the current head: both Erlang versions, docs, examples,
  all protocol-smoke variants, and PR metadata checks. Earlier Hex throttling
  and chatroom-count failures cleared on retry.

Includes one `beryl` Fixed changelog fragment. The distributed fixtures also
support the follow-up recovery cases from #365.
