### PR TITLE
fix(runtime): drain committed worker reports

### DIFF
--- a/.changes/unreleased/beryl-apply-committed-worker-reports.toml
+++ b/.changes/unreleased/beryl-apply-committed-worker-reports.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Apply committed worker reports before closing a topic whose worker has exited."

--- a/packages/beryl/src/beryl/runtime.gleam
+++ b/packages/beryl/src/beryl/runtime.gleam
@@ -2430,6 +2430,13 @@ fn apply_stopping_report(
   worker: WorkerRef,
   message: Message(message),
 ) -> State(model, message) {
+  run(state, socket_id, committed_worker_report_steps(worker, message))
+}
+
+fn committed_worker_report_steps(
+  worker: WorkerRef,
+  message: Message(message),
+) -> List(Step(message)) {
   case message {
     WorkerReport(_, topic, _, report, reservation) -> {
       let report = case report {
@@ -2442,12 +2449,49 @@ fn apply_stopping_report(
         ]
         None -> []
       }
-      run(state, socket_id, [
-        StepWorkerReport(topic, report, ContinueDriving),
-        ..acknowledgements
-      ])
+      [StepWorkerReport(topic, report, ContinueDriving), ..acknowledgements]
     }
-    _ -> state
+    _ -> []
+  }
+}
+
+fn take_committed_worker_report_steps(
+  state: State(model, message),
+  socket_id: String,
+  worker: WorkerRef,
+) -> #(State(model, message), List(Step(message))) {
+  let #(queued, others) =
+    dict.get(state.queued, socket_id)
+    |> result.unwrap([])
+    |> list.partition(fn(message) {
+      case message {
+        WorkerReport(worker: pid, ..) -> pid == worker.pid
+        _ -> False
+      }
+    })
+  let state =
+    State(..state, queued: case others {
+      [] -> dict.delete(state.queued, socket_id)
+      _ -> dict.insert(state.queued, socket_id, others)
+    })
+  let queued_steps =
+    queued
+    |> list.reverse
+    |> list.flat_map(committed_worker_report_steps(worker, _))
+  #(state, list.append(queued_steps, take_committed_inbox_steps(state, worker)))
+}
+
+fn take_committed_inbox_steps(
+  state: State(model, message),
+  worker: WorkerRef,
+) -> List(Step(message)) {
+  case take_worker_report(state.inbox, worker.pid) {
+    Error(Nil) -> []
+    Ok(#(_, message)) ->
+      list.append(
+        committed_worker_report_steps(worker, message),
+        take_committed_inbox_steps(state, worker),
+      )
   }
 }
 
@@ -7215,9 +7259,11 @@ fn close_worker_topic(
   continuation: Continuation,
 ) -> Execution(model, message) {
   // A stopped worker has no termination callback to run. Its `Down` message
-  // can still be queued or not yet received. Continue the close without
-  // waiting for the termination timeout.
+  // can still be queued or not yet received. Apply reports it committed
+  // before death, then continue the close without a termination timeout.
   use <- bool.lazy_guard(when: !process.is_alive(worker.pid), return: fn() {
+    let #(state, reports) =
+      take_committed_worker_report_steps(state, socket_id, worker)
     work_queue.release_producer(state.inbox, worker.pid)
     state.logger
     |> log.error("Topic worker already exited; closing without on_terminate", [
@@ -7225,14 +7271,17 @@ fn close_worker_topic(
       #("topic", topic_name),
     ])
     process.demonitor_process(worker.monitor)
-    Continue(state, [
-      StepEffects(
-        [],
-        None,
-        [],
-        ContinueClosingTopic(topic_name, close_join_ref, reason, continuation),
-      ),
-    ])
+    Continue(
+      state,
+      list.append(reports, [
+        StepEffects(
+          [],
+          None,
+          [],
+          ContinueClosingTopic(topic_name, close_join_ref, reason, continuation),
+        ),
+      ]),
+    )
   })
   case state.stopping {
     False -> {

--- a/packages/beryl/test/beryl_test_process_ffi.erl
+++ b/packages/beryl/test/beryl_test_process_ffi.erl
@@ -2,13 +2,26 @@
 -export([mailbox_length/1, queue_memory_evidence/0, with_suspended/2,
          queue_call_lifecycle/0, publication_cleanup_races/0,
          stale_lifecycle_signals/3, monitored_by_count/1,
-         suspend_process/1, resume_process/1, socket_queue/2]).
+         suspend_process/1, resume_process/1, socket_queue/2,
+         socket_actor/2, worker_report_pending/3]).
 
 socket_queue(Router, SocketId) ->
     {registered_name, Name} = process_info(Router, registered_name),
     {ok, {Table, Router, _, _, _, _, _}} = beryl_work_queue_ffi:lookup(Name),
     [{{target, SocketId}, Queue}] = ets:lookup(Table, {target, SocketId}),
     Queue.
+
+socket_actor(Router, SocketId) ->
+    {_, Owner, _, _, _, _, _} = socket_queue(Router, SocketId),
+    Owner.
+
+worker_report_pending(Router, SocketId, Worker) ->
+    {Table, _, _, _, _, _, _} = socket_queue(Router, SocketId),
+    [{state, #{leases := Leases}}] = ets:lookup(Table, state),
+    lists:any(fun
+        ({pending, _, _, {worker_report, _, _, Worker, _, _}}) -> true;
+        (_) -> false
+    end, maps:values(Leases)).
 
 stale_lifecycle_signals(Router, SocketId, OldActor) ->
     {registered_name, Name} = process_info(Router, registered_name),

--- a/packages/beryl/test/channel_worker_test.gleam
+++ b/packages/beryl/test/channel_worker_test.gleam
@@ -8,8 +8,10 @@
 
 import beryl
 import beryl/channel
+import beryl/runtime
 import beryl/transport
 import beryl/wire
+import beryl/work_queue
 import channel_dispatch_helper as helper
 import gleam/erlang/process
 import gleam/int
@@ -17,10 +19,38 @@ import gleam/json
 import gleam/list
 import gleam/string
 import gleeunit/should
+import test_helper
 
 pub type Poke {
   Poke
 }
+
+type Gate
+
+@external(erlang, "beryl_supervisor_test_ffi", "gate_new")
+fn new_gate() -> Gate
+
+@external(erlang, "beryl_supervisor_test_ffi", "gate_wait")
+fn wait_for_gate(gate: Gate) -> Nil
+
+@external(erlang, "beryl_supervisor_test_ffi", "gate_release")
+fn release_gate(gate: Gate) -> Nil
+
+@external(erlang, "beryl_test_process_ffi", "socket_queue")
+fn socket_queue(
+  router: process.Pid,
+  socket_id: String,
+) -> work_queue.Queue(runtime.Message(Nil))
+
+@external(erlang, "beryl_test_process_ffi", "socket_actor")
+fn socket_actor(router: process.Pid, socket_id: String) -> process.Pid
+
+@external(erlang, "beryl_test_process_ffi", "worker_report_pending")
+fn worker_report_pending(
+  router: process.Pid,
+  socket_id: String,
+  worker: process.Pid,
+) -> Bool
 
 /// What a test channel reports as it runs.
 type Report {
@@ -354,6 +384,67 @@ pub fn a_notify_from_join_is_served_after_the_join_is_indexed_test() -> Nil {
 }
 
 // --- worker death -------------------------------------------------------------
+
+pub fn a_dead_worker_committed_report_runs_before_its_topic_closes_test() -> Nil {
+  let gate = new_gate()
+  let reports = process.new_subject()
+  let entered = process.new_subject()
+  let terminating = process.new_subject()
+  let handler =
+    channel.handler("room:*", fn(context) {
+      process.send(reports, Ran(context.topic, "join", process.self()))
+      channel.accept(Nil)
+      |> channel.on_message(fn(_state, message) {
+        process.send(entered, Nil)
+        wait_for_gate(gate)
+        channel.next(Nil, [
+          channel.push("committed", json.null()),
+          channel.reply_ok(message.reply, json.null()),
+        ])
+      })
+      |> channel.on_terminate(fn(_state, _reason) {
+        process.send(terminating, Nil)
+        []
+      })
+    })
+  let channels = helper.start(config(), [handler])
+  let frames = helper.connect(channels, "s1")
+  helper.join(channels, "s1", "room:a", "jr-1", "r-1")
+  let _ = helper.recv(frames)
+  let worker = ran_pid(reports, "join")
+  let assert Ok(router) = transport.runtime_pid(channels)
+  let actor = socket_actor(router, "s1")
+
+  helper.push(channels, "s1", "room:a", "echo", "r-2")
+  process.receive(entered, 1000) |> should.equal(Ok(Nil))
+  test_helper.suspend_process(actor)
+  helper.leave(channels, "s1", "room:a", "jr-1", "r-3")
+
+  release_gate(gate)
+  test_helper.wait_until(
+    fn() { worker_report_pending(router, "s1", worker) },
+    1000,
+    5,
+  )
+  process.kill(worker)
+  wait_until_dead(worker)
+  test_helper.resume_process(actor)
+
+  helper.recv(frames) |> string.contains("\"r-3\"") |> should.be_true
+  helper.recv(frames) |> string.contains("\"committed\"") |> should.be_true
+  helper.recv(frames) |> string.contains("\"r-2\"") |> should.be_true
+  helper.recv(frames) |> string.contains("phx_close") |> should.be_true
+  helper.recv_none(frames)
+  process.receive(terminating, 100) |> should.be_error
+  test_helper.wait_until(
+    fn() {
+      let assert Ok(occupancy) = work_queue.snapshot(socket_queue(router, "s1"))
+      occupancy.items == 0
+    },
+    1000,
+    5,
+  )
+}
 
 pub fn a_close_of_a_dead_worker_does_not_wait_for_the_terminate_timeout_test() -> Nil {
   let reports = process.new_subject()


### PR DESCRIPTION
## Summary

- drain reports committed by a dead topic worker before cleanup and close
- preserve report order across buffered and queued socket work

Closes #429