### PR TITLE
fix(presence): remove unavailable replica visibility

### DIFF
--- a/.changes/unreleased/beryl-hide-unavailable-presence-replicas.toml
+++ b/.changes/unreleased/beryl-hide-unavailable-presence-replicas.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Hide unavailable presence replicas and emit leave diffs after actor, node, or membership loss while preserving causal state for reconnect."

--- a/.changes/unreleased/beryl-hide-unavailable-presence-replicas.toml
+++ b/.changes/unreleased/beryl-hide-unavailable-presence-replicas.toml
@@ -1,3 +1,3 @@
 package = "beryl"
 kind = "Fixed"
-body = "Hide unavailable presence replicas and emit leave diffs after actor, node, or membership loss while preserving causal state for reconnect."
+body = "Hide unavailable presence replicas after actor, node, or membership loss. Keep replica-view diffs node-local while preserving cluster-wide application diffs and causal state for reconnect."

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -651,6 +651,8 @@ pub type AppHandle {
     route_binary: fn(String, BitArray) -> Result(Nil, overload.AdmissionError),
     broadcast: fn(String, String, json.Json, Option(String)) ->
       Result(Nil, overload.AdmissionError),
+    broadcast_local: fn(String, String, json.Json) ->
+      Result(Nil, overload.AdmissionError),
     stop: fn() -> Result(Nil, StopError),
     /// Current pid of the supervised runtime, if running (used by tests
     /// and PubSub sender attribution).
@@ -1238,6 +1240,12 @@ fn app_handle(
         runtime.Broadcast(topic_name, event_name, payload, except),
       )
     },
+    broadcast_local: fn(topic_name, event_name, payload) {
+      send_runtime(
+        name,
+        runtime.LocalBroadcast(topic_name, event_name, payload),
+      )
+    },
     stop: fn() { request_runtime_stop(supervisor) },
     runtime_owner: fn() { process.subject_owner(subject) },
     socket_factory_owner: fn() { process.subject_owner(factory) },
@@ -1407,19 +1415,26 @@ pub fn broadcast(
 /// }
 /// ```
 ///
-/// When the system was started with PubSub, the broadcast is distributed
-/// using the same semantics as `broadcast`.
+/// Honors `presence.diff_scope`: application-mutation and explicitly constructed
+/// `Cluster` diffs use the same distributed semantics as `broadcast`.
+/// `LocalNode` diffs from replication, failure detection, and recovery reach
+/// only local socket subscribers, including other local runtimes in the same
+/// PubSub scope. They must not change healthy clients on another node.
+///
+/// Pass the original diff from `presence.with_on_diff`. Encoding or rebuilding
+/// the diff before an unconditional `broadcast` loses this routing metadata.
 pub fn broadcast_presence_diff(
   channels: Sockets,
   topic_name: String,
   diff: Diff,
 ) -> Result(Nil, overload.AdmissionError) {
-  broadcast(
-    channels,
-    topic_name,
-    "presence_diff",
-    presence_wire.encode_diff(diff, topic_name),
-  )
+  let payload = presence_wire.encode_diff(diff, topic_name)
+  case presence.diff_scope(diff) {
+    presence.Cluster ->
+      broadcast(channels, topic_name, "presence_diff", payload)
+    presence.LocalNode ->
+      channels.app.broadcast_local(topic_name, "presence_diff", payload)
+  }
 }
 
 /// Broadcast a message to all subscribers except one socket.

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -6,6 +6,7 @@
 //// - Publishes an actor-owned ETS read model
 //// - Requests snapshots at startup and periodically through PubSub
 //// - Receives remote snapshots and merges them internally
+//// - Hides unavailable remote replicas without forgetting their causal state
 //// - Invokes `on_diff` when local changes or merges produce non-empty diffs
 ////
 //// Presence is independent of the beryl runtime and runs under your
@@ -169,29 +170,46 @@ fn unique_strings(
   }
 }
 
