### PR TITLE
docs(connection): clarify per-system ceilings

### DIFF
--- a/.changes/unreleased/beryl-clarify-that-with-max.toml
+++ b/.changes/unreleased/beryl-clarify-that-with-max.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Clarify that with_max_connections applies independently to each beryl system on each BEAM node."

--- a/.changes/unreleased/beryl_ewe-clarify-that-total-connection.toml
+++ b/.changes/unreleased/beryl_ewe-clarify-that-total-connection.toml
@@ -1,0 +1,3 @@
+package = "beryl_ewe"
+kind = "Fixed"
+body = "Clarify that total connection limits apply independently to each beryl system on a node."

--- a/.changes/unreleased/beryl_mist-clarify-that-total-connection.toml
+++ b/.changes/unreleased/beryl_mist-clarify-that-total-connection.toml
@@ -1,0 +1,3 @@
+package = "beryl_mist"
+kind = "Fixed"
+body = "Clarify that total connection limits apply independently to each beryl system on a node."

--- a/docs/talks/beryl-interview/deck.md
+++ b/docs/talks/beryl-interview/deck.md
@@ -659,7 +659,7 @@ workload baselines: https://github.com/tylerbutler/beryl/issues/400.
 
 ## Production status
 
-**Built in:** per-IP connection caps · node-wide connection ceiling
+**Built in:** per-IP connection caps · per-system connection ceiling
 token-bucket rate limits · same-origin WebSocket policy by default
 
 **Deployment requirements:** edge proxy with a frame-size limit
@@ -674,7 +674,7 @@ limits."
 
 BUILT IN (config on the transport, name the real APIs):
 - `with_max_connections_per_ip`: per-IP connection caps, plus a
-  node-wide total connection ceiling so one node
+  per-system total connection ceiling on each node so one system
   cannot be socket-flooded past its capacity.
 - `with_message_rate`: token-bucket rate limiting per socket. This is
   what tamed the cursor firehose in the demo.

