### PR TITLE
docs: qualify deployment guidance

### DIFF
--- a/packages/beryl/src/beryl/snapshot.gleam
+++ b/packages/beryl/src/beryl/snapshot.gleam
@@ -4,9 +4,9 @@
 //// servicing the request. Counts may lag in-flight connect and disconnect
 //// notifications that have not yet reached that process, so they are
 //// eventually consistent rather than exact at the instant of the call. They
-//// are intended for operational polling, not as an event stream. Poll no
-//// more frequently than roughly once per second so observation does not add
-//// meaningful runtime load.
+//// are intended for operational polling, not as an event stream. Start with
+//// roughly once-per-second polling or less, then measure the observation load
+//// for your workload.
 
 import beryl
 import beryl/overload
@@ -45,7 +45,8 @@ pub type SnapshotError {
 /// Neither condition panics. This API reports only the node represented by
 /// `sockets`; aggregate multi-node statistics outside beryl.
 ///
-/// Poll no more frequently than roughly once per second.
+/// Start with roughly once-per-second polling or less, then measure the
+/// observation load for your workload.
 pub fn get(sockets: beryl.Sockets) -> Result(Snapshot, SnapshotError) {
   case beryl.app_dispatch(sockets).stats() {
     Error(beryl.StatsRuntimeUnavailable) -> Error(RuntimeUnavailable)

--- a/website/src/content/docs/architecture/pubsub-and-distribution.md
+++ b/website/src/content/docs/architecture/pubsub-and-distribution.md
@@ -115,7 +115,7 @@ A process on any peer node can:
 applies only to inbound WebSocket frames. It does not screen messages that
 arrive via distribution.
 
-Refer to the [Production Hardening guide](/guides/production-hardening/#erlang-cluster-security-boundary)
+Refer to the [deployment hardening guide](/guides/production-hardening/#erlang-cluster-security-boundary)
 for the full cluster security requirements (network isolation, mutually
 verified TLS distribution, EPMD port restrictions, and cookie handling).
 

--- a/website/src/content/docs/architecture/runtime.md
+++ b/website/src/content/docs/architecture/runtime.md
@@ -205,7 +205,7 @@ do not establish an end-to-end or node-wide memory bound. See
 | Shared router ingress and fan-out | 4096 items / 32 MiB before local publication and connection-child startup. Fan-out reserves destination capacity and continues past saturated recipients. |
 | Presence mutations | 4096 items / 32 MiB, including reserved runtime-session cleanup. Pending timeouts cancel; running timeouts retain capacity. |
 | Generic PubSub and remote presence sync | No pre-receipt bound. Downstream local socket fan-out still needs admission. |
-| Outbound connection queue | Send requests have no configured count/byte budget or slow-reader eviction policy. A slow writer can accumulate requests independently of the socket actor. |
+| Outbound connection queue | Each transport connection has a configurable frame and payload-byte budget. A slow writer can still cause the connection to close when it reaches that budget. Inbound transport buffering before frame receipt remains outside this ledger. |
 
 Accounted bytes cover inspectable structure and binary backing allocations,
 not closure environments or arbitrary app state. Queue snapshots and
@@ -214,8 +214,8 @@ Owner death invalidates its reservations. Recovery reclaims unpublished work
 from dead producers; published work stays charged until consumption or
 cancellation.
 
-[#249](https://github.com/tylerbutler/beryl/issues/249) tracks outbound queues
-and slow-client eviction. Heartbeat checks still cannot interrupt a blocked
+Outbound budgets reduce the risk from slow clients, but they do not provide
+an end-to-end memory bound. Heartbeat checks still cannot interrupt a blocked
 callback. Use finite connection/topic populations and deployment-level limits,
 and measure your workload.
 

--- a/website/src/content/docs/examples.mdx
+++ b/website/src/content/docs/examples.mdx
@@ -17,8 +17,9 @@ git clone https://github.com/tylerbutler/beryl.git
 cd beryl
 ```
 
-<Aside type="note" title="Pre-1.0">
-beryl is not yet version 1.0. Minor releases can change the API, and the library is not ready for production. Report problems to help define version 1.0.
+<Aside type="note" title="Stability">
+beryl is pre-1.0. Minor releases can change the API. See the
+[stability policy](/reference/#versioning-before-10) before you adopt it.
 </Aside>
 
 ## Showcase

--- a/website/src/content/docs/guides/authentication.md
+++ b/website/src/content/docs/guides/authentication.md
@@ -225,8 +225,9 @@ See [Use the typed sender](/guides/channels/#read-joincontext-and-use-its-typed-
   time and return the result as `on_connect` metadata. The `Join` branches in
   `update` should only apply authorization rules to the verified claims.
 - **Cookie sessions need origin checks.** If you authenticate from a cookie
-  instead of a token, always pair it with `with_allowed_origins` to prevent
-  Cross-Site WebSocket Hijacking. See
+  instead of a token, keep the default same-origin policy or configure an
+  explicit `with_allowed_origins` list to prevent Cross-Site WebSocket
+  Hijacking. See
   [Block Cross-Site WebSocket Hijacking](/guides/websocket#block-cross-site-websocket-hijacking-cswsh).
 - **Rejection response.** For the client-visible error when a join or connection is
   refused, see [Reject a connection during authentication](/guides/error-handling#reject-a-connection-during-authentication).

--- a/website/src/content/docs/guides/observability.md
+++ b/website/src/content/docs/guides/observability.md
@@ -130,10 +130,11 @@ Monitor its mailbox and limit queued work. Another process avoids adding work
 to the request, but an unlimited mailbox can still overload the system. Detach
 the handler during shutdown. beryl does not need an exporter dependency.
 
-Useful derived signals include upgrade rejection rate by outcome, frame decode
-and rate-limit rates, join/message callback failures, connection lifetime,
-broadcast recipient counts, and latency histograms. Alert on sustained rates
-and tail latency rather than individual events.
+Candidate derived signals include upgrade rejection rate by outcome, frame
+decode and rate-limit rates, join/message callback failures, connection
+lifetime, broadcast recipient counts, and latency histograms. Consider alerts
+for sustained rates and tail latency rather than individual events, then tune
+those thresholds from observed workload behavior.
 
 ## Read runtime counts
 
@@ -165,19 +166,21 @@ across nodes in the monitoring system. `joined_socket_topic_pairs` counts
 memberships. One socket on two topics adds two. The runtime records counts when
 it handles the request, so concurrent connection changes can appear later.
 
-Poll no more than once per second. Each poll sends a request through the
-runtime. Many synchronized scrapers can add load. Use one application poller
-per node. Cache the latest successful snapshot, add jitter, and expose the
-snapshot age. Do not convert a timeout to a zero-valued snapshot. A timeout can
-mean restart or overload, not an idle system.
+Start with polling at once per second or less, then measure the overhead for
+your workload. Each poll sends a request through the runtime, and many
+synchronized scrapers can add load. Use one application poller per node. Cache
+the latest successful snapshot, add jitter, and expose the snapshot age. Do not
+convert a timeout to a zero-valued snapshot. A timeout can mean restart or
+overload, not an idle system.
 
 For a runnable JSON endpoint combining beryl and BEAM runtime gauges, see the
 benchmark server's [`/stats` reference](https://github.com/tylerbutler/beryl/blob/main/examples/load_test/README.md#health-and-stats)
 and
 [`http.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/load_test/src/load_test/http.gleam).
 That endpoint polls on request and is a benchmark fixture, not a bundled
-exporter. In production, prefer one application-owned poller per node and
-serve its cached snapshot through your metrics handler.
+exporter. For a deployment, one application-owned poller per node can reduce
+scraper-driven load; serve its cached snapshot through your metrics handler
+and validate that this pattern fits your workload.
 
 ## Measure capacity
 

--- a/website/src/content/docs/guides/overload.md
+++ b/website/src/content/docs/guides/overload.md
@@ -177,8 +177,8 @@ OTP supervisor/bootstrap RPC mailboxes and arbitrary system traffic remain
 outside the ledger protocol. Do not infer a bound for an externally suspended
 socket factory from the router's admission limit.
 
-Outbound connection queues remain outside this contract; follow
-[issue #249](https://github.com/tylerbutler/beryl/issues/249). Per-owner limits
-also need finite connection and topic populations before they can support a
-node-wide memory estimate. The existing unlimited connection defaults have
-not changed. See [production controls](/guides/production-hardening/).
+Transport connection queues have their own per-connection outbound budget.
+That budget limits queued frames and payload bytes, but it does not bound
+transport buffering before a complete inbound frame reaches beryl. Per-owner
+limits also need finite connection and topic populations before they can support
+a node-wide memory estimate. See [deployment hardening](/guides/production-hardening/).

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -1,13 +1,21 @@
 ---
-title: Prepare beryl for production
+title: Evaluate deployment hardening
 description: Configure traffic limits, authentication, and Erlang distribution security.
 ---
 
 beryl disables rate and connection limits by default because each deployment
-needs different values. These defaults are suitable for development. In
-production, one hostile or faulty client can degrade a server that has no
-traffic controls. beryl logs a startup warning when all controls are off. This
-guide explains which controls to configure.
+needs different values. These defaults are suitable for development. A hostile
+or faulty client can degrade a server that has no traffic controls. beryl logs
+a startup warning when all controls are off. This guide describes defensive
+controls and testable starting points; it does not provide production-validated
+capacity recommendations.
+
+:::caution[Validate these settings]
+beryl is a new project. The values in this guide are examples, not settings
+validated by long-running production deployments. Measure your workload, test
+failure and recovery paths, and adjust the limits for your application and
+infrastructure.
+:::
 
 ## Controls enabled by default
 
@@ -35,22 +43,20 @@ Even with no configuration, beryl enforces:
 
 The frame-size check limits decoding and routing work. It does **not** limit
 transport memory because buffering and reassembly occur before beryl receives
-the frame. In production, set a WebSocket frame or message limit in the reverse
+the frame. At deployment, set a WebSocket frame or message limit in the reverse
 proxy or load balancer. Set it at or below beryl's limit. Also set a matching
 HTTP request or body limit for the upgrade.
 
-## Configure production limits
+## Choose initial limits
 
 ```gleam
 let config =
   beryl.config(wire.phoenix_codec())
   // Drop over-rate complete frames before decoding them.
   |> beryl.with_frame_rate(per_second: 150, burst: 300)
-  // Cap messages per socket. Size to your chattiest legitimate client:
-  // for most interactive apps 50-100 msg/s with 2x burst is generous.
+  // Example only. Measure your busiest legitimate client and tune this value.
   |> beryl.with_message_rate(per_second: 100, burst: 200)
-  // Joins are much rarer than messages. 10/s per socket tolerates
-  // aggressive reconnect/rejoin loops while stopping join floods.
+  // Example only. Tune this for your reconnect and rejoin behavior.
   |> beryl.with_join_rate(per_second: 10, burst: 20)
   // Cap connection attempts per client IP. This allowance survives
   // disconnects and app runtime restarts.
@@ -89,7 +95,8 @@ and resynchronize instead of receiving a stream with silently dropped frames.
 
 Set the byte budget above the largest legitimate encoded outbound frame. Size
 the frame budget for short write stalls, not sustained client outages. The
-defaults allow 256 frames and 1 MiB per connection.
+current defaults allow 256 frames and 1 MiB per connection. Validate whether
+those defaults fit your workload.
 
 Optionally, `with_channel_rate` adds a per-socket-per-topic limit on top of
 the global per-socket message rate, useful when a single busy topic must not
@@ -144,10 +151,11 @@ addresses.
 
 ## Check origins and authenticate
 
-- `with_allowed_origins` on the Mist transport rejects browser connections
-  from unexpected origins before the WebSocket handshake.
-- `with_on_connect` authenticates the connection once, before upgrade.
-  reject unauthenticated clients with a 403 rather than at join time.
+- `server.default_config` uses same-origin checks by default. Use
+  `with_allowed_origins` when you need an explicit list of browser origins;
+  unexpected origins are rejected before the WebSocket handshake.
+- `with_on_connect` authenticates the connection once, before upgrade. Reject
+  unauthenticated clients with a 403 rather than at join time.
 - Authorize each topic in your update's `Join` arm; clients cannot
   send events to topics they have not joined.
 

--- a/website/src/content/docs/guides/supervision.md
+++ b/website/src/content/docs/guides/supervision.md
@@ -174,11 +174,11 @@ case beryl.child_spec(config, init: init, update: update) {
 transport connections and stops the runtime without a restart. A second call
 returns `Error(NotRunning)`. Other operations after `stop` do nothing.
 
-## Production checklist
+## Deployment checklist
 
 - Add the returned specification to your long-lived application supervisor.
 - Add application-owned presence and group child specifications alongside the
   beryl child.
 - Configure PubSub when running more than one BEAM node.
 - Configure rate limits to protect against faulty or hostile clients. See
-  [Production Hardening](/guides/production-hardening/).
+  [deployment hardening](/guides/production-hardening/).

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -246,6 +246,7 @@ import { Aside } from '@astrojs/starlight/components';
 	</article>
 </div>
 
-<Aside type="note" title="Pre-1.0">
-beryl is not yet version 1.0. Minor releases can change the API, and the library is not ready for production. Report problems to help define version 1.0.
+<Aside type="note" title="Stability">
+beryl is pre-1.0. Minor releases can change the API. See the
+[stability policy](/reference/#versioning-before-10) before you adopt it.
 </Aside>

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -2,10 +2,9 @@
 title: What is beryl?
 ---
 
-:::note[Pre-1.0]
-beryl is not yet version 1.0. Minor releases can change the API, and the
-library is not ready for production. Report problems to help define version
-1.0.
+:::note[Stability]
+beryl is pre-1.0. Minor releases can change the API. See the
+[stability policy](/reference/#versioning-before-10) before you adopt it.
 :::
 
 beryl is a **type-safe library for real-time Gleam channels and presence** on
@@ -170,6 +169,6 @@ modules, callbacks, and assigns with both beryl APIs.
 - [Quick Start](/quick-start/) — get a working server in minutes
 - [Channels guide](/guides/channels/) — handlers, typed state, actions, and close behavior
 - [Dispatch guide](/guides/dispatch/) — route topics, messages, and close events in one app
-- [Supervision guide](/guides/supervision/) — production startup with OTP supervision
+- [Supervision guide](/guides/supervision/) — recommended startup order and OTP supervision
 - [Error Handling guide](/guides/error-handling/) — rejected joins, rate limits, and more
 - [Troubleshooting](/troubleshooting/) — symptom-first diagnostics

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -5,8 +5,9 @@ description: Build a beryl socket app with a channel handler, WebSocket server, 
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
-<Aside type="note" title="Pre-1.0">
-beryl is not yet version 1.0. Minor releases can change the API, and the library is not ready for production. Report problems to help define version 1.0.
+<Aside type="note" title="Stability">
+beryl is pre-1.0. Minor releases can change the API. See the
+[stability policy](/reference/#versioning-before-10) before you adopt it.
 </Aside>
 
 This guide shows how to build a real-time app. You will create a Gleam server

--- a/website/src/content/docs/reference/api/beryl-snapshot.md
+++ b/website/src/content/docs/reference/api/beryl-snapshot.md
@@ -20,9 +20,9 @@ A point-in-time snapshot of local runtime state.
  servicing the request. Counts may lag in-flight connect and disconnect
  notifications that have not yet reached that process, so they are
  eventually consistent rather than exact at the instant of the call. They
- are intended for operational polling, not as an event stream. Poll no
- more frequently than roughly once per second so observation does not add
- meaningful runtime load.
+ are intended for operational polling, not as an event stream. Start with
+ roughly once-per-second polling or less, then measure the observation load
+ for your workload.
 
 <nav class="api-symbol-index" aria-label="Module contents">
 <section class="api-symbol-index__group">
@@ -134,7 +134,8 @@ Request a snapshot from the local runtime.
  Neither condition panics. This API reports only the node represented by
  `sockets`; aggregate multi-node statistics outside beryl.
 
- Poll no more frequently than roughly once per second.
+ Start with roughly once-per-second polling or less, then measure the
+ observation load for your workload.
 
 <div class="api-entry-anchor" id="api-function-joined_socket_topic_pairs" aria-hidden="true"></div>
 

--- a/website/src/content/docs/reference/index.md
+++ b/website/src/content/docs/reference/index.md
@@ -3,10 +3,9 @@ title: Reference
 description: Find beryl modules, message-sending APIs, Phoenix frame formats, and compatible clients.
 ---
 
-:::note[Pre-1.0]
-beryl is not yet version 1.0. Minor releases can change the API. The library is
-not ready for production. See the
-[stability policy](#versioning-before-10).
+:::note[Stability]
+beryl is pre-1.0. Minor releases can change the API. Review the
+[stability policy](#versioning-before-10) before you adopt it.
 :::
 
 The site generates the function-level API reference from Gleam docs metadata.

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -224,8 +224,9 @@ recent joins or leaves.
 
 1. **Client heartbeat interval vs. server timeout.** The Phoenix JS client
    sends heartbeats every 30 s by default. The beryl default server timeout is
-   60 s, which gives a safe margin. If you lower `heartbeat_timeout_ms`, keep
-   the client interval at or below half the server timeout.
+   60 s, which leaves time for a delayed heartbeat reply. If you lower
+   `heartbeat_timeout_ms`, keep the client interval at or below half the server
+   timeout.
 
 2. **Load balancer idle timeout.** Some load balancers (AWS ALB, nginx) have their own WebSocket idle timeouts. Set the load balancer timeout to be longer than the client heartbeat interval, or configure load-balancer-level keepalives.
 

--- a/website/src/content/docs/tutorial/supervising-beryl.md
+++ b/website/src/content/docs/tutorial/supervising-beryl.md
@@ -178,7 +178,7 @@ rest of the tree.
 
 ## Start processes before the WebSocket listener
 
-A production startup path makes four decisions, in this order:
+A recommended startup order makes four decisions, in this order:
 
 1. Build beryl's handle and child specification.
 2. Start your domain actors from a long-lived application process, or under

--- a/website/src/content/docs/tutorial/where-the-analogy-ends.md
+++ b/website/src/content/docs/tutorial/where-the-analogy-ends.md
@@ -11,7 +11,7 @@ It does not bring your socket state back after a crash. One router actor keeps
 the list of sockets and sends broadcasts to them. Each socket actor calls your
 update function and runs the effects it returns, in order.
 
-The frontend analogy does not cover beryl's production behavior.
+The frontend analogy does not cover beryl's runtime and failure behavior.
 
 ## Follow one frame
 
@@ -138,9 +138,9 @@ beryl.config(wire.phoenix_codec())
 
 This exact excerpt comes from
 [`step_05.gleam`](https://github.com/tylerbutler/beryl/blob/main/examples/live_poll/src/live_poll/step_05.gleam).
-These values make the example look like a production app. They are not correct
-for every app. Choose your limits from the traffic you expect and the capacity
-you have.
+These values make the example look like a deployed app. They are illustrative,
+not production-validated defaults. Choose your limits from the traffic you
+expect and the capacity you have, then test the result.
 
 ## PubSub and presence follow different rules
 
@@ -193,8 +193,8 @@ normal app code.
 
 ## Rules to remember
 
-The earlier chapters started with a familiar update loop. In production, keep
-these differences in view:
+The earlier chapters started with a familiar update loop. In a deployed app,
+keep these differences in view:
 
 - beryl has no `view`.
 - Raw `init` runs once per socket.


### PR DESCRIPTION
## Summary

- Reframe deployment guidance as defensive, workload-specific starting points.
- Remove unsupported tuning claims and qualify monitoring recommendations.
- Correct outbound queue documentation and regenerate the snapshot API reference.
- Consolidate repeated pre-1.0 messaging around the stability policy.
- Clarify same-origin defaults for cookie-authenticated WebSockets.

## Validation

- `just docs`
- `cd website && pnpm run check:astro`
- `cd website && pnpm run check:snippets`
- `cd website && pnpm run test:reference`
- `cd website && pnpm run build:site`

The Astro checks report existing deprecation warnings and one existing TypeScript hint; the site build reports existing chunk-size and `/404` route warnings. Internal links remain valid.