-fn wrap_state_diff(diff: state.Diff) -> Diff {
-  Diff(
-    joins: state_entries_to_presence_entries(diff.joins),
-    leaves: state_entries_to_presence_entries(diff.leaves),
-  )
+type VisibleEntry =
+  #(String, String, String, json.Json)
+
+fn visible_counts(crdt: State) -> Dict(VisibleEntry, Int) {
+  state.online_list(crdt)
+  |> list.fold(dict.new(), fn(counts, entry) {
+    let count = dict.get(counts, entry) |> result.unwrap(0)
+    dict.insert(counts, entry, count + 1)
+  })
 }
 
-fn state_entries_to_presence_entries(
-  entries: Dict(String, List(#(String, String, json.Json))),
+fn added_entries(
+  after: Dict(VisibleEntry, Int),
+  before: Dict(VisibleEntry, Int),
 ) -> Dict(String, List(PresenceEntry)) {
-  entries
-  |> dict.to_list
-  |> list.map(fn(entry) {
-    let #(topic, topic_entries) = entry
-    #(
+  dict.fold(after, dict.new(), fn(grouped, entry, count) {
+    let added = count - { dict.get(before, entry) |> result.unwrap(0) }
+    use <- bool.guard(when: added <= 0, return: grouped)
+    let #(session_id, topic, key, meta) = entry
+    let existing = dict.get(grouped, topic) |> result.unwrap([])
+    dict.insert(
+      grouped,
       topic,
-      list.map(topic_entries, fn(topic_entry) {
-        let #(key, session_id, meta) = topic_entry
-        PresenceEntry(session_id: session_id, key: key, meta: meta)
-      }),
+      list.append(
+        list.repeat(PresenceEntry(session_id, key, meta), added),
+        existing,
+      ),
     )
   })
-  |> dict.from_list
+}
+
+/// The CRDT's merge diff includes hidden entries. Compare final visible
+/// multisets instead, preserving duplicate non-object metas without phx_ref.
+fn visible_diff(before: State, after: State) -> Diff {
+  let before = visible_counts(before)
+  let after = visible_counts(after)
+  Diff(
+    joins: added_entries(after, before),
+    leaves: added_entries(before, after),
+  )
 }
 
 /// The snapshot request carried over PubSub between presence replicas.
@@ -307,6 +325,7 @@ pub opaque type Message {
   /// Incoming PubSub snapshot request from a remote replica.
   RemoteSync(pubsub_message: pubsub.Message(SyncPayload))
   RemoteSnapshot(reply: SyncReply)
+  RemoteReplicaDown(down: process.Down)
 }
 
 /// Acknowledgement of an asynchronous presence mutation.
@@ -465,11 +484,16 @@ type PendingSync {
   PendingSync(request: Reference, round: Int)
 }
 
+type ReplicaOwner {
+  ReplicaOwner(pid: process.Pid, monitor: Option(process.Monitor))
+}
+
 type SyncState {
   SyncState(
     reply: Subject(SyncReply),
     requests: Dict(process.Pid, PendingSync),
     round: Int,
+    owners: Dict(String, ReplicaOwner),
   )
 }
 
@@ -513,6 +537,13 @@ pub fn default_config(replica: String) -> Config {
 }
 
 /// Enable PubSub replication for presence.
+///
+/// Remote visibility follows monitored actor ownership and the local `pg`
+/// membership view. Actor exit, node disconnection, or membership loss hides
+/// that replica and emits leaves. Its causal state remains available for repair.
+/// A fresh snapshot from the same actor restores its current entries; a
+/// replacement actor starts a new incarnation. A partition can therefore hide
+/// sessions that remain connected to their local node.
 pub fn with_pubsub(config: Config, pubsub: PubSub(SyncPayload)) -> Config {
   Config(..config, pubsub: Some(pubsub))
 }
@@ -549,7 +580,8 @@ pub fn with_call_timeout(config: Config, timeout_ms: Int) -> Config {
   Config(..config, call_timeout_ms: timeout_ms)
 }
 
-/// Set the callback for diffs from local changes or remote merges.
+/// Set the callback for diffs from local changes, remote merges, or replica
+/// availability changes.
 ///
 /// The callback runs synchronously on the presence actor, for both local
 /// mutations (`track`/`update`/`untrack`/`untrack_all`, and the asynchronous
@@ -678,7 +710,12 @@ fn build_presence(
         let initial =
           ActorState(
             ..initial,
-            sync: Some(SyncState(reply: reply, requests: dict.new(), round: 0)),
+            sync: Some(SyncState(
+              reply: reply,
+              requests: dict.new(),
+              round: 0,
+              owners: dict.new(),
+            )),
           )
         let logger = internal.logger("beryl.presence")
         logger
@@ -692,6 +729,7 @@ fn build_presence(
           process.new_selector()
           |> process.select(subject)
           |> process.select_map(reply, RemoteSnapshot)
+          |> process.select_monitors(RemoteReplicaDown)
           |> pubsub.selecting(subscriber, RemoteSync)
 
         process.send(subject, BroadcastTick)
@@ -717,13 +755,14 @@ fn request_snapshots(
   actor_state: ActorState,
   pubsub_instance: PubSub(SyncPayload),
 ) -> ActorState {
+  let members =
+    pubsub.subscribers(pubsub_instance, sync_topic)
+    |> list.filter(fn(member) { member != process.self() })
+    |> set.from_list
+  let actor_state = reconcile_membership(actor_state, members)
   case actor_state.sync {
     None -> actor_state
     Some(sync) -> {
-      let members =
-        pubsub.subscribers(pubsub_instance, sync_topic)
-        |> list.filter(fn(member) { member != process.self() })
-        |> set.from_list
       let sync =
         SyncState(
           ..sync,
@@ -738,6 +777,100 @@ fn request_snapshots(
         })
       ActorState(..actor_state, sync: Some(sync))
     }
+  }
+}
+
+fn reconcile_membership(
+  actor_state: ActorState,
+  members: Set(process.Pid),
+) -> ActorState {
+  case actor_state.sync {
+    None -> actor_state
+    Some(sync) ->
+      dict.fold(sync.owners, actor_state, fn(actor_state, replica, owner) {
+        case set.contains(members, owner.pid) {
+          True -> actor_state
+          False -> hide_replica(actor_state, replica)
+        }
+      })
+  }
+}
+
+fn hide_replica(actor_state: ActorState, replica: String) -> ActorState {
+  case actor_state.sync {
+    None -> actor_state
+    Some(sync) ->
+      case dict.get(sync.owners, replica) {
+        Error(Nil) | Ok(ReplicaOwner(_, None)) -> actor_state
+        Ok(ReplicaOwner(pid, Some(monitor))) -> {
+          process.demonitor_process(monitor)
+          let #(crdt, _diff) = state.replica_down(actor_state.crdt, replica)
+          commit_replication(
+            ActorState(
+              ..actor_state,
+              sync: Some(
+                SyncState(
+                  ..sync,
+                  requests: dict.delete(sync.requests, pid),
+                  owners: dict.insert(
+                    sync.owners,
+                    replica,
+                    ReplicaOwner(pid, None),
+                  ),
+                ),
+              ),
+            ),
+            crdt,
+          )
+        }
+      }
+  }
+}
+
+fn handle_replica_down(
+  actor_state: ActorState,
+  down: process.Down,
+) -> ActorState {
+  case actor_state.sync, down {
+    Some(sync), process.ProcessDown(monitor, pid, _) ->
+      dict.fold(sync.owners, actor_state, fn(actor_state, replica, owner) {
+        case owner.pid == pid && owner.monitor == Some(monitor) {
+          True -> hide_replica(actor_state, replica)
+          False -> actor_state
+        }
+      })
+    None, _ | _, process.PortDown(_, _, _) -> actor_state
+  }
+}
+
+fn watch_replica(
+  actor_state: ActorState,
+  replica: String,
+  pid: process.Pid,
+) -> ActorState {
+  case actor_state.sync {
+    None -> actor_state
+    Some(sync) ->
+      case dict.get(sync.owners, replica) {
+        Ok(ReplicaOwner(owner, Some(_))) if owner == pid -> actor_state
+        previous -> {
+          case previous {
+            Ok(ReplicaOwner(_, Some(monitor))) ->
+              process.demonitor_process(monitor)
+            Ok(ReplicaOwner(_, None)) | Error(Nil) -> Nil
+          }
+          let owner = ReplicaOwner(pid, Some(process.monitor(pid)))
+          ActorState(
+            ..actor_state,
+            sync: Some(
+              SyncState(
+                ..sync,
+                owners: dict.insert(sync.owners, replica, owner),
+              ),
+            ),
+          )
+        }
+      }
   }
 }
 
@@ -810,24 +943,9 @@ fn base_replica(replica: String) -> String {
   }
 }
 
-/// Prune CRDT state left behind by dead incarnations of the given live
-/// replicas (the sync sender and ourselves).
-///
-/// This is the beryl-side workaround for replica reuse across restarts
-/// (first-class incarnations are proposed upstream in lattice): any replica
-/// sharing a live replica's base but not its suffix belongs to a dead
-/// predecessor. Hide it (emitting leave diffs through `on_diff`) and prune
-/// it. A lagging peer can briefly resurrect pruned entries until it
-/// observes the live incarnation itself; the prune re-applies on every
-/// sync, so the cluster converges within about one broadcast interval.
-///
-/// Returns the pruned CRDT along with every topic its pruning touched, so
-/// the caller can republish exactly those topics' read-model snapshots.
-fn prune_superseded(
-  config: Config,
-  crdt: State,
-  live: List(String),
-) -> #(State, List(String)) {
+/// Replacement handling is separate from liveness-only replica_down changes,
+/// which hide entries without deleting causal history.
+fn prune_superseded(crdt: State, live: List(String)) -> State {
   let stale =
     dict.keys(state.compacted_clocks(crdt))
     |> list.filter(fn(replica) {
@@ -836,15 +954,9 @@ fn prune_superseded(
         && base_replica(replica) == base_replica(live_replica)
       })
     })
-  list.fold(stale, #(crdt, []), fn(pruned, replica) {
-    let #(crdt, touched_topics) = pruned
-    let #(crdt, down_diff) = state.replica_down(crdt, replica)
-    let diff = wrap_state_diff(down_diff)
-    maybe_invoke_on_diff(config, diff)
-    let crdt = state.remove_down_replica(crdt, replica)
-    let newly_touched =
-      list.append(dict.keys(diff.joins), dict.keys(diff.leaves))
-    #(crdt, list.append(touched_topics, newly_touched))
+  list.fold(stale, crdt, fn(crdt, replica) {
+    let #(crdt, _diff) = state.replica_down(crdt, replica)
+    state.remove_down_replica(crdt, replica)
   })
 }
 
@@ -1295,6 +1407,8 @@ fn handle_message(
     }
 
     RemoteSnapshot(reply) -> handle_snapshot(actor_state, reply)
+    RemoteReplicaDown(down) ->
+      actor.continue(handle_replica_down(actor_state, down))
   }
 }
 
@@ -1712,6 +1826,7 @@ fn handle_snapshot(
                 ),
               ),
             ),
+            reply.owner,
             reply.state,
           )
         // Duplicates and replies to requests cancelled by membership loss.
@@ -1722,6 +1837,7 @@ fn handle_snapshot(
 
 fn merge_remote_sync(
   actor_state: ActorState,
+  owner: process.Pid,
   remote_state: State,
 ) -> actor.Next(ActorState, Message) {
   // Crash boundary — see internal.rescue. Version skew or bugs can produce
@@ -1730,31 +1846,16 @@ fn merge_remote_sync(
   // merge, on_diff, prune, and read-model publication all complete.
   let processed =
     internal.rescue(fn() {
-      let #(new_crdt, state_diff) =
-        state.merge_with_diff(actor_state.crdt, remote_state)
-      let diff = wrap_state_diff(state_diff)
-      maybe_invoke_on_diff(actor_state.config, diff)
-      // The merge may have (re)admitted state from dead incarnations —
-      // the sender's predecessors, or our own pre-restart self echoed back
-      // by a peer. Prune anything superseded by the two incarnations known
-      // to be live right now: the sender and ourselves.
-      let #(new_crdt, pruned_topics) =
-        prune_superseded(actor_state.config, new_crdt, [
-          state.replica(remote_state),
-          state.replica(new_crdt),
-        ])
-      // Republish every topic touched by either the merge or the prune,
-      // from the final crdt, in one pass — readers only ever see the
-      // fully-merged-and-pruned snapshot, never an intermediate one.
-      let touched_topics =
-        list.append(dict.keys(diff.joins), dict.keys(diff.leaves))
-        |> list.append(pruned_topics)
-        |> unique_strings(set.new(), [])
-      publish_topics(actor_state.read_table, new_crdt, touched_topics)
-      ActorState(..actor_state, crdt: new_crdt)
+      let sender = state.replica(remote_state)
+      let new_crdt =
+        state.merge(actor_state.crdt, remote_state)
+        |> apply_replica_visibility(actor_state.sync, sender)
+        |> prune_superseded([sender, state.replica(actor_state.crdt)])
+      #(commit_replication(actor_state, new_crdt), sender)
     })
   case processed {
-    Ok(next_state) -> actor.continue(next_state)
+    Ok(#(next_state, sender)) ->
+      actor.continue(watch_replica(next_state, sender, owner))
     Error(crash) -> {
       let logger = internal.logger("beryl.presence")
       logger
@@ -1764,4 +1865,37 @@ fn merge_remote_sync(
       actor.continue(actor_state)
     }
   }
+}
+
+fn apply_replica_visibility(
+  crdt: State,
+  sync: Option(SyncState),
+  sender: String,
+) -> State {
+  dict.keys(state.compacted_clocks(crdt))
+  |> list.fold(crdt, fn(crdt, replica) {
+    let available =
+      replica == state.replica(crdt)
+      || replica == sender
+      || case sync {
+        None -> False
+        Some(sync) ->
+          case dict.get(sync.owners, replica) {
+            Ok(ReplicaOwner(_, Some(_))) -> True
+            Ok(ReplicaOwner(_, None)) | Error(Nil) -> False
+          }
+      }
+    let #(crdt, _diff) = case available {
+      True -> state.replica_up(crdt, replica)
+      False -> state.replica_down(crdt, replica)
+    }
+    crdt
+  })
+}
+
+fn commit_replication(actor_state: ActorState, crdt: State) -> ActorState {
+  let diff = visible_diff(actor_state.crdt, crdt)
+  maybe_invoke_on_diff(actor_state.config, diff)
+  publish_topics(actor_state.read_table, crdt, diff_topics(diff))
+  ActorState(..actor_state, crdt: crdt)
 }

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -106,14 +106,25 @@ pub opaque type Presence {
 type State =
   state.State
 
+/// The audience for a presence diff.
+pub type DiffScope {
+  /// Application mutations and explicitly constructed diffs may be broadcast
+  /// to the cluster.
+  Cluster
+  /// Replication, failure detection, and recovery describe this node's view.
+  /// Deliver these diffs only to socket subscribers on the observing node.
+  LocalNode
+}
+
 /// An opaque diff representing presence joins and leaves grouped by topic.
 ///
 /// beryl passes this value to `Config.on_diff`.
-/// `beryl.broadcast_presence_diff` also accepts it.
+/// `beryl.broadcast_presence_diff` preserves its delivery scope automatically.
 pub opaque type Diff {
   Diff(
     joins: Dict(String, List(PresenceEntry)),
     leaves: Dict(String, List(PresenceEntry)),
+    scope: DiffScope,
   )
 }
 
@@ -128,12 +139,31 @@ pub type PresenceEntry {
 /// Build a presence diff from topic-grouped joins and leaves.
 ///
 /// Most applications receive diffs from `Config.on_diff`. Use this function
-/// to construct a diff for `beryl.broadcast_presence_diff`.
+/// to construct an application diff with `Cluster` scope for
+/// `beryl.broadcast_presence_diff`. Do not rebuild a replica-view diff with
+/// this function: that would discard its `LocalNode` scope.
 pub fn diff(
   joins joins: List(#(String, List(PresenceEntry))),
   leaves leaves: List(#(String, List(PresenceEntry))),
 ) -> Diff {
-  Diff(joins: dict.from_list(joins), leaves: dict.from_list(leaves))
+  Diff(
+    joins: dict.from_list(joins),
+    leaves: dict.from_list(leaves),
+    scope: Cluster,
+  )
+}
+
+/// Return where this diff may be delivered.
+///
+/// Local application mutations produce `Cluster` diffs. Remote snapshots and
+/// replica availability changes produce `LocalNode` diffs, even when one
+/// update contains both causal changes and liveness changes. They repair the
+/// observing node's view and must not be rebroadcast to other nodes.
+///
+/// Prefer `beryl.broadcast_presence_diff`, which handles this distinction.
+/// Custom publishers must preserve it; the Phoenix JSON payload has no scope.
+pub fn diff_scope(diff: Diff) -> DiffScope {
+  diff.scope
 }
 
 /// List topics touched by this diff.
@@ -209,6 +239,7 @@ fn visible_diff(before: State, after: State) -> Diff {
   Diff(
     joins: added_entries(after, before),
     leaves: added_entries(before, after),
+    scope: LocalNode,
   )
 }
 
@@ -582,6 +613,13 @@ pub fn with_call_timeout(config: Config, timeout_ms: Int) -> Config {
 
 /// Set the callback for diffs from local changes, remote merges, or replica
 /// availability changes.
+///
+/// Pass the original diff to `beryl.broadcast_presence_diff` to preserve its
+/// delivery scope. Application mutations publish cluster-wide at their source.
+/// Replication and availability callbacks repair local clients only. A custom
+/// publisher must inspect `diff_scope` rather than broadcast encoded JSON
+/// unconditionally. A local worker may handle the callback; do not move a
+/// `LocalNode` diff to another node for publication.
 ///
 /// The callback runs synchronously on the presence actor, for both local
 /// mutations (`track`/`update`/`untrack`/`untrack_all`, and the asynchronous
@@ -1642,6 +1680,7 @@ fn do_track(
         ]),
       ]),
       leaves: removed.leaves,
+      scope: Cluster,
     ),
   )
   let new_refs =
@@ -1676,7 +1715,7 @@ fn do_untrack_refs(actor_state: ActorState, refs: List(String)) -> ActorState {
   )
   maybe_invoke_on_diff(
     actor_state.config,
-    Diff(joins: dict.new(), leaves: removed.leaves),
+    Diff(joins: dict.new(), leaves: removed.leaves, scope: Cluster),
   )
   internal.logger("beryl.presence")
   |> log.debug("Presence untracked", [
@@ -1732,7 +1771,7 @@ fn leave_all_diff(crdt: State, session_id: String) -> Diff {
       ])
     })
 
-  Diff(joins: dict.new(), leaves: leaves)
+  Diff(joins: dict.new(), leaves: leaves, scope: Cluster)
 }
 
 /// Invoke the on_diff callback if configured and the diff is non-empty

--- a/packages/beryl/src/beryl/presence/wire.gleam
+++ b/packages/beryl/src/beryl/presence/wire.gleam
@@ -11,6 +11,10 @@ import gleam/result
 /// The resulting JSON has `joins` and `leaves` maps. Presence keys index the
 /// maps. Each value contains the tracked metadata under `metas`.
 ///
+/// Encoding does not include the diff's delivery scope. Prefer
+/// `beryl.broadcast_presence_diff` for socket delivery; a custom publisher must
+/// honor `presence.diff_scope` before sending this payload to other nodes.
+///
 /// ```json
 /// {
 ///   "joins": { "user:1": { "metas": [{ "status": "online" }] } },

--- a/packages/beryl/src/beryl/pubsub.gleam
+++ b/packages/beryl/src/beryl/pubsub.gleam
@@ -398,6 +398,22 @@ pub fn local_broadcast(
   })
 }
 
+/// Broadcast to other local subscribers using the unchanged scoped wire tuple.
+@internal
+pub fn local_broadcast_from(
+  pubsub_instance: PubSub(payload),
+  from: Pid,
+  topic: String,
+  event: String,
+  payload: payload,
+) -> Nil {
+  let message =
+    Message(topic: topic, event: event, payload: payload, from: FromPid(from))
+  ffi_get_local_members(pubsub_instance.scope, pubsub_instance.registry, topic)
+  |> list.filter(fn(pid) { pid != from })
+  |> list.each(ffi_send_to_pid(_, pubsub_instance.scope, message))
+}
+
 /// Return all topic subscribers on all nodes.
 pub fn subscribers(
   pubsub_instance: PubSub(payload),

--- a/packages/beryl/src/beryl/runtime.gleam
+++ b/packages/beryl/src/beryl/runtime.gleam
@@ -144,6 +144,8 @@ pub type Message(message) {
   /// Broadcast fan-out: local subscribers plus PubSub forwarding to other
   /// runtimes when PubSub is configured.
   Broadcast(topic: String, event: String, payload: Json, except: Option(String))
+  /// Originated here, but restricted to socket subscribers on this node.
+  LocalBroadcast(topic: String, event: String, payload: Json)
   RemoteBroadcast(pubsub.Message(Json))
   CheckHeartbeats
   GetStats(reply: fn(StatsSnapshot) -> Nil)
@@ -1028,7 +1030,7 @@ fn handle_suspended_work(
   let next =
     work_queue.take_matching(state.inbox, fn(message) {
       case message {
-        Broadcast(..) -> True
+        Broadcast(..) | LocalBroadcast(..) -> True
         WorkerReport(socket_id, _, pid, _, _) ->
           case dict.get(state.suspended, socket_id) {
             Ok(Suspension(waiting: WorkerWait(worker: worker, ..), ..)) ->
@@ -1135,6 +1137,10 @@ fn handle_message(
         RouterRole(..) ->
           broadcast_with_pubsub(state, topic_name, event_name, payload, except)
       }
+      actor.continue(state)
+    }
+    LocalBroadcast(topic_name, event_name, payload) -> {
+      broadcast_locally(state, topic_name, event_name, payload)
       actor.continue(state)
     }
     RemoteBroadcast(pubsub_message) ->
@@ -1649,6 +1655,7 @@ fn dispatch_socket_msg(
     // Not socket-scoped, so never deferred to this dispatcher.
     AdmitSocket(..)
     | Broadcast(..)
+    | LocalBroadcast(..)
     | RemoteBroadcast(..)
     | CheckHeartbeats
     | GetStats(..)
@@ -5903,6 +5910,28 @@ fn emit_broadcast(
   )
 }
 
+/// Keep local delivery independent of pg recovery, and forward to other local
+/// runtimes without echoing to this router or sending to another node.
+fn broadcast_locally(
+  state: State(model, message),
+  topic_name: String,
+  event_name: String,
+  payload: Json,
+) -> Nil {
+  emit_broadcast(state, topic_name, event_name, payload, None, telemetry.Local)
+  case state.pubsub {
+    Some(pubsub_instance) ->
+      pubsub.local_broadcast_from(
+        pubsub_instance,
+        process.self(),
+        topic_name,
+        event_name,
+        payload,
+      )
+    None -> Nil
+  }
+}
+
 /// Local fan-out plus distributed forwarding when PubSub is configured.
 /// Used by the effect interpreter, which runs inside the runtime actor —
 /// the actor's own pid is the PubSub sender, so the runtime does not echo
@@ -7325,6 +7354,7 @@ fn resume_worker_close(
             | HandleBinary(..)
             | AppInfo(..)
             | Broadcast(..)
+            | LocalBroadcast(..)
             | RemoteBroadcast(..)
             | CheckHeartbeats
             | GetStats(..)
@@ -7419,6 +7449,7 @@ fn worker_termination_effects(
     | HandleBinary(..)
     | AppInfo(..)
     | Broadcast(..)
+    | LocalBroadcast(..)
     | RemoteBroadcast(..)
     | CheckHeartbeats
     | GetStats(..)

--- a/packages/beryl/test/beryl_presence_distributed_test.erl
+++ b/packages/beryl/test/beryl_presence_distributed_test.erl
@@ -1,7 +1,8 @@
 -module(beryl_presence_distributed_test).
 -include_lib("eunit/include/eunit.hrl").
 -export([start_replica/3, view/1, sync_round/1, kill_replica/1,
-         begin_outage/1, end_outage/1, take_diffs/1]).
+         begin_outage/1, end_outage/1, take_diffs/1, diff_history/1,
+         retained/1, replica/1]).
 
 -define(TOPIC, <<"room:distributed">>).
 -define(SYNC_TOPIC, <<"beryl:presence:sync">>).
@@ -84,6 +85,80 @@ empty_restart_repairs_without_track_test_() ->
             Restarted = start(A, <<"source">>, 30),
             await_view(A, Restarted, [<<"receiver-entry">>]),
             await_view(B, Receiver, [<<"receiver-entry">>])
+        end)
+    end}.
+
+actor_failure_hides_only_its_entries_test_() ->
+    {timeout, 30, fun() ->
+        with_peers(3, fun([A, B, C]) ->
+            connect(A, B),
+            connect(A, C),
+            connect(B, C),
+            Source = start(A, <<"source">>, 30),
+            Healthy = start(C, <<"healthy">>, 30),
+            %% Equal non-object metas still represent two independent refs.
+            {ok, _} = track(A, Source, <<"gone">>),
+            {ok, _} = track(A, Source, <<"gone">>),
+            {ok, _} = track(C, Healthy, <<"healthy">>),
+            await_members(B, 2),
+            Receiver = start(B, <<"receiver">>, 0),
+            {ok, _} = track(B, Receiver, <<"local">>),
+            await_view(B, Receiver,
+                [<<"gone">>, <<"gone">>, <<"healthy">>, <<"local">>]),
+            SourceReplica = call(A, ?MODULE, replica, [Source]),
+            nil = call(A, ?MODULE, kill_replica, [Source]),
+            await_view(B, Receiver, [<<"healthy">>, <<"local">>]),
+            await_diff(B, Receiver, leaves, [<<"gone">>, <<"gone">>]),
+            #{clocks := Clocks, entries := 4} =
+                call(B, ?MODULE, retained, [Receiver]),
+            ?assert(maps:is_key(SourceReplica, Clocks))
+        end)
+    end}.
+
+node_failure_emits_remote_leaves_test_() ->
+    {timeout, 30, fun() ->
+        with_peers(2, fun([{Controller, _Node} = A, B]) ->
+            connect(A, B),
+            Source = start(A, <<"source">>, 30),
+            Receiver = start(B, <<"receiver">>, 0),
+            {ok, _} = track(A, Source, <<"gone">>),
+            {ok, _} = track(B, Receiver, <<"local">>),
+            await_view(B, Receiver, [<<"gone">>, <<"local">>]),
+            ok = peer:cast(Controller, erlang, halt, []),
+            await_view(B, Receiver, [<<"local">>]),
+            await_diff(B, Receiver, leaves, [<<"gone">>]),
+            await_members(B, 1)
+        end)
+    end}.
+
+partition_retains_history_and_rejoins_current_state_test_() ->
+    {timeout, 30, fun() ->
+        with_peers(2, fun([A, B]) ->
+            connect(A, B),
+            Source = start(A, <<"source">>, 30),
+            Receiver = start(B, <<"receiver">>, 30),
+            {ok, OldRef} = track(A, Source, <<"before-partition">>),
+            {ok, _} = track(B, Receiver, <<"local">>),
+            await_view(B, Receiver, [<<"before-partition">>, <<"local">>]),
+            SourceReplica = call(A, ?MODULE, replica, [Source]),
+            #{clocks := Before} = call(B, ?MODULE, retained, [Receiver]),
+            disconnect(A, B),
+            await_view(B, Receiver, [<<"local">>]),
+            await_diff(B, Receiver, leaves, [<<"before-partition">>]),
+            #{clocks := During, entries := 2} =
+                call(B, ?MODULE, retained, [Receiver]),
+            ?assertEqual(maps:get(SourceReplica, Before),
+                         maps:get(SourceReplica, During)),
+            {ok, nil} = presence_call(A, untrack, [handle(Source), OldRef]),
+            {ok, _} = track(A, Source, <<"after-partition">>),
+            connect(A, B),
+            await_view(B, Receiver, [<<"after-partition">>, <<"local">>]),
+            await_diff(B, Receiver, joins,
+                [<<"after-partition">>, <<"before-partition">>, <<"local">>]),
+            %% Removing a hidden entry must not emit a second leave; the
+            %% reconnect must not first publish the retained, obsolete meta.
+            await_diff(B, Receiver, leaves, [<<"before-partition">>]),
+            ?assertEqual(SourceReplica, call(A, ?MODULE, replica, [Source]))
         end)
     end}.
 
@@ -173,6 +248,14 @@ sync_round(#{pid := Pid}) ->
     {some, Sync} = element(5, sys:get_state(Pid)),
     element(4, Sync).
 
+replica(#{pid := Pid}) ->
+    'lattice_presence@presence_state':replica(element(2, sys:get_state(Pid))).
+
+retained(#{pid := Pid}) ->
+    Crdt = element(2, sys:get_state(Pid)),
+    #{clocks => 'lattice_presence@presence_state':compacted_clocks(Crdt),
+      entries => 'lattice_presence@presence_state':entry_count(Crdt)}.
+
 await_round(Peer, Instance) ->
     Before = call(Peer, ?MODULE, sync_round, [Instance]),
     await({quiet_repair_tick, element(2, Peer)}, fun() ->
@@ -193,6 +276,12 @@ await_view(Peer, Instance, Keys) ->
         call(Peer, ?MODULE, view, [Instance]) =:= Expected
     end),
     ?assertEqual(Expected, call(Peer, ?MODULE, view, [Instance])).
+
+await_diff(Peer, Instance, Kind, Keys) ->
+    await({presence_diff, element(2, Peer), Kind, Keys}, fun() ->
+        History = call(Peer, ?MODULE, diff_history, [Instance]),
+        maps:get(Kind, History) =:= lists:sort(Keys)
+    end).
 
 await(Phase, Check) ->
     try 'test_helper':wait_until(Check, 5000, 10)
@@ -224,7 +313,10 @@ collect_diffs(Diffs) ->
         {presence_diff, Diff} -> collect_diffs([Diff | Diffs]);
         {take_diffs, Caller, Ref} ->
             Caller ! {Ref, lists:reverse(Diffs)},
-            collect_diffs([])
+            collect_diffs([]);
+        {diff_history, Caller, Ref} ->
+            Caller ! {Ref, lists:reverse(Diffs)},
+            collect_diffs(Diffs)
     end.
 
 take_diffs(#{collector := Collector}) ->
@@ -233,3 +325,18 @@ take_diffs(#{collector := Collector}) ->
     receive {Ref, Diffs} -> Diffs
     after 5000 -> error(diff_collector_timeout)
     end.
+
+diff_history(#{collector := Collector}) ->
+    Ref = make_ref(),
+    Collector ! {diff_history, self(), Ref},
+    receive
+        {Ref, Diffs} ->
+            #{joins => diff_keys(Diffs, diff_joins),
+              leaves => diff_keys(Diffs, diff_leaves)}
+    after 5000 -> error(diff_collector_timeout)
+    end.
+
+diff_keys(Diffs, Accessor) ->
+    lists:sort([Key || Diff <- Diffs,
+        {presence_entry, _Session, Key, _Meta} <-
+            apply('beryl@presence', Accessor, [Diff, ?TOPIC])]).

--- a/packages/beryl/test/beryl_presence_distributed_test.erl
+++ b/packages/beryl/test/beryl_presence_distributed_test.erl
@@ -7,6 +7,82 @@
 -define(TOPIC, <<"room:distributed">>).
 -define(SYNC_TOPIC, <<"beryl:presence:sync">>).
 -define(SCOPE, <<"beryl_presence_distributed_test">>).
+-define(SOCKET_SCOPE, <<"beryl_presence_socket_frames_test">>).
+
+presence_scope_outage_diffs_stay_on_observing_node_test_() ->
+    {timeout, 30, fun() ->
+        with_peers(2, fun([A, B]) ->
+            connect(A, B),
+            Source = start_socket_replica(A, <<"source">>),
+            Receiver = start_socket_replica(B, <<"receiver">>),
+            OtherLocal = call(B, presence_socket_test_helper, start_client, [?SOCKET_SCOPE]),
+            ClientA = maps:get(client, Source),
+            ClientB = maps:get(client, Receiver),
+            Clients = [{A, ClientA}, {B, ClientB}, {B, OtherLocal}],
+            lists:foreach(fun({Peer, Client}) -> await_client(Peer, Client) end, Clients),
+            lists:foreach(fun(Peer) ->
+                Config = call(Peer, 'beryl@pubsub', config_with_scope, [?SOCKET_SCOPE]),
+                PubSub = call(Peer, 'beryl@pubsub', start, [Config]),
+                await({socket_members, element(2, Peer)}, fun() ->
+                    call(Peer, 'beryl@pubsub', subscriber_count, [PubSub, ?TOPIC]) =:= 3
+                end)
+            end, [A, B]),
+            Ref = track_socket_presence(A, Source, <<"healthy-a">>),
+            await_view(B, Receiver, [<<"healthy-a">>]),
+            lists:foreach(fun({Peer, Client}) ->
+                await_frame_barrier(Peer, Client, <<"receiver">>, <<"joins">>,
+                    <<"healthy-a">>, Ref, 1)
+            end, Clients),
+            OriginalJoins = length(diff_frames(client_frames(A, ClientA),
+                <<"joins">>, <<"healthy-a">>, Ref)),
+            Outage = call(B, ?MODULE, begin_outage, [?SCOPE]),
+            try
+                await_members(A, 1),
+                await_view(B, Receiver, []),
+                lists:foreach(fun({Peer, Client}) ->
+                    await_frame_barrier(Peer, Client, <<"receiver">>, <<"leaves">>,
+                        <<"healthy-a">>, Ref, 1)
+                end, Clients),
+                %% The healthy source still owns this entry. A receiver's
+                %% local pg outage must not send its clients a false leave.
+                await_view(A, Source, [<<"healthy-a">>]),
+                ?assertEqual([], diff_frames(client_frames(A, ClientA),
+                    <<"leaves">>, <<"healthy-a">>, Ref)),
+                lists:foreach(fun(Client) ->
+                    ?assertEqual(1, length(diff_frames(client_frames(B, Client),
+                        <<"leaves">>, <<"healthy-a">>, Ref)))
+                end, [ClientB, OtherLocal]),
+                %% Application diffs must still cross the healthy socket
+                %% PubSub scope while presence replication on B is unavailable.
+                NormalRef = track_socket_presence(A, Source, <<"normal">>),
+                lists:foreach(fun({Peer, Client}) ->
+                    await_frame_barrier(Peer, Client, <<"source">>, <<"joins">>,
+                        <<"normal">>, NormalRef, 1),
+                    ?assertEqual(1, length(diff_frames(client_frames(Peer, Client),
+                        <<"joins">>, <<"normal">>, NormalRef)))
+                end, Clients),
+                await_view(B, Receiver, []),
+                {ok, nil} = presence_call(A, untrack, [handle(Source), NormalRef]),
+                lists:foreach(fun({Peer, Client}) ->
+                    await_frame_barrier(Peer, Client, <<"source">>, <<"leaves">>,
+                        <<"normal">>, NormalRef, 1),
+                    ?assertEqual(1, length(diff_frames(client_frames(Peer, Client),
+                        <<"leaves">>, <<"normal">>, NormalRef)))
+                end, Clients)
+            after
+                nil = call(B, ?MODULE, end_outage, [Outage])
+            end,
+            await_view(B, Receiver, [<<"healthy-a">>]),
+            lists:foreach(fun({Peer, Client}) ->
+                await_frame_barrier(Peer, Client, <<"receiver">>, <<"joins">>,
+                    <<"healthy-a">>, Ref, 2)
+            end, Clients),
+            ?assertEqual(OriginalJoins, length(diff_frames(client_frames(A, ClientA),
+                <<"joins">>, <<"healthy-a">>, Ref))),
+            ?assertEqual([], diff_frames(client_frames(A, ClientA),
+                <<"leaves">>, <<"healthy-a">>, Ref))
+        end)
+    end}.
 
 late_joiner_gets_quiet_snapshot_test_() ->
     {timeout, 30, fun() ->
@@ -210,6 +286,51 @@ disconnect(A, {_Controller, Node} = B) ->
 
 start(Peer, Replica, Interval) ->
     call(Peer, ?MODULE, start_replica, [?SCOPE, Replica, Interval]).
+
+start_socket_replica(Peer, Replica) ->
+    Client = call(Peer, presence_socket_test_helper, start_client, [?SOCKET_SCOPE]),
+    {Presence, Pid} = call(Peer, presence_socket_test_helper, start_presence,
+        [Client, ?SCOPE, Replica]),
+    #{handle => Presence, pid => Pid, client => Client}.
+
+track_socket_presence(Peer, Instance, Key) ->
+    {ok, Ref} = presence_call(Peer, track,
+        [handle(Instance), ?TOPIC, Key, Key, 'gleam@json':object([])]),
+    Ref.
+
+client_frames(Peer, Client) ->
+    [json:decode(Frame) || Frame <-
+        call(Peer, presence_socket_test_helper, frames, [Client])].
+
+await_client(Peer, Client) ->
+    await({socket_join, element(2, Peer)}, fun() ->
+        lists:any(fun
+            ([<<"join">>, <<"join">>, ?TOPIC, <<"phx_reply">>,
+              #{<<"status">> := <<"ok">>}]) -> true;
+            (_) -> false
+        end, client_frames(Peer, Client))
+    end).
+
+diff_frames(Frames, Side, Key, Ref) ->
+    [Payload || [null, null, ?TOPIC, <<"presence_diff">>, Payload] <- Frames,
+        diff_contains_ref(Payload, Side, Key, Ref)].
+
+diff_contains_ref(Payload, Side, Key, Ref) ->
+    case maps:find(Key, maps:get(Side, Payload)) of
+        {ok, #{<<"metas">> := Metas}} ->
+            lists:any(fun(Meta) -> maps:get(<<"phx_ref">>, Meta) =:= Ref end, Metas);
+        error -> false
+    end.
+
+await_frame_barrier(Peer, Client, Replica, Side, Key, Ref, Count) ->
+    await({socket_diff_barrier, element(2, Peer), Replica, Side, Key}, fun() ->
+        Markers = [ok ||
+            [null, null, ?TOPIC, <<"presence_diff_barrier">>, Marker] <-
+                client_frames(Peer, Client),
+            maps:get(<<"replica">>, Marker) =:= Replica,
+            diff_contains_ref(maps:get(<<"diff">>, Marker), Side, Key, Ref)],
+        length(Markers) >= Count
+    end).
 
 start_replica(Scope, Replica, Interval) ->
     PubSub = 'beryl@pubsub':start('beryl@pubsub':config_with_scope(Scope)),

--- a/packages/beryl/test/presence_replication_test.gleam
+++ b/packages/beryl/test/presence_replication_test.gleam
@@ -620,11 +620,20 @@ pub fn restart_prune_updates_read_model_count_test() -> Nil {
   // The pruned ghost must not inflate the peer's count once it converges
   // on the restarted incarnation.
   test_helper.wait_until(
-    fn() { presence_count(tracker2, "room:lobby") == 1 },
+    fn() {
+      let identities =
+        presence_entries(tracker2, "room:lobby")
+        |> list.map(fn(entry) { #(entry.session_id, entry.key) })
+      presence_count(tracker2, "room:lobby") == 1
+      && identities == [#("socket-live", "user:live")]
+    },
     3000,
     10,
   )
   presence_count(tracker2, "room:lobby") |> should.equal(1)
+  presence_entries(tracker2, "room:lobby")
+  |> list.map(fn(entry) { #(entry.session_id, entry.key) })
+  |> should.equal([#("socket-live", "user:live")])
 }
 
 // ── Reads stay responsive while the actor mailbox is busy ────────────

--- a/packages/beryl/test/presence_socket_test_helper.gleam
+++ b/packages/beryl/test/presence_socket_test_helper.gleam
@@ -1,0 +1,125 @@
+import app_test_helper
+import beryl
+import beryl/presence
+import beryl/presence/wire as presence_wire
+import beryl/pubsub
+import beryl/socket
+import beryl/transport
+import beryl/transport/server
+import beryl/wire
+import gleam/erlang/process
+import gleam/json
+import gleam/list
+import gleam/option
+
+const topic = "room:distributed"
+
+pub opaque type Client {
+  Client(channels: beryl.Sockets, control: process.Subject(Message))
+}
+
+type Message {
+  Outbound(server.SendRequest)
+  Frames(reply: process.Subject(List(String)))
+}
+
+/// Run a real socket runtime and its shared WebSocket transport on this node.
+/// The adapter records encoded text frames and acknowledges outbound writes.
+pub fn start_client(scope: String) -> Client {
+  let ready = process.new_subject()
+  let _owner =
+    process.spawn_unlinked(fn() {
+      let pubsub = pubsub.start(pubsub.config_with_scope(scope))
+      let assert Ok(channels) =
+        app_test_helper.start_app(
+          beryl.config(wire.phoenix_codec()) |> beryl.with_pubsub(pubsub),
+          init: app_test_helper.accepting_init,
+          update: app_test_helper.accepting_update,
+        )
+      let control = process.new_subject()
+      let assert Ok(permit) =
+        transport.acquire_connection_slot(channels, "127.0.0.1")
+      let #(connection, outbound) =
+        server.init_connection(
+          sockets: channels,
+          seed: socket.empty_seed(),
+          connection_permit: permit,
+          base_selector: process.new_selector(),
+          config: server.default_config("/socket"),
+          force_close: fn() { Ok(Nil) },
+          logger_name: "beryl.presence.socket.test",
+          telemetry: transport.telemetry(channels, transport.Mist),
+          codec: option.None,
+        )
+      let selector =
+        process.map_selector(outbound, Outbound)
+        |> process.select(control)
+      let assert server.Continue(connection) =
+        server.handle_text_frame(
+          connection,
+          "[\"join\",\"join\",\"room:distributed\",\"phx_join\",{}]",
+        )
+      process.send(ready, Client(channels, control))
+      receive_frames(connection, selector, [])
+    })
+  let assert Ok(client) = process.receive(ready, 5000)
+  client
+}
+
+/// Use the documented diff callback, followed by an ordered global marker.
+/// The marker proves a remote client has passed this callback's delivery turn.
+pub fn start_presence(
+  client: Client,
+  scope: String,
+  replica: String,
+) -> #(presence.Presence, process.Pid) {
+  let pubsub = pubsub.start(pubsub.config_with_scope(scope))
+  let config =
+    presence.default_config(replica)
+    |> presence.with_pubsub(pubsub)
+    |> presence.with_broadcast_interval(30)
+    |> presence.with_on_diff(fn(diff) {
+      let assert Ok(Nil) =
+        beryl.broadcast_presence_diff(client.channels, topic, diff)
+      let assert Ok(Nil) =
+        beryl.broadcast(
+          client.channels,
+          topic,
+          "presence_diff_barrier",
+          json.object([
+            #("replica", json.string(replica)),
+            #("diff", presence_wire.encode_diff(diff, topic)),
+          ]),
+        )
+      Nil
+    })
+  let assert Ok(tracker) = presence.start(config)
+  let assert Ok(pid) = process.subject_owner(presence.subject(tracker))
+  process.unlink(pid)
+  #(tracker, pid)
+}
+
+/// Read only frames the transport has completed writing.
+pub fn frames(client: Client) -> List(String) {
+  process.call(client.control, 1000, Frames)
+}
+
+fn receive_frames(
+  connection: server.ConnectionState,
+  selector: process.Selector(Message),
+  frames: List(String),
+) -> Nil {
+  case process.selector_receive_forever(selector) {
+    Frames(reply) -> {
+      process.send(reply, list.reverse(frames))
+      receive_frames(connection, selector, frames)
+    }
+    Outbound(server.SendText(text, bytes)) -> {
+      let assert server.Continue(connection) =
+        server.finish_outbound_write(connection, bytes, True)
+      receive_frames(connection, selector, [text, ..frames])
+    }
+    Outbound(server.SendBinary(_, _)) -> panic as "Expected Phoenix text frames"
+    Outbound(server.Close) -> server.close_connection(connection)
+  }
+}

--- a/packages/beryl/test/presence_test.gleam
+++ b/packages/beryl/test/presence_test.gleam
@@ -18,6 +18,35 @@ fn test_config(replica: String) -> presence.Config {
   presence.default_config(replica)
 }
 
+pub fn explicitly_constructed_diffs_have_cluster_scope_test() -> Nil {
+  presence.diff(joins: [], leaves: [])
+  |> presence.diff_scope
+  |> should.equal(presence.Cluster)
+}
+
+pub fn application_mutation_diffs_have_cluster_scope_test() -> Nil {
+  let scopes = process.new_subject()
+  let assert Ok(tracker) =
+    presence.start(
+      test_config("application-diffs")
+      |> presence.with_on_diff(fn(diff) {
+        process.send(scopes, presence.diff_scope(diff))
+      }),
+    )
+  let assert Ok(ref) =
+    presence.track(tracker, "room:lobby", "user", "session", json.object([]))
+  let assert Ok(updated) = presence.update(tracker, ref, json.object([]))
+  let assert Ok(Nil) = presence.untrack(tracker, updated)
+  let assert Ok(_) =
+    presence.track(tracker, "room:lobby", "user", "session", json.object([]))
+  let assert Ok(Nil) = presence.untrack_all(tracker, "session")
+  list.each(list.repeat(presence.Cluster, 5), fn(scope) {
+    process.receive(scopes, 1000) |> should.equal(Ok(scope))
+  })
+  process.receive(scopes, 0) |> should.equal(Error(Nil))
+  test_helper.kill_presence(tracker)
+}
+
 pub fn presence_start_test() -> Nil {
   let #(tracker, spec) = presence.child_spec(test_config("node1"))
   let assert Ok(_root) =

--- a/website/src/content/docs/architecture/overview.md
+++ b/website/src/content/docs/architecture/overview.md
@@ -55,7 +55,7 @@ flowchart TB
 | `beryl/socket` | The app-facing dispatch types: `Input`, `Next`, `Effect`, `JoinRef`/`ReplyRef`, `ConnectInfo`/`ConnectSeed`, typed `Sender`/`notify` | [Runtime](/architecture/runtime) |
 | `beryl/runtime` | Router, socket actors, and topic workers: subscriber index, per-socket models, per-topic channel processes, event delivery, returned effects, and heartbeat enforcement | [Runtime](/architecture/runtime) |
 | `beryl/pubsub` | Distributed publish and subscribe through Erlang `pg` | [Broadcasts Across Nodes](/architecture/pubsub-and-distribution) |
-| `beryl/presence` | OTP actor wrapping an add-wins OR-set CRDT; track/untrack, cross-node diff broadcast, `on_diff` callbacks | [Presence](/architecture/presence) |
+| `beryl/presence` | OTP actor wrapping an add-wins OR-set CRDT; track/untrack, replication, scoped `on_diff` callbacks | [Presence](/architecture/presence) |
 | `beryl/presence/wire` | Phoenix-compatible JSON encoding for presence diffs (`joins`/`leaves` maps) | [Presence](/architecture/presence) |
 | `beryl/wire` | Message encoding; includes `phoenix_codec()` for `[join_ref, ref, topic, event, payload]` frames | [WebSocket Frames & Transports](/architecture/wire-and-transport) |
 | `beryl/wire/codec` | `Codec` functions such as `decode_text`, `decode_binary`, and `encode_*` | [WebSocket Frames & Transports](/architecture/wire-and-transport) |

--- a/website/src/content/docs/architecture/presence.md
+++ b/website/src/content/docs/architecture/presence.md
@@ -88,7 +88,8 @@ PubSub copies presence state between nodes.
 
 | Function | Description |
 |---|---|
-| `diff(joins, leaves)` | Construct a diff from topic-grouped join and leave lists |
+| `diff(joins, leaves)` | Construct a `Cluster` application diff from topic-grouped join and leave lists |
+| `diff_scope(diff)` | Read `Cluster` or `LocalNode` delivery scope |
 | `diff_topics(diff)` | List every topic touched by this diff |
 | `diff_joins(diff, topic)` | Get joined entries for a topic |
 | `diff_leaves(diff, topic)` | Get departed entries for a topic |
@@ -142,6 +143,18 @@ It retains the entries and causal context. Peer snapshots cannot make an
 unavailable or unconfirmed replica visible. Diffs compare the visible state
 before and after the complete transition, so removing a hidden entry does
 not emit a second leave.
+
+Replica-view diffs have `LocalNode` scope. This includes remote merges,
+failure detection, and reconnects, even when one commit also contains causal
+data changes. `beryl.broadcast_presence_diff` keeps them on the observing node
+instead of publishing its availability decision to healthy peers. Application
+mutations and explicitly constructed diffs retain `Cluster` delivery.
+
+The runtime admits both kinds through its queue. Local-view delivery uses
+the same per-socket encoding path and forwards only to other local runtimes
+in the application PubSub scope. Phoenix frames and the PubSub wire tuple
+do not change. Custom callbacks must preserve `diff_scope`; see
+[sending presence diffs](/guides/presence/#send-phoenix-compatible-presence_diff-events).
 
 A temporary partition can make a remote session appear offline while its
 source node still lists it. Local tracking and local reads remain available.

--- a/website/src/content/docs/architecture/presence.md
+++ b/website/src/content/docs/architecture/presence.md
@@ -129,6 +129,32 @@ Automated tests cover quiet bootstrap, partition repair, empty restart, and
 [Issue #365](https://github.com/tylerbutler/beryl/issues/365) tracks the broader
 distributed PubSub and presence matrix.
 
+## Replica availability
+
+After a successful snapshot exchange, beryl associates the replica identity
+with the source actor's PID and monitors that process. A process exit or an
+Erlang distribution disconnection hides that replica's entries and emits
+matching leave diffs. Each repair tick also checks `pg` membership, so scope
+recovery or membership loss can hide an actor that still runs.
+
+beryl uses the CRDT's `replica_down` for these local visibility changes.
+It retains the entries and causal context. Peer snapshots cannot make an
+unavailable or unconfirmed replica visible. Diffs compare the visible state
+before and after the complete transition, so removing a hidden entry does
+not emit a second leave.
+
+A temporary partition can make a remote session appear offline while its
+source node still lists it. Local tracking and local reads remain available.
+On reconnect, membership alone does not restore visibility: a fresh snapshot
+from the same actor first incorporates changes made during the partition,
+then restores its current entries with join diffs. This favors local
+availability over a single cluster-wide online/offline decision.
+
+Actor restart creates a new incarnation with empty local state and new
+tracking refs. Clients must re-track their local presence. Failure detection
+depends on Erlang process/distribution signals and actor progress; the repair
+interval does not bound node-failure detection time.
+
 ## Request and sync flow
 
 ```mermaid

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -262,6 +262,14 @@ or replies. Keep a positive interval for quiet recovery. Presence sync
 version 2 does not interoperate with version 1; upgrade all replicas in one
 presence scope together. The outer PubSub wire format has not changed.
 
+Remote entries disappear, with leave diffs, when beryl detects their actor
+exit, node disconnection, or loss of sync-group membership. This also applies
+to temporary partitions: your local sessions remain available, but peers can
+show them as offline. beryl retains causal history while they are unavailable.
+A fresh snapshot after reconnect restores the source actor's current entries,
+without first exposing obsolete retained entries. See
+[replica availability](/architecture/presence/#replica-availability).
+
 The underlying CRDT state is intentionally internal. Applications should use PubSub replication rather than constructing or merging raw presence state values.
 
 ## Use presence from raw dispatch

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -204,6 +204,7 @@ let config =
   |> presence.with_pubsub(pubsub_handle)
   |> presence.with_broadcast_interval(1500)
   |> presence.with_on_diff(fn(diff) {
+    // Keep the original diff so the helper can apply its delivery scope.
     case beryl.broadcast_presence_diff(channels, "room:lobby", diff) {
       Ok(Nil) -> Nil
       Error(reason) -> io.println(overload.describe(reason))
@@ -238,9 +239,34 @@ The payload matches Phoenix Presence's shape, with joins and leaves grouped by p
 ```
 
 For direct integrations, `beryl/presence/wire.encode_diff(diff, topic)`
-returns the encoded JSON payload without broadcasting it. If channels use
-PubSub, `broadcast_presence_diff` uses the same cross-node delivery as
-`beryl.broadcast`.
+returns the encoded JSON payload without broadcasting it. The JSON contains
+no delivery-scope metadata. `beryl.broadcast_presence_diff` reads
+`presence.diff_scope(diff)` before encoding:
+
+| Diff source | Scope | Socket delivery |
+|---|---|---|
+| Application mutations or `presence.diff(...)` | `Cluster` | Normal local and cross-node PubSub delivery |
+| Remote snapshots, replica failure, and recovery | `LocalNode` | Local socket subscribers, including other local runtimes in the same PubSub scope |
+
+A node's failure detector reports its own view, not a cluster-wide leave.
+For example, B can hide A during a presence-scope outage while A still has
+live sessions. The local diff must not remove those sessions from A's clients.
+Normal application track/untrack diffs still cross the application PubSub
+scope even while presence replication is unavailable.
+
+:::caution[Preserve the diff's scope]
+Use the callback above on each presence node. Do not replace the helper with
+`encode_diff` followed by an unconditional `beryl.broadcast`, or rebuild a
+received diff through `presence.diff(...)`: both discard its local scope.
+Custom publishers must inspect `diff_scope` and publish `LocalNode` diffs
+only on the observing node. A local worker may handle the callback; do not
+forward a local-view diff to another node for publication.
+:::
+
+Application mutations publish cluster-wide at their source. Replication
+callbacks repair each receiver's local clients; they are not cluster-wide
+relays. Applications that previously used one receiver's callback as the sole
+global publisher must move application-change publishing to the source.
 
 ## Replicate presence across nodes
 

--- a/website/src/content/docs/reference/api/beryl-presence-wire.md
+++ b/website/src/content/docs/reference/api/beryl-presence-wire.md
@@ -44,6 +44,10 @@ Encode a presence diff for one topic as a Phoenix-compatible payload.
  The resulting JSON has `joins` and `leaves` maps. Presence keys index the
  maps. Each value contains the tracked metadata under `metas`.
 
+ Encoding does not include the diff's delivery scope. Prefer
+ `beryl.broadcast_presence_diff` for socket delivery; a custom publisher must
+ honor `presence.diff_scope` before sending this payload to other nodes.
+
  ```json
  {
    "joins": { "user:1": { "metas": [{ "status": "online" }] } },

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -71,6 +71,7 @@ Distributed presence tracking with a CRDT
   <ul>
 <li><a href="#api-type-config"><code>Config</code></a></li>
 <li><a href="#api-type-diff"><code>Diff</code></a></li>
+<li><a href="#api-type-diffscope"><code>DiffScope</code></a></li>
 <li><a href="#api-type-message"><code>Message</code></a></li>
 <li><a href="#api-type-presence"><code>Presence</code></a></li>
 <li><a href="#api-type-presenceentry"><code>PresenceEntry</code></a></li>
@@ -86,6 +87,7 @@ Distributed presence tracking with a CRDT
 <li><a href="#api-function-diff"><code>diff</code></a></li>
 <li><a href="#api-function-diff_joins"><code>diff_joins</code></a></li>
 <li><a href="#api-function-diff_leaves"><code>diff_leaves</code></a></li>
+<li><a href="#api-function-diff_scope"><code>diff_scope</code></a></li>
 <li><a href="#api-function-diff_topics"><code>diff_topics</code></a></li>
 <li><a href="#api-function-get_by_key"><code>get_by_key</code></a></li>
 <li><a href="#api-function-list"><code>list</code></a></li>
@@ -130,7 +132,40 @@ pub type Diff
 An opaque diff representing presence joins and leaves grouped by topic.
 
  beryl passes this value to `Config.on_diff`.
- `beryl.broadcast_presence_diff` also accepts it.
+ `beryl.broadcast_presence_diff` preserves its delivery scope automatically.
+
+<div class="api-entry-anchor" id="api-type-diffscope" aria-hidden="true"></div>
+
+### `DiffScope`
+
+```gleam
+pub type DiffScope {
+  Cluster
+  LocalNode
+}
+```
+
+The audience for a presence diff.
+
+#### Constructors
+
+##### `Cluster`
+
+```gleam
+Cluster
+```
+
+Application mutations and explicitly constructed diffs may be broadcast
+ to the cluster.
+
+##### `LocalNode`
+
+```gleam
+LocalNode
+```
+
+Replication, failure detection, and recovery describe this node's view.
+ Deliver these diffs only to socket subscribers on the observing node.
 
 <div class="api-entry-anchor" id="api-type-message" aria-hidden="true"></div>
 
@@ -282,7 +317,9 @@ pub fn diff(
 Build a presence diff from topic-grouped joins and leaves.
 
  Most applications receive diffs from `Config.on_diff`. Use this function
- to construct a diff for `beryl.broadcast_presence_diff`.
+ to construct an application diff with `Cluster` scope for
+ `beryl.broadcast_presence_diff`. Do not rebuild a replica-view diff with
+ this function: that would discard its `LocalNode` scope.
 
 <div class="api-entry-anchor" id="api-function-diff_joins" aria-hidden="true"></div>
 
@@ -309,6 +346,24 @@ pub fn diff_leaves(
 ```
 
 Return presence leaves for a topic in this diff.
+
+<div class="api-entry-anchor" id="api-function-diff_scope" aria-hidden="true"></div>
+
+### `diff_scope`
+
+```gleam
+pub fn diff_scope(Diff) -> DiffScope
+```
+
+Return where this diff may be delivered.
+
+ Local application mutations produce `Cluster` diffs. Remote snapshots and
+ replica availability changes produce `LocalNode` diffs, even when one
+ update contains both causal changes and liveness changes. They repair the
+ observing node's view and must not be rebroadcast to other nodes.
+
+ Prefer `beryl.broadcast_presence_diff`, which handles this distinction.
+ Custom publishers must preserve it; the Phoenix JSON payload has no scope.
 
 <div class="api-entry-anchor" id="api-function-diff_topics" aria-hidden="true"></div>
 
@@ -516,6 +571,13 @@ pub fn with_on_diff(
 
 Set the callback for diffs from local changes, remote merges, or replica
  availability changes.
+
+ Pass the original diff to `beryl.broadcast_presence_diff` to preserve its
+ delivery scope. Application mutations publish cluster-wide at their source.
+ Replication and availability callbacks repair local clients only. A custom
+ publisher must inspect `diff_scope` rather than broadcast encoded JSON
+ unconditionally. A local worker may handle the callback; do not move a
+ `LocalNode` diff to another node for publication.
 
  The callback runs synchronously on the presence actor, for both local
  mutations (`track`/`update`/`untrack`/`untrack_all`, and the asynchronous

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -22,6 +22,7 @@ Distributed presence tracking with a CRDT
  - Publishes an actor-owned ETS read model
  - Requests snapshots at startup and periodically through PubSub
  - Receives remote snapshots and merges them internally
+ - Hides unavailable remote replicas without forgetting their causal state
  - Invokes `on_diff` when local changes or merges produce non-empty diffs
 
  Presence is independent of the beryl runtime and runs under your
@@ -513,7 +514,8 @@ pub fn with_on_diff(
 ) -> Config
 ```
 
-Set the callback for diffs from local changes or remote merges.
+Set the callback for diffs from local changes, remote merges, or replica
+ availability changes.
 
  The callback runs synchronously on the presence actor, for both local
  mutations (`track`/`update`/`untrack`/`untrack_all`, and the asynchronous
@@ -551,6 +553,13 @@ pub fn with_pubsub(
 ```
 
 Enable PubSub replication for presence.
+
+ Remote visibility follows monitored actor ownership and the local `pg`
+ membership view. Actor exit, node disconnection, or membership loss hides
+ that replica and emits leaves. Its causal state remains available for repair.
+ A fresh snapshot from the same actor restores its current entries; a
+ replacement actor starts a new incarnation. A partition can therefore hide
+ sessions that remain connected to their local node.
 
 <div class="api-entry-anchor" id="api-function-with_queue_limits" aria-hidden="true"></div>
 

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -371,8 +371,14 @@ Broadcast a Phoenix-compatible `presence_diff` event for a topic.
  }
  ```
 
- When the system was started with PubSub, the broadcast is distributed
- using the same semantics as `broadcast`.
+ Honors `presence.diff_scope`: application-mutation and explicitly constructed
+ `Cluster` diffs use the same distributed semantics as `broadcast`.
+ `LocalNode` diffs from replication, failure detection, and recovery reach
+ only local socket subscribers, including other local runtimes in the same
+ PubSub scope. They must not change healthy clients on another node.
+
+ Pass the original diff from `presence.with_on_diff`. Encoding or rebuilding
+ the diff before an unconditional `broadcast` loses this routing metadata.
 
 <div class="api-entry-anchor" id="api-function-child_spec" aria-hidden="true"></div>
 

--- a/website/src/content/docs/reference/index.md
+++ b/website/src/content/docs/reference/index.md
@@ -57,7 +57,7 @@ frames, or select a compatible client.
 | Broadcast to all sockets on a topic | `socket.Broadcast(topic, event, payload)` inside `update`, or `beryl.broadcast(sockets, topic, event, payload)` outside it | All subscribers, including the sender |
 | Broadcast, excluding sender | `socket.BroadcastFrom(topic, event, payload)` inside `update`, or `beryl.broadcast_from(sockets, socket_id, topic, event, payload)` outside it | Excludes one socket ID; preserved across PubSub nodes |
 | Send a typed server-side message to one socket | `socket.notify(sender, message)` | Store `ConnectInfo.self` from `init`; delivered later as `socket.Info(message)` |
-| Broadcast presence diff | `beryl.broadcast_presence_diff(sockets, topic, diff)` | Manual Phoenix-shaped `presence_diff`; ordinary socket/channel presence effects are applied asynchronously by the runtime |
+| Broadcast presence diff | `beryl.broadcast_presence_diff(sockets, topic, diff)` | Phoenix-shaped `presence_diff`; application diffs use cluster delivery, replica-view diffs stay node-local |
 
 The channel layer provides topic-scoped versions through ordered
 `channel.Action(Active)` lists. These actions include `push`, `broadcast`,

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -197,6 +197,12 @@ recent joins or leaves.
 
 3. **`on_diff` not broadcasting.** If clients rely on receiving `presence_diff` events, confirm `on_diff` is configured and calls `beryl.broadcast_presence_diff`. See the [Presence guide](/guides/presence).
 
+4. **Healthy clients receive false leaves.** Pass the original callback diff to
+   `beryl.broadcast_presence_diff`. Encoding it and calling a generic broadcast
+   loses its delivery scope. Replica-view diffs, including failure and recovery
+   decisions, must stay on the observing node; application mutations retain
+   cluster-wide delivery.
+
 ---
 
 ## Authentication failures


### PR DESCRIPTION
Closes #425.

- Track replica processes and hide remote presence entries when their actor or node becomes unavailable, while retaining the CRDT state needed for recovery.
- Restore visibility only after a fresh snapshot, and keep replica-view leave/join diffs local to the affected node so healthy peers do not receive false presence changes.
- Add separate-node coverage for actor failure, node failure, partitions, reconnects, and client-visible diff scope. All CI checks pass.
