### PR TITLE
fix(presence): fence stale incarnations and compact safely

### DIFF
--- a/.changes/unreleased/beryl-fence-stale-presence-incarnations.toml
+++ b/.changes/unreleased/beryl-fence-stale-presence-incarnations.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Fence stale presence incarnations and compact unavailable replica history safely after 60 seconds using fresh owner-only snapshots."

--- a/docs/talks/beryl-interview/deck.md
+++ b/docs/talks/beryl-interview/deck.md
@@ -575,7 +575,7 @@ result.
 
 Implementation notes (brief): the CRDT comes from the `lattice_presence`
 package. beryl wraps it in an OTP actor on each node. Initial and periodic
-requests exchange versioned **full CRDT snapshots**, including while replicas
+requests exchange versioned **full owner snapshots**, including while replicas
 are quiet. Peers merge them and report local/merge diffs through `with_on_diff`.
 Those replication payloads are not the client wire format. The app separately
 emits Phoenix-compatible `presence_state` / `presence_diff` joins/leaves maps,

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -9,6 +9,11 @@
 //// - Hides unavailable remote replicas without forgetting their causal state
 //// - Invokes `on_diff` when local changes or merges produce non-empty diffs
 ////
+//// Each actor owns its local entries. Remote snapshots are accepted only from
+//// a live owner answering an outstanding request, never through a relay.
+//// Unavailable state is retained for 60 seconds before safe compaction; see
+//// `with_pubsub` for the recovery and incarnation rules.
+////
 //// Presence is independent of the beryl runtime and runs under your
 //// application's supervision tree.
 ////
@@ -78,6 +83,13 @@ const sync_topic = "beryl:presence:sync"
 
 /// PubSub event name for presence sync messages
 const sync_event = "presence_sync"
+
+const replica_retention_ms = 60_000
+
+const retirement_check_interval_ms = 1000
+
+@external(erlang, "beryl_ffi", "monotonic_time_ms")
+fn monotonic_time_ms() -> Int
 
 /// A running Presence instance.
 ///
