### PR TITLE
feat(presence)!: upgrade to lattice_presence 2.0

### DIFF
--- a/.changes/unreleased/beryl-presence-replica-identities-now.toml
+++ b/.changes/unreleased/beryl-presence-replica-identities-now.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Changed"
+body = "Presence replica identities now use the dependency's incarnation format, a retired incarnation keeps a high-water clock, and a snapshot that claims the local replica identity is dropped with an error log and a telemetry event."

--- a/.changes/unreleased/beryl-require-lattice-presence-2.toml
+++ b/.changes/unreleased/beryl-require-lattice-presence-2.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Dependencies"
+body = "Require lattice_presence 2.0, which adds youid as a transitive dependency."

--- a/examples/chatrooms/manifest.toml
+++ b/examples/chatrooms/manifest.toml
@@ -8,7 +8,7 @@
 
 packages = [
   { name = "beryl", version = "0.4.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
-  { name = "beryl_mist", version = "0.3.2", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
+  { name = "beryl_mist", version = "0.3.2", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "glisten", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
   { name = "example_helper", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
   { name = "exception", version = "2.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "6BDEA95248093599391C3B5DF1835C5C6A86C353C2F99CE539B450E3432FE117" },
@@ -18,15 +18,17 @@ packages = [
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "DE4CA6850842F0266EE95317A25DD6A0A0F20CDFAB7C0ADC2E63251D7C3C72EC" },
   { name = "gleam_stdlib", version = "1.0.5", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CEE5B6C076A85B45F60C585F4316C63EC8B7127C119D5738C3958A9C4D50404E" },
+  { name = "gleam_time", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56539216E4C4B1748714652AB38F0BD16B9101F61DB62769FDC7CD42A8E5E833" },
   { name = "gleeunit", version = "1.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "EC31ABA74256AEA531EDF8169931D775BBB384FED0A8A1BDC4DD9354E3E21826" },
   { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
   { name = "gramps", version = "6.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D55636072DEE173F6586A5679D3C02EC7A0DE3F8646B78C351B72908FF223DF7" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
-  { name = "lattice_presence", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "lattice_presence", source = "hex", outer_checksum = "4528FFC4B4DFCA076FAA0FA22D98CE4DF1B05BD0E9B4B90581DEA8799642C8B7" },
+  { name = "lattice_presence", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "youid"], otp_app = "lattice_presence", source = "hex", outer_checksum = "3E59B585A4E536A8BF2FC71BCEBCDABAD33A6475915CDD10CFAC112D64D6E764" },
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
+  { name = "youid", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_stdlib", "gleam_time"], otp_app = "youid", source = "hex", outer_checksum = "7A3ABA44B1B38BC2BDCB5474C5317AA372BE58DFBC649815EE08B03526DDA18D" },
 ]
 
 [requirements]

--- a/examples/collab_docs/manifest.toml
+++ b/examples/collab_docs/manifest.toml
@@ -8,7 +8,7 @@
 
 packages = [
   { name = "beryl", version = "0.4.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
-  { name = "beryl_mist", version = "0.3.2", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
+  { name = "beryl_mist", version = "0.3.2", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "glisten", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
   { name = "example_helper", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
   { name = "exception", version = "2.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "6BDEA95248093599391C3B5DF1835C5C6A86C353C2F99CE539B450E3432FE117" },
@@ -18,6 +18,7 @@ packages = [
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "DE4CA6850842F0266EE95317A25DD6A0A0F20CDFAB7C0ADC2E63251D7C3C72EC" },
   { name = "gleam_stdlib", version = "1.0.5", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CEE5B6C076A85B45F60C585F4316C63EC8B7127C119D5738C3958A9C4D50404E" },
+  { name = "gleam_time", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56539216E4C4B1748714652AB38F0BD16B9101F61DB62769FDC7CD42A8E5E833" },
   { name = "gleeunit", version = "1.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "EC31ABA74256AEA531EDF8169931D775BBB384FED0A8A1BDC4DD9354E3E21826" },
   { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
   { name = "gramps", version = "6.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D55636072DEE173F6586A5679D3C02EC7A0DE3F8646B78C351B72908FF223DF7" },
@@ -25,13 +26,14 @@ packages = [
   { name = "lattice_core", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "lattice_core", source = "hex", outer_checksum = "E0A7CC27CB58795D10DF4B7186891FDBF90F10A5FBF34C5862E5E936814A2CD5" },
   { name = "lattice_counters", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], otp_app = "lattice_counters", source = "hex", outer_checksum = "1F5FA78BC2E516A025D63E7DE2E4A9FE898950BD6E835812E50AECB4FB9E1F8A" },
   { name = "lattice_maps", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core", "lattice_counters", "lattice_registers", "lattice_sets"], otp_app = "lattice_maps", source = "hex", outer_checksum = "9CB3F090BEF40C96C5EEEE9CEE4FA9B16C600802A234B8F2AAF9C25B5B46667B" },
-  { name = "lattice_presence", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "lattice_presence", source = "hex", outer_checksum = "4528FFC4B4DFCA076FAA0FA22D98CE4DF1B05BD0E9B4B90581DEA8799642C8B7" },
+  { name = "lattice_presence", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "youid"], otp_app = "lattice_presence", source = "hex", outer_checksum = "3E59B585A4E536A8BF2FC71BCEBCDABAD33A6475915CDD10CFAC112D64D6E764" },
   { name = "lattice_registers", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], otp_app = "lattice_registers", source = "hex", outer_checksum = "4B85A3925CDC563DE102A5B59CDDCA68EBBB877C25602C4551B15C8DE3D8A295" },
   { name = "lattice_sets", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], otp_app = "lattice_sets", source = "hex", outer_checksum = "BA81DF518B2A25D9E77012262D08D06B959BD7A6C22B98D4F82550823A1E98AF" },
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
+  { name = "youid", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_stdlib", "gleam_time"], otp_app = "youid", source = "hex", outer_checksum = "7A3ABA44B1B38BC2BDCB5474C5317AA372BE58DFBC649815EE08B03526DDA18D" },
 ]
 
 [requirements]

--- a/examples/cursors/manifest.toml
+++ b/examples/cursors/manifest.toml
@@ -8,7 +8,7 @@
 
 packages = [
   { name = "beryl", version = "0.4.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
-  { name = "beryl_mist", version = "0.3.2", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
+  { name = "beryl_mist", version = "0.3.2", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "glisten", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
   { name = "example_helper", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../example_helpers" },
   { name = "exception", version = "2.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "6BDEA95248093599391C3B5DF1835C5C6A86C353C2F99CE539B450E3432FE117" },
@@ -18,15 +18,17 @@ packages = [
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "DE4CA6850842F0266EE95317A25DD6A0A0F20CDFAB7C0ADC2E63251D7C3C72EC" },
   { name = "gleam_stdlib", version = "1.0.5", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CEE5B6C076A85B45F60C585F4316C63EC8B7127C119D5738C3958A9C4D50404E" },
+  { name = "gleam_time", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56539216E4C4B1748714652AB38F0BD16B9101F61DB62769FDC7CD42A8E5E833" },
   { name = "gleeunit", version = "1.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "EC31ABA74256AEA531EDF8169931D775BBB384FED0A8A1BDC4DD9354E3E21826" },
   { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
   { name = "gramps", version = "6.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D55636072DEE173F6586A5679D3C02EC7A0DE3F8646B78C351B72908FF223DF7" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
-  { name = "lattice_presence", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "lattice_presence", source = "hex", outer_checksum = "4528FFC4B4DFCA076FAA0FA22D98CE4DF1B05BD0E9B4B90581DEA8799642C8B7" },
+  { name = "lattice_presence", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "youid"], otp_app = "lattice_presence", source = "hex", outer_checksum = "3E59B585A4E536A8BF2FC71BCEBCDABAD33A6475915CDD10CFAC112D64D6E764" },
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
+  { name = "youid", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_stdlib", "gleam_time"], otp_app = "youid", source = "hex", outer_checksum = "7A3ABA44B1B38BC2BDCB5474C5317AA372BE58DFBC649815EE08B03526DDA18D" },
 ]
 
 [requirements]

--- a/examples/example_helpers/manifest.toml
+++ b/examples/example_helpers/manifest.toml
@@ -16,14 +16,16 @@ packages = [
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "DE4CA6850842F0266EE95317A25DD6A0A0F20CDFAB7C0ADC2E63251D7C3C72EC" },
   { name = "gleam_stdlib", version = "1.0.5", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CEE5B6C076A85B45F60C585F4316C63EC8B7127C119D5738C3958A9C4D50404E" },
+  { name = "gleam_time", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56539216E4C4B1748714652AB38F0BD16B9101F61DB62769FDC7CD42A8E5E833" },
   { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
   { name = "gramps", version = "6.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D55636072DEE173F6586A5679D3C02EC7A0DE3F8646B78C351B72908FF223DF7" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
-  { name = "lattice_presence", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "lattice_presence", source = "hex", outer_checksum = "4528FFC4B4DFCA076FAA0FA22D98CE4DF1B05BD0E9B4B90581DEA8799642C8B7" },
+  { name = "lattice_presence", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "youid"], otp_app = "lattice_presence", source = "hex", outer_checksum = "3E59B585A4E536A8BF2FC71BCEBCDABAD33A6475915CDD10CFAC112D64D6E764" },
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
+  { name = "youid", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_stdlib", "gleam_time"], otp_app = "youid", source = "hex", outer_checksum = "7A3ABA44B1B38BC2BDCB5474C5317AA372BE58DFBC649815EE08B03526DDA18D" },
 ]
 
 [requirements]

--- a/examples/live_poll/manifest.toml
+++ b/examples/live_poll/manifest.toml
@@ -8,7 +8,7 @@
 
 packages = [
   { name = "beryl", version = "0.4.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
-  { name = "beryl_mist", version = "0.3.2", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
+  { name = "beryl_mist", version = "0.3.2", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "glisten", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
   { name = "exception", version = "2.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "6BDEA95248093599391C3B5DF1835C5C6A86C353C2F99CE539B450E3432FE117" },
   { name = "gleam_crypto", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "2DE9E4EF53CF6FEE049D4F765731F7178F7A11AEFAE00EEE63BF7536B354AD3F" },
@@ -22,7 +22,7 @@ packages = [
   { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
   { name = "gramps", version = "6.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D55636072DEE173F6586A5679D3C02EC7A0DE3F8646B78C351B72908FF223DF7" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
-  { name = "lattice_presence", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "youid"], otp_app = "lattice_presence", source = "hex", outer_checksum = "464E88DAD86B8D714FC675785AD49FAC01AD7C7D6244DA2B96E3B6A80E44B969" },
+  { name = "lattice_presence", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "youid"], otp_app = "lattice_presence", source = "hex", outer_checksum = "3E59B585A4E536A8BF2FC71BCEBCDABAD33A6475915CDD10CFAC112D64D6E764" },
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },

--- a/examples/load_test/manifest.toml
+++ b/examples/load_test/manifest.toml
@@ -8,8 +8,8 @@
 
 packages = [
   { name = "beryl", version = "0.4.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
-  { name = "beryl_ewe", version = "0.2.2", build_tools = ["gleam"], requirements = ["beryl", "ewe", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], source = "local", path = "../../packages/beryl_ewe" },
-  { name = "beryl_mist", version = "0.3.2", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
+  { name = "beryl_ewe", version = "0.2.2", build_tools = ["gleam"], requirements = ["beryl", "ewe", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "glisten"], source = "local", path = "../../packages/beryl_ewe" },
+  { name = "beryl_mist", version = "0.3.2", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "glisten", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "compresso", version = "0.1.0", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_stdlib", "gleam_yielder", "logging"], otp_app = "compresso", source = "hex", outer_checksum = "8BE29A1EDA42F70826ED148EAE40C46BB3FC18E78FE472663DB01DD4A38172D4" },
   { name = "envoy", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "9C6FBB6BFA02A52798BEEC5977A738CAD6E4A057F4B67FD0C8061AD2502C191A" },
   { name = "ewe", version = "4.0.1", build_tools = ["gleam"], requirements = ["compresso", "exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "logging", "websocks"], otp_app = "ewe", source = "hex", outer_checksum = "1A6CBE2E07B7E784F9B9503C94C0F23CDD644AC5EA4E1B957F3A5550541699DB" },
@@ -21,17 +21,19 @@ packages = [
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "DE4CA6850842F0266EE95317A25DD6A0A0F20CDFAB7C0ADC2E63251D7C3C72EC" },
   { name = "gleam_stdlib", version = "1.0.5", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CEE5B6C076A85B45F60C585F4316C63EC8B7127C119D5738C3958A9C4D50404E" },
+  { name = "gleam_time", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56539216E4C4B1748714652AB38F0BD16B9101F61DB62769FDC7CD42A8E5E833" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
   { name = "gleeunit", version = "1.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "EC31ABA74256AEA531EDF8169931D775BBB384FED0A8A1BDC4DD9354E3E21826" },
   { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
   { name = "gramps", version = "6.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D55636072DEE173F6586A5679D3C02EC7A0DE3F8646B78C351B72908FF223DF7" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
-  { name = "lattice_presence", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "lattice_presence", source = "hex", outer_checksum = "4528FFC4B4DFCA076FAA0FA22D98CE4DF1B05BD0E9B4B90581DEA8799642C8B7" },
+  { name = "lattice_presence", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "youid"], otp_app = "lattice_presence", source = "hex", outer_checksum = "3E59B585A4E536A8BF2FC71BCEBCDABAD33A6475915CDD10CFAC112D64D6E764" },
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
   { name = "websocks", version = "3.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_stdlib"], otp_app = "websocks", source = "hex", outer_checksum = "C70340E5B6C3390383ADA17029DCA6F8903863A7AD8CD8E1520EDCC4FE70D6FD" },
+  { name = "youid", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_stdlib", "gleam_time"], otp_app = "youid", source = "hex", outer_checksum = "7A3ABA44B1B38BC2BDCB5474C5317AA372BE58DFBC649815EE08B03526DDA18D" },
 ]
 
 [requirements]

--- a/examples/showcase/manifest.toml
+++ b/examples/showcase/manifest.toml
@@ -8,7 +8,7 @@
 
 packages = [
   { name = "beryl", version = "0.4.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_presence", "palabres", "telemetry"], source = "local", path = "../../packages/beryl" },
-  { name = "beryl_mist", version = "0.3.2", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "mist"], source = "local", path = "../../packages/beryl_mist" },
+  { name = "beryl_mist", version = "0.3.2", build_tools = ["gleam"], requirements = ["beryl", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib", "glisten", "mist"], source = "local", path = "../../packages/beryl_mist" },
   { name = "chatroom", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "beryl_mist", "example_helper", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../chatrooms" },
   { name = "collab_document", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "beryl_mist", "example_helper", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "lattice_core", "lattice_maps", "mist"], source = "local", path = "../collab_docs" },
   { name = "cursor", version = "0.1.0", build_tools = ["gleam"], requirements = ["beryl", "beryl_mist", "envoy", "example_helper", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "mist"], source = "local", path = "../cursors" },
@@ -21,6 +21,7 @@ packages = [
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "DE4CA6850842F0266EE95317A25DD6A0A0F20CDFAB7C0ADC2E63251D7C3C72EC" },
   { name = "gleam_stdlib", version = "1.0.5", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CEE5B6C076A85B45F60C585F4316C63EC8B7127C119D5738C3958A9C4D50404E" },
+  { name = "gleam_time", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56539216E4C4B1748714652AB38F0BD16B9101F61DB62769FDC7CD42A8E5E833" },
   { name = "gleeunit", version = "1.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "EC31ABA74256AEA531EDF8169931D775BBB384FED0A8A1BDC4DD9354E3E21826" },
   { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
   { name = "gramps", version = "6.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D55636072DEE173F6586A5679D3C02EC7A0DE3F8646B78C351B72908FF223DF7" },
@@ -28,13 +29,14 @@ packages = [
   { name = "lattice_core", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "lattice_core", source = "hex", outer_checksum = "E0A7CC27CB58795D10DF4B7186891FDBF90F10A5FBF34C5862E5E936814A2CD5" },
   { name = "lattice_counters", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], otp_app = "lattice_counters", source = "hex", outer_checksum = "1F5FA78BC2E516A025D63E7DE2E4A9FE898950BD6E835812E50AECB4FB9E1F8A" },
   { name = "lattice_maps", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core", "lattice_counters", "lattice_registers", "lattice_sets"], otp_app = "lattice_maps", source = "hex", outer_checksum = "9CB3F090BEF40C96C5EEEE9CEE4FA9B16C600802A234B8F2AAF9C25B5B46667B" },
-  { name = "lattice_presence", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "lattice_presence", source = "hex", outer_checksum = "4528FFC4B4DFCA076FAA0FA22D98CE4DF1B05BD0E9B4B90581DEA8799642C8B7" },
+  { name = "lattice_presence", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "youid"], otp_app = "lattice_presence", source = "hex", outer_checksum = "3E59B585A4E536A8BF2FC71BCEBCDABAD33A6475915CDD10CFAC112D64D6E764" },
   { name = "lattice_registers", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], otp_app = "lattice_registers", source = "hex", outer_checksum = "4B85A3925CDC563DE102A5B59CDDCA68EBBB877C25602C4551B15C8DE3D8A295" },
   { name = "lattice_sets", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], otp_app = "lattice_sets", source = "hex", outer_checksum = "BA81DF518B2A25D9E77012262D08D06B959BD7A6C22B98D4F82550823A1E98AF" },
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
+  { name = "youid", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_stdlib", "gleam_time"], otp_app = "youid", source = "hex", outer_checksum = "7A3ABA44B1B38BC2BDCB5474C5317AA372BE58DFBC649815EE08B03526DDA18D" },
 ]
 
 [requirements]

--- a/packages/beryl/gleam.toml
+++ b/packages/beryl/gleam.toml
@@ -24,7 +24,7 @@ gleam_otp = ">= 1.2.0 and < 2.0.0"
 gleam_json = ">= 3.1.0 and < 4.0.0"
 gleam_crypto = ">= 1.6.0 and < 2.0.0"
 gleam_http = ">= 4.3.0 and < 5.0.0"
-lattice_presence = ">= 1.0.0 and < 2.0.0"
+lattice_presence = ">= 2.0.0 and < 3.0.0"
 telemetry = ">= 1.4.2 and < 2.0.0"
 
 [dev-dependencies]

--- a/packages/beryl/manifest.toml
+++ b/packages/beryl/manifest.toml
@@ -21,13 +21,14 @@ packages = [
   { name = "gleeunit", version = "1.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "EC31ABA74256AEA531EDF8169931D775BBB384FED0A8A1BDC4DD9354E3E21826" },
   { name = "glexer", version = "2.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "D423CF63B8D4F9654EF53D0AF4904B249EB0679BD41C63440170AC508C9CC65E" },
   { name = "glinter", version = "2.19.2", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "19CBB4D78E58E54D6B0E8554C389DC01071334FB11E9140C9487C9A4BBCA6158" },
-  { name = "lattice_presence", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "lattice_presence", source = "hex", outer_checksum = "4528FFC4B4DFCA076FAA0FA22D98CE4DF1B05BD0E9B4B90581DEA8799642C8B7" },
+  { name = "lattice_presence", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "youid"], otp_app = "lattice_presence", source = "hex", outer_checksum = "3E59B585A4E536A8BF2FC71BCEBCDABAD33A6475915CDD10CFAC112D64D6E764" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
   { name = "phoenix_channel_fixtures", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], source = "git", repo = "https://github.com/tylerbutler/phoenix_channel_fixtures.git", commit = "7daccb856d17db6278980277237c201b2acdcdf1" },
   { name = "simplifile", version = "2.7.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "A2727627B063E87351934C7F7F008F2D1FDB16F6DE0B8C79F9E46459CFC9C164" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
+  { name = "youid", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_stdlib", "gleam_time"], otp_app = "youid", source = "hex", outer_checksum = "7A3ABA44B1B38BC2BDCB5474C5317AA372BE58DFBC649815EE08B03526DDA18D" },
 ]
 
 [requirements]
@@ -40,7 +41,7 @@ gleam_otp = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glinter = { version = ">= 2.19.0 and < 3.0.0" }
-lattice_presence = { version = ">= 1.0.0 and < 2.0.0" }
+lattice_presence = { version = ">= 2.0.0 and < 3.0.0" }
 palabres = { version = ">= 1.0.4 and < 2.0.0" }
 phoenix_channel_fixtures = { git = "https://github.com/tylerbutler/phoenix_channel_fixtures.git", ref = "7daccb856d17db6278980277237c201b2acdcdf1" }
 telemetry = { version = ">= 1.4.2 and < 2.0.0" }

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -2039,7 +2039,10 @@ fn merged_snapshot(
   sender: String,
   remote_state: State,
 ) -> Option(#(ActorState, String)) {
-  let crdt = retire_predecessor(actor_state, sender)
+  // accepts_snapshot rejects same-base senders, which is the only supersede
+  // error. This assertion is inside rescue, so an invariant violation drops
+  // the sync without crashing the presence actor.
+  let assert Ok(#(crdt, _diff)) = state.supersede(actor_state.crdt, sender)
   case state.merge(crdt, owner_snapshot(remote_state)) {
     Ok(crdt) -> {
       let #(crdt, _diff) = state.replica_up(crdt, sender)
@@ -2048,7 +2051,7 @@ fn merged_snapshot(
     Error(state.SameReplica(replica)) -> {
       telemetry.emit(
         actor_state.config.telemetry,
-        telemetry.PresenceSyncRejected(telemetry.SameReplicaRejection),
+        telemetry.PresenceSyncRejected,
       )
       internal.logger("beryl.presence")
       |> log.error("Dropped presence sync that claims this replica identity", [
@@ -2057,26 +2060,6 @@ fn merged_snapshot(
         #("conflicting_replica", replica),
       ])
       None
-    }
-  }
-}
-
-/// Retire every other incarnation of the sender's replica name.
-///
-/// The dependency keeps the causal history needed to reject stale updates
-/// from the incarnations it removes. `CannotSupersedeLocalReplica` cannot
-/// happen here because `accepts_snapshot` already rejects a sender that
-/// shares this replica's base name; keep the state unchanged if it does.
-fn retire_predecessor(actor_state: ActorState, sender: String) -> State {
-  case state.supersede(actor_state.crdt, sender) {
-    Ok(#(crdt, _diff)) -> crdt
-    Error(state.CannotSupersedeLocalReplica(local_replica, current_replica)) -> {
-      internal.logger("beryl.presence")
-      |> log.error("Refused to retire the local presence replica", [
-        #("local_replica", local_replica),
-        #("remote_replica", current_replica),
-      ])
-      actor_state.crdt
     }
   }
 }

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -1404,8 +1404,10 @@ fn handle_message(
       handle_available_work(actor_state)
     }
     Track(topic, key, session_id, meta, reply) -> {
-      let #(new_state, ref, _meta) =
-        do_track(actor_state, topic, key, session_id, meta, SupersedeNothing)
+      use #(new_state, ref, _meta) <- continue_with_track(
+        actor_state,
+        do_track(actor_state, topic, key, session_id, meta, SupersedeNothing),
+      )
       log_tracked(logger, topic, key, session_id, ref)
       // The read model was published inside `do_track`, before this reply,
       // so a `track(); list()` caller always observes the entry it just
@@ -1417,7 +1419,8 @@ fn handle_message(
     Update(ref, meta, reply) -> {
       case dict.get(actor_state.refs, ref) {
         Ok(TrackedPresence(topic, key, session_id, _, _, PublicOwner)) -> {
-          let #(new_state, new_ref, _meta) =
+          use #(new_state, new_ref, _meta) <- continue_with_track(
+            actor_state,
             do_track(
               actor_state,
               topic,
@@ -1425,7 +1428,8 @@ fn handle_message(
               session_id,
               meta,
               SupersedePublicRef(ref),
-            )
+            ),
+          )
           log_tracked(logger, topic, key, session_id, new_ref)
           reply(Ok(new_ref))
           actor.continue(new_state)
@@ -1449,15 +1453,19 @@ fn handle_message(
       reply,
     ) ->
       case process.is_alive(owner) {
-        False -> {
-          let assert Ok(Nil) =
-            work_queue.activate_cleanup(actor_state.inbox, owner)
-          process.send(reply, MutationAck(tag, operation_id, Untracked))
-          actor.continue(actor_state)
-        }
+        False ->
+          handle_dead_track_owner(
+            actor_state,
+            owner,
+            tag,
+            operation_id,
+            reply,
+            logger,
+          )
         True -> {
           let actor_state = monitor_runtime_owner(actor_state, owner)
-          let #(new_state, ref, stored_meta) =
+          use #(new_state, ref, stored_meta) <- continue_with_track(
+            actor_state,
             do_track(
               actor_state,
               topic,
@@ -1465,7 +1473,8 @@ fn handle_message(
               session_id,
               meta,
               SupersedeSameKey(explicit: replace, owner: owner),
-            )
+            ),
+          )
           log_tracked(logger, topic, key, session_id, ref)
           process.send(
             reply,
@@ -1539,6 +1548,40 @@ fn handle_message(
       }
       actor.continue(retire_unavailable(actor_state))
     }
+  }
+}
+
+fn handle_dead_track_owner(
+  actor_state: ActorState,
+  owner: process.Pid,
+  tag: String,
+  operation_id: Int,
+  reply: Subject(MutationAck),
+  logger: log.Logger,
+) -> actor.Next(ActorState, Message) {
+  let actor_state = case work_queue.activate_cleanup(actor_state.inbox, owner) {
+    Ok(Nil) -> actor_state
+    Error(error) -> {
+      log.warn(logger, "Presence cleanup activation failed", [
+        #("reason", overload.describe(error)),
+      ])
+      // This actor owns the state, so direct cleanup is the safe fallback
+      // when its queue cannot schedule the obligation.
+      do_untrack_runtime_owner(actor_state, owner)
+    }
+  }
+  process.send(reply, MutationAck(tag, operation_id, Untracked))
+  actor.continue(actor_state)
+}
+
+fn continue_with_track(
+  actor_state: ActorState,
+  tracked: Result(value, Nil),
+  next: fn(value) -> actor.Next(ActorState, Message),
+) -> actor.Next(ActorState, Message) {
+  case tracked {
+    Ok(value) -> next(value)
+    Error(Nil) -> actor.continue(actor_state)
   }
 }
 
@@ -1734,7 +1777,8 @@ fn superseded_refs(
 
 /// Track one key, superseding previous refs for it (see `Supersede`) in the
 /// same turn. Returns the new actor state, the generated ref, and the meta
-/// as stored (the caller's meta with `phx_ref` merged in).
+/// as stored (the caller's meta with `phx_ref` merged in). Returns an error
+/// if the CRDT does not expose the local clock that `state.join` must create.
 fn do_track(
   actor_state: ActorState,
   topic: String,
@@ -1742,7 +1786,7 @@ fn do_track(
   session_id: String,
   meta: json.Json,
   supersede: Supersede,
-) -> #(ActorState, String, json.Json) {
+) -> Result(#(ActorState, String, json.Json), Nil) {
   let ref = generate_ref()
   let stored_meta = meta_with_phx_ref(meta, ref)
   // Superseding removes the old entries and adds the new one before
@@ -1762,7 +1806,17 @@ fn do_track(
     SupersedeSameKey(owner:, ..) -> RuntimeOwner(owner)
   }
   let replica = state.replica(new_crdt)
-  let assert Ok(clock) = dict.get(state.compacted_clocks(new_crdt), replica)
+  // state.join inserts this clock. Keep the lookup fallible so a dependency
+  // contract regression rejects the mutation instead of crashing the library.
+  use clock <- result.try(
+    dict.get(state.compacted_clocks(new_crdt), replica)
+    |> result.map_error(fn(error) {
+      log.error(internal.logger("beryl.presence"), "Local CRDT clock missing", [
+        #("replica", replica),
+      ])
+      error
+    }),
+  )
   maybe_invoke_on_diff(
     actor_state.config,
     Diff(
@@ -1793,7 +1847,11 @@ fn do_track(
     new_crdt,
     unique_strings([topic, ..removed.topics], set.new(), []),
   )
-  #(ActorState(..actor_state, crdt: new_crdt, refs: new_refs), ref, stored_meta)
+  Ok(#(
+    ActorState(..actor_state, crdt: new_crdt, refs: new_refs),
+    ref,
+    stored_meta,
+  ))
 }
 
 /// Remove every named ref in one turn. Unknown or already-removed refs are
@@ -1989,15 +2047,15 @@ fn merge_remote_sync(
               #("replica", sender),
             ],
           )
-          None
+          Error(Nil)
         }
         True -> merged_snapshot(actor_state, sender, remote_state)
       }
     })
   case processed {
-    Ok(Some(#(next_state, sender))) ->
+    Ok(Ok(#(next_state, sender))) ->
       actor.continue(watch_replica(next_state, sender, owner, round))
-    Ok(None) -> actor.continue(actor_state)
+    Ok(Error(Nil)) -> actor.continue(actor_state)
     Error(crash) -> {
       let logger = internal.logger("beryl.presence")
       logger
@@ -2031,22 +2089,31 @@ fn accepts_snapshot(
 
 /// Merge an accepted snapshot after retiring the sender's predecessors.
 ///
-/// Returns `None` when the sender claims this replica's identity, which
-/// means two live actors share one base name or the peer relayed stale
-/// local history. Dropping the round keeps local state authoritative.
+/// Returns an error when the sender conflicts with this replica's identity.
+/// Dropping the round keeps local state authoritative.
 fn merged_snapshot(
   actor_state: ActorState,
   sender: String,
   remote_state: State,
-) -> Option(#(ActorState, String)) {
-  // accepts_snapshot rejects same-base senders, which is the only supersede
-  // error. This assertion is inside rescue, so an invariant violation drops
-  // the sync without crashing the presence actor.
-  let assert Ok(#(crdt, _diff)) = state.supersede(actor_state.crdt, sender)
+) -> Result(#(ActorState, String), Nil) {
+  // accepts_snapshot rejects local-base senders first. Match the dependency
+  // error too, so this library remains total if either contract changes.
+  use #(crdt, _diff) <- result.try(
+    state.supersede(actor_state.crdt, sender)
+    |> result.map_error(fn(error) {
+      let state.CannotSupersedeLocalReplica(local_replica, remote_replica) =
+        error
+      internal.logger("beryl.presence")
+      |> log.error("Refused to retire the local presence replica", [
+        #("local_replica", local_replica),
+        #("remote_replica", remote_replica),
+      ])
+    }),
+  )
   case state.merge(crdt, owner_snapshot(remote_state)) {
     Ok(crdt) -> {
       let #(crdt, _diff) = state.replica_up(crdt, sender)
-      Some(#(commit_replication(actor_state, crdt), sender))
+      Ok(#(commit_replication(actor_state, crdt), sender))
     }
     Error(state.SameReplica(replica)) -> {
       telemetry.emit(
@@ -2059,7 +2126,7 @@ fn merged_snapshot(
         #("remote_replica", sender),
         #("conflicting_replica", replica),
       ])
-      None
+      Error(Nil)
     }
   }
 }

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -58,6 +58,7 @@ import beryl/internal
 import beryl/log
 import beryl/overload
 import beryl/pubsub.{type PubSub}
+import beryl/telemetry
 import beryl/wire
 import beryl/work_queue
 import gleam/bit_array
@@ -286,9 +287,9 @@ pub opaque type Config {
     pubsub: Option(PubSub(SyncPayload)),
     /// This node's replica base name. Must identify at most one live node
     /// in the cluster. Each actor start derives a unique incarnation name
-    /// from it (`base@suffix`), so restarting a node never reuses the
-    /// previous incarnation's CRDT clocks; state from older incarnations
-    /// of the same base is pruned automatically. Two *live* nodes sharing
+    /// from it, so restarting a node never reuses the previous
+    /// incarnation's CRDT clocks; state from older incarnations of the
+    /// same base is pruned automatically. Two *live* nodes sharing
     /// a base violate the ownership contract; concurrent reuse is unsupported.
     replica: String,
     /// How often to request snapshots for replication (ms). Non-positive
@@ -744,9 +745,10 @@ fn build_presence(
   // name after a restart would reset its clocks while peers still remember
   // the old ones: new joins would be silently filtered as already-seen,
   // and the previous incarnation's entries would resurrect via merges.
-  // A unique suffix separates clocks. Receiver-issued requests establish
-  // incarnation freshness; the suffix itself does not order actor starts.
-  let crdt = state.new(incarnate_replica(config.replica))
+  // The library mints an identity that is unique per start and keeps the
+  // configured name recoverable. Receiver-issued requests establish
+  // incarnation freshness; the identity itself does not order actor starts.
+  let crdt = state.new_incarnation(config.replica)
 
   actor.new_with_initialiser(5000, fn(subject) {
     // Created here, in the actor process itself, so the read model's
@@ -932,7 +934,7 @@ fn watch_replica(
   case actor_state.sync {
     None -> actor_state
     Some(sync) -> {
-      let base = base_replica(replica)
+      let base = state.base_replica(replica)
       let previous = dict.get(sync.owners, base)
       let monitor = case previous {
         Ok(ReplicaOwner(_, old_pid, Available(monitor), _)) if old_pid == pid ->
@@ -1067,44 +1069,19 @@ fn generate_ref() -> String {
   |> bit_array.base16_encode()
 }
 
-/// Separates a replica base name from its per-start incarnation suffix.
-const incarnation_separator = "@"
-
-/// Derive a unique incarnation name for this actor start.
-fn incarnate_replica(base: String) -> String {
-  base <> incarnation_separator <> generate_ref()
-}
-
-/// Recover the configured base from an incarnation-qualified replica name.
-///
-/// The suffix we mint never contains the separator, so everything before
-/// the last separator is the base — even when the base itself contains one
-/// (e.g. Erlang-style `app@host` names). Names without a separator (from
-/// nodes running older beryl versions) are their own base.
-fn base_replica(replica: String) -> String {
-  case list.reverse(string.split(replica, incarnation_separator)) {
-    [_suffix, ..rest] if rest != [] ->
-      string.join(list.reverse(rest), incarnation_separator)
-    _ -> replica
-  }
-}
-
 fn compact_replica(crdt: State, replica: String) -> State {
   let #(crdt, _diff) = state.replica_down(crdt, replica)
   state.remove_down_replica(crdt, replica)
 }
 
-/// Full-state beryl snapshots have a compacted clock for every entry owner.
-/// Use the dependency's lifecycle API rather than its opaque representation.
-fn owner_snapshot(crdt: State) -> State {
-  dict.keys(state.compacted_clocks(crdt))
-  |> list.fold(crdt, fn(crdt, replica) {
-    case replica == state.replica(crdt) {
-      True -> crdt
-      False -> compact_replica(crdt, replica)
-    }
-  })
-}
+/// Reduce a state to the data its own replica owns.
+///
+/// beryl replicates one full state per owner. The dependency's lifecycle API
+/// keeps a high-water clock for every replica it removes, which is correct for
+/// local state but wrong to relay: a receiver that adopted a peer's clocks for
+/// a third replica would treat that replica's later entries as already seen.
+@external(erlang, "beryl_presence_state_ffi", "owner_snapshot")
+fn owner_snapshot(crdt: State) -> State
 
 /// Merge the server-generated tracking ref into the tracked meta as
 /// `phx_ref`, matching Phoenix behaviour. Phoenix client `Presence` helpers
@@ -2014,12 +1991,7 @@ fn merge_remote_sync(
           )
           None
         }
-        True -> {
-          let crdt = retire_predecessor(actor_state, sender)
-          let crdt = state.merge(crdt, owner_snapshot(remote_state))
-          let #(crdt, _diff) = state.replica_up(crdt, sender)
-          Some(#(commit_replication(actor_state, crdt), sender))
-        }
+        True -> merged_snapshot(actor_state, sender, remote_state)
       }
     })
   case processed {
@@ -2043,8 +2015,8 @@ fn accepts_snapshot(
   owner: process.Pid,
   round: Int,
 ) -> Bool {
-  let base = base_replica(sender)
-  base != base_replica(state.replica(actor_state.crdt))
+  let base = state.base_replica(sender)
+  !state.same_base(sender, state.replica(actor_state.crdt))
   && case actor_state.sync {
     None -> False
     Some(sync) ->
@@ -2057,15 +2029,55 @@ fn accepts_snapshot(
   }
 }
 
+/// Merge an accepted snapshot after retiring the sender's predecessors.
+///
+/// Returns `None` when the sender claims this replica's identity, which
+/// means two live actors share one base name or the peer relayed stale
+/// local history. Dropping the round keeps local state authoritative.
+fn merged_snapshot(
+  actor_state: ActorState,
+  sender: String,
+  remote_state: State,
+) -> Option(#(ActorState, String)) {
+  let crdt = retire_predecessor(actor_state, sender)
+  case state.merge(crdt, owner_snapshot(remote_state)) {
+    Ok(crdt) -> {
+      let #(crdt, _diff) = state.replica_up(crdt, sender)
+      Some(#(commit_replication(actor_state, crdt), sender))
+    }
+    Error(state.SameReplica(replica)) -> {
+      telemetry.emit(
+        actor_state.config.telemetry,
+        telemetry.PresenceSyncRejected(telemetry.SameReplicaRejection),
+      )
+      internal.logger("beryl.presence")
+      |> log.error("Dropped presence sync that claims this replica identity", [
+        #("local_replica", state.replica(actor_state.crdt)),
+        #("remote_replica", sender),
+        #("conflicting_replica", replica),
+      ])
+      None
+    }
+  }
+}
+
+/// Retire every other incarnation of the sender's replica name.
+///
+/// The dependency keeps the causal history needed to reject stale updates
+/// from the incarnations it removes. `CannotSupersedeLocalReplica` cannot
+/// happen here because `accepts_snapshot` already rejects a sender that
+/// shares this replica's base name; keep the state unchanged if it does.
 fn retire_predecessor(actor_state: ActorState, sender: String) -> State {
-  case actor_state.sync {
-    None -> actor_state.crdt
-    Some(sync) ->
-      case dict.get(sync.owners, base_replica(sender)) {
-        Ok(previous) if previous.replica != sender ->
-          compact_replica(actor_state.crdt, previous.replica)
-        Ok(_) | Error(Nil) -> actor_state.crdt
-      }
+  case state.supersede(actor_state.crdt, sender) {
+    Ok(#(crdt, _diff)) -> crdt
+    Error(state.CannotSupersedeLocalReplica(local_replica, current_replica)) -> {
+      internal.logger("beryl.presence")
+      |> log.error("Refused to retire the local presence replica", [
+        #("local_replica", local_replica),
+        #("remote_replica", current_replica),
+      ])
+      actor_state.crdt
+    }
   }
 }
 

--- a/packages/beryl/src/beryl/telemetry.gleam
+++ b/packages/beryl/src/beryl/telemetry.gleam
@@ -105,16 +105,6 @@ pub type QueueOutcome {
   QueueRejected
 }
 
-/// Why a replicated presence snapshot was refused.
-///
-/// `SameReplicaRejection` means a peer sent state that claims this node's
-/// replica identity, or echoed local causal history this node has not seen.
-/// It indicates two live nodes configured with the same identity, or stale
-/// state from an earlier run.
-pub type PresenceSyncRejection {
-  SameReplicaRejection
-}
-
 /// Stable, low-cardinality beryl telemetry events.
 pub type Event {
   QueueOccupancy(occupancy: overload.Occupancy, outcome: QueueOutcome)
@@ -144,7 +134,7 @@ pub type Event {
     callback_result: CallbackResult,
   )
   BroadcastStop(duration: Int, recipients: Int, origin: BroadcastOrigin)
-  PresenceSyncRejected(reason: PresenceSyncRejection)
+  PresenceSyncRejected
 }
 
 @external(erlang, "beryl_telemetry_ffi", "execute")

--- a/packages/beryl/src/beryl/telemetry.gleam
+++ b/packages/beryl/src/beryl/telemetry.gleam
@@ -105,6 +105,16 @@ pub type QueueOutcome {
   QueueRejected
 }
 
+/// Why a replicated presence snapshot was refused.
+///
+/// `SameReplicaRejection` means a peer sent state that claims this node's
+/// replica identity, or echoed local causal history this node has not seen.
+/// It indicates two live nodes configured with the same identity, or stale
+/// state from an earlier run.
+pub type PresenceSyncRejection {
+  SameReplicaRejection
+}
+
 /// Stable, low-cardinality beryl telemetry events.
 pub type Event {
   QueueOccupancy(occupancy: overload.Occupancy, outcome: QueueOutcome)
@@ -134,6 +144,7 @@ pub type Event {
     callback_result: CallbackResult,
   )
   BroadcastStop(duration: Int, recipients: Int, origin: BroadcastOrigin)
+  PresenceSyncRejected(reason: PresenceSyncRejection)
 }
 
 @external(erlang, "beryl_telemetry_ffi", "execute")

--- a/packages/beryl/src/beryl_presence_state_ffi.erl
+++ b/packages/beryl/src/beryl_presence_state_ffi.erl
@@ -1,7 +1,7 @@
 -module(beryl_presence_state_ffi).
--export([remove_tag/2]).
+-export([remove_tag/2, owner_snapshot/1]).
 
-%% lattice_presence 1.x exposes tuple-wide leave operations but not removal by
+%% lattice_presence 2.x exposes tuple-wide leave operations but not removal by
 %% its public Tag. Preserve every opaque state field while dropping one value.
 remove_tag({state, Replica, Context, Clouds, Values, Replicas}, Tag)
   when is_map(Values) ->
@@ -12,4 +12,22 @@ remove_tag({state, Replica, Context, Clouds, Values, Replicas}, Tag)
             {{state, Replica, Context, Clouds, Remaining, Replicas}, true}
     end;
 remove_tag(_State, _Tag) ->
+    erlang:error(unsupported_lattice_presence_state).
+
+%% Keep only the data this replica owns.
+%%
+%% beryl replicates one full state per owner, so a reply must not carry
+%% another replica's clocks. The lifecycle API retains a high-water clock for
+%% every replica it removes; relaying those clocks would make the receiver
+%% treat a peer's later entries as already observed.
+owner_snapshot({state, Replica, Context, Clouds, Values, _Replicas})
+  when is_map(Context), is_map(Clouds), is_map(Values) ->
+    {state,
+     Replica,
+     maps:with([Replica], Context),
+     maps:with([Replica], Clouds),
+     maps:filter(fun({tag, Owner, _Clock}, _Entry) -> Owner =:= Replica end,
+                 Values),
+     #{Replica => up}};
+owner_snapshot(_State) ->
     erlang:error(unsupported_lattice_presence_state).

--- a/packages/beryl/src/beryl_telemetry_ffi.erl
+++ b/packages/beryl/src/beryl_telemetry_ffi.erl
@@ -72,11 +72,11 @@ execute({broadcast_stop, Duration, Recipients, Origin}) ->
         #{origin => broadcast_origin(Origin)}
     ),
     nil;
-execute({presence_sync_rejected, Reason}) ->
+execute(presence_sync_rejected) ->
     telemetry:execute(
         [beryl, presence, sync, rejected],
         #{count => 1},
-        #{reason => presence_sync_rejection(Reason)}
+        #{reason => same_replica}
     ),
     nil.
 
@@ -148,5 +148,3 @@ disconnect_reason(admission_disconnect) -> admission_rejected.
 
 broadcast_origin(local) -> local;
 broadcast_origin(remote) -> remote.
-
-presence_sync_rejection(same_replica_rejection) -> same_replica.

--- a/packages/beryl/src/beryl_telemetry_ffi.erl
+++ b/packages/beryl/src/beryl_telemetry_ffi.erl
@@ -71,6 +71,13 @@ execute({broadcast_stop, Duration, Recipients, Origin}) ->
         },
         #{origin => broadcast_origin(Origin)}
     ),
+    nil;
+execute({presence_sync_rejected, Reason}) ->
+    telemetry:execute(
+        [beryl, presence, sync, rejected],
+        #{count => 1},
+        #{reason => presence_sync_rejection(Reason)}
+    ),
     nil.
 
 monotonic_time() ->
@@ -141,3 +148,5 @@ disconnect_reason(admission_disconnect) -> admission_rejected.
 
 broadcast_origin(local) -> local;
 broadcast_origin(remote) -> remote.
+
+presence_sync_rejection(same_replica_rejection) -> same_replica.

--- a/packages/beryl/test/beryl_presence_distributed_test.erl
+++ b/packages/beryl/test/beryl_presence_distributed_test.erl
@@ -270,15 +270,18 @@ lagging_peer_cannot_restore_retired_history_test_() ->
             {ok, _} = track(A, Current, <<"current">>),
             await_view(B, Receiver, [<<"current">>]),
             #{clocks := Before} = call(B, ?MODULE, retained, [Receiver]),
-            ?assertNot(maps:is_key(OldReplica, Before)),
+            %% Retirement keeps the retired incarnation's watermark clock.
+            %% That watermark is what rejects a replay of its history.
+            ?assert(maps:is_key(OldReplica, Before)),
             %% A third BEAM node speaks the original v2 full-state protocol.
             %% Its valid reply includes a retired replica's values and clocks.
             _LegacyPid = call(C, ?MODULE, start_lagging_replica, [?SCOPE, OldState]),
             connect(B, C),
             await_view(B, Receiver, [<<"current">>, <<"lagging">>]),
-            #{clocks := After, entries := 2} =
+            #{clocks := After, entries := 2, entry_replicas := EntryReplicas} =
                 call(B, ?MODULE, retained, [Receiver]),
-            ?assertNot(maps:is_key(OldReplica, After)),
+            ?assert(maps:is_key(OldReplica, After)),
+            ?assertNot(lists:member(OldReplica, EntryReplicas)),
             await_diff(B, Receiver, leaves, [<<"old">>])
         end)
     end}.
@@ -316,9 +319,9 @@ retirement_revokes_old_replies_and_requires_fresh_rejoin_test_() ->
             %% Exercise the real 60-second policy, including with periodic
             %% requests disabled. No clock rewriting or shortened test TTL.
             await({retirement, element(2, B)}, fun() ->
-                #{clocks := Clocks, owners := Owners} =
+                #{owners := Owners, entry_replicas := EntryReplicas} =
                     call(B, ?MODULE, retained, [Receiver]),
-                Owners =:= 0 andalso not maps:is_key(CurrentReplica, Clocks)
+                Owners =:= 0 andalso not lists:member(CurrentReplica, EntryReplicas)
             end, 70000),
             Elapsed = call(B, erlang, monotonic_time, [millisecond]) - Started,
             ?assert(Elapsed >= 60000),
@@ -358,7 +361,9 @@ restart_churn_keeps_one_incarnation_per_base_test_() ->
                 await_view(B, Receiver, [Key]),
                 #{clocks := Clocks, entries := 1, owners := 1} =
                     call(B, ?MODULE, retained, [Receiver]),
-                ?assertEqual(1, map_size(Clocks)),
+                %% One live incarnation, plus one watermark clock per
+                %% retired incarnation. Growth stays bounded by restarts.
+                ?assertEqual(Index + 1, map_size(Clocks)),
                 Current
             end, Source, lists:seq(1, 8))
         end)
@@ -532,8 +537,11 @@ retained(#{pid := Pid}) ->
     Actor = sys:get_state(Pid),
     Crdt = element(2, Actor),
     {some, Sync} = element(5, Actor),
+    Values = 'lattice_presence@presence_state':internal_values(Crdt),
     #{clocks => 'lattice_presence@presence_state':compacted_clocks(Crdt),
       entries => 'lattice_presence@presence_state':entry_count(Crdt),
+      entry_replicas => lists:usort([Replica ||
+                                     {tag, Replica, _Clock} <- maps:keys(Values)]),
       owners => map_size(element(5, Sync))}.
 
 request_round(#{handle := Presence, pid := Pid}) ->
@@ -577,14 +585,14 @@ proxy_call(Proxy, Operation) ->
     end.
 
 start_lagging_replica(Scope, RemoteState) ->
-    Local = 'lattice_presence@presence_state':new(<<"lagging@legacy">>),
-    Merged = 'lattice_presence@presence_state':merge(Local, RemoteState),
+    Local = 'lattice_presence@presence_state':new_incarnation(<<"lagging">>),
+    {ok, Merged} = 'lattice_presence@presence_state':merge(Local, RemoteState),
     State = 'lattice_presence@presence_state':join(
         Merged, <<"lagging">>, ?TOPIC, <<"lagging">>, 'gleam@json':null()),
     start_snapshot_replica(Scope, State, direct).
 
 start_held_replica(Scope, Gate) ->
-    Local = 'lattice_presence@presence_state':new(<<"source@held">>),
+    Local = 'lattice_presence@presence_state':new_incarnation(<<"source">>),
     State = 'lattice_presence@presence_state':join(
         Local, <<"old">>, ?TOPIC, <<"old">>, 'gleam@json':null()),
     #{pid => start_snapshot_replica(Scope, State, {held, Gate})}.
@@ -616,13 +624,14 @@ snapshot_replica(Scope, State, Delivery) ->
     end.
 
 legacy_snapshot(#{pid := Pid}) ->
-    State = 'lattice_presence@presence_state':new(<<"source@legacy">>),
+    State = 'lattice_presence@presence_state':new_incarnation(<<"source">>),
     Snapshot = 'lattice_presence@presence_state':join(
         State, <<"legacy">>, ?TOPIC, <<"legacy">>, 'gleam@json':null()),
     nil = beryl_pubsub_ffi:send_to_pid(
         Pid, binary_to_existing_atom(?SCOPE, utf8),
         {message, ?SYNC_TOPIC, <<"presence_sync">>,
-         {sync_payload, 1, <<"source@legacy">>, Snapshot}, system}),
+         {sync_payload, 1, 'lattice_presence@presence_state':replica(State),
+          Snapshot}, system}),
     _ = sys:get_state(Pid),
     nil.
 

--- a/packages/beryl_ewe/manifest.toml
+++ b/packages/beryl_ewe/manifest.toml
@@ -27,7 +27,7 @@ packages = [
   { name = "glexer", version = "2.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "D423CF63B8D4F9654EF53D0AF4904B249EB0679BD41C63440170AC508C9CC65E" },
   { name = "glinter", version = "2.19.2", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "19CBB4D78E58E54D6B0E8554C389DC01071334FB11E9140C9487C9A4BBCA6158" },
   { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
-  { name = "lattice_presence", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "lattice_presence", source = "hex", outer_checksum = "4528FFC4B4DFCA076FAA0FA22D98CE4DF1B05BD0E9B4B90581DEA8799642C8B7" },
+  { name = "lattice_presence", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "youid"], otp_app = "lattice_presence", source = "hex", outer_checksum = "3E59B585A4E536A8BF2FC71BCEBCDABAD33A6475915CDD10CFAC112D64D6E764" },
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
   { name = "simplifile", version = "2.7.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "A2727627B063E87351934C7F7F008F2D1FDB16F6DE0B8C79F9E46459CFC9C164" },
@@ -35,6 +35,7 @@ packages = [
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
   { name = "websocks", version = "3.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_stdlib"], otp_app = "websocks", source = "hex", outer_checksum = "C70340E5B6C3390383ADA17029DCA6F8903863A7AD8CD8E1520EDCC4FE70D6FD" },
+  { name = "youid", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_stdlib", "gleam_time"], otp_app = "youid", source = "hex", outer_checksum = "7A3ABA44B1B38BC2BDCB5474C5317AA372BE58DFBC649815EE08B03526DDA18D" },
 ]
 
 [requirements]

--- a/packages/beryl_mist/manifest.toml
+++ b/packages/beryl_mist/manifest.toml
@@ -31,7 +31,7 @@ packages = [
   { name = "gramps", version = "6.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D55636072DEE173F6586A5679D3C02EC7A0DE3F8646B78C351B72908FF223DF7" },
   { name = "gun", version = "2.5.0", build_tools = ["make", "rebar3"], requirements = ["cowlib"], otp_app = "gun", source = "hex", outer_checksum = "3839576181456F5553FC1BE006FD95681576B916CC9AD68D422A287ED4A770DD" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
-  { name = "lattice_presence", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "lattice_presence", source = "hex", outer_checksum = "4528FFC4B4DFCA076FAA0FA22D98CE4DF1B05BD0E9B4B90581DEA8799642C8B7" },
+  { name = "lattice_presence", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "youid"], otp_app = "lattice_presence", source = "hex", outer_checksum = "3E59B585A4E536A8BF2FC71BCEBCDABAD33A6475915CDD10CFAC112D64D6E764" },
   { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
   { name = "mist", version = "6.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "1B07F321D5FA0CB162D81496F2DE96AEB6EF8980F4F38230A4CC3F849497E020" },
   { name = "palabres", version = "1.0.4", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib"], otp_app = "palabres", source = "hex", outer_checksum = "2809B7C10AE929E82454B4A6A0FB7D02073C5A509F9A63EE9F7B268A75D98965" },
@@ -41,6 +41,7 @@ packages = [
   { name = "telemetry", version = "1.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
   { name = "websocks", version = "4.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_stdlib"], otp_app = "websocks", source = "hex", outer_checksum = "89B0C31A032CBE28D4C5FB5CC25A8A690669FEBA501C63F99A4E8F5748750B2A" },
+  { name = "youid", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_stdlib", "gleam_time"], otp_app = "youid", source = "hex", outer_checksum = "7A3ABA44B1B38BC2BDCB5474C5317AA372BE58DFBC649815EE08B03526DDA18D" },
 ]
 
 [requirements]

--- a/website/src/content/docs/architecture/presence.md
+++ b/website/src/content/docs/architecture/presence.md
@@ -177,8 +177,8 @@ interval does not bound node-failure detection time.
 
 ## Incarnation freshness and retirement
 
-Use one live actor per replica base in a scope. The per-start random suffix
-separates CRDT clocks; it does not prove which incarnation is newer.
+Use one live actor per replica base in a scope. The per-start incarnation
+identity separates CRDT clocks; it does not prove which incarnation is newer.
 
 The receiver orders its own snapshot requests and keeps one confirmed owner
 per base. A different incarnation can replace that owner only by answering a
@@ -187,12 +187,13 @@ replacement started. A delayed answer to an older request cannot displace the
 confirmed replacement, even if the receiver had never confirmed the old
 process. Concurrent live actors with one base violate this ownership rule.
 
-beryl uses the CRDT's `replica_down` and `remove_down_replica` operations with
-these compaction conditions:
+beryl uses the CRDT's `supersede`, `replica_down`, and `remove_down_replica`
+operations with these compaction conditions:
 
-1. A confirmed replacement retires the previous incarnation's values and
-   causal context. The receiver also removes its owner monitor and pending
-   request.
+1. A confirmed replacement retires the previous incarnation's values. The
+   CRDT keeps that incarnation's high-water clock, which is what rejects a
+   later replay of its history. The receiver also removes its owner monitor
+   and pending request.
 2. Without a replacement, beryl retains an unavailable owner's state for
    **60 seconds**. A separate **one-second** tick checks retention, even with
    periodic snapshot requests disabled. Unanswered requests to missing members
@@ -211,7 +212,8 @@ them through a fresh exchange on reconnect.
 
 This policy retains at most one confirmed incarnation per base, and keeps
 unavailable history only for the retention window plus the next runnable
-check. It does not impose a global memory bound on peer count, entry count,
+check. A retired incarnation still leaves one high-water clock behind, so
+clock storage grows with the number of retired incarnations. It does not impose a global memory bound on peer count, entry count,
 metadata size, or work blocked in callbacks. Each reply copies the source's
 owned entries; projecting a snapshot with the dependency's lifecycle API also
 scans retained state. See [#400](https://github.com/tylerbutler/beryl/issues/400)


### PR DESCRIPTION
## Summary

Upgrades `lattice_presence` from 1.0.1 to 2.0.0 and adapts beryl's presence actor to the new API.

## Breaking changes handled

- `merge` now returns `Result(State, MergeError)`. A snapshot that claims the local replica identity is dropped, the previous CRDT state is kept, and the event is logged at error level.
- The dependency's incarnation API (`new_incarnation`, `base_replica`, `same_base`) replaces beryl's private `base@suffix` scheme, and `supersede` replaces the private predecessor compaction. Replica identities on the wire change format; mixed-version clusters are not supported.
- Retirement now keeps a high-water clock for every retired incarnation. Outbound sync replies therefore strip all foreign clocks through a new `owner_snapshot` FFI. Without that step a receiver adopts a peer's clock for a third replica and then drops that replica's later entries.

## Added

- Telemetry event `[beryl, presence, sync, rejected]` with a low-cardinality `reason` (`same_replica`).

## Validation

- `just format-check`, `just check`, `just lint`, `just test` (595 beryl tests), `just build-strict`, and `just audit-licences` pass. The new transitive dependency `youid` is Apache-2.0 and passes the allowlist.
- `just examples-test` and `just site-snippets` fail locally because of a pre-existing pnpm/corepack version mismatch, unrelated to this change.
