### PR TITLE
fix(load-test): name callback delay as elapsed

### DIFF
--- a/examples/load_test/README.md
+++ b/examples/load_test/README.md
@@ -67,6 +67,7 @@ rate is non-positive, the limit is disabled regardless of its burst value.
 | `BIND_ADDRESS` | `127.0.0.1` | Listener interface |
 | `PORT` | `8000` | Listener TCP port |
 | `SERVER` | Mist | `ewe` selects Ewe in the shipment entry point; every other value selects Mist |
+| `BENCH_CALLBACK_ELAPSED_US` | `0` | Minimum elapsed time added to each message callback, in microseconds |
 | `BERYL_HEARTBEAT_TIMEOUT_MS` | `60000` | Server staleness/eviction window, in ms |
 | `BERYL_MAX_CONNECTIONS_PER_IP` | `0` | Concurrent connections per real peer IP; `<= 0` is unlimited |
 | `BERYL_MAX_CONNECTIONS` | `0` | Concurrent connections on this BEAM node; `<= 0` is unlimited |
@@ -84,6 +85,14 @@ rate is non-positive, the limit is disabled regardless of its burst value.
 | `BERYL_MAX_INBOUND_FRAME_BYTES` | `1048576` | Maximum assembled inbound frame size in bytes (1 MiB) |
 | `BERYL_MAX_JOINED_TOPICS_PER_SOCKET` | `1000` | Maximum simultaneous joined topics per socket |
 | `BERYL_TELEMETRY` | `false` | Enables beryl telemetry for `1`, `true`, `yes`, or `on`, case-insensitively |
+
+`BENCH_CALLBACK_ELAPSED_US` uses a monotonic deadline and busy-waits while the
+callback process is scheduled. The loop is preemptible. Scheduler contention
+and suspension advance the deadline, so the value is elapsed callback time,
+not fixed or calibrated CPU work. Keep it at zero for CPU-capacity comparisons
+unless this elapsed-delay model is intentional. For comparative runs, record
+the value, OTP and scheduler settings, hardware, and that no CPU calibration
+applies.
 
 If `BERYL_TELEMETRY` is missing it is false; any value not in the four-value
 true set is also false. Enabling it only emits events. This fixture does not