@@ -277,7 +289,7 @@ pub opaque type Config {
     /// from it (`base@suffix`), so restarting a node never reuses the
     /// previous incarnation's CRDT clocks; state from older incarnations
     /// of the same base is pruned automatically. Two *live* nodes sharing
-    /// a base will continuously prune each other — do not do that.
+    /// a base violate the ownership contract; concurrent reuse is unsupported.
     replica: String,
     /// How often to request snapshots for replication (ms). Non-positive
     /// values disable periodic requests, but not the initial exchange or replies.
@@ -357,6 +369,7 @@ pub opaque type Message {
   RemoteSync(pubsub_message: pubsub.Message(SyncPayload))
   RemoteSnapshot(reply: SyncReply)
   RemoteReplicaDown(down: process.Down)
+  RetirementTick
 }
 
 /// Acknowledgement of an asynchronous presence mutation.
@@ -512,11 +525,21 @@ type TrackedPresence {
 }
 
 type PendingSync {
-  PendingSync(request: Reference, round: Int)
+  PendingSync(request: Reference, round: Int, requested_at: Int)
+}
+
+type ReplicaAvailability {
+  Available(monitor: process.Monitor)
+  Unavailable(since: Int)
 }
 
 type ReplicaOwner {
-  ReplicaOwner(pid: process.Pid, monitor: Option(process.Monitor))
+  ReplicaOwner(
+    replica: String,
+    pid: process.Pid,
+    availability: ReplicaAvailability,
+    confirmed_round: Int,
+  )
 }
 
 type SyncState {
@@ -524,6 +547,7 @@ type SyncState {
     reply: Subject(SyncReply),
     requests: Dict(process.Pid, PendingSync),
     round: Int,
+    /// One confirmed incarnation per configured replica base.
     owners: Dict(String, ReplicaOwner),
   )
 }
@@ -575,6 +599,18 @@ pub fn default_config(replica: String) -> Config {
 /// A fresh snapshot from the same actor restores its current entries; a
 /// replacement actor starts a new incarnation. A partition can therefore hide
 /// sessions that remain connected to their local node.
+///
+/// Each snapshot contains only its sender's authoritative state. A receiver's
+/// request order, not a random suffix or message arrival order, determines
+/// whether a new incarnation can replace its known owner. Concurrent live
+/// actors sharing a replica base in one scope are unsupported.
+///
+/// A confirmed replacement retires its predecessor. Otherwise, unavailable
+/// state remains for 60 seconds, checked every second while the actor runs.
+/// Compaction invalidates outstanding requests. A returning actor must answer
+/// a new request with its current full local snapshot, so delayed replies and
+/// lagging peers cannot reintroduce compacted history. The retention check also
+/// runs when periodic snapshot requests are disabled. Actor work can delay it.
 pub fn with_pubsub(config: Config, pubsub: PubSub(SyncPayload)) -> Config {
   Config(..config, pubsub: Some(pubsub))
 }
@@ -708,8 +744,8 @@ fn build_presence(
   // name after a restart would reset its clocks while peers still remember
   // the old ones: new joins would be silently filtered as already-seen,
   // and the previous incarnation's entries would resurrect via merges.
-  // A unique per-start suffix makes every incarnation a distinct replica;
-  // `prune_superseded` cleans up the dead predecessors.
+  // A unique suffix separates clocks. Receiver-issued requests establish
+  // incarnation freshness; the suffix itself does not order actor starts.
   let crdt = state.new(incarnate_replica(config.replica))
 
   actor.new_with_initialiser(5000, fn(subject) {
@@ -771,6 +807,7 @@ fn build_presence(
           |> pubsub.selecting(subscriber, RemoteSync)
 
         process.send(subject, BroadcastTick)
+        schedule_retirement_tick(subject)
 
         actor.initialised(initial)
         |> actor.selecting(selector)
@@ -825,22 +862,22 @@ fn reconcile_membership(
   case actor_state.sync {
     None -> actor_state
     Some(sync) ->
-      dict.fold(sync.owners, actor_state, fn(actor_state, replica, owner) {
+      dict.fold(sync.owners, actor_state, fn(actor_state, base, owner) {
         case set.contains(members, owner.pid) {
           True -> actor_state
-          False -> hide_replica(actor_state, replica)
+          False -> hide_replica(actor_state, base)
         }
       })
   }
 }
 
-fn hide_replica(actor_state: ActorState, replica: String) -> ActorState {
+fn hide_replica(actor_state: ActorState, base: String) -> ActorState {
   case actor_state.sync {
     None -> actor_state
     Some(sync) ->
-      case dict.get(sync.owners, replica) {
-        Error(Nil) | Ok(ReplicaOwner(_, None)) -> actor_state
-        Ok(ReplicaOwner(pid, Some(monitor))) -> {
+      case dict.get(sync.owners, base) {
+        Error(Nil) | Ok(ReplicaOwner(_, _, Unavailable(_), _)) -> actor_state
+        Ok(ReplicaOwner(replica, pid, Available(monitor), round)) -> {
           process.demonitor_process(monitor)
           let #(crdt, _diff) = state.replica_down(actor_state.crdt, replica)
           commit_replication(
@@ -852,8 +889,13 @@ fn hide_replica(actor_state: ActorState, replica: String) -> ActorState {
                   requests: dict.delete(sync.requests, pid),
                   owners: dict.insert(
                     sync.owners,
-                    replica,
-                    ReplicaOwner(pid, None),
+                    base,
+                    ReplicaOwner(
+                      replica,
+                      pid,
+                      Unavailable(monotonic_time_ms()),
+                      round,
+                    ),
                   ),
                 ),
               ),
@@ -871,9 +913,9 @@ fn handle_replica_down(
 ) -> ActorState {
   case actor_state.sync, down {
     Some(sync), process.ProcessDown(monitor, pid, _) ->
-      dict.fold(sync.owners, actor_state, fn(actor_state, replica, owner) {
-        case owner.pid == pid && owner.monitor == Some(monitor) {
-          True -> hide_replica(actor_state, replica)
+      dict.fold(sync.owners, actor_state, fn(actor_state, base, owner) {
+        case owner.pid == pid && owner.availability == Available(monitor) {
+          True -> hide_replica(actor_state, base)
           False -> actor_state
         }
       })
@@ -885,30 +927,96 @@ fn watch_replica(
   actor_state: ActorState,
   replica: String,
   pid: process.Pid,
+  round: Int,
 ) -> ActorState {
   case actor_state.sync {
     None -> actor_state
-    Some(sync) ->
-      case dict.get(sync.owners, replica) {
-        Ok(ReplicaOwner(owner, Some(_))) if owner == pid -> actor_state
-        previous -> {
-          case previous {
-            Ok(ReplicaOwner(_, Some(monitor))) ->
-              process.demonitor_process(monitor)
-            Ok(ReplicaOwner(_, None)) | Error(Nil) -> Nil
-          }
-          let owner = ReplicaOwner(pid, Some(process.monitor(pid)))
-          ActorState(
-            ..actor_state,
-            sync: Some(
-              SyncState(
-                ..sync,
-                owners: dict.insert(sync.owners, replica, owner),
-              ),
-            ),
-          )
+    Some(sync) -> {
+      let base = base_replica(replica)
+      let previous = dict.get(sync.owners, base)
+      let monitor = case previous {
+        Ok(ReplicaOwner(_, old_pid, Available(monitor), _)) if old_pid == pid ->
+          monitor
+        Ok(ReplicaOwner(_, _, Available(monitor), _)) -> {
+          process.demonitor_process(monitor)
+          process.monitor(pid)
         }
+        Ok(ReplicaOwner(_, _, Unavailable(_), _)) | Error(Nil) ->
+          process.monitor(pid)
       }
+      let requests = case previous {
+        Ok(previous) if previous.pid != pid ->
+          dict.delete(sync.requests, previous.pid)
+        Ok(_) | Error(Nil) -> sync.requests
+      }
+      ActorState(
+        ..actor_state,
+        sync: Some(
+          SyncState(
+            ..sync,
+            requests: requests,
+            owners: dict.insert(
+              sync.owners,
+              base,
+              ReplicaOwner(replica, pid, Available(monitor), round),
+            ),
+          ),
+        ),
+      )
+    }
+  }
+}
+
+fn schedule_retirement_tick(subject: Subject(Message)) -> Nil {
+  let _timer =
+    process.send_after(subject, retirement_check_interval_ms, RetirementTick)
+  Nil
+}
+
+fn retire_unavailable(actor_state: ActorState) -> ActorState {
+  let members = case actor_state.config.pubsub {
+    Some(pubsub_instance) ->
+      pubsub.subscribers(pubsub_instance, sync_topic) |> set.from_list
+    None -> set.new()
+  }
+  let actor_state = reconcile_membership(actor_state, members)
+  case actor_state.sync {
+    None -> actor_state
+    Some(sync) -> {
+      let now = monotonic_time_ms()
+      let sync =
+        SyncState(
+          ..sync,
+          requests: dict.filter(sync.requests, fn(pid, pending) {
+            set.contains(members, pid)
+            || now - pending.requested_at < replica_retention_ms
+          }),
+        )
+      let actor_state = ActorState(..actor_state, sync: Some(sync))
+      let retired =
+        dict.filter(sync.owners, fn(_base, owner) {
+          case owner.availability {
+            Available(_) -> False
+            Unavailable(since) -> now - since >= replica_retention_ms
+          }
+        })
+      use <- bool.guard(when: dict.is_empty(retired), return: actor_state)
+      let crdt =
+        dict.fold(retired, actor_state.crdt, fn(crdt, _base, owner) {
+          compact_replica(crdt, owner.replica)
+        })
+      let owners =
+        dict.fold(retired, sync.owners, fn(owners, base, _) {
+          dict.delete(owners, base)
+        })
+      // Dropping a base's freshness record is safe only after revoking every
+      // pre-compaction reply, including requests to unconfirmed old owners.
+      ActorState(
+        ..actor_state,
+        crdt: crdt,
+        sync: Some(SyncState(..sync, owners: owners, requests: dict.new())),
+      )
+    }
   }
 }
 
@@ -921,7 +1029,9 @@ fn request_snapshot(
   let round = sync.round + 1
   let pending =
     dict.get(sync.requests, member)
-    |> result.lazy_unwrap(fn() { PendingSync(reference.new(), round) })
+    |> result.lazy_unwrap(fn() {
+      PendingSync(reference.new(), round, monotonic_time_ms())
+    })
   pubsub.send_to(
     pubsub_instance,
     member,
@@ -962,9 +1072,7 @@ const incarnation_separator = "@"
 
 /// Derive a unique incarnation name for this actor start.
 fn incarnate_replica(base: String) -> String {
-  base
-  <> incarnation_separator
-  <> bit_array.base16_encode(crypto.strong_random_bytes(4))
+  base <> incarnation_separator <> generate_ref()
 }
 
 /// Recover the configured base from an incarnation-qualified replica name.
@@ -981,20 +1089,20 @@ fn base_replica(replica: String) -> String {
   }
 }
 
-/// Replacement handling is separate from liveness-only replica_down changes,
-/// which hide entries without deleting causal history.
-fn prune_superseded(crdt: State, live: List(String)) -> State {
-  let stale =
-    dict.keys(state.compacted_clocks(crdt))
-    |> list.filter(fn(replica) {
-      list.any(live, fn(live_replica) {
-        replica != live_replica
-        && base_replica(replica) == base_replica(live_replica)
-      })
-    })
-  list.fold(stale, crdt, fn(crdt, replica) {
-    let #(crdt, _diff) = state.replica_down(crdt, replica)
-    state.remove_down_replica(crdt, replica)
+fn compact_replica(crdt: State, replica: String) -> State {
+  let #(crdt, _diff) = state.replica_down(crdt, replica)
+  state.remove_down_replica(crdt, replica)
+}
+
+/// Full-state beryl snapshots have a compacted clock for every entry owner.
+/// Use the dependency's lifecycle API rather than its opaque representation.
+fn owner_snapshot(crdt: State) -> State {
+  dict.keys(state.compacted_clocks(crdt))
+  |> list.fold(crdt, fn(crdt, replica) {
+    case replica == state.replica(crdt) {
+      True -> crdt
+      False -> compact_replica(crdt, replica)
+    }
   })
 }
 
@@ -1447,6 +1555,13 @@ fn handle_message(
     RemoteSnapshot(reply) -> handle_snapshot(actor_state, reply)
     RemoteReplicaDown(down) ->
       actor.continue(handle_replica_down(actor_state, down))
+    RetirementTick -> {
+      case actor_state.self_subject {
+        Some(subject) -> schedule_retirement_tick(subject)
+        None -> Nil
+      }
+      actor.continue(retire_unavailable(actor_state))
+    }
   }
 }
 
@@ -1800,7 +1915,7 @@ fn handle_sync_payload(
         SyncReply(
           request: payload.request,
           owner: process.self(),
-          state: actor_state.crdt,
+          state: owner_snapshot(actor_state.crdt),
         ),
       )
       case payload.request_back {
@@ -1866,6 +1981,7 @@ fn handle_snapshot(
               ),
             ),
             reply.owner,
+            pending.round,
             reply.state,
           )
         // Duplicates and replies to requests cancelled by membership loss.
@@ -1877,6 +1993,7 @@ fn handle_snapshot(
 fn merge_remote_sync(
   actor_state: ActorState,
   owner: process.Pid,
+  round: Int,
   remote_state: State,
 ) -> actor.Next(ActorState, Message) {
   // Crash boundary — see internal.rescue. Version skew or bugs can produce
@@ -1886,15 +2003,29 @@ fn merge_remote_sync(
   let processed =
     internal.rescue(fn() {
       let sender = state.replica(remote_state)
-      let new_crdt =
-        state.merge(actor_state.crdt, remote_state)
-        |> apply_replica_visibility(actor_state.sync, sender)
-        |> prune_superseded([sender, state.replica(actor_state.crdt)])
-      #(commit_replication(actor_state, new_crdt), sender)
+      case accepts_snapshot(actor_state, sender, owner, round) {
+        False -> {
+          log.debug(
+            internal.logger("beryl.presence"),
+            "Ignored stale presence incarnation",
+            [
+              #("replica", sender),
+            ],
+          )
+          None
+        }
+        True -> {
+          let crdt = retire_predecessor(actor_state, sender)
+          let crdt = state.merge(crdt, owner_snapshot(remote_state))
+          let #(crdt, _diff) = state.replica_up(crdt, sender)
+          Some(#(commit_replication(actor_state, crdt), sender))
+        }
+      }
     })
   case processed {
-    Ok(#(next_state, sender)) ->
-      actor.continue(watch_replica(next_state, sender, owner))
+    Ok(Some(#(next_state, sender))) ->
+      actor.continue(watch_replica(next_state, sender, owner, round))
+    Ok(None) -> actor.continue(actor_state)
     Error(crash) -> {
       let logger = internal.logger("beryl.presence")
       logger
@@ -1906,30 +2037,36 @@ fn merge_remote_sync(
   }
 }
 
-fn apply_replica_visibility(
-  crdt: State,
-  sync: Option(SyncState),
+fn accepts_snapshot(
+  actor_state: ActorState,
   sender: String,
-) -> State {
-  dict.keys(state.compacted_clocks(crdt))
-  |> list.fold(crdt, fn(crdt, replica) {
-    let available =
-      replica == state.replica(crdt)
-      || replica == sender
-      || case sync {
-        None -> False
-        Some(sync) ->
-          case dict.get(sync.owners, replica) {
-            Ok(ReplicaOwner(_, Some(_))) -> True
-            Ok(ReplicaOwner(_, None)) | Error(Nil) -> False
-          }
+  owner: process.Pid,
+  round: Int,
+) -> Bool {
+  let base = base_replica(sender)
+  base != base_replica(state.replica(actor_state.crdt))
+  && case actor_state.sync {
+    None -> False
+    Some(sync) ->
+      case dict.get(sync.owners, base) {
+        Error(Nil) -> True
+        Ok(current) ->
+          { current.replica == sender && current.pid == owner }
+          || round > current.confirmed_round
       }
-    let #(crdt, _diff) = case available {
-      True -> state.replica_up(crdt, replica)
-      False -> state.replica_down(crdt, replica)
-    }
-    crdt
-  })
+  }
+}
+
+fn retire_predecessor(actor_state: ActorState, sender: String) -> State {
+  case actor_state.sync {
+    None -> actor_state.crdt
+    Some(sync) ->
+      case dict.get(sync.owners, base_replica(sender)) {
+        Ok(previous) if previous.replica != sender ->
+          compact_replica(actor_state.crdt, previous.replica)
+        Ok(_) | Error(Nil) -> actor_state.crdt
+      }
+  }
 }
 
 fn commit_replication(actor_state: ActorState, crdt: State) -> ActorState {

--- a/packages/beryl/test/beryl_presence_distributed_test.erl
+++ b/packages/beryl/test/beryl_presence_distributed_test.erl
@@ -1,8 +1,10 @@
 -module(beryl_presence_distributed_test).
 -include_lib("eunit/include/eunit.hrl").
 -export([start_replica/3, view/1, sync_round/1, kill_replica/1,
-         begin_outage/1, end_outage/1, take_diffs/1, diff_history/1,
-         retained/1, replica/1]).
+         begin_outage/1, end_outage/1, diff_history/1,
+         retained/1, replica/1, crdt/1, request_round/1, pending_request/2,
+         start_reply_gate/1, held_reply_count/1, release_replies/1,
+         start_lagging_replica/2, start_held_replica/2, legacy_snapshot/1]).
 
 -define(TOPIC, <<"room:distributed">>).
 -define(SYNC_TOPIC, <<"beryl:presence:sync">>).
@@ -238,6 +240,154 @@ partition_retains_history_and_rejoins_current_state_test_() ->
         end)
     end}.
 
+old_inflight_reply_cannot_evict_replacement_test_() ->
+    {timeout, 30, fun() ->
+        with_peers(2, fun([A, B]) ->
+            {Old, _New, Receiver, Proxy, _CurrentRef} = held_predecessor(A, B),
+            ?assert(call(B, ?MODULE, pending_request, [Receiver, maps:get(pid, Old)])),
+            nil = call(B, ?MODULE, release_replies, [Proxy]),
+            ?assertNot(call(B, ?MODULE, pending_request,
+                [Receiver, maps:get(pid, Old)])),
+            nil = call(B, ?MODULE, legacy_snapshot, [Receiver]),
+            await_view(B, Receiver, [<<"current">>]),
+            await_diff(B, Receiver, joins, [<<"current">>]),
+            await_diff(B, Receiver, leaves, [])
+        end)
+    end}.
+
+lagging_peer_cannot_restore_retired_history_test_() ->
+    {timeout, 30, fun() ->
+        with_peers(3, fun([A, B, C]) ->
+            connect(A, B),
+            Old = start(A, <<"source">>, 0),
+            Receiver = start(B, <<"receiver">>, 30),
+            {ok, _} = track(A, Old, <<"old">>),
+            await_view(B, Receiver, [<<"old">>]),
+            OldState = call(A, ?MODULE, crdt, [Old]),
+            OldReplica = call(A, ?MODULE, replica, [Old]),
+            nil = call(A, ?MODULE, kill_replica, [Old]),
+            Current = start(A, <<"source">>, 0),
+            {ok, _} = track(A, Current, <<"current">>),
+            await_view(B, Receiver, [<<"current">>]),
+            #{clocks := Before} = call(B, ?MODULE, retained, [Receiver]),
+            ?assertNot(maps:is_key(OldReplica, Before)),
+            %% A third BEAM node speaks the original v2 full-state protocol.
+            %% Its valid reply includes a retired replica's values and clocks.
+            _LegacyPid = call(C, ?MODULE, start_lagging_replica, [?SCOPE, OldState]),
+            connect(B, C),
+            await_view(B, Receiver, [<<"current">>, <<"lagging">>]),
+            #{clocks := After, entries := 2} =
+                call(B, ?MODULE, retained, [Receiver]),
+            ?assertNot(maps:is_key(OldReplica, After)),
+            await_diff(B, Receiver, leaves, [<<"old">>])
+        end)
+    end}.
+
+retirement_revokes_old_replies_and_requires_fresh_rejoin_test_() ->
+    {timeout, 90, fun() ->
+        with_peers(2, fun([A, B]) ->
+            {Old, Current, Receiver, Proxy, CurrentRef} = held_predecessor(A, B),
+            OldPid = maps:get(pid, Old),
+            CurrentReplica = call(A, ?MODULE, replica, [Current]),
+            PendingScope = <<"beryl_presence_unconfirmed_retirement_test">>,
+            PendingOnly = call(B, ?MODULE, start_replica,
+                [PendingScope, <<"pending-only">>, 0]),
+            PendingGate = call(B, ?MODULE, start_reply_gate, [PendingOnly]),
+            Unconfirmed = call(A, ?MODULE, start_held_replica,
+                [PendingScope, PendingGate]),
+            UnconfirmedPid = maps:get(pid, Unconfirmed),
+            await_member(B, PendingScope, UnconfirmedPid),
+            nil = call(B, ?MODULE, request_round, [PendingOnly]),
+            await({unconfirmed_reply, element(2, B)}, fun() ->
+                call(B, ?MODULE, held_reply_count, [PendingGate]) > 0
+            end),
+            nil = call(A, ?MODULE, kill_replica, [Unconfirmed]),
+            ?assert(call(B, ?MODULE, pending_request, [PendingOnly, UnconfirmedPid])),
+            {ok, _} = track(B, Receiver, <<"local">>),
+            Started = call(B, erlang, monotonic_time, [millisecond]),
+            disconnect(A, B),
+            await_view(B, Receiver, [<<"local">>]),
+            #{clocks := Retained, entries := 2} =
+                call(B, ?MODULE, retained, [Receiver]),
+            ?assert(maps:is_key(CurrentReplica, Retained)),
+            ?assert(call(B, ?MODULE, pending_request, [Receiver, OldPid])),
+            {ok, nil} = presence_call(A, untrack, [handle(Current), CurrentRef]),
+            {ok, _} = track(A, Current, <<"after-retention">>),
+            %% Exercise the real 60-second policy, including with periodic
+            %% requests disabled. No clock rewriting or shortened test TTL.
+            await({retirement, element(2, B)}, fun() ->
+                #{clocks := Clocks, owners := Owners} =
+                    call(B, ?MODULE, retained, [Receiver]),
+                Owners =:= 0 andalso not maps:is_key(CurrentReplica, Clocks)
+            end, 70000),
+            Elapsed = call(B, erlang, monotonic_time, [millisecond]) - Started,
+            ?assert(Elapsed >= 60000),
+            ?assertNot(call(B, ?MODULE, pending_request, [Receiver, OldPid])),
+            ?assertNot(call(B, ?MODULE, pending_request,
+                [PendingOnly, UnconfirmedPid])),
+            nil = call(B, ?MODULE, release_replies, [PendingGate]),
+            await_view(B, PendingOnly, []),
+            nil = call(B, ?MODULE, release_replies, [Proxy]),
+            await_view(B, Receiver, [<<"local">>]),
+            await_diff(B, Receiver, leaves, [<<"current">>]),
+            connect(A, B),
+            await_member(A, maps:get(pid, Receiver)),
+            await_member(B, maps:get(pid, Current)),
+            nil = call(A, ?MODULE, request_round, [Current]),
+            await_view(B, Receiver, [<<"after-retention">>, <<"local">>]),
+            await_diff(B, Receiver, joins,
+                [<<"after-retention">>, <<"current">>, <<"local">>]),
+            await_diff(B, Receiver, leaves, [<<"current">>]),
+            ?assertEqual(CurrentReplica, call(A, ?MODULE, replica, [Current]))
+        end)
+    end}.
+
+restart_churn_keeps_one_incarnation_per_base_test_() ->
+    {timeout, 30, fun() ->
+        with_peers(2, fun([A, B]) ->
+            connect(A, B),
+            Source = start(A, <<"source@slot">>, 0),
+            Receiver = start(B, <<"receiver">>, 30),
+            {ok, _} = track(A, Source, <<"initial">>),
+            await_view(B, Receiver, [<<"initial">>]),
+            _Last = lists:foldl(fun(Index, Previous) ->
+                nil = call(A, ?MODULE, kill_replica, [Previous]),
+                Current = start(A, <<"source@slot">>, 0),
+                Key = <<"generation-", (integer_to_binary(Index))/binary>>,
+                {ok, _} = track(A, Current, Key),
+                await_view(B, Receiver, [Key]),
+                #{clocks := Clocks, entries := 1, owners := 1} =
+                    call(B, ?MODULE, retained, [Receiver]),
+                ?assertEqual(1, map_size(Clocks)),
+                Current
+            end, Source, lists:seq(1, 8))
+        end)
+    end}.
+
+held_predecessor(A, B) ->
+    %% A protocol peer sends its valid reply into an in-flight gate on B.
+    %% The old PID can die before that reply reaches the presence mailbox.
+    Receiver = start(B, <<"receiver">>, 0),
+    Proxy = call(B, ?MODULE, start_reply_gate, [Receiver]),
+    Old = call(A, ?MODULE, start_held_replica, [?SCOPE, Proxy]),
+    await({initial_round, element(2, B)}, fun() ->
+        call(B, ?MODULE, sync_round, [Receiver]) > 0
+    end),
+    connect(A, B),
+    await_member(A, maps:get(pid, Receiver)),
+    await_member(B, maps:get(pid, Old)),
+    nil = call(B, ?MODULE, request_round, [Receiver]),
+    await({held_old_reply, element(2, B)}, fun() ->
+        call(B, ?MODULE, held_reply_count, [Proxy]) > 0
+    end),
+    nil = call(A, ?MODULE, kill_replica, [Old]),
+    Current = start(A, <<"source">>, 0),
+    {ok, CurrentRef} = track(A, Current, <<"current">>),
+    await_member(B, maps:get(pid, Current)),
+    nil = call(A, ?MODULE, request_round, [Current]),
+    await_view(B, Receiver, [<<"current">>]),
+    {Old, Current, Receiver, Proxy, CurrentRef}.
+
 %% The control channel is standard I/O, not distribution. Polling a partitioned
 %% peer therefore cannot reconnect the nodes under test. Linked controllers and
 %% nested after blocks also clean up nodes when boot or an assertion fails.
@@ -267,7 +417,10 @@ presence_call(Peer, Function, Arguments) ->
     call(Peer, 'beryl@presence', Function, Arguments).
 
 presence_pubsub(Peer) ->
-    Config = call(Peer, 'beryl@pubsub', config_with_scope, [?SCOPE]),
+    presence_pubsub(Peer, ?SCOPE).
+
+presence_pubsub(Peer, Scope) ->
+    Config = call(Peer, 'beryl@pubsub', config_with_scope, [Scope]),
     call(Peer, 'beryl@pubsub', start, [Config]).
 
 connect(A, {_Controller, Node} = B) ->
@@ -372,10 +525,106 @@ sync_round(#{pid := Pid}) ->
 replica(#{pid := Pid}) ->
     'lattice_presence@presence_state':replica(element(2, sys:get_state(Pid))).
 
+crdt(#{pid := Pid}) ->
+    element(2, sys:get_state(Pid)).
+
 retained(#{pid := Pid}) ->
-    Crdt = element(2, sys:get_state(Pid)),
+    Actor = sys:get_state(Pid),
+    Crdt = element(2, Actor),
+    {some, Sync} = element(5, Actor),
     #{clocks => 'lattice_presence@presence_state':compacted_clocks(Crdt),
-      entries => 'lattice_presence@presence_state':entry_count(Crdt)}.
+      entries => 'lattice_presence@presence_state':entry_count(Crdt),
+      owners => map_size(element(5, Sync))}.
+
+request_round(#{handle := Presence, pid := Pid}) ->
+    'gleam@erlang@process':send('beryl@presence':subject(Presence), broadcast_tick),
+    _ = sys:get_state(Pid),
+    nil.
+
+pending_request(#{pid := Pid}, Owner) ->
+    {some, Sync} = element(5, sys:get_state(Pid)),
+    maps:is_key(Owner, element(3, Sync)).
+
+start_reply_gate(#{pid := Pid}) ->
+    spawn(fun() -> reply_proxy(Pid, []) end).
+
+reply_proxy(Target, Held) ->
+    receive
+        {hold_reply, Subject, Reply = {sync_reply, _Request, _Owner, _State}} ->
+            reply_proxy(Target, [{Subject, Reply} | Held]);
+        {held_reply_count, Caller, Ref} ->
+            Caller ! {Ref, length(Held)},
+            reply_proxy(Target, Held);
+        {release_replies, Caller, Ref} ->
+            lists:foreach(fun({Subject, Reply}) ->
+                'gleam@erlang@process':send(Subject, Reply)
+            end, lists:reverse(Held)),
+            %% Same-sender barrier: the target processes the delayed replies
+            %% before the test checks its final state and callback history.
+            _ = sys:get_state(Target),
+            Caller ! {Ref, nil},
+            reply_proxy(Target, [])
+    end.
+
+held_reply_count(Proxy) -> proxy_call(Proxy, held_reply_count).
+release_replies(Proxy) -> proxy_call(Proxy, release_replies).
+
+proxy_call(Proxy, Operation) ->
+    Ref = make_ref(),
+    Proxy ! {Operation, self(), Ref},
+    receive {Ref, Reply} -> Reply
+    after 5000 -> error({reply_proxy_timeout, Operation})
+    end.
+
+start_lagging_replica(Scope, RemoteState) ->
+    Local = 'lattice_presence@presence_state':new(<<"lagging@legacy">>),
+    Merged = 'lattice_presence@presence_state':merge(Local, RemoteState),
+    State = 'lattice_presence@presence_state':join(
+        Merged, <<"lagging">>, ?TOPIC, <<"lagging">>, 'gleam@json':null()),
+    start_snapshot_replica(Scope, State, direct).
+
+start_held_replica(Scope, Gate) ->
+    Local = 'lattice_presence@presence_state':new(<<"source@held">>),
+    State = 'lattice_presence@presence_state':join(
+        Local, <<"old">>, ?TOPIC, <<"old">>, 'gleam@json':null()),
+    #{pid => start_snapshot_replica(Scope, State, {held, Gate})}.
+
+start_snapshot_replica(Scope, State, Delivery) ->
+    Parent = self(),
+    Ref = make_ref(),
+    Pid = spawn(fun() ->
+        PubSub = 'beryl@pubsub':start('beryl@pubsub':config_with_scope(Scope)),
+        Subscriber = 'beryl@pubsub':subscriber(PubSub),
+        nil = 'beryl@pubsub':join(Subscriber, ?SYNC_TOPIC),
+        Parent ! {Ref, ready},
+        snapshot_replica(binary_to_existing_atom(Scope, utf8), State, Delivery)
+    end),
+    receive {Ref, ready} -> Pid
+    after 5000 -> error(lagging_replica_start_timeout)
+    end.
+
+snapshot_replica(Scope, State, Delivery) ->
+    receive
+        {Scope, ?SYNC_TOPIC, <<"presence_sync">>,
+         {sync_payload, 2, Request, Reply, _RequestBack}, {from_pid, _Sender}} ->
+            Snapshot = {sync_reply, Request, self(), State},
+            case Delivery of
+                direct -> 'gleam@erlang@process':send(Reply, Snapshot);
+                {held, Gate} -> Gate ! {hold_reply, Reply, Snapshot}
+            end,
+            snapshot_replica(Scope, State, Delivery)
+    end.
+
+legacy_snapshot(#{pid := Pid}) ->
+    State = 'lattice_presence@presence_state':new(<<"source@legacy">>),
+    Snapshot = 'lattice_presence@presence_state':join(
+        State, <<"legacy">>, ?TOPIC, <<"legacy">>, 'gleam@json':null()),
+    nil = beryl_pubsub_ffi:send_to_pid(
+        Pid, binary_to_existing_atom(?SCOPE, utf8),
+        {message, ?SYNC_TOPIC, <<"presence_sync">>,
+         {sync_payload, 1, <<"source@legacy">>, Snapshot}, system}),
+    _ = sys:get_state(Pid),
+    nil.
 
 await_round(Peer, Instance) ->
     Before = call(Peer, ?MODULE, sync_round, [Instance]),
@@ -388,6 +637,16 @@ await_members(Peer, Count) ->
     await({pg_members, element(2, Peer), Count}, fun() ->
         call(Peer, 'beryl@pubsub', subscriber_count, [PubSub, ?SYNC_TOPIC])
             =:= Count
+    end).
+
+await_member(Peer, Pid) ->
+    await_member(Peer, ?SCOPE, Pid).
+
+await_member(Peer, Scope, Pid) ->
+    PubSub = presence_pubsub(Peer, Scope),
+    await({pg_member, element(2, Peer), Pid}, fun() ->
+        lists:member(Pid,
+            call(Peer, 'beryl@pubsub', subscribers, [PubSub, ?SYNC_TOPIC]))
     end).
 
 await_view(Peer, Instance, Keys) ->
@@ -405,7 +664,10 @@ await_diff(Peer, Instance, Kind, Keys) ->
     end).
 
 await(Phase, Check) ->
-    try 'test_helper':wait_until(Check, 5000, 10)
+    await(Phase, Check, 5000).
+
+await(Phase, Check, Timeout) ->
+    try 'test_helper':wait_until(Check, Timeout, 10)
     catch
         error:Reason:Stack -> erlang:raise(error, {Phase, Reason}, Stack)
     end.
@@ -432,19 +694,9 @@ end_outage(Supervisor) ->
 collect_diffs(Diffs) ->
     receive
         {presence_diff, Diff} -> collect_diffs([Diff | Diffs]);
-        {take_diffs, Caller, Ref} ->
-            Caller ! {Ref, lists:reverse(Diffs)},
-            collect_diffs([]);
         {diff_history, Caller, Ref} ->
             Caller ! {Ref, lists:reverse(Diffs)},
             collect_diffs(Diffs)
-    end.
-
-take_diffs(#{collector := Collector}) ->
-    Ref = make_ref(),
-    Collector ! {take_diffs, self(), Ref},
-    receive {Ref, Diffs} -> Diffs
-    after 5000 -> error(diff_collector_timeout)
     end.
 
 diff_history(#{collector := Collector}) ->

--- a/website/src/content/docs/architecture/presence.md
+++ b/website/src/content/docs/architecture/presence.md
@@ -7,8 +7,10 @@ title: Presence
 beryl presence uses an OTP actor and an **add-wins, observed-remove
 conflict-free replicated data type (CRDT)** from
 [`lattice_presence/presence_state`](https://hex.pm/packages/lattice_presence).
-Each cluster node keeps one copy. Nodes can merge their copies in any order.
-Joins and leaves that happen at the same time produce the same final result.
+Each actor owns its local entries and accepts full snapshots from the other
+owners it can reach. Causal merge handles repeated and reordered snapshots
+within an incarnation. Admission and retirement rules determine which
+incarnations may contribute state.
 
 Each tracked entry has a **replica name**, set by the `replica` argument to
 `default_config/1`. Use a unique name for each cluster node. The CRDT uses this
@@ -103,9 +105,10 @@ at startup and then at the configured interval, which defaults to 1500 ms:
    The actor sends each other member a request with a unique ref and a reply
    subject. It keeps one outstanding ref per member and retries unanswered
    requests, so a slow reply can span multiple ticks.
-2. Each member replies directly with its full CRDT state, even when it has no
-   new mutations. The requester accepts only a reply to that member's current
-   request, merges it with `state.merge_with_diff`, and updates its read model.
+2. Each member replies with its own entries and causal context, even when it
+   has no new mutations. The requester accepts only a reply to that member's
+   current request, removes any forwarded replica state, merges the owner's
+   snapshot, and updates its read model.
    A request permits one reciprocal request, so a replica with its periodic
    timer disabled can still receive updates. Reciprocal requests do not repeat.
 3. If the merge changes membership, the actor calls `on_diff` with the
@@ -115,7 +118,10 @@ at startup and then at the configured interval, which defaults to 1500 ms:
 This repairs late joins, missed delivery, and restored `pg` membership without
 an unrelated application mutation. The interval is a retry cadence, not a
 convergence deadline: membership propagation, network delivery, and actor work
-can take longer. Repair requires continued successful exchanges.
+can take longer. Repair requires continued successful exchanges. Replicas need
+direct Erlang distribution connections and shared `pg` membership to see each
+other; an intermediate peer does not extend remote visibility across a
+partition.
 
 Use `with_broadcast_interval(0)` to disable periodic requests. The initial
 request and replies to peers still run, but quiet recovery is not guaranteed.
@@ -135,11 +141,12 @@ distributed PubSub and presence matrix.
 After a successful snapshot exchange, beryl associates the replica identity
 with the source actor's PID and monitors that process. A process exit or an
 Erlang distribution disconnection hides that replica's entries and emits
-matching leave diffs. Each repair tick also checks `pg` membership, so scope
-recovery or membership loss can hide an actor that still runs.
+matching leave diffs. Repair and retention ticks also check `pg` membership,
+so scope recovery or membership loss can hide an actor that still runs.
 
 beryl uses the CRDT's `replica_down` for these local visibility changes.
-It retains the entries and causal context. Peer snapshots cannot make an
+It retains the entries and causal context during the retention window below.
+Peer snapshots cannot make an
 unavailable or unconfirmed replica visible. Diffs compare the visible state
 before and after the complete transition, so removing a hidden entry does
 not emit a second leave.
@@ -168,6 +175,48 @@ tracking refs. Clients must re-track their local presence. Failure detection
 depends on Erlang process/distribution signals and actor progress; the repair
 interval does not bound node-failure detection time.
 
+## Incarnation freshness and retirement
+
+Use one live actor per replica base in a scope. The per-start random suffix
+separates CRDT clocks; it does not prove which incarnation is newer.
+
+The receiver orders its own snapshot requests and keeps one confirmed owner
+per base. A different incarnation can replace that owner only by answering a
+later-issued request. An old process cannot answer a request issued after its
+replacement started. A delayed answer to an older request cannot displace the
+confirmed replacement, even if the receiver had never confirmed the old
+process. Concurrent live actors with one base violate this ownership rule.
+
+beryl uses the CRDT's `replica_down` and `remove_down_replica` operations with
+these compaction conditions:
+
+1. A confirmed replacement retires the previous incarnation's values and
+   causal context. The receiver also removes its owner monitor and pending
+   request.
+2. Without a replacement, beryl retains an unavailable owner's state for
+   **60 seconds**. A separate **one-second** tick checks retention, even with
+   periodic snapshot requests disabled. Unanswered requests to missing members
+   also expire after 60 seconds. Actor work can delay this check.
+3. Before forgetting an unavailable owner's freshness record, beryl revokes
+   **all outstanding snapshot requests**. A returning owner must answer a new
+   request with its current full local snapshot. Delayed replies from before
+   compaction no longer match a request.
+
+The 60-second limit alone would not make forgetting causal history safe.
+beryl also rejects unsolicited snapshots and removes forwarded owners' entries
+and clocks from accepted snapshots. A lagging third peer therefore cannot
+restore retired state. A long partition can expire the receiver's retained
+history; the source still owns its current entries and clocks and supplies
+them through a fresh exchange on reconnect.
+
+This policy retains at most one confirmed incarnation per base, and keeps
+unavailable history only for the retention window plus the next runnable
+check. It does not impose a global memory bound on peer count, entry count,
+metadata size, or work blocked in callbacks. Each reply copies the source's
+owned entries; projecting a snapshot with the dependency's lifecycle API also
+scans retained state. See [#400](https://github.com/tylerbutler/beryl/issues/400)
+for broader replication-cost measurements.
+
 ## Request and sync flow
 
 ```mermaid
@@ -186,7 +235,7 @@ sequenceDiagram
   loop every broadcast_interval
     Pres->>PS: request snapshots from current members
     PS-->>Remote: snapshot request
-    Remote-->>Pres: requested CRDT snapshot
+    Remote-->>Pres: requested owner snapshot
   end
   Pres->>Pres: merge -> diff
   Pres-->>App: on_diff(diff)

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -272,7 +272,7 @@ global publisher must move application-change publishing to the source.
 
 When you configure PubSub, the presence actor:
 
-1. Requests full CRDT snapshots from the current `pg` members at startup and
+1. Requests full owner snapshots from the current `pg` members at startup and
    every configured interval (1500 ms by default).
 2. Replies to peer requests even when local state has not changed.
 3. Merges remote state with the AWORSet merge algorithm.
@@ -291,10 +291,19 @@ presence scope together. The outer PubSub wire format has not changed.
 Remote entries disappear, with leave diffs, when beryl detects their actor
 exit, node disconnection, or loss of sync-group membership. This also applies
 to temporary partitions: your local sessions remain available, but peers can
-show them as offline. beryl retains causal history while they are unavailable.
+show them as offline. beryl retains their causal history for 60 seconds.
 A fresh snapshot after reconnect restores the source actor's current entries,
 without first exposing obsolete retained entries. See
 [replica availability](/architecture/presence/#replica-availability).
+
+Use one live actor per replica base. beryl orders receiver-issued requests to
+reject delayed old-incarnation replies, and accepts only the answering
+owner's entries and clocks. A confirmed replacement retires its predecessor.
+After the retention window, beryl invalidates outstanding requests before
+compacting unavailable history; a returning actor must provide a new full
+snapshot. See [safe retirement](/architecture/presence/#incarnation-freshness-and-retirement)
+for the conditions and bounds. Remote visibility requires a direct node
+connection, not a snapshot relayed by another peer.
 
 The underlying CRDT state is intentionally internal. Applications should use PubSub replication rather than constructing or merging raw presence state values.
 

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -25,6 +25,11 @@ Distributed presence tracking with a CRDT
  - Hides unavailable remote replicas without forgetting their causal state
  - Invokes `on_diff` when local changes or merges produce non-empty diffs
 
+ Each actor owns its local entries. Remote snapshots are accepted only from
+ a live owner answering an outstanding request, never through a relay.
+ Unavailable state is retained for 60 seconds before safe compaction; see
+ `with_pubsub` for the recovery and incarnation rules.
+
  Presence is independent of the beryl runtime and runs under your
  application's supervision tree.
 
@@ -622,6 +627,18 @@ Enable PubSub replication for presence.
  A fresh snapshot from the same actor restores its current entries; a
  replacement actor starts a new incarnation. A partition can therefore hide
  sessions that remain connected to their local node.
+
+ Each snapshot contains only its sender's authoritative state. A receiver's
+ request order, not a random suffix or message arrival order, determines
+ whether a new incarnation can replace its known owner. Concurrent live
+ actors sharing a replica base in one scope are unsupported.
+
+ A confirmed replacement retires its predecessor. Otherwise, unavailable
+ state remains for 60 seconds, checked every second while the actor runs.
+ Compaction invalidates outstanding requests. A returning actor must answer
+ a new request with its current full local snapshot, so delayed replies and
+ lagging peers cannot reintroduce compacted history. The retention check also
+ runs when periodic snapshot requests are disabled. Actor work can delay it.
 
 <div class="api-entry-anchor" id="api-function-with_queue_limits" aria-hidden="true"></div>
 


### PR DESCRIPTION
Closes #426.

- Fence delayed replies from stale replica incarnations by using receiver-issued request order and owner-only snapshot admission.
- Retire replaced incarnations immediately; retain other unavailable state for 60 seconds before safely compacting entries, clocks, requests, and freshness records.
- Add separate-node coverage for stale replies, legacy full-state peers, repeated restarts, and the full retention window. All CI checks pass.
