### PR TITLE
fix(runtime): bound crash diagnostics

### DIFF
--- a/.changes/unreleased/beryl-bound-crash-diagnostic-formatting.toml
+++ b/.changes/unreleased/beryl-bound-crash-diagnostic-formatting.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Bound crash diagnostic formatting and retained memory for large exception reasons."

--- a/packages/beryl/src/beryl_ffi.erl
+++ b/packages/beryl/src/beryl_ffi.erl
@@ -19,8 +19,9 @@ rescue(Fun) ->
     catch
         Class:Reason ->
             Formatted = unicode:characters_to_binary(
-                io_lib:format("~p:~P", [Class, Reason, 10])),
-            {error, string:slice(Formatted, 0, 512)}
+                io_lib:format(
+                    "~p:~P", [Class, Reason, 10], [{chars_limit, 512}])),
+            {error, binary:copy(string:slice(Formatted, 0, 512))}
     end.
 
 %% Return Erlang monotonic time in milliseconds

--- a/packages/beryl/test/beryl_diagnostic_test_ffi.erl
+++ b/packages/beryl/test/beryl_diagnostic_test_ffi.erl
@@ -1,0 +1,29 @@
+-module(beryl_diagnostic_test_ffi).
+-export([rescue_description/2, abnormal_exit_description/1,
+         referenced_byte_size/1]).
+
+rescue_description(<<"error">>, Shape) ->
+    rescue(fun() -> erlang:error(reason(Shape)) end);
+rescue_description(<<"exit">>, Shape) ->
+    rescue(fun() -> erlang:exit(reason(Shape)) end);
+rescue_description(<<"throw">>, Shape) ->
+    rescue(fun() -> erlang:throw(reason(Shape)) end).
+
+abnormal_exit_description(Shape) ->
+    beryl_error_ffi:describe_abnormal_exit({abnormal, reason(Shape)}).
+
+referenced_byte_size(Binary) ->
+    binary:referenced_byte_size(Binary).
+
+rescue(Fun) ->
+    {error, Description} = beryl_ffi:rescue(Fun),
+    Description.
+
+reason(<<"small">>) ->
+    <<"boom">>;
+reason(<<"flat">>) ->
+    lists:duplicate(2000000, $x);
+reason(<<"unicode">>) ->
+    lists:duplicate(200000, 16#00E5);
+reason(<<"nested">>) ->
+    {outer, #{reason => [lists:duplicate(2000000, $x)]}}.

--- a/packages/beryl/test/beryl_test.gleam
+++ b/packages/beryl/test/beryl_test.gleam
@@ -16,6 +16,15 @@ import gleam/string
 import gleeunit
 import gleeunit/should
 
+@external(erlang, "beryl_diagnostic_test_ffi", "rescue_description")
+fn rescue_description(class: String, shape: String) -> String
+
+@external(erlang, "beryl_diagnostic_test_ffi", "abnormal_exit_description")
+fn abnormal_exit_description(shape: String) -> String
+
+@external(erlang, "beryl_diagnostic_test_ffi", "referenced_byte_size")
+fn referenced_byte_size(value: String) -> Int
+
 fn text_frame(frame: codec.Frame) -> String {
   let assert codec.TextFrame(text) = frame
   text
@@ -466,6 +475,36 @@ pub fn start_failure_description_bounds_large_exit_reasons_test() -> Nil {
   string.starts_with(description, prefix) |> should.be_true
   { string.length(description) <= string.length(prefix) + 512 }
   |> should.be_true
+}
+
+pub fn rescued_crash_description_preserves_exception_classes_test() -> Nil {
+  rescue_description("error", "small")
+  |> string.starts_with("error:")
+  |> should.be_true
+  rescue_description("exit", "small")
+  |> string.starts_with("exit:")
+  |> should.be_true
+  rescue_description("throw", "small")
+  |> string.starts_with("throw:")
+  |> should.be_true
+}
+
+pub fn rescued_crash_description_preserves_unicode_test() -> Nil {
+  let description = rescue_description("throw", "unicode")
+
+  string.starts_with(description, "throw:") |> should.be_true
+  string.contains(description, "å") |> should.be_true
+  { string.length(description) <= 512 } |> should.be_true
+}
+
+pub fn crash_descriptions_bound_formatting_and_retained_memory_test() -> Nil {
+  let rescued = rescue_description("error", "flat")
+  { string.length(rescued) <= 512 } |> should.be_true
+  { referenced_byte_size(rescued) <= 4096 } |> should.be_true
+
+  let abnormal_exit = abnormal_exit_description("nested")
+  { string.length(abnormal_exit) <= 512 } |> should.be_true
+  { referenced_byte_size(abnormal_exit) <= 4096 } |> should.be_true
 }
 
 pub fn topic_namespace_test() -> Nil {


### PR DESCRIPTION
## Summary

- limit exception formatting before binary conversion
- copy truncated diagnostics so large exception terms cannot retain their backing allocation

Closes #431