### PR TITLE
fix(examples): tie presence store to tracker lifetime

### DIFF
--- a/examples/example_helpers/src/example_helper/session_presence.gleam
+++ b/examples/example_helpers/src/example_helper/session_presence.gleam
@@ -67,22 +67,25 @@ fn store_count(table: Store, topic: String) -> Int
 @external(erlang, "example_session_presence_ffi", "snapshot")
 fn store_snapshot(table: Store, topic: String) -> List(#(String, json.Json))
 
+@external(erlang, "example_session_presence_ffi", "exists")
+fn store_exists(table: Store) -> Bool
+
 pub fn start() -> Tracker {
-  let table = new_store()
   let ready = process.new_subject()
   let owner = process.self()
   let pid =
     process.spawn_unlinked(fn() {
+      let table = new_store()
       let subject = process.new_subject()
       let owner_monitor = process.monitor(owner)
       let selector =
         process.new_selector()
         |> process.select_map(subject, Message)
         |> process.select_specific_monitor(owner_monitor, fn(_) { OwnerDown })
-      process.send(ready, subject)
+      process.send(ready, #(subject, table))
       loop(selector, table, State(sockets: None, owners: dict.new()))
     })
-  let assert Ok(subject) = process.receive(ready, start_timeout_ms)
+  let assert Ok(#(subject, table)) = process.receive(ready, start_timeout_ms)
   Tracker(pid, subject, table)
 }
 
@@ -96,6 +99,9 @@ pub fn configure(tracker: Tracker, sockets: beryl.Sockets) -> Nil {
 ///
 /// The publisher also monitors the process that called [`start`](#start), so
 /// it cannot outlive an owner that exits without an explicit stop.
+///
+/// Do not use the tracker after this function returns. Its ETS store is
+/// released with the publisher process.
 pub fn stop(tracker: Tracker) -> Nil {
   let monitor = process.monitor(tracker.pid)
   process.call(tracker.subject, call_timeout_ms, fn(reply) { Stop(reply) })
@@ -114,6 +120,11 @@ pub fn is_running(tracker: Tracker) -> Bool {
 @internal
 pub fn process_id(tracker: Tracker) -> Pid {
   tracker.pid
+}
+
+@internal
+pub fn store_is_alive(tracker: Tracker) -> Bool {
+  store_exists(tracker.table)
 }
 
 pub fn track(

--- a/examples/example_helpers/src/example_session_presence_ffi.erl
+++ b/examples/example_helpers/src/example_session_presence_ffi.erl
@@ -1,5 +1,5 @@
 -module(example_session_presence_ffi).
--export([new_store/0, track/4, untrack/3, count/2, snapshot/2]).
+-export([new_store/0, track/4, untrack/3, count/2, snapshot/2, exists/1]).
 
 new_store() ->
     ets:new(?MODULE, [
@@ -26,3 +26,6 @@ snapshot(Table, Topic) ->
      || {{StoredTopic, SessionId}, Meta} <- ets:tab2list(Table),
         StoredTopic =:= Topic
     ].
+
+exists(Table) ->
+    ets:info(Table) =/= undefined.

--- a/examples/example_helpers/test/example_helper_test.gleam
+++ b/examples/example_helpers/test/example_helper_test.gleam
@@ -104,3 +104,49 @@ pub fn owner_death_reclaims_admitted_capacity_test() -> Nil {
   |> should.equal(Ok(Nil))
   session_presence.stop(tracker)
 }
+
+pub fn stop_releases_the_populated_store_test() -> Nil {
+  let tracker = session_presence.start()
+  session_presence.track(tracker, "room:stop", "session", json.object([]))
+
+  session_presence.store_is_alive(tracker) |> should.be_true
+  session_presence.count(tracker, "room:stop") |> should.equal(1)
+  session_presence.stop(tracker)
+  session_presence.store_is_alive(tracker) |> should.be_false
+}
+
+pub fn tracker_failure_releases_the_store_test() -> Nil {
+  let tracker = session_presence.start()
+  session_presence.track(
+    tracker,
+    "room:tracker-failure",
+    "session",
+    json.object([]),
+  )
+  let monitor = process.monitor(session_presence.process_id(tracker))
+
+  process.kill(session_presence.process_id(tracker))
+  await_down(monitor)
+
+  session_presence.store_is_alive(tracker) |> should.be_false
+}
+
+pub fn starter_failure_releases_the_store_test() -> Nil {
+  let started = process.new_subject()
+  let starter =
+    process.spawn_unlinked(fn() {
+      let tracker = session_presence.start()
+      process.send(started, tracker)
+      process.receive_forever(process.new_subject())
+    })
+  let assert Ok(tracker) = process.receive(started, 1000)
+  let starter_monitor = process.monitor(starter)
+  let tracker_monitor = process.monitor(session_presence.process_id(tracker))
+
+  session_presence.store_is_alive(tracker) |> should.be_true
+  process.kill(starter)
+  await_down(starter_monitor)
+  await_down(tracker_monitor)
+
+  session_presence.store_is_alive(tracker) |> should.be_false
+}


### PR DESCRIPTION
## Summary

- create the session presence ETS table in the tracker process
- let BEAM ownership release entries on stop, tracker failure, or starter failure
- document that tracker operations are invalid after stop

Closes #448