--- a/packages/beryl/src/beryl.gleam
+++ b/packages/beryl/src/beryl.gleam
@@ -130,7 +130,8 @@ pub opaque type Config {
     heartbeat_timeout_ms: Int,
     /// Max connections per IP (0 = unlimited)
     max_connections_per_ip: Int,
-    /// Max concurrent connections node-wide across all IPs (0 = unlimited)
+    /// Max concurrent connections for this beryl system on this node
+    /// (0 = unlimited)
     max_connections: Int,
     /// Per-IP connection attempt rate limit (connections/sec, 0 = unlimited)
     connection_rate_per_ip: Int,
@@ -390,35 +391,38 @@ pub fn with_connection_rate_per_ip(
   Config(..config, connection_rate_per_ip: rate, connection_burst_per_ip: burst)
 }
 
-/// Configure the maximum number of concurrent connections allowed across the
-/// whole node, regardless of source IP.
+/// Configure the maximum number of concurrent connections for this beryl
+/// system on one BEAM node, regardless of source IP.
 ///
 /// A value of 0, the default, means unlimited. When a limit is set, a
-/// transport admits a connection only while the node is below the limit. It
-/// rejects other connections before it allocates long-lived per-socket state.
-/// The transport frees the slot when the connection closes, its process dies,
-/// or its handshake or setup fails. The limiter actor performs the check and
-/// increment atomically. Concurrent opens cannot materially exceed the
+/// transport admits a connection only while this system is below the limit.
+/// It rejects other connections before it allocates long-lived per-socket
+/// state. The transport frees the slot when the connection closes, its process
+/// dies, or its handshake or setup fails. The limiter actor performs the check
+/// and increment atomically. Concurrent opens cannot materially exceed the
 /// ceiling.
+///
+/// Each independently constructed `Sockets` system owns a separate limiter.
+/// Two systems on the same node therefore each have their own configured
+/// capacity; this is not one shared ceiling for every beryl system on the node.
 ///
 /// ## Composition with per-IP limits
 ///
-/// This node-wide ceiling works with `with_max_connections_per_ip`. When both
+/// This per-system ceiling works with `with_max_connections_per_ip`. When both
 /// are set, a connection must be under *both* limits. The per-IP limit
-/// throttles any single abusive peer, while this global ceiling
-/// bounds the node's total resource use so that many distinct source addresses
-/// (for example, a botnet or IPv6 address rotation) cannot exhaust the node's
-/// process, socket, and runtime budget. A per-IP limit alone cannot stop this
-/// case.
+/// throttles any single abusive peer, while this total ceiling bounds the
+/// system's resource use so that many distinct source addresses (for example,
+/// a botnet or IPv6 address rotation) cannot exhaust its process, socket, and
+/// runtime budget. A per-IP limit alone cannot stop this case.
 ///
 /// ## Composition with external load balancers
 ///
-/// This ceiling is enforced per BEAM node. If you run several nodes behind a
-/// load balancer, each node enforces its own limit independently, so the
-/// cluster's effective ceiling is roughly `max_connections × node_count`
-/// (subject to how the balancer distributes connections). Size the per-node
-/// value against a single node's capacity. Use the load balancer's
-/// global connection/rate controls when you need a cluster-wide cap.
+/// Each beryl system enforces this ceiling independently on its BEAM node. With
+/// one system per node, a load-balanced cluster's effective ceiling is roughly
+/// `max_connections × node_count` (subject to how the balancer distributes
+/// connections). Multiple systems on one node contribute separate allowances.
+/// Size their combined limits against that node's capacity. Use the load
+/// balancer's global connection/rate controls when you need a cluster-wide cap.
 pub fn with_max_connections(
   config: Config,
   max_connections max_connections: Int,

--- a/packages/beryl/src/beryl/connection_limit.gleam
+++ b/packages/beryl/src/beryl/connection_limit.gleam
@@ -3,9 +3,10 @@
 //// Enforces three independent dimensions in a single serialized actor:
 ////
 //// - a per-IP ceiling (`max_per_ip`), which throttles a single peer, and
-//// - a node-wide ceiling (`max_total`), which caps concurrent connections
-////   across every IP so distributed/rotating source addresses cannot exhaust
-////   the node's process, socket, and runtime budget, and
+//// - a per-system total ceiling (`max_total`) on one node, which caps
+////   concurrent connections across every IP so distributed/rotating source
+////   addresses cannot exhaust that system's process, socket, and runtime
+////   budget, and
 //// - a per-IP token bucket, which prevents reconnect churn from repeatedly
 ////   refreshing per-connection frame and message bursts.
 ////
@@ -75,7 +76,7 @@ type State {
     store_key: process.Name(Message),
     /// Per-IP ceiling; 0 disables the per-IP check.
     max_per_ip: Int,
-    /// Node-wide ceiling across all IPs; 0 disables the global check.
+    /// Per-system ceiling across all IPs; 0 disables the total check.
     max_total: Int,
     /// Per-IP connection-attempt rate limit; `None` disables it.
     connection_rate: Option(rate_limit.RateLimitConfig),
@@ -317,7 +318,7 @@ fn release_reservation(
   }
 }
 
-/// Reclaim a slot in both dimensions: decrement the node-wide total and the
+/// Reclaim a slot in both dimensions: decrement the per-system total and the
 /// per-IP count. Every acquire increments both, so every release (explicit or
 /// via a holder's death) decrements both symmetrically.
 fn release_slot(state: State, ip: String) -> State {

--- a/packages/beryl/src/beryl/transport.gleam
+++ b/packages/beryl/src/beryl/transport.gleam
@@ -37,7 +37,7 @@ pub opaque type ConnectionPermit {
 ///
 /// Pass the real socket peer IP. Do not pass a client-supplied address such as
 /// `X-Forwarded-For`. Return `Error(Nil)` when the configured per-IP or
-/// node-wide limit is already reached.
+/// per-system limit on this node is already reached.
 pub fn acquire_connection_slot(
   sockets: Sockets,
   ip: String,

--- a/packages/beryl/src/beryl/transport/server.gleam
+++ b/packages/beryl/src/beryl/transport/server.gleam
@@ -238,7 +238,7 @@ pub fn is_websocket_request(request: Request(body)) -> Bool {
 /// 1. Applies the configured origin policy and the `?vsn` version check,
 ///    rejecting failures with `reject(403)`.
 /// 2. Acquires a connection slot for `request_ip(request)` (per-IP and
-///    node-wide ceilings), rejecting with `reject(429)` when at a limit.
+///    per-system ceilings), rejecting with `reject(429)` when at a limit.
 /// 3. Runs any `on_connect` callback; on `Error(ConnectRejected)` the slot is
 ///    released and the request is rejected with `reject(403)`.
 /// 4. Hands admitted requests to `accept` with the callback's connect
@@ -269,15 +269,14 @@ pub fn is_websocket_request(request: Request(body)) -> Bool {
 /// exhausted. Its state survives disconnects and app runtime restarts, so
 /// reconnecting does not refresh the configured burst.
 ///
-/// When `beryl.with_max_connections` is configured, a node-wide ceiling on
-/// concurrent connections across all IPs is likewise enforced with
-/// `reject(429)` before allocating any long-lived socket/runtime state. The
-/// two limits compose: a connection must be under both to be admitted. The
-/// node-wide ceiling bounds total resource use when a per-IP limit alone
-/// cannot (many distributed source addresses / IPv6 rotation). It is enforced
-/// per BEAM node, so across a load-balanced cluster the effective ceiling
-/// scales with the node count. Use the load balancer's controls for a
-/// cluster-wide cap.
+/// When `beryl.with_max_connections` is configured, a ceiling on concurrent
+/// connections across all IPs for the supplied `Sockets` system is likewise
+/// enforced with `reject(429)` before allocating any long-lived socket/runtime
+/// state. The two limits compose: a connection must be under both to be
+/// admitted. The total ceiling bounds resource use when a per-IP limit alone
+/// cannot (many distributed source addresses / IPv6 rotation). Each
+/// independently constructed system has a separate limiter on its BEAM node.
+/// Use the load balancer's controls for a cluster-wide cap.
 pub fn upgrade(
   request request: Request(body),
   sockets sockets: Sockets,

--- a/packages/beryl/test/global_connection_limit_test.gleam
+++ b/packages/beryl/test/global_connection_limit_test.gleam
@@ -1,11 +1,12 @@
-//// Node-wide (global) connection ceiling enforcement tests.
+//// Per-system connection ceiling enforcement tests.
 ////
 //// These exercise the same public transport-facing API
 //// (`transport.acquire_connection_slot` / `transport.bind_connection_slot` /
 //// `transport.release_connection_slot`) the Mist transport uses, but focus on
-//// node-wide ceiling configured with `beryl.with_max_connections` — the limit
-//// that bounds concurrent connections across *all* source IPs, which a per-IP
-//// limit alone cannot enforce against distributed/rotating addresses.
+//// the total ceiling configured with `beryl.with_max_connections` for one
+//// beryl system on one node. It bounds connections across *all* source IPs,
+//// which a per-IP limit alone cannot enforce against distributed or rotating
+//// addresses.
 
 import app_test_helper
 import beryl
@@ -62,7 +63,7 @@ pub fn global_zero_means_unlimited_test() -> Nil {
   Nil
 }
 
-// Connections at or below the node-wide limit are admitted regardless of which
+// Connections at or below the per-system limit are admitted regardless of which
 // IP they come from.
 pub fn admits_connections_under_global_limit_test() -> Nil {
   let channels = start_with_global_limit(3)
@@ -75,8 +76,8 @@ pub fn admits_connections_under_global_limit_test() -> Nil {
   Nil
 }
 
-// A connection that would exceed the node-wide limit is rejected even though it
-// comes from a brand-new IP — this is the distributed-source case a per-IP
+// A connection that would exceed the per-system limit is rejected even though
+// it comes from a brand-new IP — this is the distributed-source case a per-IP
 // limit cannot stop.
 pub fn rejects_connection_over_global_limit_test() -> Nil {
   let channels = start_with_global_limit(2)
@@ -92,7 +93,7 @@ pub fn rejects_connection_over_global_limit_test() -> Nil {
   Nil
 }
 
-// Releasing a slot frees node-wide capacity so a subsequent connection (from
+// Releasing a slot frees per-system capacity so a subsequent connection (from
 // any IP) succeeds. Guards against global-slot leaks on normal close.
 pub fn releasing_slot_frees_global_capacity_test() -> Nil {
   let channels = start_with_global_limit(1)
@@ -139,15 +140,15 @@ pub fn global_slot_reclaimed_when_holder_dies_without_release_test() -> Nil {
   Nil
 }
 
-// The per-IP and node-wide ceilings compose: a connection must be under both.
-// Here the node-wide ceiling refuses a second IP even though that IP is under
+// The per-IP and per-system ceilings compose: a connection must be under both.
+// Here the total ceiling refuses a second IP even though that IP is under
 // its own per-IP limit.
 pub fn per_ip_and_global_compose_test() -> Nil {
-  // Per-IP allows 5 each, but the node as a whole allows only 1.
+  // Per-IP allows 5 each, but this system as a whole allows only 1.
   let channels = start_with_both_limits(5, 1)
 
   should.be_ok(transport.acquire_connection_slot(channels, "10.0.4.1"))
-  // Different IP, well under its per-IP limit, but the node is full.
+  // Different IP, well under its per-IP limit, but the system is full.
   transport.acquire_connection_slot(channels, "10.0.4.2")
   |> should.equal(Error(Nil))
 
@@ -155,23 +156,23 @@ pub fn per_ip_and_global_compose_test() -> Nil {
   Nil
 }
 
-// The per-IP limit still bites under a generous node-wide ceiling: a single IP
-// cannot exceed its per-IP allotment even when the node has global room.
+// The per-IP limit still bites under a generous per-system ceiling: a single IP
+// cannot exceed its per-IP allotment even when the system has total room.
 pub fn per_ip_limit_still_enforced_under_global_test() -> Nil {
   let channels = start_with_both_limits(1, 10)
 
   should.be_ok(transport.acquire_connection_slot(channels, "10.0.5.1"))
-  // Same IP is at its per-IP limit even though the node has room.
+  // Same IP is at its per-IP limit even though the system has room.
   transport.acquire_connection_slot(channels, "10.0.5.1")
   |> should.equal(Error(Nil))
-  // A different IP is admitted (node still under its global ceiling).
+  // A different IP is admitted (the system is still under its total ceiling).
   should.be_ok(transport.acquire_connection_slot(channels, "10.0.5.2"))
 
   let assert Ok(Nil) = beryl.stop(channels)
   Nil
 }
 
-// Concurrent opens cannot race past the node-wide ceiling. Many processes
+// Concurrent opens cannot race past the per-system ceiling. Many processes
 // attempt to acquire at once; because the check-and-increment is serialized
 // inside the limiter actor, exactly `ceiling` of them succeed.
 pub fn concurrent_opens_do_not_exceed_global_ceiling_test() -> Nil {
@@ -183,7 +184,7 @@ pub fn concurrent_opens_do_not_exceed_global_ceiling_test() -> Nil {
   int.range(from: 1, to: attempts + 1, with: Nil, run: fn(_, i) {
     process.spawn_unlinked(fn() {
       // Each attempt uses a unique IP so per-IP tracking cannot be what caps
-      // the total — only the node-wide ceiling can.
+      // the total — only the per-system ceiling can.
       let ip = "10.9." <> int.to_string(i) <> ".1"
       let outcome = case transport.acquire_connection_slot(channels, ip) {
         Ok(permit) -> {
@@ -214,5 +215,23 @@ pub fn concurrent_opens_do_not_exceed_global_ceiling_test() -> Nil {
   |> should.equal(ceiling)
 
   let assert Ok(Nil) = beryl.stop(channels)
+  Nil
+}
+
+// Independently constructed systems on one node do not share total capacity.
+pub fn independent_systems_have_independent_limits_test() -> Nil {
+  let first = start_with_global_limit(1)
+  let second = start_with_global_limit(1)
+
+  should.be_ok(transport.acquire_connection_slot(first, "10.10.0.1"))
+  should.be_ok(transport.acquire_connection_slot(second, "10.10.0.2"))
+
+  transport.acquire_connection_slot(first, "10.10.0.3")
+  |> should.equal(Error(Nil))
+  transport.acquire_connection_slot(second, "10.10.0.4")
+  |> should.equal(Error(Nil))
+
+  let assert Ok(Nil) = beryl.stop(first)
+  let assert Ok(Nil) = beryl.stop(second)
   Nil
 }

--- a/packages/beryl_ewe/src/beryl_ewe.gleam
+++ b/packages/beryl_ewe/src/beryl_ewe.gleam
@@ -40,8 +40,9 @@ import glisten/transport as glisten_transport
 /// ```
 ///
 /// Path matching, origin policy, `?vsn` version negotiation, connection
-/// limits (per-IP and node-wide, rejected with `429 Too Many Requests`), and
-/// the `on_connect` callback use the shared admission pipeline. See
+/// limits (per-IP and per beryl system on the current node, rejected with
+/// `429 Too Many Requests`), and the `on_connect` callback use the shared
+/// admission pipeline. See
 /// `beryl/transport/server.upgrade` for the full contract. Enforcement
 /// uses the real socket peer IP from the TCP connection; forwarded headers
 /// such as `X-Forwarded-For` are not trusted.

--- a/packages/beryl_mist/src/beryl_mist.gleam
+++ b/packages/beryl_mist/src/beryl_mist.gleam
@@ -37,8 +37,9 @@ import mist.{type Connection, type ResponseData, type WebsocketConnection}
 /// ```
 ///
 /// Path matching, origin policy, `?vsn` version negotiation, connection
-/// limits (per-IP and node-wide, rejected with `429 Too Many Requests`), and
-/// the `on_connect` callback use the shared admission pipeline. See
+/// limits (per-IP and per beryl system on the current node, rejected with
+/// `429 Too Many Requests`), and the `on_connect` callback use the shared
+/// admission pipeline. See
 /// `beryl/transport/server.upgrade` for the full contract. Enforcement
 /// uses the real socket peer IP from the TCP connection; forwarded headers
 /// such as `X-Forwarded-For` are not trusted.

--- a/website/src/content/docs/architecture/runtime.md
+++ b/website/src/content/docs/architecture/runtime.md
@@ -196,7 +196,7 @@ do not establish an end-to-end or node-wide memory bound. See
 
 | Boundary | Current control and overload behavior |
 |---|---|
-| Connection admission | Optional per-IP attempt-rate and concurrent connection limits, plus a node-wide concurrent connection limit. All default to disabled. The limiter owns accounting; a rejected upgrade receives HTTP `429`. |
+| Connection admission | Optional per-IP attempt-rate and concurrent connection limits, plus a per-system concurrent connection limit on each node. All default to disabled. Each beryl system owns its limiter; a rejected upgrade receives HTTP `429`. |
 | Complete inbound frames | The connection process closes the connection for frames over 1 MiB by default, after assembly. Optional frame-rate limiting drops over-rate frames before decoding. Neither bounds pre-assembly buffers or router queues. |
 | Decoded socket input | Socket actors own optional message, join, and channel/topic rate buckets. Rates default to disabled. Over-rate messages are dropped; over-rate joins receive an error reply. These are not worker queue limits. |
 | Topic-worker input | 256 outstanding inputs and 8 MiB per worker. Client input rejection closes the topic; server notifications return errors. |

--- a/website/src/content/docs/guides/production-hardening.md
+++ b/website/src/content/docs/guides/production-hardening.md
@@ -58,8 +58,8 @@ let config =
   // Concurrent connections per client IP. Size to your expected
   // clients-behind-one-NAT worst case; see the caveat below.
   |> beryl.with_max_connections_per_ip(max_connections: 100)
-  // Node-wide ceiling on concurrent connections across all IPs. Size to a
-  // single node's process/socket/runtime budget; see below.
+  // Per-system ceiling on this node across all IPs. Size all systems on a
+  // node to its combined process/socket/runtime budget; see below.
   |> beryl.with_max_connections(max_connections: 10_000)
 
 let assert Ok(websocket_config) =
@@ -105,20 +105,23 @@ removed after their allowance has fully refilled.
 
 `with_max_connections_per_ip` separately throttles a single peer's concurrent
 connections, while `with_max_connections` caps concurrent connections across
-the whole node. A connection must pass every configured rate and concurrency
-limit; otherwise the transport rejects it with `429` **before** allocating any
-long-lived socket or runtime state. Freed concurrency capacity is reclaimed on
-normal close, transport failure, heartbeat eviction, crash, and setup failure.
+all IP addresses for one beryl system on one BEAM node. A connection must pass
+every configured rate and concurrency limit; otherwise the transport rejects it
+with `429` **before** allocating any long-lived socket or runtime state. Freed
+concurrency capacity is reclaimed on normal close, transport failure, heartbeat
+eviction, crash, and setup failure.
 
 A per-IP limit cannot stop many source addresses. A botnet or a host that
 rotates IPv6 addresses can open a few connections from each address. Together,
-these connections can exhaust the node. The node-wide ceiling limits the total
-number of connections across all IP addresses.
+these connections can exhaust the system's capacity. The per-system ceiling
+limits the total number of connections across all IP addresses.
 
-Because it is enforced per BEAM node, a load-balanced cluster of N nodes has an
-effective ceiling of roughly `max_connections × N`. Size the per-node value
-against one node's capacity, and use your load balancer's own global
-connection/rate controls when you need a cluster-wide cap.
+Each independently constructed `Sockets` system has its own limiter. Two
+systems on one node can therefore each admit up to their configured limit. With
+one system per node, a load-balanced cluster of N nodes has an effective
+ceiling of roughly `max_connections × N`. If a node runs multiple systems, size
+their combined limits against that node's capacity. Use your load balancer's
+own global connection/rate controls when you need a cluster-wide cap.
 
 ### Limits behind proxies and shared IP addresses
 

--- a/website/src/content/docs/reference/api/beryl-transport-server.md
+++ b/website/src/content/docs/reference/api/beryl-transport-server.md
@@ -438,7 +438,7 @@ Run the shared upgrade admission pipeline for a request.
  1. Applies the configured origin policy and the `?vsn` version check,
     rejecting failures with `reject(403)`.
  2. Acquires a connection slot for `request_ip(request)` (per-IP and
-    node-wide ceilings), rejecting with `reject(429)` when at a limit.
+    per-system ceilings), rejecting with `reject(429)` when at a limit.
  3. Runs any `on_connect` callback; on `Error(ConnectRejected)` the slot is
     released and the request is rejected with `reject(403)`.
  4. Hands admitted requests to `accept` with the callback's connect
@@ -469,15 +469,14 @@ Run the shared upgrade admission pipeline for a request.
  exhausted. Its state survives disconnects and app runtime restarts, so
  reconnecting does not refresh the configured burst.
 
- When `beryl.with_max_connections` is configured, a node-wide ceiling on
- concurrent connections across all IPs is likewise enforced with
- `reject(429)` before allocating any long-lived socket/runtime state. The
- two limits compose: a connection must be under both to be admitted. The
- node-wide ceiling bounds total resource use when a per-IP limit alone
- cannot (many distributed source addresses / IPv6 rotation). It is enforced
- per BEAM node, so across a load-balanced cluster the effective ceiling
- scales with the node count. Use the load balancer's controls for a
- cluster-wide cap.
+ When `beryl.with_max_connections` is configured, a ceiling on concurrent
+ connections across all IPs for the supplied `Sockets` system is likewise
+ enforced with `reject(429)` before allocating any long-lived socket/runtime
+ state. The two limits compose: a connection must be under both to be
+ admitted. The total ceiling bounds resource use when a per-IP limit alone
+ cannot (many distributed source addresses / IPv6 rotation). Each
+ independently constructed system has a separate limiter on its BEAM node.
+ Use the load balancer's controls for a cluster-wide cap.
 
 <div class="api-entry-anchor" id="api-function-with_allow_all_origins" aria-hidden="true"></div>
 

--- a/website/src/content/docs/reference/api/beryl-transport.md
+++ b/website/src/content/docs/reference/api/beryl-transport.md
@@ -182,7 +182,7 @@ Try to acquire a configured connection slot for a transport.
 
  Pass the real socket peer IP. Do not pass a client-supplied address such as
  `X-Forwarded-For`. Return `Error(Nil)` when the configured per-IP or
- node-wide limit is already reached.
+ per-system limit on this node is already reached.
 
 <div class="api-entry-anchor" id="api-function-active_codec" aria-hidden="true"></div>
 

--- a/website/src/content/docs/reference/api/beryl.md
+++ b/website/src/content/docs/reference/api/beryl.md
@@ -631,35 +631,38 @@ pub fn with_max_connections(
 ) -> Config
 ```
 
-Configure the maximum number of concurrent connections allowed across the
- whole node, regardless of source IP.
+Configure the maximum number of concurrent connections for this beryl
+ system on one BEAM node, regardless of source IP.
 
  A value of 0, the default, means unlimited. When a limit is set, a
- transport admits a connection only while the node is below the limit. It
- rejects other connections before it allocates long-lived per-socket state.
- The transport frees the slot when the connection closes, its process dies,
- or its handshake or setup fails. The limiter actor performs the check and
- increment atomically. Concurrent opens cannot materially exceed the
+ transport admits a connection only while this system is below the limit.
+ It rejects other connections before it allocates long-lived per-socket
+ state. The transport frees the slot when the connection closes, its process
+ dies, or its handshake or setup fails. The limiter actor performs the check
+ and increment atomically. Concurrent opens cannot materially exceed the
  ceiling.
+
+ Each independently constructed `Sockets` system owns a separate limiter.
+ Two systems on the same node therefore each have their own configured
+ capacity; this is not one shared ceiling for every beryl system on the node.
 
  #### Composition with per-IP limits
 
- This node-wide ceiling works with `with_max_connections_per_ip`. When both
+ This per-system ceiling works with `with_max_connections_per_ip`. When both
  are set, a connection must be under *both* limits. The per-IP limit
- throttles any single abusive peer, while this global ceiling
- bounds the node's total resource use so that many distinct source addresses
- (for example, a botnet or IPv6 address rotation) cannot exhaust the node's
- process, socket, and runtime budget. A per-IP limit alone cannot stop this
- case.
+ throttles any single abusive peer, while this total ceiling bounds the
+ system's resource use so that many distinct source addresses (for example,
+ a botnet or IPv6 address rotation) cannot exhaust its process, socket, and
+ runtime budget. A per-IP limit alone cannot stop this case.
 
  #### Composition with external load balancers
 
- This ceiling is enforced per BEAM node. If you run several nodes behind a
- load balancer, each node enforces its own limit independently, so the
- cluster's effective ceiling is roughly `max_connections × node_count`
- (subject to how the balancer distributes connections). Size the per-node
- value against a single node's capacity. Use the load balancer's
- global connection/rate controls when you need a cluster-wide cap.
+ Each beryl system enforces this ceiling independently on its BEAM node. With
+ one system per node, a load-balanced cluster's effective ceiling is roughly
+ `max_connections × node_count` (subject to how the balancer distributes
+ connections). Multiple systems on one node contribute separate allowances.
+ Size their combined limits against that node's capacity. Use the load
+ balancer's global connection/rate controls when you need a cluster-wide cap.
 
 <div class="api-entry-anchor" id="api-function-with_max_connections_per_ip" aria-hidden="true"></div>
 

--- a/website/src/content/docs/reference/api/beryl_ewe.md
+++ b/website/src/content/docs/reference/api/beryl_ewe.md
@@ -100,8 +100,9 @@ Upgrade a request to WebSocket if it matches the configured path.
  ```
 
  Path matching, origin policy, `?vsn` version negotiation, connection
- limits (per-IP and node-wide, rejected with `429 Too Many Requests`), and
- the `on_connect` callback use the shared admission pipeline. See
+ limits (per-IP and per beryl system on the current node, rejected with
+ `429 Too Many Requests`), and the `on_connect` callback use the shared
+ admission pipeline. See
  `beryl/transport/server.upgrade` for the full contract. Enforcement
  uses the real socket peer IP from the TCP connection; forwarded headers
  such as `X-Forwarded-For` are not trusted.

--- a/website/src/content/docs/reference/api/beryl_mist.md
+++ b/website/src/content/docs/reference/api/beryl_mist.md
@@ -96,8 +96,9 @@ Upgrade a request to WebSocket if it matches the configured path.
  ```
 
  Path matching, origin policy, `?vsn` version negotiation, connection
- limits (per-IP and node-wide, rejected with `429 Too Many Requests`), and
- the `on_connect` callback use the shared admission pipeline. See
+ limits (per-IP and per beryl system on the current node, rejected with
+ `429 Too Many Requests`), and the `on_connect` callback use the shared
+ admission pipeline. See
  `beryl/transport/server.upgrade` for the full contract. Enforcement
  uses the real socket peer IP from the TCP connection; forwarded headers
  such as `X-Forwarded-For` are not trusted.


### PR DESCRIPTION
## Summary

- clarify that `with_max_connections` is per beryl system on each BEAM node
- align transport and deployment guidance, then regenerate API reference pages

Closes #438