### PR TITLE
fix(presence): untrack only local entries

### DIFF
--- a/.changes/unreleased/beryl-ensure-untrack-all-removes.toml
+++ b/.changes/unreleased/beryl-ensure-untrack-all-removes.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Ensure untrack_all removes and reports only locally owned presence entries."

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -1174,7 +1174,11 @@ pub fn untrack(
   call(presence, fn(reply) { Untrack(ref, reply) })
 }
 
-/// Untrack all presences for a session, such as when a socket disconnects.
+/// Untrack all presences locally tracked for a session, such as when a socket
+/// disconnects.
+///
+/// Replicated entries owned by another presence actor are not removed, even
+/// when they use the same session ID.
 ///
 /// Returns a typed call error on admission failure, owner exit, or timeout.
 /// A timeout cancels pending work, but a running mutation may still complete.
@@ -1881,19 +1885,10 @@ fn do_untrack_refs(actor_state: ActorState, refs: List(String)) -> ActorState {
 }
 
 fn do_untrack_all(actor_state: ActorState, session_id: String) -> ActorState {
-  let diff = leave_all_diff(actor_state.crdt, session_id)
-  let new_crdt = state.leave_by_pid(actor_state.crdt, session_id)
-  maybe_invoke_on_diff(actor_state.config, diff)
-  // Drop any refs that pointed at the removed session so they cannot leak
-  // or later leave presences they no longer own.
-  let new_refs =
-    dict.filter(actor_state.refs, fn(_ref, tracked) {
-      tracked.session_id != session_id
-    })
-  // A single session can hold presences in several topics; republish
-  // every topic the leave touched (from the pre-mutation diff).
-  publish_topics(actor_state.read_table, new_crdt, dict.keys(diff.leaves))
-  ActorState(..actor_state, crdt: new_crdt, refs: new_refs)
+  actor_state.refs
+  |> dict.filter(fn(_ref, tracked) { tracked.session_id == session_id })
+  |> dict.keys
+  |> do_untrack_refs(actor_state, _)
 }
 
 fn do_untrack_runtime_owner(
@@ -1904,24 +1899,6 @@ fn do_untrack_runtime_owner(
   |> dict.filter(fn(_ref, tracked) { tracked.owner == RuntimeOwner(owner) })
   |> dict.keys
   |> do_untrack_refs(actor_state, _)
-}
-
-fn leave_all_diff(crdt: State, session_id: String) -> Diff {
-  let leaves =
-    state.online_list(crdt)
-    |> list.filter(fn(entry) { entry.0 == session_id })
-    |> list.fold(dict.new(), fn(grouped, entry) {
-      let #(_, topic, key, meta) = entry
-      let existing =
-        dict.get(grouped, topic)
-        |> result.unwrap([])
-      dict.insert(grouped, topic, [
-        PresenceEntry(session_id: session_id, key: key, meta: meta),
-        ..existing
-      ])
-    })
-
-  Diff(joins: dict.new(), leaves: leaves, scope: Cluster)
 }
 
 /// Invoke the on_diff callback if configured and the diff is non-empty

--- a/packages/beryl/test/presence_replication_test.gleam
+++ b/packages/beryl/test/presence_replication_test.gleam
@@ -296,6 +296,59 @@ pub fn untrack_propagates_via_pubsub_test() -> Nil {
   list.length(presence_entries(tracker2, "room:lobby")) |> should.equal(0)
 }
 
+pub fn untrack_all_reports_only_removed_local_entries_test() -> Nil {
+  let pubsub_instance = test_pubsub("untrack_all_local_only")
+  let leaves = process.new_subject()
+  let config1 =
+    test_config(pubsub_instance, "node1", 30)
+    |> presence.with_on_diff(fn(diff) {
+      case presence.diff_leaves(diff, "room:lobby") {
+        [] -> Nil
+        entries -> process.send(leaves, entries)
+      }
+    })
+  let assert Ok(tracker1) = presence.start(config1)
+  let assert Ok(tracker2) =
+    presence.start(test_config(pubsub_instance, "node2", 30))
+
+  let assert Ok(_) =
+    presence.track(
+      tracker2,
+      "room:lobby",
+      "user:remote",
+      "shared-session",
+      json.null(),
+    )
+  test_helper.wait_until(
+    fn() { presence_count(tracker1, "room:lobby") == 1 },
+    2000,
+    20,
+  )
+
+  let assert Ok(_) = presence.untrack_all(tracker1, "shared-session")
+
+  presence_count(tracker1, "room:lobby") |> should.equal(1)
+  process.receive(leaves, 0) |> should.equal(Error(Nil))
+
+  let assert Ok(_) =
+    presence.track(
+      tracker1,
+      "room:lobby",
+      "user:local",
+      "shared-session",
+      json.null(),
+    )
+  presence_count(tracker1, "room:lobby") |> should.equal(2)
+
+  let assert Ok(_) = presence.untrack_all(tracker1, "shared-session")
+
+  let assert [remaining] = presence_entries(tracker1, "room:lobby")
+  remaining.key |> should.equal("user:remote")
+  let assert Ok([left]) = process.receive(leaves, 1000)
+  left.key |> should.equal("user:local")
+  process.receive(leaves, 0) |> should.equal(Error(Nil))
+}
+
 // ── Resilience: malformed sync messages ──────────────────────────────
 //
 // The sync payload is now a native, typed `SyncPayload` term rather than a

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -495,7 +495,11 @@ pub fn untrack_all(
 ) -> Result(Nil, overload.CallError)
 ```
 
-Untrack all presences for a session, such as when a socket disconnects.
+Untrack all presences locally tracked for a session, such as when a socket
+ disconnects.
+
+ Replicated entries owned by another presence actor are not removed, even
+ when they use the same session ID.
 
  Returns a typed call error on admission failure, owner exit, or timeout.
  A timeout cancels pending work, but a running mutation may still complete.


### PR DESCRIPTION
## Summary

- remove session entries through their locally owned tracking refs
- keep replicated entries with the same session ID visible and out of leave diffs
- document local ownership

Closes #430