### PR TITLE
docs: remove Lustre effect comparison

### DIFF
--- a/website/src/content/docs/tutorial/one-update-function-many-socket-events.mdx
+++ b/website/src/content/docs/tutorial/one-update-function-many-socket-events.mdx
@@ -177,7 +177,7 @@ runs the list as:
 
 The socket actor runs the effects in list order and writes the frames in the
 same order. For one socket, list order is wire order. This is a beryl
-guarantee. Lustre makes no such promise for its effects.
+guarantee.
 
 Across two connections, this does not guarantee which browser observes its
 frame first. The [two-socket experiment](#compare-replies-and-broadcasts-with-two-tabs)


### PR DESCRIPTION
## Summary

Remove the unnecessary comparison with Lustre from the explanation of beryl effect ordering.