### PR TITLE
fix(examples): reclaim abandoned presence entries

### DIFF
--- a/examples/chatrooms/src/chatroom/app.gleam
+++ b/examples/chatrooms/src/chatroom/app.gleam
@@ -91,11 +91,13 @@ fn accept_room(
       max_room_users,
     )
   {
-    Error(Nil) ->
+    Error(session_presence.AtCapacity) ->
       channel.reject(error_with_code(
         403,
         "Room is full (max " <> int.to_string(max_room_users) <> ")",
       ))
+    Error(session_presence.OwnerExited) ->
+      channel.reject(error_with_code(503, "Room admission failed"))
     Ok(Nil) -> {
       announce_rooms_changed(application_context, state.room_name)
       case channel.notify(join_context.self, PublishRoster) {

--- a/examples/example_helpers/gleam.toml
+++ b/examples/example_helpers/gleam.toml
@@ -12,3 +12,6 @@ gleam_http = ">= 4.3.0 and < 5.0.0"
 mist = ">= 6.0.0 and < 7.0.0"
 gleam_otp = ">= 1.2.0 and < 2.0.0"
 gleam_json = ">= 3.1.0 and < 4.0.0"
+
+[dev-dependencies]
+gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/examples/example_helpers/manifest.toml
+++ b/examples/example_helpers/manifest.toml
@@ -17,6 +17,7 @@ packages = [
   { name = "gleam_otp", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "DE4CA6850842F0266EE95317A25DD6A0A0F20CDFAB7C0ADC2E63251D7C3C72EC" },
   { name = "gleam_stdlib", version = "1.0.5", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CEE5B6C076A85B45F60C585F4316C63EC8B7127C119D5738C3958A9C4D50404E" },
   { name = "gleam_time", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56539216E4C4B1748714652AB38F0BD16B9101F61DB62769FDC7CD42A8E5E833" },
+  { name = "gleeunit", version = "1.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "EC31ABA74256AEA531EDF8169931D775BBB384FED0A8A1BDC4DD9354E3E21826" },
   { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
   { name = "gramps", version = "6.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D55636072DEE173F6586A5679D3C02EC7A0DE3F8646B78C351B72908FF223DF7" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
@@ -35,4 +36,5 @@ gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
 gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_otp = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
+gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 mist = { version = ">= 6.0.0 and < 7.0.0" }

--- a/examples/example_helpers/src/example_helper/session_presence.gleam
+++ b/examples/example_helpers/src/example_helper/session_presence.gleam
@@ -21,6 +21,11 @@ pub opaque type Tracker {
   Tracker(pid: Pid, subject: Subject(Command), table: Store)
 }
 
+pub type TrackError {
+  AtCapacity
+  OwnerExited
+}
+
 type Store
 
 type Command {
@@ -31,7 +36,7 @@ type Command {
     session_id: String,
     meta: json.Json,
     maximum: Int,
-    reply: Subject(Result(Nil, Nil)),
+    reply: Subject(Result(Nil, TrackError)),
   )
   Publish(topic: String)
   Stop(reply: Subject(Nil))
@@ -151,7 +156,7 @@ pub fn track_if_below(
   session_id: String,
   meta: json.Json,
   maximum: Int,
-) -> Result(Nil, Nil) {
+) -> Result(Nil, TrackError) {
   let owner = process.self()
   process.call(tracker.subject, call_timeout_ms, fn(reply) {
     TrackIfBelow(owner, topic, session_id, meta, maximum, reply)
@@ -185,7 +190,7 @@ fn loop(selector: Selector(Event), table: Store, state: State) -> Nil {
     Message(TrackIfBelow(owner, topic, session_id, meta, maximum, reply)) -> {
       case store_count(table, topic) < maximum {
         False -> {
-          process.send(reply, Error(Nil))
+          process.send(reply, Error(AtCapacity))
           loop(selector, table, state)
         }
         True -> {
@@ -193,7 +198,7 @@ fn loop(selector: Selector(Event), table: Store, state: State) -> Nil {
           case process.is_alive(owner) {
             False -> {
               process.demonitor_process(monitor)
-              process.send(reply, Error(Nil))
+              process.send(reply, Error(OwnerExited))
               loop(selector, table, state)
             }
             True -> {

--- a/examples/example_helpers/src/example_helper/session_presence.gleam
+++ b/examples/example_helpers/src/example_helper/session_presence.gleam
@@ -7,6 +7,7 @@
 
 import beryl
 import beryl/overload
+import gleam/dict.{type Dict}
 import gleam/erlang/process.{type Pid, type Selector, type Subject}
 import gleam/io
 import gleam/json
@@ -25,6 +26,7 @@ type Store
 type Command {
   Configure(sockets: beryl.Sockets, reply: Subject(Nil))
   TrackIfBelow(
+    owner: Pid,
     topic: String,
     session_id: String,
     meta: json.Json,
@@ -38,10 +40,11 @@ type Command {
 type Event {
   Message(Command)
   OwnerDown
+  SessionOwnerDown(owner: Pid, topic: String, session_id: String)
 }
 
 type State {
-  State(sockets: Option(beryl.Sockets))
+  State(sockets: Option(beryl.Sockets), owners: Dict(#(String, String), Pid))
 }
 
 @external(erlang, "example_session_presence_ffi", "new_store")
@@ -77,7 +80,7 @@ pub fn start() -> Tracker {
         |> process.select_map(subject, Message)
         |> process.select_specific_monitor(owner_monitor, fn(_) { OwnerDown })
       process.send(ready, subject)
-      loop(selector, table, State(sockets: None))
+      loop(selector, table, State(sockets: None, owners: dict.new()))
     })
   let assert Ok(subject) = process.receive(ready, start_timeout_ms)
   Tracker(pid, subject, table)
@@ -108,6 +111,11 @@ pub fn is_running(tracker: Tracker) -> Bool {
   process.is_alive(tracker.pid)
 }
 
+@internal
+pub fn process_id(tracker: Tracker) -> Pid {
+  tracker.pid
+}
+
 pub fn track(
   tracker: Tracker,
   topic: String,
@@ -135,7 +143,8 @@ pub fn track_without_publish(
 /// Atomically track a session when the topic is below `maximum`.
 ///
 /// The tracker actor serializes the count and insert so concurrent socket
-/// joins cannot oversubscribe a bounded room.
+/// joins cannot oversubscribe a bounded room. It also monitors the calling
+/// process and removes the session if that owner exits.
 pub fn track_if_below(
   tracker: Tracker,
   topic: String,
@@ -143,8 +152,9 @@ pub fn track_if_below(
   meta: json.Json,
   maximum: Int,
 ) -> Result(Nil, Nil) {
+  let owner = process.self()
   process.call(tracker.subject, call_timeout_ms, fn(reply) {
-    TrackIfBelow(topic, session_id, meta, maximum, reply)
+    TrackIfBelow(owner, topic, session_id, meta, maximum, reply)
   })
 }
 
@@ -170,18 +180,36 @@ fn loop(selector: Selector(Event), table: Store, state: State) -> Nil {
   case process.selector_receive_forever(selector) {
     Message(Configure(sockets, reply)) -> {
       process.send(reply, Nil)
-      loop(selector, table, State(sockets: Some(sockets)))
+      loop(selector, table, State(..state, sockets: Some(sockets)))
     }
-    Message(TrackIfBelow(topic, session_id, meta, maximum, reply)) -> {
-      let result = case store_count(table, topic) < maximum {
-        True -> {
-          store_track(table, topic, session_id, meta)
-          Ok(Nil)
+    Message(TrackIfBelow(owner, topic, session_id, meta, maximum, reply)) -> {
+      case store_count(table, topic) < maximum {
+        False -> {
+          process.send(reply, Error(Nil))
+          loop(selector, table, state)
         }
-        False -> Error(Nil)
+        True -> {
+          let monitor = process.monitor(owner)
+          case process.is_alive(owner) {
+            False -> {
+              process.demonitor_process(monitor)
+              process.send(reply, Error(Nil))
+              loop(selector, table, state)
+            }
+            True -> {
+              store_track(table, topic, session_id, meta)
+              let selector =
+                process.select_specific_monitor(selector, monitor, fn(_) {
+                  SessionOwnerDown(owner, topic, session_id)
+                })
+              let owners =
+                dict.insert(state.owners, #(topic, session_id), owner)
+              process.send(reply, Ok(Nil))
+              loop(selector, table, State(..state, owners: owners))
+            }
+          }
+        }
       }
-      process.send(reply, result)
-      loop(selector, table, state)
     }
     Message(Publish(topic)) -> {
       broadcast_snapshot(state.sockets, topic, store_snapshot(table, topic))
@@ -192,6 +220,23 @@ fn loop(selector: Selector(Event), table: Store, state: State) -> Nil {
     }
     OwnerDown -> {
       Nil
+    }
+    SessionOwnerDown(owner, topic, session_id) -> {
+      case dict.get(state.owners, #(topic, session_id)) {
+        Ok(current_owner) if current_owner == owner -> {
+          store_untrack(table, topic, session_id)
+          broadcast_snapshot(state.sockets, topic, store_snapshot(table, topic))
+          loop(
+            selector,
+            table,
+            State(
+              ..state,
+              owners: dict.delete(state.owners, #(topic, session_id)),
+            ),
+          )
+        }
+        Ok(_) | Error(Nil) -> loop(selector, table, state)
+      }
     }
   }
 }

--- a/examples/example_helpers/test/example_helper_test.gleam
+++ b/examples/example_helpers/test/example_helper_test.gleam
@@ -69,6 +69,18 @@ pub fn abandoned_queued_admission_does_not_consume_capacity_test() -> Nil {
   session_presence.stop(tracker)
 }
 
+pub fn at_capacity_returns_descriptive_error_test() -> Nil {
+  let tracker = session_presence.start()
+  let topic = "room:full"
+
+  session_presence.track_if_below(tracker, topic, "first", json.object([]), 1)
+  |> should.equal(Ok(Nil))
+  session_presence.track_if_below(tracker, topic, "second", json.object([]), 1)
+  |> should.equal(Error(session_presence.AtCapacity))
+
+  session_presence.stop(tracker)
+}
+
 pub fn owner_death_reclaims_admitted_capacity_test() -> Nil {
   let tracker = session_presence.start()
   let topic = "room:owner"

--- a/examples/example_helpers/test/example_helper_test.gleam
+++ b/examples/example_helpers/test/example_helper_test.gleam
@@ -1,0 +1,106 @@
+import example_helper/session_presence
+import gleam/erlang/process
+import gleam/json
+import gleeunit
+import gleeunit/should
+
+@external(erlang, "example_session_presence_test_ffi", "mailbox_length")
+fn mailbox_length(pid: process.Pid) -> Int
+
+@external(erlang, "example_session_presence_test_ffi", "with_suspended")
+fn with_suspended(pid: process.Pid, action: fn() -> a) -> a
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+fn wait_until(check: fn() -> Bool, timeout_ms: Int) -> Nil {
+  case check() {
+    True -> Nil
+    False -> {
+      case timeout_ms <= 0 {
+        True -> should.be_true(False)
+        False -> {
+          process.sleep(10)
+          wait_until(check, timeout_ms - 10)
+        }
+      }
+    }
+  }
+}
+
+fn await_down(monitor: process.Monitor) -> Nil {
+  let assert Ok(_) =
+    process.new_selector()
+    |> process.select_specific_monitor(monitor, fn(down) { down })
+    |> process.selector_receive(1000)
+  Nil
+}
+
+pub fn abandoned_queued_admission_does_not_consume_capacity_test() -> Nil {
+  let tracker = session_presence.start()
+  let topic = "room:queued"
+
+  with_suspended(session_presence.process_id(tracker), fn() {
+    let caller =
+      process.spawn_unlinked(fn() {
+        let _ =
+          session_presence.track_if_below(
+            tracker,
+            topic,
+            "abandoned",
+            json.object([]),
+            1,
+          )
+        Nil
+      })
+    let monitor = process.monitor(caller)
+    wait_until(
+      fn() { mailbox_length(session_presence.process_id(tracker)) > 0 },
+      1000,
+    )
+    process.kill(caller)
+    await_down(monitor)
+  })
+
+  session_presence.track_if_below(tracker, topic, "live", json.object([]), 1)
+  |> should.equal(Ok(Nil))
+  session_presence.count(tracker, topic) |> should.equal(1)
+  session_presence.stop(tracker)
+}
+
+pub fn owner_death_reclaims_admitted_capacity_test() -> Nil {
+  let tracker = session_presence.start()
+  let topic = "room:owner"
+  let admitted = process.new_subject()
+  let owner =
+    process.spawn_unlinked(fn() {
+      let result =
+        session_presence.track_if_below(
+          tracker,
+          topic,
+          "departed",
+          json.object([]),
+          1,
+        )
+      process.send(admitted, result)
+      process.receive_forever(process.new_subject())
+    })
+  let monitor = process.monitor(owner)
+
+  process.receive(admitted, 1000) |> should.equal(Ok(Ok(Nil)))
+  session_presence.count(tracker, topic) |> should.equal(1)
+  process.kill(owner)
+  await_down(monitor)
+  wait_until(fn() { session_presence.count(tracker, topic) == 0 }, 1000)
+
+  session_presence.track_if_below(
+    tracker,
+    topic,
+    "replacement",
+    json.object([]),
+    1,
+  )
+  |> should.equal(Ok(Nil))
+  session_presence.stop(tracker)
+}

--- a/examples/example_helpers/test/example_session_presence_test_ffi.erl
+++ b/examples/example_helpers/test/example_session_presence_test_ffi.erl
@@ -1,0 +1,14 @@
+-module(example_session_presence_test_ffi).
+-export([mailbox_length/1, with_suspended/2]).
+
+mailbox_length(Pid) ->
+    case erlang:process_info(Pid, message_queue_len) of
+        {message_queue_len, Length} -> Length;
+        undefined -> 0
+    end.
+
+with_suspended(Pid, Action) ->
+    true = erlang:suspend_process(Pid),
+    try Action()
+    after erlang:resume_process(Pid)
+    end.

--- a/examples/showcase/src/showcase/channel/room.gleam
+++ b/examples/showcase/src/showcase/channel/room.gleam
@@ -88,11 +88,13 @@ fn accept_room(
       max_room_users,
     )
   {
-    Error(Nil) ->
+    Error(session_presence.AtCapacity) ->
       channel.reject(error_with_code(
         403,
         "Room is full (max " <> int.to_string(max_room_users) <> ")",
       ))
+    Error(session_presence.OwnerExited) ->
+      channel.reject(error_with_code(503, "Room admission failed"))
     Ok(Nil) -> {
       // The room list lives on another topic, so it is the one thing here
       // that goes through the hub.

--- a/gleam.toml
+++ b/gleam.toml
@@ -11,14 +11,12 @@ members = ["packages/*", "examples/**"]
 "@release" = ["examples/**"]
 lint = ["examples/**"]
 docs = ["examples/**"]
-# Examples excluded from `trellis run test`: example_helper has no test/
-# directory (gleam test fails when the <package>_test module is missing), and
-# chatroom/cursor have tests that are not wired into the workspace run yet.
-# collab_document, its client, and showcase run here.
+# Examples excluded from `trellis run test`: chatroom/cursor have tests that
+# are not wired into the workspace run yet. collab_document, its client,
+# example_helper, and showcase run here.
 test = [
   "examples/chatrooms",
   "examples/cursors",
-  "examples/example_helpers",
 ]
 
 # Tag individual package versions in addition to repository series tags,


### PR DESCRIPTION
## Summary

- bind bounded-room presence entries to the calling topic worker
- reject queued admissions whose owner exited before insertion
- reclaim admitted entries and publish the updated roster when an owner dies

Closes #447