### PR TITLE
fix(presence): contain diff callback failures

### DIFF
--- a/.changes/unreleased/beryl-contain-on-diff-callback.toml
+++ b/.changes/unreleased/beryl-contain-on-diff-callback.toml
@@ -1,0 +1,3 @@
+package = "beryl"
+kind = "Fixed"
+body = "Contain on_diff callback failures so successful presence mutations and remote merges still publish state and acknowledge while preserving synchronous ordering."

--- a/packages/beryl/src/beryl/presence.gleam
+++ b/packages/beryl/src/beryl/presence.gleam
@@ -680,7 +680,20 @@ pub fn with_call_timeout(config: Config, timeout_ms: Int) -> Config {
 /// `list`/`get_by_key`/`count` calls from other processes do not use the
 /// mailbox and are not delayed. A socket with an active presence effect waits
 /// for the callback. Callers of synchronous mutations also wait for their
-/// replies.
+/// replies. Enqueue a small message to a bounded application-owned worker and
+/// return. Do not make network calls or synchronously mutate the same presence
+/// actor from this callback.
+///
+/// beryl catches and logs callback exceptions, exits, and throws. A callback
+/// failure does not veto an otherwise successful local mutation or remote
+/// merge: beryl still publishes the snapshot and replies or acknowledges.
+/// beryl does not retry the callback, and it cannot roll back callback effects
+/// that completed before the failure. Treat delivery as a notification, not
+/// exactly-once application processing.
+///
+/// Presence queue snapshots and occupancy telemetry retain an admitted local
+/// mutation while its callback runs. They do not impose a callback deadline,
+/// apply to remote sync, or bound an application worker's mailbox.
 pub fn with_on_diff(config: Config, callback: fn(Diff) -> Nil) -> Config {
   Config(..config, on_diff: Some(callback))
 }
@@ -1924,16 +1937,26 @@ fn leave_all_diff(crdt: State, session_id: String) -> Diff {
   Diff(joins: dict.new(), leaves: leaves, scope: Cluster)
 }
 
-/// Invoke the on_diff callback if configured and the diff is non-empty
+/// Invoke the on_diff callback if configured and the diff is non-empty.
 fn maybe_invoke_on_diff(config: Config, diff: Diff) -> Nil {
   case config.on_diff {
     None -> Nil
-    Some(callback) -> {
-      case dict.is_empty(diff.joins) && dict.is_empty(diff.leaves) {
-        True -> Nil
-        False -> callback(diff)
-      }
-    }
+    Some(callback) -> invoke_on_diff(callback, diff)
+  }
+}
+
+fn invoke_on_diff(callback: fn(Diff) -> Nil, diff: Diff) -> Nil {
+  use <- bool.guard(
+    when: dict.is_empty(diff.joins) && dict.is_empty(diff.leaves),
+    return: Nil,
+  )
+  case internal.rescue(fn() { callback(diff) }) {
+    Ok(Nil) -> Nil
+    Error(crash) ->
+      internal.logger("beryl.presence")
+      |> log.error("Presence on_diff callback failed", [
+        #("crash", crash),
+      ])
   }
 }
 
@@ -2034,7 +2057,8 @@ fn merge_remote_sync(
   // Crash boundary — see internal.rescue. Version skew or bugs can produce
   // malformed sync state; Erlang distribution peers are fully trusted (see
   // the production-hardening guide). Preserve the previous actor state unless
-  // merge, on_diff, prune, and read-model publication all complete.
+  // merge, prune, and read-model publication all complete. `on_diff` has its
+  // own callback-only boundary, so its failure cannot discard a valid merge.
   let processed =
     internal.rescue(fn() {
       let sender = state.replica(remote_state)

--- a/packages/beryl/test/presence_replication_test.gleam
+++ b/packages/beryl/test/presence_replication_test.gleam
@@ -342,18 +342,12 @@ pub fn survives_unknown_envelope_version_test() -> Nil {
   |> should.equal(2)
 }
 
-// ── Resilience: exception raised inside the merge/processing path ─────
+// ── Resilience: exception raised by a remote-merge callback ───────────
 
-/// A valid remote sync can decode successfully yet still crash while the
-/// merge result is processed — for example, a user-supplied `on_diff`
-/// callback that panics, a mixed-version peer, or a compromised node. The
-/// exception must be contained: the shared presence actor stays alive and its
-/// state is not partially mutated by the poisoned sync.
-pub fn survives_exception_in_processing_path_test() -> Nil {
+pub fn remote_callback_panic_is_reported_and_merge_is_published_test() -> Nil {
   let pubsub_instance = test_pubsub("processing_crash")
+  let selector = test_helper.begin_capture()
 
-  // Node1's on_diff panics whenever a diff touches "room:poison". Diffs for
-  // any other topic pass through untouched, so local tracking still works.
   let config1 =
     presence.default_config("node1")
     |> presence.with_pubsub(pubsub_instance)
@@ -364,8 +358,9 @@ pub fn survives_exception_in_processing_path_test() -> Nil {
       }
     })
   let assert Ok(tracker1) = presence.start(config1)
+  let assert Ok(owner_before) =
+    process.subject_owner(presence.subject(tracker1))
 
-  // Prove the actor is alive and record its state before the poisoned sync.
   let assert Ok(_) =
     presence.track(
       tracker1,
@@ -376,9 +371,6 @@ pub fn survives_exception_in_processing_path_test() -> Nil {
     )
   list.length(presence_entries(tracker1, "room:lobby")) |> should.equal(1)
 
-  // Node2 broadcasts a *valid* sync that decodes cleanly but produces a diff
-  // touching "room:poison", tripping node1's panicking callback inside the
-  // merge/processing path.
   let config2 = test_config(pubsub_instance, "node2", 50)
   let assert Ok(tracker2) = presence.start(config2)
   let assert Ok(_) =
@@ -390,10 +382,14 @@ pub fn survives_exception_in_processing_path_test() -> Nil {
       json.null(),
     )
 
-  // Give node1 time to receive and reject several broadcasts of the poison.
-  process.sleep(200)
+  test_helper.receive_log(selector, "Presence on_diff callback failed", 10)
+  |> should.be_ok
+  test_helper.wait_until(
+    fn() { presence_count(tracker1, "room:poison") == 1 },
+    2000,
+    10,
+  )
 
-  // The actor is still alive: a fresh local track succeeds.
   let assert Ok(_) =
     presence.track(
       tracker1,
@@ -403,60 +399,11 @@ pub fn survives_exception_in_processing_path_test() -> Nil {
       json.null(),
     )
   list.length(presence_entries(tracker1, "room:lobby")) |> should.equal(2)
+  presence_count(tracker1, "room:poison") |> should.equal(1)
+  process.subject_owner(presence.subject(tracker1))
+  |> should.equal(Ok(owner_before))
 
-  // State was not partially mutated: the poisoned sync never merged, so
-  // "room:poison" remains empty on node1.
-  presence_entries(tracker1, "room:poison") |> should.equal([])
-}
-
-pub fn merge_failure_leaves_read_model_unchanged_test() -> Nil {
-  let pubsub_instance = test_pubsub("merge_failure_read_model")
-
-  let config1 =
-    presence.default_config("node1")
-    |> presence.with_pubsub(pubsub_instance)
-    |> presence.with_on_diff(fn(diff) {
-      case presence.diff_joins(diff, "room:poison") {
-        [] -> Nil
-        _ -> panic as "poisoned diff"
-      }
-    })
-  let assert Ok(tracker1) = presence.start(config1)
-
-  // Snapshot the read model for an unrelated topic before the poisoned sync.
-  let assert Ok(_) =
-    presence.track(
-      tracker1,
-      "room:lobby",
-      "user:safe",
-      "socket-safe",
-      json.null(),
-    )
-  let before_entries = presence_entries(tracker1, "room:lobby")
-  let before_count = presence_count(tracker1, "room:lobby")
-
-  let config2 = test_config(pubsub_instance, "node2", 50)
-  let assert Ok(tracker2) = presence.start(config2)
-  let assert Ok(_) =
-    presence.track(
-      tracker2,
-      "room:poison",
-      "user:boom",
-      "socket-boom",
-      json.null(),
-    )
-
-  // Give node1 time to receive and reject the poisoned broadcast.
-  process.sleep(200)
-
-  // The read model for the untouched topic is byte-for-byte unchanged.
-  presence_entries(tracker1, "room:lobby") |> should.equal(before_entries)
-  presence_count(tracker1, "room:lobby") |> should.equal(before_count)
-  // The poisoned topic's read model was never published in the first
-  // place -- it reads empty because the merge was rejected before any
-  // ETS write happened, not because of a later prune or partial write.
-  presence_entries(tracker1, "room:poison") |> should.equal([])
-  presence_count(tracker1, "room:poison") |> should.equal(0)
+  test_helper.stop_capture()
 }
 
 // ── Helper to drain stray messages ──────────────────────────────────
@@ -670,6 +617,7 @@ pub fn reads_stay_responsive_while_actor_mailbox_is_blocked_test() -> Nil {
       }
     })
   let assert Ok(tracker) = presence.start(config)
+  let assert Ok(owner_before) = process.subject_owner(presence.subject(tracker))
   let assert Ok(_) =
     presence.track(tracker, "room:lobby", "user:1", "socket-1", json.null())
 
@@ -687,6 +635,21 @@ pub fn reads_stay_responsive_while_actor_mailbox_is_blocked_test() -> Nil {
   // ahead of both that diff's read-model publish and its own reply.
   let assert Ok(release) = process.receive(entered, 1000)
 
+  let unrelated_done = process.new_subject()
+  process.spawn_unlinked(fn() {
+    let assert Ok(_) =
+      presence.track(tracker, "room:other", "user:3", "socket-3", json.null())
+    process.send(unrelated_done, Nil)
+  })
+  test_helper.wait_until(
+    fn() {
+      let assert Ok(current) = presence.queue_snapshot(tracker)
+      current.items == 2
+    },
+    1000,
+    5,
+  )
+
   // Reads must stay responsive, and still see the already-published
   // user:1 state, even though the actor's mailbox is busy handling the
   // still-blocked second track call.
@@ -700,12 +663,87 @@ pub fn reads_stay_responsive_while_actor_mailbox_is_blocked_test() -> Nil {
   // present-tense check on a fixed synchronization point, not a timing
   // race, since the actor cannot have replied while parked above.
   process.receive(track_done, 0) |> should.equal(Error(Nil))
+  process.receive(unrelated_done, 0) |> should.equal(Error(Nil))
+  presence_count(tracker, "room:other") |> should.equal(0)
+  process.is_alive(owner_before) |> should.be_true
 
   // Release the callback and drain completion so it can't bleed into a
   // later test.
   process.send(release, Nil)
   let assert Ok(_) = process.receive(track_done, 1000)
-  Nil
+  let assert Ok(Nil) = process.receive(unrelated_done, 1000)
+  presence_count(tracker, "room:lobby") |> should.equal(2)
+  presence_count(tracker, "room:other") |> should.equal(1)
+  process.subject_owner(presence.subject(tracker))
+  |> should.equal(Ok(owner_before))
+}
+
+pub fn remote_callback_blocks_publication_and_later_mutations_test() -> Nil {
+  let pubsub_instance = test_pubsub("slow_remote_callback")
+  let entered = process.new_subject()
+  let receiver_config =
+    presence.default_config("receiver")
+    |> presence.with_pubsub(pubsub_instance)
+    |> presence.with_broadcast_interval(0)
+    |> presence.with_on_diff(fn(diff) {
+      case presence.diff_joins(diff, "room:remote") {
+        [] -> Nil
+        _ -> {
+          let release = process.new_subject()
+          process.send(entered, release)
+          let assert Ok(Nil) = process.receive(release, 5000)
+          Nil
+        }
+      }
+    })
+  let assert Ok(receiver) = presence.start(receiver_config)
+  let assert Ok(owner_before) =
+    process.subject_owner(presence.subject(receiver))
+  let assert Ok(source) =
+    presence.start(test_config(pubsub_instance, "source", 30))
+
+  let assert Ok(_) =
+    presence.track(
+      source,
+      "room:remote",
+      "user:remote",
+      "socket-remote",
+      json.null(),
+    )
+  let assert Ok(release) = process.receive(entered, 2000)
+
+  let local_done = process.new_subject()
+  process.spawn_unlinked(fn() {
+    let assert Ok(_) =
+      presence.track(
+        receiver,
+        "room:local",
+        "user:local",
+        "socket-local",
+        json.null(),
+      )
+    process.send(local_done, Nil)
+  })
+  test_helper.wait_until(
+    fn() {
+      let assert Ok(current) = presence.queue_snapshot(receiver)
+      current.items == 1
+    },
+    1000,
+    5,
+  )
+
+  presence_count(receiver, "room:remote") |> should.equal(0)
+  presence_count(receiver, "room:local") |> should.equal(0)
+  process.receive(local_done, 0) |> should.equal(Error(Nil))
+  process.is_alive(owner_before) |> should.be_true
+
+  process.send(release, Nil)
+  let assert Ok(Nil) = process.receive(local_done, 1000)
+  presence_count(receiver, "room:remote") |> should.equal(1)
+  presence_count(receiver, "room:local") |> should.equal(1)
+  process.subject_owner(presence.subject(receiver))
+  |> should.equal(Ok(owner_before))
 }
 
 // ── track/untrack reply only after the read model is published ───────

--- a/packages/beryl/test/presence_test.gleam
+++ b/packages/beryl/test/presence_test.gleam
@@ -682,6 +682,49 @@ pub fn on_diff_callback_receives_all_rapid_diffs_test() -> Nil {
   list.length(joins2) |> should.equal(1)
 }
 
+pub fn on_diff_panic_is_reported_without_blocking_ack_or_owner_test() -> Nil {
+  let selector = test_helper.begin_capture()
+  let assert Ok(tracker) =
+    presence.start(
+      presence.default_config("callback-panic")
+      |> presence.with_on_diff(fn(_) { panic as "expected on_diff failure" }),
+    )
+  let assert Ok(owner_before) = process.subject_owner(presence.subject(tracker))
+  let reply = process.new_subject()
+
+  presence.track_async(
+    tracker,
+    "room:panic",
+    "user:1",
+    "socket-1",
+    json.null(),
+    None,
+    process.self(),
+    "track",
+    1,
+    reply,
+  )
+  |> should.equal(Ok(Nil))
+
+  let assert Ok(presence.MutationAck(
+    outcome: presence.Tracked(..),
+    tag: "track",
+    operation_id: 1,
+  )) = process.receive(reply, 1000)
+  presence_count(tracker, "room:panic") |> should.equal(1)
+  test_helper.receive_log(selector, "Presence on_diff callback failed", 5)
+  |> should.be_ok
+
+  let assert Ok(_) =
+    presence.track(tracker, "room:unrelated", "user:2", "socket-2", json.null())
+  presence_count(tracker, "room:unrelated") |> should.equal(1)
+  process.subject_owner(presence.subject(tracker))
+  |> should.equal(Ok(owner_before))
+
+  test_helper.stop_capture()
+  test_helper.kill_presence(tracker)
+}
+
 pub fn diff_accessors_return_empty_lists_for_unmentioned_topics_test() -> Nil {
   let diff =
     presence.diff(

--- a/website/src/content/docs/guides/presence.md
+++ b/website/src/content/docs/guides/presence.md
@@ -165,9 +165,26 @@ The presence actor calls the callback for local changes and remote merges. It
 calls the function before it publishes new read-model snapshots and before it
 replies to the source call. If the callback calls `list`, `get_by_key`, or
 `count` for an affected topic, it reads the previous snapshot. Read the change
-from the `Diff` argument with `diff_joins` and `diff_leaves`. Keep the callback
-short. A slow callback delays snapshot publication, the source call reply, and
-later actor messages.
+from the `Diff` argument with `diff_joins` and `diff_leaves`.
+
+Keep the callback bounded and non-blocking. Enqueue a small message to a
+bounded application-owned worker and return. Do not make network calls or
+synchronously mutate the same presence actor. A slow callback delays snapshot
+publication, the source call reply or runtime mutation acknowledgement, and
+all later actor messages, including mutations for unrelated topics.
+
+beryl catches and logs callback exceptions, exits, and throws. The callback is
+a notification, not a veto: an otherwise successful local mutation or remote
+merge still publishes its snapshot and replies or acknowledges. beryl does not
+retry the callback and cannot roll back effects that completed before it
+failed. Treat delivery as a notification, not exactly-once application
+processing.
+
+Presence queue snapshots and `[beryl, queue, occupancy]` telemetry show an
+admitted local mutation while its callback runs. These controls do not set a
+callback deadline, apply to remote sync, or bound an application worker's
+mailbox. See [Handle overload](/guides/overload/#observe-capacity) and the
+[queue contract in #397](https://github.com/tylerbutler/beryl/issues/397).
 
 ```gleam
 let config =

--- a/website/src/content/docs/reference/api/beryl-presence.md
+++ b/website/src/content/docs/reference/api/beryl-presence.md
@@ -606,7 +606,20 @@ Set the callback for diffs from local changes, remote merges, or replica
  `list`/`get_by_key`/`count` calls from other processes do not use the
  mailbox and are not delayed. A socket with an active presence effect waits
  for the callback. Callers of synchronous mutations also wait for their
- replies.
+ replies. Enqueue a small message to a bounded application-owned worker and
+ return. Do not make network calls or synchronously mutate the same presence
+ actor from this callback.
+
+ beryl catches and logs callback exceptions, exits, and throws. A callback
+ failure does not veto an otherwise successful local mutation or remote
+ merge: beryl still publishes the snapshot and replies or acknowledges.
+ beryl does not retry the callback, and it cannot roll back callback effects
+ that completed before the failure. Treat delivery as a notification, not
+ exactly-once application processing.
+
+ Presence queue snapshots and occupancy telemetry retain an admitted local
+ mutation while its callback runs. They do not impose a callback deadline,
+ apply to remote sync, or bound an application worker's mailbox.
 
 <div class="api-entry-anchor" id="api-function-with_pubsub" aria-hidden="true"></div>
 


### PR DESCRIPTION
- Contain `on_diff` callback failures without discarding successful local mutations or remote merges.
- Preserve synchronous callback, snapshot publication, and acknowledgement ordering.
- Document bounded callback work, delivery limits, and queue telemetry semantics.

Closes #398