--- a/examples/load_test/src/load_test/app.gleam
+++ b/examples/load_test/src/load_test/app.gleam
@@ -15,12 +15,12 @@ pub type App {
 
 pub fn start() -> App {
   let presence_tracker = session_presence.start()
-  let cost_us = bench.callback_cost_us()
+  let callback_elapsed_us = bench.callback_elapsed_us()
   let assert Ok(#(channels, specification)) = case bench.use_channel_layer() {
     True ->
       beryl_channel.child_spec(
         environment_config(),
-        handlers: channel.handlers(presence_tracker, cost_us),
+        handlers: channel.handlers(presence_tracker, callback_elapsed_us),
       )
       |> result.map_error(fn(error) { string.inspect(error) })
     False ->
@@ -28,7 +28,7 @@ pub fn start() -> App {
         environment_config(),
         init: channel.init,
         update: fn(model, input) {
-          channel.update(presence_tracker, cost_us, model, input)
+          channel.update(presence_tracker, callback_elapsed_us, model, input)
         },
       )
       |> result.map_error(fn(error) { string.inspect(error) })

--- a/examples/load_test/src/load_test/bench.gleam
+++ b/examples/load_test/src/load_test/bench.gleam
@@ -11,10 +11,11 @@ pub fn environment_integer(name: String, default: Int) -> Int {
   |> result.unwrap(default)
 }
 
-/// `BENCH_CALLBACK_COST_US`: CPU time for each message callback, in
-/// microseconds. The default is zero.
-pub fn callback_cost_us() -> Int {
-  environment_integer("BENCH_CALLBACK_COST_US", 0)
+/// `BENCH_CALLBACK_ELAPSED_US`: minimum elapsed time for each message
+/// callback, in microseconds. The default is zero. The wait uses CPU while
+/// scheduled, but preemption and suspension count toward the elapsed time.
+pub fn callback_elapsed_us() -> Int {
+  environment_integer("BENCH_CALLBACK_ELAPSED_US", 0)
 }
 
 /// `BERYL_API`: `raw` (default) runs the topics through `beryl.child_spec`;
@@ -23,6 +24,8 @@ pub fn use_channel_layer() -> Bool {
   envoy.get("BERYL_API") == Ok("channel")
 }
 
-/// Use CPU on the calling process for `microseconds` microseconds.
-@external(erlang, "load_test_bench_ffi", "busy_wait")
-pub fn burn(microseconds: Int) -> Nil
+/// Busy-wait until `microseconds` have elapsed.
+///
+/// This is preemptible elapsed-time behavior, not fixed or calibrated CPU work.
+@external(erlang, "load_test_bench_ffi", "wait_elapsed")
+pub fn wait_elapsed(microseconds: Int) -> Nil

--- a/examples/load_test/src/load_test/channel.gleam
+++ b/examples/load_test/src/load_test/channel.gleam
@@ -19,7 +19,7 @@ pub fn init(_info: socket.ConnectInfo(message)) -> #(Nil, List(Effect)) {
 
 pub fn update(
   presence: session_presence.Tracker,
-  cost_us: Int,
+  callback_elapsed_us: Int,
   model: Nil,
   input: Input(message),
 ) -> Next(Nil) {
@@ -34,7 +34,7 @@ pub fn update(
         RejectJoin(ref, json.object([#("reason", json.string("unmatched"))])),
       ])
     Message(topic, event_name, payload, ref) -> {
-      bench.burn(cost_us)
+      bench.wait_elapsed(callback_elapsed_us)
       socket.Next(
         model,
         message_effects(presence, topic, event_name, payload, ref),
@@ -147,7 +147,7 @@ fn reply_error(
 /// topology. `message_effects` defines the behavior of each event.
 pub fn handlers(
   presence: session_presence.Tracker,
-  cost_us: Int,
+  callback_elapsed_us: Int,
 ) -> List(channel.Handler) {
   [
     channel.handler("guardrail:forbidden", fn(_context) {
@@ -156,7 +156,7 @@ pub fn handlers(
     channel.handler("bench:*", fn(context) {
       channel.accept(Nil)
       |> channel.on_message(fn(_state, message) {
-        bench.burn(cost_us)
+        bench.wait_elapsed(callback_elapsed_us)
         channel.next(Nil, actions(presence, context.topic, message))
       })
     }),

--- a/examples/load_test/src/load_test_bench_ffi.erl
+++ b/examples/load_test/src/load_test_bench_ffi.erl
@@ -1,11 +1,11 @@
 -module(load_test_bench_ffi).
--export([busy_wait/1]).
+-export([wait_elapsed/1]).
 
-%% Use CPU on the calling process for `Micros` microseconds. This operation
-%% represents application callback work, such as a database request or a
-%% large payload. Unlike `timer:sleep/1`, it holds the scheduler.
-busy_wait(Micros) when Micros =< 0 -> nil;
-busy_wait(Micros) ->
+%% Busy-wait until `Micros` microseconds have elapsed. The loop uses CPU while
+%% scheduled, but it is preemptible and suspension time advances the deadline.
+%% It does not provide a fixed or calibrated amount of CPU work.
+wait_elapsed(Micros) when Micros =< 0 -> nil;
+wait_elapsed(Micros) ->
     spin(erlang:monotonic_time(microsecond) + Micros).
 
 spin(Deadline) ->

--- a/examples/load_test/test/load_test_test.gleam
+++ b/examples/load_test/test/load_test_test.gleam
@@ -14,6 +14,7 @@ import gleam/string
 import gleeunit
 import gleeunit/should
 import load_test/app as load_app
+import load_test/bench
 import load_test/channel
 import load_test/ewe as ewe_http
 import load_test/http
@@ -21,6 +22,9 @@ import load_test/mist as mist_http
 
 @external(erlang, "load_test_test_ffi", "run_after")
 fn run_after(run: fn() -> value, cleanup: fn() -> Nil) -> value
+
+@external(erlang, "load_test_test_ffi", "elapsed_wait_advances_while_suspended")
+fn elapsed_wait_advances_while_suspended() -> Bool
 
 pub fn main() -> Nil {
   gleeunit.main()
@@ -175,6 +179,16 @@ pub fn broadcast_fans_out_full_payload_test() -> Nil {
   let publisher_messages = recv(publisher) <> recv(publisher)
   publisher_messages |> string.contains("fanout-1") |> should.be_true
   recv(peer) |> string.contains("fanout-1") |> should.be_true
+}
+
+pub fn callback_elapsed_knob_uses_elapsed_time_name_test() -> Nil {
+  with_environment_value("BENCH_CALLBACK_ELAPSED_US", Some("123"), fn() {
+    bench.callback_elapsed_us() |> should.equal(123)
+  })
+}
+
+pub fn callback_elapsed_wait_includes_suspension_test() -> Nil {
+  elapsed_wait_advances_while_suspended() |> should.be_true
 }
 
 pub fn app_configures_frame_rate_from_environment_test() -> Nil {

--- a/examples/load_test/test/load_test_test_ffi.erl
+++ b/examples/load_test/test/load_test_test_ffi.erl
@@ -1,7 +1,47 @@
 -module(load_test_test_ffi).
--export([run_after/2]).
+-export([elapsed_wait_advances_while_suspended/0, run_after/2]).
 
 run_after(Run, Cleanup) ->
     try Run()
     after Cleanup()
+    end.
+
+elapsed_wait_advances_while_suspended() ->
+    Parent = self(),
+    Worker = spawn(fun() ->
+        receive
+            start ->
+                load_test_bench_ffi:wait_elapsed(1000000),
+                Parent ! {elapsed_wait_done, self()}
+        end
+    end),
+    try
+        {reductions, InitialReductions} = process_info(Worker, reductions),
+        Worker ! start,
+        case wait_for_reductions(Worker, InitialReductions + 1000, 500) of
+            false -> false;
+            true ->
+                true = erlang:suspend_process(Worker),
+                timer:sleep(1100),
+                true = erlang:resume_process(Worker),
+                receive
+                    {elapsed_wait_done, Worker} -> true
+                after 500 ->
+                    false
+                end
+        end
+    after
+        catch erlang:resume_process(Worker),
+        exit(Worker, kill)
+    end.
+
+wait_for_reductions(_Worker, _Minimum, 0) ->
+    false;
+wait_for_reductions(Worker, Minimum, Attempts) ->
+    case process_info(Worker, reductions) of
+        {reductions, Reductions} when Reductions >= Minimum -> true;
+        undefined -> false;
+        _ ->
+            timer:sleep(1),
+            wait_for_reductions(Worker, Minimum, Attempts - 1)
     end.

--- a/load/README.md
+++ b/load/README.md
@@ -152,6 +152,13 @@ non-negative integer. Profile files accept only `constant-vus`,
 `per-vu-iterations`, or `constant-arrival-rate`, require a non-empty `exec`
 and threshold arrays, and require positive VUs or arrival-rate allocation.
 
+The benchmark server's `BENCH_CALLBACK_ELAPSED_US` setting models elapsed
+callback delay. Its preemptible loop uses CPU only while scheduled; contention
+or suspension counts toward the deadline. It is not a calibrated CPU workload.
+Keep it at zero for CPU-capacity comparisons unless this elapsed-delay model
+is part of the workload. Record the exact value and this assumption with the
+target's hardware, OTP version, and scheduler settings.
+
 The benchmark contract is explicit: `echo` returns the submitted marker;
 `broadcast` and `broadcast_ack` fan out unchanged payloads;
 `presence_track`/`presence_untrack` produce matching `presence_diff` entries;
@@ -310,7 +317,8 @@ repeats from overwriting one another.
 ## Controlled baselines
 
 1. Pin the commit, k6 image digest, target image digest, OS and OTP settings,
-   topology, profile, and effective environment.
+   topology, profile, and effective client and server environment, including
+   `BENCH_CALLBACK_ELAPSED_US`.
 2. Pass `protocol-smoke`, then run an unrecorded whole-system warmup long
    enough for code loading, pools, and caches. `BROADCAST_WARMUP_MS` only
    coordinates group membership.


### PR DESCRIPTION
## Summary

- rename the callback benchmark knob to `BENCH_CALLBACK_ELAPSED_US`
- document that the preemptible deadline includes suspension and is not calibrated CPU work

Closes #452